### PR TITLE
Refactor `Worker` and `WorkerProxy` to accept a variety of `RegistrarLike`, `DiscoveryLike`, and `LoadBalancerLike` factories

### DIFF
--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -19,10 +19,10 @@ from wool._work import routine
 from wool._work import work
 from wool._worker import Worker
 from wool._worker import WorkerService
-from wool._worker_discovery import DiscoveryService
-from wool._worker_discovery import LanDiscoveryService
-from wool._worker_discovery import LanRegistryService
-from wool._worker_discovery import RegistryService
+from wool._worker_discovery import Discovery
+from wool._worker_discovery import LanDiscovery
+from wool._worker_discovery import LanRegistrar
+from wool._worker_discovery import Registrar
 from wool._worker_pool import WorkerPool
 from wool._worker_proxy import WorkerProxy
 
@@ -54,20 +54,22 @@ try:
 except PackageNotFoundError:
     __version__ = "unknown"
 
-__proxy__: Final[ContextVar[WorkerProxy | None]] = ContextVar("__proxy__", default=None)
+__proxy__: Final[ContextVar[WorkerProxy | None]] = ContextVar(
+    "__proxy__", default=None
+)
 
 __proxy_pool__: Final[ContextVar[ResourcePool[WorkerProxy] | None]] = ContextVar(
     "__proxy_pool__", default=None
 )
 
 __all__ = [
-    "LanDiscoveryService",
-    "LanRegistryService",
+    "LanDiscovery",
+    "LanRegistrar",
     "Worker",
-    "DiscoveryService",
+    "Discovery",
     "WorkerPool",
     "WorkerProxy",
-    "RegistryService",
+    "Registrar",
     "WorkerService",
     "WoolTask",
     "WoolTaskEvent",

--- a/wool/src/wool/_worker.py
+++ b/wool/src/wool/_worker.py
@@ -13,7 +13,10 @@ from multiprocessing import Process
 from multiprocessing.connection import Connection
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import AsyncContextManager
 from typing import AsyncIterator
+from typing import Awaitable
+from typing import ContextManager
 from typing import Final
 from typing import Generic
 from typing import Protocol
@@ -31,14 +34,12 @@ from wool import _protobuf as pb
 from wool._resource_pool import ResourcePool
 from wool._work import WoolTask
 from wool._work import WoolTaskEvent
-from wool._worker_discovery import RegistryServiceLike
+from wool._worker_discovery import Factory
+from wool._worker_discovery import RegistrarLike
 from wool._worker_discovery import WorkerInfo
 
 if TYPE_CHECKING:
     from wool._worker_proxy import WorkerProxy
-
-_ip_address: str | None = None
-_EXTERNAL_DNS_SERVER: Final[str] = "8.8.8.8"  # Google DNS for IP detection
 
 
 @contextmanager
@@ -80,13 +81,8 @@ def _signal_handlers(service: "WorkerService"):
         signal.signal(signal.SIGINT, old_sigint)
 
 
-_T_RegistryService = TypeVar(
-    "_T_RegistryService", bound=RegistryServiceLike, covariant=True
-)
-
-
 # public
-class Worker(ABC, Generic[_T_RegistryService]):
+class Worker(ABC):
     """Abstract base class for worker implementations in the wool framework.
 
     Workers are individual processes that execute distributed tasks within
@@ -94,36 +90,40 @@ class Worker(ABC, Generic[_T_RegistryService]):
     a discovery service to be found by client sessions.
 
     This class defines the core interface that all worker implementations
-    must provide, including lifecycle management and registry service
+    must provide, including lifecycle management and registrar service
     integration for peer-to-peer discovery.
 
     :param tags:
         Capability tags associated with this worker for filtering and
         selection by client sessions.
-    :param registry_service:
-        Service instance for worker registration and discovery within
-        the distributed pool.
+    :param registrar:
+        Service instance or factory for worker registration and discovery
+        within the distributed pool. Can be provided as:
+
+        - **Instance**: Direct registrar service object
+        - **Factory function**: Function returning a registrar service instance
+        - **Context manager factory**: Function returning a context manager
+            that yields a registrar service
     :param extra:
         Additional arbitrary metadata as key-value pairs.
     """
 
     _info: WorkerInfo | None = None
     _started: bool = False
-    _registry_service: RegistryServiceLike
+    _registrar: RegistrarLike | Factory[RegistrarLike]
+    _registrar_service: RegistrarLike | None = None
+    _registrar_context: Any | None = None
     _uid: Final[str]
     _tags: Final[set[str]]
     _extra: Final[dict[str, Any]]
 
     def __init__(
-        self,
-        *tags: str,
-        registry_service: _T_RegistryService,
-        **extra: Any,
+        self, *tags: str, registrar: RegistrarLike | Factory[RegistrarLike], **extra: Any
     ):
         self._uid = f"worker-{uuid.uuid4().hex}"
         self._tags = set(tags)
         self._extra = extra
-        self._registry_service = registry_service
+        self._registrar = registrar
 
     @property
     def uid(self) -> str:
@@ -167,14 +167,21 @@ class Worker(ABC, Generic[_T_RegistryService]):
 
         This method is a final implementation that calls the abstract
         `_start` method to initialize the worker process and register
-        it with the registry service.
+        it with the registrar service.
         """
         if self._started:
             raise RuntimeError("Worker has already been started")
-        if self._registry_service:
-            await self._registry_service.start()
+
+        self._registrar_service, self._registrar_context = await self._enter_context(
+            self._registrar
+        )
+        if not isinstance(self._registrar_service, RegistrarLike):
+            raise ValueError("Registrar factory must return a RegistrarLike instance")
+
         await self._start()
         self._started = True
+        assert self._info
+        await self._registrar_service.register(self._info)
 
     @final
     async def stop(self):
@@ -182,13 +189,23 @@ class Worker(ABC, Generic[_T_RegistryService]):
 
         This method is a final implementation that calls the abstract
         `_stop` method to gracefully shut down the worker process and
-        unregister it from the registry service.
+        unregister it from the registrar service.
         """
         if not self._started:
             raise RuntimeError("Worker has not been started")
-        await self._stop()
-        if self._registry_service:
-            await self._registry_service.stop()
+        try:
+            if not self._info:
+                raise RuntimeError("Cannot unregister - worker has no info")
+            assert self._registrar_service is not None
+            await self._registrar_service.unregister(self._info)
+        finally:
+            try:
+                await self._stop()
+            finally:
+                await self._exit_context(self._registrar_context)
+                self._registrar_service = None
+                self._registrar_context = None
+                self._started = False
 
     @abstractmethod
     async def _start(self):
@@ -208,10 +225,36 @@ class Worker(ABC, Generic[_T_RegistryService]):
         """
         ...
 
+    async def _enter_context(self, factory):
+        """Enter context for factory objects, handling different factory types."""
+        ctx = None
+        if isinstance(factory, ContextManager):
+            ctx = factory
+            obj = ctx.__enter__()
+        elif isinstance(factory, AsyncContextManager):
+            ctx = factory
+            obj = await ctx.__aenter__()
+        elif callable(factory):
+            return await self._enter_context(factory())
+        elif isinstance(factory, Awaitable):
+            obj = await factory
+        else:
+            obj = factory
+        return obj, ctx
+
+    async def _exit_context(
+        self, ctx: AsyncContextManager | ContextManager | None, *args
+    ):
+        """Exit context for context managers."""
+        if isinstance(ctx, AsyncContextManager):
+            await ctx.__aexit__(*args)
+        elif isinstance(ctx, ContextManager):
+            ctx.__exit__(*args)
+
 
 # public
-class WorkerFactory(Generic[_T_RegistryService], Protocol):
-    """Protocol for creating worker instances with registry integration.
+class WorkerFactory(Protocol):
+    """Protocol for creating worker instances with registrar integration.
 
     Defines the callable interface for worker factory implementations
     that can create :py:class:`Worker` instances configured with specific
@@ -221,7 +264,7 @@ class WorkerFactory(Generic[_T_RegistryService], Protocol):
     worker processes with consistent configuration.
     """
 
-    def __call__(self, *tags: str, **_) -> Worker[_T_RegistryService]:
+    def __call__(self, *tags: str, **_) -> Worker:
         """Create a new worker instance.
 
         :param tags:
@@ -235,12 +278,12 @@ class WorkerFactory(Generic[_T_RegistryService], Protocol):
 
 
 # public
-class LocalWorker(Worker[_T_RegistryService]):
+class LocalWorker(Worker):
     """Local worker implementation that runs tasks in a separate process.
 
     :py:class:`LocalWorker` creates and manages a dedicated worker process
     that hosts a gRPC server for executing distributed wool tasks. Each
-    worker automatically registers itself with the provided registry service
+    worker automatically registers itself with the provided registrar service
     for discovery by client sessions.
 
     The worker process runs independently and can handle multiple concurrent
@@ -250,8 +293,8 @@ class LocalWorker(Worker[_T_RegistryService]):
     :param tags:
         Capability tags to associate with this worker for filtering
         and selection by client sessions.
-    :param registry_service:
-        Service instance for worker registration and discovery.
+    :param registrar:
+        Service instance or factory for worker registration and discovery.
     :param extra:
         Additional arbitrary metadata as key-value pairs.
     """
@@ -263,10 +306,10 @@ class LocalWorker(Worker[_T_RegistryService]):
         *tags: str,
         host: str = "127.0.0.1",
         port: int = 0,
-        registry_service: _T_RegistryService,
+        registrar: RegistrarLike | Factory[RegistrarLike],
         **extra: Any,
     ):
-        super().__init__(*tags, registry_service=registry_service, **extra)
+        super().__init__(*tags, registrar=registrar, **extra)
         self._worker_process = WorkerProcess(host=host, port=port)
 
     @property
@@ -299,9 +342,9 @@ class LocalWorker(Worker[_T_RegistryService]):
     async def _start(self):
         """Start the worker process and register it with the pool.
 
-        Initializes the registry service, starts the worker process
+        Initializes the registrar service, starts the worker process
         with its gRPC server, and registers the worker's network
-        address with the registry for discovery by client sessions.
+        address with the registrar for discovery by client sessions.
         """
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._worker_process.start)
@@ -324,30 +367,24 @@ class LocalWorker(Worker[_T_RegistryService]):
             tags=self._tags,
             extra=self._extra,
         )
-        await self._registry_service.register(self._info)
 
     async def _stop(self):
         """Stop the worker process and unregister it from the pool.
 
-        Unregisters the worker from the registry service, gracefully
+        Unregisters the worker from the registrar service, gracefully
         shuts down the worker process using SIGINT, and cleans up
-        the registry service. If graceful shutdown fails, the process
+        the registrar service. If graceful shutdown fails, the process
         is forcefully terminated.
         """
+        if not self._worker_process.is_alive():
+            return
         try:
-            if not self._info:
-                raise RuntimeError("Cannot unregister - worker has no info")
-            await self._registry_service.unregister(self._info)
-        finally:
-            if not self._worker_process.is_alive():
-                return
-            try:
-                if self._worker_process.pid:
-                    os.kill(self._worker_process.pid, signal.SIGINT)
-                    self._worker_process.join()
-            except OSError:
-                if self._worker_process.is_alive():
-                    self._worker_process.kill()
+            if self._worker_process.pid:
+                os.kill(self._worker_process.pid, signal.SIGINT)
+                self._worker_process.join()
+        except OSError:
+            if self._worker_process.is_alive():
+                self._worker_process.kill()
 
 
 class WorkerProcess(Process):

--- a/wool/src/wool/_worker_proxy.py
+++ b/wool/src/wool/_worker_proxy.py
@@ -27,9 +27,9 @@ from wool._resource_pool import Resource
 from wool._resource_pool import ResourcePool
 from wool._worker import WorkerClient
 from wool._worker_discovery import DiscoveryEvent
+from wool._worker_discovery import DiscoveryLike
 from wool._worker_discovery import Factory
-from wool._worker_discovery import LocalDiscoveryService
-from wool._worker_discovery import ReducibleAsyncIteratorLike
+from wool._worker_discovery import LocalDiscovery
 from wool._worker_discovery import WorkerInfo
 
 if TYPE_CHECKING:
@@ -106,6 +106,7 @@ class NoWorkersAvailable(Exception):
     """
 
 
+# public
 @runtime_checkable
 class LoadBalancerLike(Protocol):
     """Protocol for load balancer v2 that directly dispatches tasks.
@@ -122,17 +123,14 @@ class LoadBalancerLike(Protocol):
     def dispatch(self, task: WoolTask) -> AsyncIterator: ...
 
     def worker_added_callback(
-        self, client: Resource[WorkerClient], info: WorkerInfo
+        self, client: Callable[[], Resource[WorkerClient]], info: WorkerInfo
     ): ...
 
     def worker_updated_callback(
-        self, client: Resource[WorkerClient], info: WorkerInfo
+        self, client: Callable[[], Resource[WorkerClient]], info: WorkerInfo
     ): ...
 
     def worker_removed_callback(self, info: WorkerInfo): ...
-
-
-LoadBalancerFactory: TypeAlias = Factory[LoadBalancerLike]
 
 
 DispatchCall: TypeAlias = grpc.aio.UnaryStreamCall[pb.task.Task, pb.worker.Response]
@@ -213,10 +211,14 @@ class RoundRobinLoadBalancer:
             f"All {len(self._workers)} workers failed with transient errors"
         )
 
-    def worker_added_callback(self, client: Resource[WorkerClient], info: WorkerInfo):
+    def worker_added_callback(
+        self, client: Callable[[], Resource[WorkerClient]], info: WorkerInfo
+    ):
         self._workers[info] = client
 
-    def worker_updated_callback(self, client: Resource[WorkerClient], info: WorkerInfo):
+    def worker_updated_callback(
+        self, client: Callable[[], Resource[WorkerClient]], info: WorkerInfo
+    ):
         self._workers[info] = client
 
     def worker_removed_callback(self, info: WorkerInfo):
@@ -251,15 +253,12 @@ class WorkerProxy:
         Load balancer implementation or factory for task distribution.
     """
 
-    _discovery: (
-        ReducibleAsyncIteratorLike[DiscoveryEvent]
-        | Factory[AsyncIterator[DiscoveryEvent]]
-    )
+    _discovery: DiscoveryLike | Factory[DiscoveryLike]
     _discovery_manager: (
-        AsyncContextManager[AsyncIterator[DiscoveryEvent]]
-        | ContextManager[AsyncIterator[DiscoveryEvent]]
+        AsyncContextManager[DiscoveryLike] | ContextManager[DiscoveryLike]
     )
-    _loadbalancer = LoadBalancerLike | LoadBalancerFactory
+
+    _loadbalancer = LoadBalancerLike | Factory[LoadBalancerLike]
     _loadbalancer_manager: (
         AsyncContextManager[LoadBalancerLike] | ContextManager[LoadBalancerLike]
     )
@@ -268,11 +267,10 @@ class WorkerProxy:
     def __init__(
         self,
         *,
-        discovery: (
-            ReducibleAsyncIteratorLike[DiscoveryEvent]
-            | Factory[AsyncIterator[DiscoveryEvent]]
-        ),
-        loadbalancer: LoadBalancerLike | LoadBalancerFactory = RoundRobinLoadBalancer,
+        discovery: DiscoveryLike | Factory[DiscoveryLike],
+        loadbalancer: (
+            LoadBalancerLike | Factory[LoadBalancerLike]
+        ) = RoundRobinLoadBalancer,
     ): ...
 
     @overload
@@ -280,7 +278,8 @@ class WorkerProxy:
         self,
         *,
         workers: Sequence[WorkerInfo],
-        loadbalancer: LoadBalancerLike | LoadBalancerFactory = RoundRobinLoadBalancer,
+        loadbalancer: LoadBalancerLike
+        | Factory[LoadBalancerLike] = RoundRobinLoadBalancer,
     ): ...
 
     @overload
