### PR TITLE
Fix bug causing tag-version job or publish-release workflow to be skipped

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -20,7 +20,7 @@ jobs:
   tag-version:
     name: Tag version
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.merged == true }}
+    if: ${{ github.event.pull_request.merged == true || github.event.inputs.version != '' }}
     permissions:
       contents: write
     outputs:


### PR DESCRIPTION
The tag-version job checks that the triggering PR has been merged before proceeding, but in the manual release scenario, there is no PR. This PR extends the check into an or-clause that also checks to see if a version is specified.