### PR TITLE
Fixed glob patterns in `label-pr`, `publish-release`, and `validate-pr` workflows

### DIFF
--- a/.github/workflows/label-pr.yaml
+++ b/.github/workflows/label-pr.yaml
@@ -10,8 +10,8 @@ on:
       - opened
       - reopened
     paths:
-      - src/**
-      - pyproject.toml
+      - */src/**
+      - */pyproject.toml
     
 jobs:
   add-code-change-label:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -9,8 +9,8 @@ on:
     types:
       - closed
     paths:
-      - src/**
-      - pyproject.toml
+      - */src/**
+      - */pyproject.toml
 
 jobs:
   tag-version:

--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -12,8 +12,8 @@ on:
       - reopened
       - synchronize
     paths:
-      - src/**
-      - pyproject.toml
+      - */src/**
+      - */pyproject.toml
     
 jobs:
   merge-forbidden:


### PR DESCRIPTION
This pull request updates the file path patterns in several GitHub Actions workflows to make them correctly match subpackages.