@@ -288,20 +287,18 @@ class WorkerProxy:
         self,
         pool_uri: str,
         *tags: str,
-        loadbalancer: LoadBalancerLike | LoadBalancerFactory = RoundRobinLoadBalancer,
+        loadbalancer: LoadBalancerLike
+        | Factory[LoadBalancerLike] = RoundRobinLoadBalancer,
     ): ...
 
     def __init__(
         self,
         pool_uri: str | None = None,
         *tags: str,
-        discovery: (
-            ReducibleAsyncIteratorLike[DiscoveryEvent]
-            | Factory[AsyncIterator[DiscoveryEvent]]
-            | None
-        ) = None,
+        discovery: (DiscoveryLike | Factory[DiscoveryLike] | None) = None,
         workers: Sequence[WorkerInfo] | None = None,
-        loadbalancer: LoadBalancerLike | LoadBalancerFactory = RoundRobinLoadBalancer,
+        loadbalancer: LoadBalancerLike
+        | Factory[LoadBalancerLike] = RoundRobinLoadBalancer,
     ):
         if not (pool_uri or discovery or workers):
             raise ValueError(
@@ -316,7 +313,7 @@ class WorkerProxy:
 
         match (pool_uri, discovery, workers):
             case (pool_uri, None, None) if pool_uri is not None:
-                self._discovery = LocalDiscoveryService(
+                self._discovery = LocalDiscovery(
                     pool_uri, filter=lambda w: bool({pool_uri, *tags} & w.tags)
                 )
             case (None, discovery, None) if discovery is not None:
@@ -399,7 +396,7 @@ class WorkerProxy:
         self._discovery_service, self._discovery_ctx = await self._enter_context(
             self._discovery
         )
-        if not isinstance(self._discovery_service, AsyncIterator):
+        if not isinstance(self._discovery_service, DiscoveryLike):
             raise ValueError
 
         self._proxy_token = wool.__proxy__.set(self)
@@ -463,16 +460,16 @@ class WorkerProxy:
 
     async def _enter_context(self, factory):
         ctx = None
-        if callable(factory):
-            obj = factory()
-            if isinstance(obj, ContextManager):
-                ctx = obj
-                obj = obj.__enter__()
-            elif isinstance(obj, AsyncContextManager):
-                ctx = obj
-                obj = await obj.__aenter__()
-            elif isinstance(obj, Awaitable):
-                obj = await obj
+        if isinstance(factory, ContextManager):
+            ctx = factory
+            obj = ctx.__enter__()
+        elif isinstance(factory, AsyncContextManager):
+            ctx = factory
+            obj = await ctx.__aenter__()
+        elif callable(factory):
+            return await self._enter_context(factory())
+        elif isinstance(factory, Awaitable):
+            obj = await factory
         else:
             obj = factory
         return obj, ctx

--- a/wool/tests/test_public.py
+++ b/wool/tests/test_public.py
@@ -23,13 +23,13 @@ def test_public_api_completeness():
     """
     # Arrange
     expected_public_api = [
-        "LanDiscoveryService",
-        "LanRegistryService",
+        "LanDiscovery",
+        "LanRegistrar",
         "Worker",
-        "DiscoveryService",
+        "Discovery",
         "WorkerPool",
         "WorkerProxy",
-        "RegistryService",
+        "Registrar",
         "WorkerService",
         "WoolTask",
         "WoolTaskEvent",

--- a/wool/tests/test_worker_discovery_integration.py
+++ b/wool/tests/test_worker_discovery_integration.py
@@ -12,13 +12,13 @@ from hypothesis import strategies as st
 from hypothesis.strategies import composite
 
 import wool
-from wool._worker_discovery import LanDiscoveryService
-from wool._worker_discovery import LanRegistryService
+from wool._worker_discovery import LanDiscovery
+from wool._worker_discovery import LanRegistrar
 from wool._worker_discovery import WorkerInfo
 
 
 def create_mock_worker_info(address: str) -> WorkerInfo:
-    """Create a :py:class:`WorkerInfo` object for testing registry operations.
+    """Create a :py:class:`WorkerInfo` object for testing registrar operations.
 
     :param address:
         The worker address in 'host:port' format.
@@ -67,7 +67,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
     """End-to-end integration tests for service registration and discovery.
 
     These integration tests verify the interaction between
-    :py:class:`LanRegistryService` and :py:class:`LanDiscoveryService`
+    :py:class:`LanRegistrar` and :py:class:`LanDiscovery`
     components work together correctly for worker lifecycle management.
     """
 
@@ -78,10 +78,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
         """Test that worker registration triggers discovery events.
 
         GIVEN
-            A :py:class:`LanRegistryService` and
-            :py:class:`LanDiscoveryService` are running
+            A :py:class:`LanRegistrar` and
+            :py:class:`LanDiscovery` are running
         WHEN
-            A worker is registered in the registry
+            A worker is registered in the registrar
         THEN
             The discovery service should detect the worker addition and
             removal events
@@ -92,10 +92,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
         discovery_future = asyncio.Future()
         removal_future = asyncio.Future()
 
-        mock_registry = LanRegistryService()
-        mock_discovery = LanDiscoveryService()
+        mock_registrar = LanRegistrar()
+        mock_discovery = LanDiscovery()
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         async def process_events():
             async for event in mock_discovery.events():
@@ -112,10 +112,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
 
         try:
             # Act
-            await mock_registry.register(mock_worker_info)
+            await mock_registrar.register(mock_worker_info)
             discovered_worker = await asyncio.wait_for(discovery_future, timeout=5.0)
 
-            await mock_registry.unregister(mock_worker_info)
+            await mock_registrar.unregister(mock_worker_info)
             removed_worker = await asyncio.wait_for(removal_future, timeout=5.0)
 
             # Assert
@@ -134,14 +134,14 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                 await event_task
             except asyncio.CancelledError:
                 pass
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
     @pytest.mark.asyncio
     async def test_discovery_filters_workers_by_tag_criteria(self):
         """Test that discovery service filters workers by tag criteria.
 
         GIVEN
-            A :py:class:`LanDiscoveryService` configured with tag filtering
+            A :py:class:`LanDiscovery` configured with tag filtering
         WHEN
             Workers with different tags are registered
         THEN
@@ -161,10 +161,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
         def mock_filter_production_workers(worker_info: WorkerInfo) -> bool:
             return "production" in worker_info.tags
 
-        mock_registry = LanRegistryService()
-        mock_discovery = LanDiscoveryService(filter=mock_filter_production_workers)
+        mock_registrar = LanRegistrar()
+        mock_discovery = LanDiscovery(filter=mock_filter_production_workers)
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         async def process_events():
             async for event in mock_discovery.events():
@@ -177,8 +177,8 @@ class TestServiceRegistrationAndDiscoveryIntegration:
 
         try:
             # Act
-            await mock_registry.register(mock_worker_development)
-            await mock_registry.register(mock_worker_production)
+            await mock_registrar.register(mock_worker_development)
+            await mock_registrar.register(mock_worker_production)
 
             await asyncio.wait_for(discovery_future, timeout=5.0)
             await asyncio.sleep(1)  # Brief wait to ensure no extra discoveries
@@ -194,15 +194,15 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                 await event_task
             except asyncio.CancelledError:
                 pass
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
     @pytest.mark.asyncio
     async def test_discovery_detects_multiple_workers_simultaneously(self):
         """Test that discovery service detects multiple registered workers.
 
         GIVEN
-            A :py:class:`LanRegistryService` and
-            :py:class:`LanDiscoveryService` are running
+            A :py:class:`LanRegistrar` and
+            :py:class:`LanDiscovery` are running
         WHEN
             Multiple workers are registered simultaneously
         THEN
@@ -220,10 +220,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
         ]
         expected_worker_count = len(mock_workers)
 
-        mock_registry = LanRegistryService()
-        mock_discovery = LanDiscoveryService()
+        mock_registrar = LanRegistrar()
+        mock_discovery = LanDiscovery()
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         async def process_events():
             nonlocal discovery_count
@@ -242,7 +242,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
         try:
             # Act
             for mock_worker in mock_workers:
-                await mock_registry.register(mock_worker)
+                await mock_registrar.register(mock_worker)
 
             await asyncio.wait_for(all_discovered, timeout=10.0)
 
@@ -268,7 +268,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                 await event_task
             except asyncio.CancelledError:
                 pass
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
     @pytest.mark.asyncio
     async def test_discovery_handles_worker_restart_scenario(self, worker_address: str):
@@ -285,10 +285,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
         discovered_events = []
         original_worker = create_mock_worker_info(worker_address)
 
-        mock_registry = LanRegistryService()
-        mock_discovery = LanDiscoveryService()
+        mock_registrar = LanRegistrar()
+        mock_discovery = LanDiscovery()
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         async def collect_events():
             async for event in mock_discovery.events():
@@ -300,11 +300,11 @@ class TestServiceRegistrationAndDiscoveryIntegration:
 
         try:
             # Act
-            await mock_registry.register(original_worker)
+            await mock_registrar.register(original_worker)
             await asyncio.sleep(0.2)  # Let registration propagate
 
             # Simulate worker stopping
-            await mock_registry.unregister(original_worker)
+            await mock_registrar.unregister(original_worker)
             await asyncio.wait_for(event_task, timeout=5.0)
 
             # Assert
@@ -321,16 +321,16 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                 await event_task
             except asyncio.CancelledError:
                 pass
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
     @pytest.mark.asyncio
-    async def test_discovery_handles_registry_startup_failure(self):
-        """Test discovery service behavior when no registry services are available.
+    async def test_discovery_handles_registrar_startup_failure(self):
+        """Test discovery service behavior when no registrar services are available.
 
         Given:
             A discovery service is configured to monitor for workers
         When:
-            No registry services are running (simulating network partition)
+            No registrar services are running (simulating network partition)
         Then:
             It should handle the absence gracefully and not discover any workers
         """
@@ -338,8 +338,8 @@ class TestServiceRegistrationAndDiscoveryIntegration:
         discovered_events = []
         discovery_timeout_reached = False
 
-        mock_discovery = LanDiscoveryService()
-        # Intentionally NOT starting any registry service
+        mock_discovery = LanDiscovery()
+        # Intentionally NOT starting any registrar service
 
         async def collect_events():
             nonlocal discovery_timeout_reached
@@ -375,11 +375,11 @@ class TestServiceRegistrationAndDiscoveryIntegration:
         discovered_events = []
         timeout_occurred = False
 
-        mock_registry = LanRegistryService()
-        mock_discovery = LanDiscoveryService()
+        mock_registrar = LanRegistrar()
+        mock_discovery = LanDiscovery()
         mock_worker = create_mock_worker_info(worker_address)
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         async def collect_events_with_timeout():
             nonlocal timeout_occurred
@@ -397,7 +397,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
 
             # Simulate delayed registration (longer than discovery timeout)
             await asyncio.sleep(DISCOVERY_TIMEOUT + 0.5)
-            await mock_registry.register(mock_worker)
+            await mock_registrar.register(mock_worker)
 
             await discovery_task
 
@@ -406,7 +406,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
             assert len(discovered_events) == 0  # No events before timeout
 
         finally:
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
     @pytest.mark.asyncio
     async def test_discovery_handles_malformed_worker_info(self, worker_address: str):
@@ -434,10 +434,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
             extra={},
         )
 
-        mock_registry = LanRegistryService()
-        mock_discovery = LanDiscoveryService()
+        mock_registrar = LanRegistrar()
+        mock_discovery = LanDiscovery()
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         async def collect_events():
             async for event in mock_discovery.events():
@@ -451,12 +451,12 @@ class TestServiceRegistrationAndDiscoveryIntegration:
             # Act
             # Try to register malformed worker first - should fail silently or be ignored
             try:
-                await mock_registry.register(malformed_worker)
+                await mock_registrar.register(malformed_worker)
             except Exception:
-                pass  # Registry may reject invalid data
+                pass  # Registrar may reject invalid data
 
             # Register valid worker
-            await mock_registry.register(valid_worker)
+            await mock_registrar.register(valid_worker)
             await asyncio.wait_for(event_task, timeout=3.0)
 
             # Assert
@@ -470,7 +470,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                 await event_task
             except asyncio.CancelledError:
                 pass
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
     @pytest.mark.asyncio
     async def test_discovery_handles_rapid_worker_churn(self):
@@ -493,10 +493,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                 port = s.getsockname()[1]
                 all_workers.append(create_mock_worker_info(f"localhost:{port}"))
 
-        mock_registry = LanRegistryService()
-        mock_discovery = LanDiscoveryService()
+        mock_registrar = LanRegistrar()
+        mock_discovery = LanDiscovery()
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         async def collect_events():
             async for event in mock_discovery.events():
@@ -511,12 +511,12 @@ class TestServiceRegistrationAndDiscoveryIntegration:
             # Act - Rapid registration and removal
             # Register all workers quickly
             for worker in all_workers:
-                await mock_registry.register(worker)
+                await mock_registrar.register(worker)
                 await asyncio.sleep(0.05)  # Brief delay to ensure ordering
 
             # Unregister all workers quickly
             for worker in all_workers:
-                await mock_registry.unregister(worker)
+                await mock_registrar.unregister(worker)
                 await asyncio.sleep(0.05)
 
             await asyncio.wait_for(event_task, timeout=10.0)
@@ -554,7 +554,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                 await event_task
             except asyncio.CancelledError:
                 pass
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
     @pytest.mark.asyncio
     async def test_discovery_handles_empty_tag_filter(self):
@@ -583,11 +583,11 @@ class TestServiceRegistrationAndDiscoveryIntegration:
 
         expected_worker_count = len(workers_with_tags)
 
-        mock_registry = LanRegistryService()
+        mock_registrar = LanRegistrar()
         # No filter provided - should discover all workers
-        mock_discovery = LanDiscoveryService(filter=None)
+        mock_discovery = LanDiscovery(filter=None)
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         async def collect_events():
             async for event in mock_discovery.events():
@@ -601,7 +601,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
         try:
             # Act
             for worker in workers_with_tags:
-                await mock_registry.register(worker)
+                await mock_registrar.register(worker)
                 await asyncio.sleep(0.05)
 
             await asyncio.wait_for(event_task, timeout=10.0)
@@ -627,7 +627,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                 await event_task
             except asyncio.CancelledError:
                 pass
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
     @pytest.mark.asyncio
     async def test_discovery_handles_complex_tag_combinations(self):
@@ -669,10 +669,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
         # Expected: workers 0 (production+web) and 1 (production+api)
         expected_discovered_count = 2
 
-        mock_registry = LanRegistryService()
-        mock_discovery = LanDiscoveryService(filter=complex_filter)
+        mock_registrar = LanRegistrar()
+        mock_discovery = LanDiscovery(filter=complex_filter)
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         async def collect_events():
             async for event in mock_discovery.events():
@@ -686,7 +686,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
         try:
             # Act
             for worker in workers_with_complex_tags:
-                await mock_registry.register(worker)
+                await mock_registrar.register(worker)
                 await asyncio.sleep(0.05)
 
             await asyncio.wait_for(event_task, timeout=10.0)
@@ -725,14 +725,14 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                 await event_task
             except asyncio.CancelledError:
                 pass
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
     @pytest.mark.asyncio
     async def test_discovery_handles_network_partition_recovery(self):
         """Test discovery service recovery after network partition simulation.
 
         Given:
-            A discovery service that loses connection to registry
+            A discovery service that loses connection to registrar
         When:
             Network connection is restored after partition
         Then:
@@ -746,10 +746,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
             port = s.getsockname()[1]
             worker_for_recovery = create_mock_worker_info(f"localhost:{port}")
 
-        mock_registry = LanRegistryService()
-        mock_discovery = LanDiscoveryService()
+        mock_registrar = LanRegistrar()
+        mock_discovery = LanDiscovery()
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         # Phase 1: Normal discovery
         async def collect_initial_events():
@@ -763,7 +763,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
 
         try:
             # Act - Phase 1: Register worker normally
-            await mock_registry.register(worker_for_recovery)
+            await mock_registrar.register(worker_for_recovery)
             await asyncio.wait_for(initial_task, timeout=5.0)
 
             # Assert Phase 1
@@ -775,7 +775,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
             initial_task.cancel()
 
             # Phase 3: Simulate recovery with new discovery instance
-            mock_discovery_recovery = LanDiscoveryService()
+            mock_discovery_recovery = LanDiscovery()
 
             async def collect_recovery_events():
                 async for event in mock_discovery_recovery.events():
@@ -807,7 +807,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                     recovery_task.cancel()
                 except Exception:
                     pass
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
     @pytest.mark.asyncio
     async def test_discovery_worker_update_propagation(self, worker_address: str):
@@ -835,10 +835,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
             extra={"update_time": "2023-11-01"},  # Different extra
         )
 
