### PR TITLE
Updated workflows using the `publish-github-release` action to create…

### DIFF
--- a/.github/actions/publish-github-release/action.yaml
+++ b/.github/actions/publish-github-release/action.yaml
@@ -22,22 +22,6 @@ runs:
       uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: ./${{ inputs.source }}-dist-${{ inputs.version }}/*.tar.gz ./${{ inputs.source }}-dist-${{ inputs.version }}/*.whl
-
-    - name: Create GitHub release
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        if [[ "${{ inputs.version }}" == *rc* ]]; then
-          prerelease_flag="--prerelease"
-        else
-          prerelease_flag=""
-        fi
-        gh release create ${{ inputs.version }} \
-          --title ${{ inputs.source }}-${{ inputs.version }} \
-          --repo ${{ github.repository }} \
-          --generate-notes \
-          $prerelease_flag
  
     - name: Upload artifact signatures to GitHub release
       shell: bash

--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -101,6 +101,24 @@ jobs:
           source: ${{ matrix.source }}
           version: ${{ needs.cut-release.outputs.version }}
       
+  create-github-release:  
+    name: Create GitHub release
+    needs: cut-release
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${{ needs.cut-release.outputs.version }}" == *rc* ]]; then
+            prerelease_flag="--prerelease"
+          else
+            prerelease_flag=""
+          fi
+          gh release create ${{ needs.cut-release.outputs.version }} \
+            --repo ${{ github.repository }} \
+            --generate-notes \
+            $prerelease_flag
+
   publish-github-release:
     name: Publish release to GitHub
     needs:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -72,6 +72,24 @@ jobs:
         with:
           source: ${{ matrix.source }}
           version: ${{ needs.tag-version.outputs.version }}
+
+  create-github-release:  
+    name: Create GitHub release
+    needs: tag-version
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [[ "${{ needs.tag-version.outputs.version }}" == *rc* ]]; then
+            prerelease_flag="--prerelease"
+          else
+            prerelease_flag=""
+          fi
+          gh release create ${{ needs.tag-version.outputs.version }} \
+            --repo ${{ github.repository }} \
+            --generate-notes \
+            $prerelease_flag
       
   publish-github-release:
     name: Publish release to GitHub


### PR DESCRIPTION
… a GitHub release once, then push all namespace packages to it