### PR TITLE
Fixed "Build release" action

### DIFF
--- a/.github/actions/build-release/action.yaml
+++ b/.github/actions/build-release/action.yaml
@@ -25,7 +25,7 @@ runs:
 
     - name: Build distribution artifacts
       shell: bash
-      run: uv build ${{ inputs.source }} --out-dir ${{ inputs.source }}-dist-${{ inputs.version }}
+      run: uv build ${{ inputs.source }} --sdist --wheel --out-dir ${{ inputs.source }}-dist-${{ inputs.version }}
 
     - name: Store distribution artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request updates the build process in the `Build distribution artifacts` step of the GitHub Actions workflow to include both source distribution (`sdist`) and wheel files as outputs.

Build process improvement:

* [`.github/actions/build-release/action.yaml`](diffhunk://#diff-46b7e3b123c06f12a6c6b506aac256da3872195c4c4bfca9f14df27fb1097b9bL28-R28): Updated the `run` command in the `Build distribution artifacts` step to include `--sdist` and `--wheel` flags, ensuring both source distribution and wheel artifacts are generated.