-        mock_registry = LanRegistryService()
-        mock_discovery = LanDiscoveryService()
+        mock_registrar = LanRegistrar()
+        mock_discovery = LanDiscovery()
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         async def collect_events():
             async for event in mock_discovery.events():
@@ -850,11 +850,11 @@ class TestServiceRegistrationAndDiscoveryIntegration:
 
         try:
             # Act
-            await mock_registry.register(original_worker)
+            await mock_registrar.register(original_worker)
             await asyncio.sleep(0.2)  # Let registration propagate
 
             # Update worker properties
-            await mock_registry.update(updated_worker)
+            await mock_registrar.update(updated_worker)
             await asyncio.wait_for(event_task, timeout=5.0)
 
             # Assert
@@ -875,7 +875,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                 await event_task
             except asyncio.CancelledError:
                 pass
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
     @pytest.mark.asyncio
     async def test_discovery_handles_worker_update_failure(self, worker_address: str):
@@ -903,10 +903,10 @@ class TestServiceRegistrationAndDiscoveryIntegration:
             extra={"update_time": "2023-11-01"},
         )
 
-        mock_registry = LanRegistryService()
-        mock_discovery = LanDiscoveryService()
+        mock_registrar = LanRegistrar()
+        mock_discovery = LanDiscovery()
 
