### PR TITLE
Make publish-release workflow by manually runnable

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -11,6 +11,10 @@ on:
     paths:
       - wool/src/**
       - wool/pyproject.toml
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
 
 jobs:
   tag-version:
@@ -26,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Determine version segment to bump
         id: determine-version-segment
+        if: ${{ github.event.inputs.version == '' }}
         run: |
           case ${{ github.base_ref }} in
             master)
@@ -49,12 +54,17 @@ jobs:
       - name: Create tag
         id: create-tag
         run: |
-          git fetch --unshallow
-          old_version=$(git describe --tags --abbrev=0)
-          new_version=$(.github/scripts/bump-version.sh ${{ steps.determine-version-segment.outputs.segment }} $old_version)
-          echo "Bumping $old_version to $new_version"
-          git tag $new_version
-          git push origin $new_version
+          if [[ "${{ github.event.inputs.version }}" != "" ]]; then
+            new_version="${{ github.event.inputs.version }}"
+            echo "Using manually specified version: $new_version"
+          else
+            git fetch --unshallow
+            old_version=$(git describe --tags --abbrev=0)
+            new_version=$(.github/scripts/bump-version.sh ${{ steps.determine-version-segment.outputs.segment }} $old_version)
+            git tag $new_version
+            git push origin $new_version
+            echo "Bumping $old_version to $new_version"
+          fi
           echo "version=$new_version" >> $GITHUB_OUTPUT
 
   build-release:


### PR DESCRIPTION
Updated .github/workflows/publish-release.yaml to support manually triggering the release workflow.