### PR TITLE
Fix latent bug in git version parser

### DIFF
--- a/build-hooks/_git.py
+++ b/build-hooks/_git.py
@@ -1,4 +1,6 @@
 import git
+
+from _version import PythonicVersion
 from _version import parser
 
 
@@ -19,8 +21,8 @@ def parse() -> str:
         raise RuntimeError(f"The repo at '{repo.working_dir}' cannot be empty!")
     head_commit = repo.head.commit
     try:
-        tag = repo.tags[-1]
-    except IndexError:
+        tag = max(repo.tags, key=lambda t: PythonicVersion.parse(str(t)))
+    except ValueError:
         tag_name = "0"
         tag_commit = None
     else:

--- a/build-hooks/_version.py
+++ b/build-hooks/_version.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 import enum
 import functools
 import re
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    Generic,
-    MutableSequence,
-    Optional,
-    Type,
-    TypeVar,
-    overload,
-)
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import Generic
+from typing import MutableSequence
+from typing import Optional
+from typing import Type
+from typing import TypeVar
+from typing import overload
 
 try:
     from typing import Self

--- a/wool/pyproject.toml
+++ b/wool/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "debugpy",
     "hatchling",
     "packaging",
-    "GitPython",
+    "gitpython",
     "toml",
     "typing-extensions",
 ]


### PR DESCRIPTION
The git version parser had a latent bug where it would pick the latest version lexicographically rather than semantically or based on the commit timestamp. This bug doesn't impact the publish-release workflow because only the target version tag is pulled from remote by the workflow, so it's the only one available to the parser. It does, however, impact local installs from source if all tags are pulled.