-        await mock_registry.start()
+        await mock_registrar.start()
 
         async def collect_events():
             async for event in mock_discovery.events():
@@ -918,24 +918,24 @@ class TestServiceRegistrationAndDiscoveryIntegration:
 
         try:
             # Act
-            await mock_registry.register(original_worker)
+            await mock_registrar.register(original_worker)
             await asyncio.wait_for(event_task, timeout=3.0)
 
             # Assert initial state
             assert len(discovered_events) == 1
             assert discovered_events[0].type == "worker_added"
 
-            # Verify registry maintains consistent state even if update might fail
-            # (The registry should be robust enough to handle Zeroconf failures)
-            original_service_count = len(mock_registry.services)
+            # Verify registrar maintains consistent state even if update might fail
+            # (The registrar should be robust enough to handle Zeroconf failures)
+            original_service_count = len(mock_registrar.services)
 
             try:
-                await mock_registry.update(updated_worker)
+                await mock_registrar.update(updated_worker)
                 # If update succeeds, that's fine too
             except Exception:
-                # If update fails, verify registry state is still consistent
-                assert len(mock_registry.services) == original_service_count
-                assert original_worker.uid in mock_registry.services
+                # If update fails, verify registrar state is still consistent
+                assert len(mock_registrar.services) == original_service_count
+                assert original_worker.uid in mock_registrar.services
 
         finally:
             event_task.cancel()
@@ -943,7 +943,7 @@ class TestServiceRegistrationAndDiscoveryIntegration:
                 await event_task
             except asyncio.CancelledError:
                 pass
-            await mock_registry.stop()
+            await mock_registrar.stop()
 
 
 # Property-Based Testing Data Generation

--- a/wool/tests/test_worker_pool.py
+++ b/wool/tests/test_worker_pool.py
@@ -16,19 +16,19 @@ from pytest_mock import MockerFixture
 
 import wool._worker_pool as wp
 from wool._worker import LocalWorker
-from wool._worker_discovery import LanRegistryService
+from wool._worker_discovery import LanRegistrar
 
 
 @pytest.fixture
-def mock_local_registry_service(mocker: MockerFixture):
-    """Create a mock :py:class:`LocalRegistryService` for test isolation."""
-    mock_registry = mocker.MagicMock(spec=LanRegistryService)
-    mock_registry.start = mocker.AsyncMock()
-    mock_registry.stop = mocker.AsyncMock()
-    mock_registry.register = mocker.AsyncMock()
-    mock_registry.unregister = mocker.AsyncMock()
-    mocker.patch.object(wp, "LocalRegistryService", return_value=mock_registry)
-    return mock_registry
+def mock_local_registrar(mocker: MockerFixture):
+    """Create a mock :py:class:`LocalRegistrar` for test isolation."""
+    mock_registrar = mocker.MagicMock(spec=LanRegistrar)
+    mock_registrar.start = mocker.AsyncMock()
+    mock_registrar.stop = mocker.AsyncMock()
+    mock_registrar.register = mocker.AsyncMock()
+    mock_registrar.unregister = mocker.AsyncMock()
+    mocker.patch.object(wp, "LocalRegistrar", return_value=mock_registrar)
+    return mock_registrar
 
 
 @pytest.fixture
@@ -67,9 +67,9 @@ def mock_local_worker(mocker: MockerFixture):
 
 @pytest.fixture
 def mock_discovery_service(mocker: MockerFixture):
-    """Mock LocalDiscoveryService for isolation from discovery behavior."""
+    """Mock LocalDiscovery for isolation from discovery behavior."""
     mock_discovery = mocker.MagicMock()
-    mocker.patch.object(wp, "LocalDiscoveryService", return_value=mock_discovery)
+    mocker.patch.object(wp, "LocalDiscovery", return_value=mock_discovery)
     return mock_discovery
 
 
@@ -191,7 +191,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
     ):
         """Test WorkerPool async context manager lifecycle.
 
@@ -219,7 +219,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
     ):
         """Test context manager cleanup when user code raises exception.
 
@@ -247,7 +247,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
     ):
         """Test context manager when worker startup fails.
 
@@ -276,7 +276,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
     ):
         """Test context manager handles various exceptions gracefully.
 
@@ -304,7 +304,7 @@ class TestWorkerPool:
         mock_shared_memory,
         mock_worker_proxy,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
     ):
         """Test context manager with custom worker factory.
 
@@ -364,7 +364,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
     ):
         """Test context manager with multiple workers.
 
@@ -391,7 +391,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
     ):
         """Test that worker information is properly maintained.
 
@@ -545,7 +545,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
     ):
         """Test context manager under concurrent operations.
 
@@ -576,7 +576,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
     ):
         """Test context manager with custom load balancer.
 
@@ -603,7 +603,7 @@ class TestWorkerPool:
         mock_shared_memory,
         mock_worker_proxy,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
         mocker: MockerFixture,
     ):
         """Test cleanup when some workers fail during startup.
@@ -646,7 +646,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
     ):
         """Test that pool startup completes within reasonable time.
 
@@ -676,7 +676,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
         mock_discovery_service,
-        mock_local_registry_service,
+        mock_local_registrar,
     ):
         """Test worker info collection after startup completes.
 
@@ -867,41 +867,39 @@ class TestWorkerPool:
             assert hasattr(pool, "_proxy")
             assert hasattr(pool, "_shared_memory")
 
-    def test_default_worker_factory_creates_separate_registry_instances(
+    def test_default_worker_factory_creates_separate_registrar_instances(
         self, mocker: MockerFixture
     ):
-        """Test default worker factory creates separate registry instances.
+        """Test default worker factory creates separate registrar instances.
 
         Given:
             A WorkerPool instance with default worker factory
         When:
             Multiple workers are created using the default factory
         Then:
-            Each worker should get its own LocalRegistryService instance
+            Each worker should get its own LocalRegistrar instance
         """
         # Arrange
         pool = wp.WorkerPool(size=0)
         uri = "test-pool-123"
 
-        # Track all LocalRegistryService instances created
-        registry_instances = []
+        # Track all LocalRegistrar instances created
+        registrar_instances = []
 
-        def mock_local_registry_service(pool_uri):
+        def mock_local_registrar(pool_uri):
             instance = mocker.MagicMock()
             instance.pool_uri = pool_uri
-            registry_instances.append(instance)
+            registrar_instances.append(instance)
             return instance
 
-        mocker.patch.object(
-            wp, "LocalRegistryService", side_effect=mock_local_registry_service
-        )
+        mocker.patch.object(wp, "LocalRegistrar", side_effect=mock_local_registrar)
 
-        # Mock LocalWorker to capture the registry_service parameter
+        # Mock LocalWorker to capture the registrar parameter
         created_workers = []
 
-        def mock_local_worker(*tags, registry_service=None, **kwargs):
+        def mock_local_worker(*tags, registrar=None, **kwargs):
             worker = mocker.MagicMock()
-            worker.registry_service = registry_service
+            worker.registrar = registrar
             worker.tags = set(tags)
             worker.kwargs = kwargs
             created_workers.append(worker)
@@ -919,25 +917,16 @@ class TestWorkerPool:
 
         # Assert
         assert len(created_workers) == 3
-        assert len(registry_instances) == 3
+        assert len(registrar_instances) == 3
 
-        # Verify each worker gets a separate registry instance
-        assert (
-            created_workers[0].registry_service
-            is not created_workers[1].registry_service
-        )
-        assert (
-            created_workers[1].registry_service
-            is not created_workers[2].registry_service
-        )
-        assert (
-            created_workers[0].registry_service
-            is not created_workers[2].registry_service
-        )
+        # Verify each worker gets a separate registrar instance
+        assert created_workers[0].registrar is not created_workers[1].registrar
+        assert created_workers[1].registrar is not created_workers[2].registrar
+        assert created_workers[0].registrar is not created_workers[2].registrar
 
-        # Verify all registry instances have the correct URI
-        for registry in registry_instances:
-            assert registry.pool_uri == uri
+        # Verify all registrar instances have the correct URI
+        for registrar in registrar_instances:
+            assert registrar.pool_uri == uri
 
         # Verify workers were created with correct tags
         assert created_workers[0].tags == {"tag1", "tag2"}

--- a/wool/tests/test_worker_proxy.py
+++ b/wool/tests/test_worker_proxy.py
@@ -11,21 +11,21 @@ from wool import _protobuf as pb
 from wool._resource_pool import Resource
 from wool._work import WoolTask
 from wool._worker import WorkerClient
+from wool._worker_discovery import Discovery
 from wool._worker_discovery import DiscoveryEvent
-from wool._worker_discovery import DiscoveryService
-from wool._worker_discovery import LanDiscoveryService
-from wool._worker_discovery import LocalDiscoveryService
+from wool._worker_discovery import LanDiscovery
+from wool._worker_discovery import LocalDiscovery
 from wool._worker_discovery import WorkerInfo
 
 
 @pytest.fixture
 def mock_lan_discovery_service(mocker: MockerFixture):
-    """Create a mock :py:class:`LanDiscoveryService` for testing.
+    """Create a mock :py:class:`LanDiscovery` for testing.
 
     Provides a mock discovery service with async methods and started state
     tracking for use in worker proxy tests.
     """
-    mock_lan_discovery_service = mocker.MagicMock(spec=LanDiscoveryService)
+    mock_lan_discovery_service = mocker.MagicMock(spec=LanDiscovery)
     mock_lan_discovery_service.started = False
     mock_lan_discovery_service.start = mocker.AsyncMock()
     mock_lan_discovery_service.stop = mocker.AsyncMock()
@@ -35,12 +35,12 @@ def mock_lan_discovery_service(mocker: MockerFixture):
 
 @pytest.fixture
 def mock_discovery_service(mocker: MockerFixture):
-    """Create a mock :py:class:`DiscoveryService` for testing.
+    """Create a mock :py:class:`Discovery` for testing.
 
     Provides a generic mock discovery service with async methods for use in
     worker proxy tests that don't require LAN-specific functionality.
     """
-    mock_discovery_service = mocker.MagicMock(spec=DiscoveryService)
+    mock_discovery_service = mocker.MagicMock(spec=Discovery)
     mock_discovery_service.started = False
     mock_discovery_service.start = mocker.AsyncMock()
     mock_discovery_service.stop = mocker.AsyncMock()
@@ -56,7 +56,7 @@ def mock_load_balancer_factory(mocker: MockerFixture):
     the load balancer instance. Used for testing factory-based load balancer
     creation patterns.
     """
-    mock_load_balancer_factory = mocker.MagicMock(spec=wp.LoadBalancerFactory)
+    mock_load_balancer_factory = mocker.MagicMock()
     mock_load_balancer = mocker.MagicMock(spec=wp.LoadBalancerLike)
     mock_load_balancer.dispatch = mocker.AsyncMock()
     mock_load_balancer._workers = {}
@@ -291,13 +291,13 @@ class TestWorkerProxy:
         **When:**
             :py:class:`WorkerProxy` is initialized.
         **Then:**
-            It should create :py:class:`LocalDiscoveryService` and use
+            It should create :py:class:`LocalDiscovery` and use
             :py:class:`RoundRobinLoadBalancer`.
         """
         # Arrange
         mock_local_discovery_service = mocker.MagicMock()
         mocker.patch.object(
-            wp, "LocalDiscoveryService", return_value=mock_local_discovery_service
+            wp, "LocalDiscovery", return_value=mock_local_discovery_service
         )
 
         # Act
@@ -454,7 +454,7 @@ class TestWorkerProxy:
         mock_factory, mock_load_balancer = mock_load_balancer_factory
         mock_local_discovery_service = mocker.MagicMock()
         mocker.patch.object(
-            wp, "LocalDiscoveryService", return_value=mock_local_discovery_service
+            wp, "LocalDiscovery", return_value=mock_local_discovery_service
         )
 
         # Act
@@ -677,7 +677,7 @@ class TestWorkerProxy:
         # Arrange
         # Use real objects instead of mocks for cloudpickle test
 
-        discovery_service = LocalDiscoveryService("test-pool")
+        discovery_service = LocalDiscovery("test-pool")
         proxy = wp.WorkerProxy(
             discovery=discovery_service, loadbalancer=wp.RoundRobinLoadBalancer
         )
@@ -712,7 +712,7 @@ class TestWorkerProxy:
         # Arrange
         # Use real objects instead of mocks for cloudpickle test
 
-        discovery_service = LocalDiscoveryService("test-pool")
+        discovery_service = LocalDiscovery("test-pool")
         proxy = wp.WorkerProxy(discovery=discovery_service)
 
         # Act & Assert
@@ -743,7 +743,7 @@ class TestWorkerProxy:
             deserialized proxy in an unstarted state and preserved ID.
         """
         # Arrange
-        # Use real objects - this creates a LocalDiscoveryService internally
+        # Use real objects - this creates a LocalDiscovery internally
         proxy = wp.WorkerProxy("pool-1")
 
         # Act & Assert
@@ -1478,7 +1478,7 @@ class TestWorkerProxyConstructorEdgeCases:
                 uid="worker-1", host="127.0.0.1", port=50051, pid=1234, version="1.0.0"
             )
         ]
-        discovery = LocalDiscoveryService("test-pool")
+        discovery = LocalDiscovery("test-pool")
 
         # Act & Assert
         with pytest.raises(ValueError, match="Must specify exactly one of"):


### PR DESCRIPTION
Cherry-picked from https://github.com/wool-labs/wool/pull/36