### PR TITLE
Add LLM skills to facilitate Wool's SDLC — Closes #1

### DIFF
--- a/llms/README.md
+++ b/llms/README.md
@@ -1,0 +1,148 @@
+# Contributing to Wool
+
+This directory contains skill definitions and guides that form a structured software development lifecycle (SDLC) pipeline for LLM agents working on the `wool` codebase. It is the canonical source for all pipeline behaviour — agent skills should be symlinked here.
+
+## Human-in-the-loop philosophy
+
+Every skill in this pipeline is collaborative, not autonomous. The LLM agent proposes; the human disposes. Concretely:
+
+- The agent reads a skill document, performs the described work, and presents the result to the user.
+- The user reviews, approves, requests changes, or overrides any decision.
+- No destructive or externally-visible action (push, PR creation, issue filing) proceeds without explicit user approval.
+- The `/audit` skill exists specifically to give the user an independent compliance check after any other skill runs.
+
+## Directory layout
+
+```
+llms/
+├── README.md            ← you are here
+├── skills/
+│   ├── issue.md         ← /issue — draft and push a GitHub issue
+│   ├── pr.md            ← /pr — create a branch and draft PR from an issue
+│   ├── implement.md     ← /implement — implement a planned PR or issue
+│   ├── test.md          ← /test — generate test specifications
+│   ├── commit.md        ← /commit — stage and commit changes atomically
+│   └── audit.md         ← /audit — post-skill compliance checker
+├── test-guides/
+│   └── python.md        ← Python testing conventions
+└── style-guides/
+    └── markdown.md      ← Markdown styling conventions
+```
+
+## Pipeline overview
+
+The typical development flow follows this sequence:
+
+1. **`/issue`** — Capture the work item as a GitHub issue with acceptance criteria.
+2. **`/pr`** — Create a feature branch and open a draft PR linked to the issue, including an implementation plan.
+3. **`/implement`** — Execute the implementation plan: write code, guided by guides (e.g., `python.md` for test conventions).
+4. **`/test`** — Generate test specifications covering public APIs of new or changed modules.
+5. **`/commit`** — Stage and commit changes in disciplined, atomic commits grouped by logical kind.
+6. **`/pr` (update)** — Update the draft PR description and mark it ready for review.
+
+**`/audit`** is a cross-cutting quality gate. It can be invoked after any skill (`/audit commit`, `/audit implement`, etc.) to spawn a fresh subagent that independently checks whether the skill's requirements were met.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent
+    participant issue as /issue
+    participant pr as /pr
+    participant implement as /implement
+    participant test as /test
+    participant commit as /commit
+    participant audit as /audit
+    participant guide as test-guides/python.md
+
+    rect rgb(0, 0, 0, 0.03)
+        Note over User, audit: Issue creation
+        User->>Agent: describe work item
+        Agent->>issue: read skill
+        Agent->>Agent: draft issue
+        Agent->>User: present issue for review
+        User->>Agent: approve / revise
+        Agent->>Agent: push issue to GitHub
+    end
+
+    rect rgb(0, 0, 0, 0.03)
+        Note over User, audit: PR creation
+        User->>Agent: /pr <number>
+        Agent->>pr: read skill
+        Agent->>Agent: create branch, draft PR with plan
+        Agent->>User: present PR for review
+        User->>Agent: approve / revise
+    end
+
+    rect rgb(0, 0, 0, 0.03)
+        Note over User, guide: Implementation
+        User->>Agent: /implement <number>
+        Agent->>implement: read skill
+        Agent->>guide: read testing conventions
+        Agent->>Agent: write code and tests
+        Agent->>User: present changes for review
+        User->>Agent: approve / request changes
+    end
+
+    rect rgb(0, 0, 0, 0.03)
+        Note over User, audit: Test specification
+        User->>Agent: /test <module>
+        Agent->>test: read skill
+        Agent->>guide: read testing conventions
+        Agent->>Agent: generate test specs
+        Agent->>User: present specs for review
+        User->>Agent: approve / revise
+    end
+
+    rect rgb(0, 0, 0, 0.03)
+        Note over User, audit: Commit
+        User->>Agent: /commit
+        Agent->>commit: read skill
+        Agent->>Agent: analyse diff, group changes
+        Agent->>User: present commit plan
+        User->>Agent: approve / revise
+        Agent->>Agent: create atomic commits
+    end
+
+    rect rgb(0, 0, 0, 0.03)
+        Note over User, audit: Verification (after any stage)
+        User->>Agent: /audit <skill>
+        Agent->>audit: read skill
+        Agent->>Agent: spawn subagent for unbiased check
+        Agent->>User: present compliance report
+        User->>Agent: acknowledge / remediate
+    end
+```
+
+## Skill and guide reference
+
+### Skills
+
+| Skill | Invocation | Purpose |
+|-------|-----------|---------|
+| [issue.md](skills/issue.md) | `/issue` | Draft and push a GitHub issue. Uses `.issue.md` if present, otherwise drafts interactively. |
+| [pr.md](skills/pr.md) | `/pr <number>` | Create a feature branch and draft PR from a GitHub issue, with an implementation plan in the PR body. |
+| [implement.md](skills/implement.md) | `/implement <number>` | Resolve a PR or issue number to a draft PR, check out the branch, and enter plan mode to design and execute the implementation. |
+| [test.md](skills/test.md) | `/test` | Generate comprehensive Given-When-Then test specifications for source modules, targeting 100% coverage of public APIs. |
+| [commit.md](skills/commit.md) | `/commit` | Analyse the working tree diff, group changes by logical kind, and create disciplined atomic commits with conventional-commit messages. |
+| [audit.md](skills/audit.md) | `/audit <skill>` | Spawn an independent subagent to evaluate whether a skill's MUST/SHALL requirements were met, using binary checklist decomposition. |
+
+### Test guides
+
+| Guide | Used by | Purpose |
+|-------|---------|---------|
+| [python.md](test-guides/python.md) | `/implement`, `/test` | Python testing conventions covering pytest, pytest-asyncio, pytest-mock, and Hypothesis. Language-specific but project-agnostic. |
+
+### Style guides
+
+The `style-guides/` directory contains format-specific authoring conventions (e.g., Markdown, YAML). These are **always-on context** — agents MUST read every file in `llms/style-guides/` at the start of a session and treat their rules as active constraints. The directory may be empty; if so, agents SHOULD default to following established convention already present in the codebase.
+
+## Registration mechanism
+
+Each agentic coding assistant has its own convention for discovering skills and instructions. The registration mechanism bridges the canonical `llms/` content into whatever directory structure a given tool expects, typically via symlinks or config files. For example, an assistant that discovers skills in `.assistant/skills/` would have symlinks like:
+
+```
+.assistant/skills/commit/SKILL.md    → ../../../llms/skills/commit.md
+.assistant/skills/implement/SKILL.md → ../../../llms/skills/implement.md
+```
+
+Guides are similarly symlinked where needed (e.g., `.assistant/skills/implement/TESTGUIDE.md → ../../../llms/test-guides/python.md`). This keeps the canonical content in `llms/` while letting each tool's skill discovery find it automatically.

--- a/llms/skills/audit.md
+++ b/llms/skills/audit.md
@@ -1,0 +1,119 @@
+---
+name: audit
+description: >
+  Post-skill compliance checker. Use this skill whenever the user says
+  "/audit <skill-name>", "audit the last skill run", "check compliance",
+  or similar. Spawns a fresh subagent with no shared context to evaluate
+  whether a skill's MUST/SHALL requirements were actually met, using binary
+  checklist decomposition for unbiased assessment.
+---
+
+The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
+
+# Audit Skill
+
+Spawn a fresh subagent to evaluate whether a skill's requirements were met during its most recent invocation. The subagent receives the skill definition and a structured action summary, extracts binary checklist items from every normative requirement, and reports a pass/fail verdict per item.
+
+## Pipeline Context
+
+This skill is a **cross-cutting quality gate** invoked at the end of every SDLC pipeline stage: `/issue` → audit → `/pr` → audit → `/implement` → audit → `/commit` → audit → `/pr` (update) → audit → `/review` → audit.
+
+## Arguments
+
+```
+/audit <skill-name> [summary]
+```
+
+- `<skill-name>` — REQUIRED. The name of the skill to audit (e.g., `issue`, `pr`, `implement`, `commit`, `test`).
+- `[summary]` — OPTIONAL. An inline action summary. If omitted, the primary agent MUST compile one from the current conversation context before spawning the subagent.
+
+## Workflow
+
+### TL;DR
+
+1. Resolve the skill definition
+2. Compile the action summary
+3. Spawn the verification subagent
+4. Present the report
+
+### 1. Resolve the skill definition
+
+Map `<skill-name>` to `llm/skills/<skill-name>.md`. If the file does not exist, inform the user that no skill definition was found for `<skill-name>` and stop.
+
+### 2. Compile the action summary
+
+If an inline summary was provided, use it. Otherwise, compile a structured action summary from the current conversation. The summary MUST include:
+
+- **Steps taken** — ordered list of actions performed during the skill invocation.
+- **Commands run** — shell commands executed, with their outcomes.
+- **Artifacts produced** — files created or modified, PRs opened or updated, issues created, commits made, etc.
+- **Key decisions** — any choices made during execution, especially where multiple valid paths existed.
+
+### 3. Spawn the verification subagent
+
+Use the `Agent` tool to launch a general-purpose subagent. The prompt MUST include:
+
+1. The full text of the skill definition (read from the resolved path).
+2. The compiled action summary.
+3. The evaluation procedure described below.
+
+The subagent prompt MUST be structured as follows:
+
+````
+You are a compliance auditor. You have been given a skill definition
+and a summary of actions taken during that skill's invocation. Your
+job is to determine whether the skill's requirements were met.
+
+## Skill Definition
+
+<full text of llm/skills/<skill-name>.md>
+
+## Action Summary
+
+<compiled action summary>
+
+## Evaluation Procedure
+
+1. Extract every normative requirement from the skill definition.
+   A normative requirement is any statement using MUST, MUST NOT,
+   SHALL, SHALL NOT, REQUIRED, or RECOMMENDED (as defined by
+   RFC 2119). Each requirement becomes one checklist item.
+
+2. For each checklist item, determine whether it was satisfied based
+   on the action summary. Assign one of:
+   - **PASS** — the requirement was clearly met, with cited evidence.
+   - **FAIL** — the requirement was clearly not met, with explanation.
+   - **SKIP** — the requirement was not applicable in this invocation
+     (e.g., an edge case that did not arise) or the user explicitly requested to ignore the requirement.
+
+3. Produce a summary report in the following format:
+
+### Verification Report: <skill-name>
+
+| # | Requirement | Verdict | Evidence |
+|---|-------------|---------|----------|
+| 1 | <requirement text> | PASS/FAIL/SKIP | <evidence or explanation> |
+
+### Summary
+
+- **Total**: N requirements
+- **Passed**: N
+- **Failed**: N
+- **Skipped**: N
+- **Verdict**: COMPLIANT / NON-COMPLIANT
+
+If any requirement has a FAIL verdict, the overall verdict MUST be
+NON-COMPLIANT. Otherwise it is COMPLIANT.
+
+For each FAIL, include an actionable description of what was missed
+and what would need to happen to remediate.
+````
+
+### 4. Present the report
+
+Display the subagent's verification report to the user. If the verdict is NON-COMPLIANT:
+
+- List the failed requirements with their remediation descriptions.
+- Ask the user whether to remediate the failures or proceed as-is.
+
+If the verdict is COMPLIANT, confirm that all requirements were met and continue.

--- a/llms/skills/commit.md
+++ b/llms/skills/commit.md
@@ -1,0 +1,271 @@
+---
+name: commit
+description: >
+  Stages and commits uncommitted changes in a git repository using a disciplined,
+  atomic commit workflow. Use this skill whenever the user asks to "commit my changes",
+  "clean up my git state", "stage and commit", "make commits from my changes", or
+  anything similar. Also trigger when the user has described a body of work and says
+  something like "can you commit this properly" or "let's checkpoint this". The skill
+  creates a staging branch, analyzes the full diff, groups changes by logical kind,
+  and commits them sequentially with well-formed messages — without ever mixing
+  unrelated changes into a single commit.
+---
+
+The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
+
+# Commit Skill
+
+This skill transforms a messy working tree into a clean sequence of atomic, well-described commits on a staging branch. It MUST NOT touch the original branch until the user is satisfied.
+
+## Pipeline Context
+
+This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update). This skill is the **fourth** stage.
+
+## Workflow
+
+### TL;DR
+
+1. Verify git state
+2. Create a staging branch
+3. Analyze the full diff
+4. Plan the commits
+5. Stage and commit sequentially
+6. Review and present
+7. Prompt the user to move onto the PR update step
+
+### 1. Verify git state
+
+```bash
+git status
+git diff HEAD
+```
+
+If the working tree is clean (nothing to commit), tell the user and stop.
+
+Untracked files SHOULD be checked for new source files, config files, etc. The user MUST be asked before including untracked files unless their inclusion is obvious. Build artifacts, cache directories, and anything in .gitignore MUST be ignored.
+
+### 2. Create a staging branch
+
+Get the current branch name:
+
+```bash
+git branch --show-current
+```
+
+Create and switch to a staging branch:
+
+```bash
+git checkout -b {current-branch-name}-staging
+```
+
+If a staging branch already exists from a previous run, the user MUST be asked whether to delete and recreate it or continue from where it left off.
+
+### 3. Analyze the full diff
+
+```bash
+git diff HEAD
+git diff HEAD --name-only
+```
+
+The diff MUST be read carefully. For each changed file, note:
+- What kind of change is it (new functionality, bug fix, docs, style/formatting, refactoring, performance, tests, build/tooling, CI, reversion)?
+- Which other changed files is it logically related to?
+- Does it mix concerns that should be separated?
+
+A commit plan MUST be built before touching anything. The goal is a sequence of commits where each one represents exactly one logical change.
+
+### 4. Plan the commits
+
+Group files and hunks into commits. The categories to use as a guide:
+
+- **New functionality** — new features or capabilities, standalone
+- **Bug fixes** — correcting incorrect behavior, isolate so they're cherry-pickable
+- **Documentation** — docs, docstrings, comments; no behavior change
+- **Style and formatting** — whitespace, formatting; MUST NOT be mixed with logic changes
+- **Refactoring** — restructuring without behavior change
+- **Performance** — speed/resource improvements, no other behavioral change
+- **Tests** — adding or correcting tests
+- **Build and tooling** — pyproject.toml, Makefile, dependencies, packaging
+- **CI** — workflow files, pipeline config
+- **Reversions** — reverting prior work, with clear reference to what and why
+
+Mixed changes in a single file are common and MUST be handled with partial staging (see below). Splitting a file's changes across commits is exactly the right thing to do when the changes are of different kinds.
+
+Logical ordering MUST be considered: if commit B depends on commit A, A comes first. Generally: refactoring before feature work, build changes before code that uses them, tests after (or alongside) the code they test.
+
+### 5. Stage and commit sequentially
+
+For each planned commit, stage exactly the right changes and commit.
+
+**Staging whole files:**
+```bash
+git add path/to/file.py
+```
+
+**Staging specific hunks from a file** (when a file mixes concerns):
+
+Use `git add -p path/to/file.py` in interactive mode to select only the relevant hunks. Since this skill runs non-interactively, use the `-e` (edit) hunk approach or use patch files instead:
+
+```bash
+# Generate a patch for just the relevant hunks, then apply selectively
+git diff HEAD -- path/to/file.py > /tmp/full.patch
+# Edit /tmp/full.patch to keep only desired hunks, then:
+git apply --cached /tmp/full.patch
+```
+
+Alternatively, for clean hunk boundaries, use:
+```bash
+git diff HEAD -U0 -- path/to/file.py
+```
+...to see exact line numbers, then stage by line range using a patch file.
+
+After staging, the staged diff MUST be verified before committing:
+```bash
+git diff --cached
+```
+
+Then commit. The message MUST be written to a temp file to avoid shell escaping issues:
+
+```bash
+cat > /tmp/commit_msg.txt << 'EOF'
+Subject line here
+
+Body here if needed.
+
+Footer here if needed.
+EOF
+git commit -F /tmp/commit_msg.txt
+```
+
+Repeat for each planned commit.
+
+### 6. Review and present
+
+After all commits:
+
+```bash
+git log {original-branch}..HEAD --oneline
+```
+
+The resulting commit list MUST be shown to the user for approval. If they want changes — different grouping, reworded messages, splitting or squashing — use `git rebase -i HEAD~N` on the staging branch to make adjustments.
+
+When the user is satisfied, remind them they can merge back:
+
+```bash
+git checkout {original-branch}
+git merge --ff-only {original-branch}-staging
+git branch -d {original-branch}-staging
+```
+
+If the original branch contains a placeholder empty commit (e.g., `chore: Open draft PR for #<number>` created by the `/pr` skill), it MUST be dropped during the merge so the final history is clean. Use rebase instead of fast-forward merge:
+
+```bash
+git checkout {original-branch}
+git rebase --onto {original-branch}~1 {original-branch} {original-branch}-staging
+git checkout -B {original-branch} {original-branch}-staging
+git branch -d {original-branch}-staging
+```
+
+Or if they prefer to review as a PR first, they can push the staging branch and open a pull request against the original branch.
+
+If the current branch is associated with a PR, the user SHOULD be prompted with the next pipeline step: "Ready to update the PR? Run `/pr <number>` to sync the PR description with the committed changes."
+
+---
+
+### 7. Prompt the user to move onto the PR update step
+
+1. Prompt the user to invoke the `/pr` skill to update the PR description: check off completed implementation steps, refresh the test cases table, and update the summary to reflect what was actually implemented. Ask the user: "Ready to update the PR description? Run `/pr <number>` to update the PR description to reflect the implementation." DO NOT proceed on your own.
+2. Inform the user that the branch is ready for review and the PR can be marked ready via `gh pr ready <number>`.
+
+## Commit Message Style Guide
+
+Every commit message MUST follow these rules.
+
+### Structure
+
+```
+<subject>
+
+<body>
+
+<footer>
+```
+
+The subject is REQUIRED. Body and footer are OPTIONAL but RECOMMENDED for anything non-trivial.
+
+### Subject line
+
+- MUST be 72 characters maximum; 50 is RECOMMENDED
+- MUST begin with a type prefix: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `build:`, `ci:`, or `revert:`
+- `!` SHOULD be used after the type for breaking changes: `feat!: Remove legacy auth endpoint`
+- MUST use imperative mood after the prefix: "feat: Add feature" not "feat: Added feature"
+- The first word after the prefix MUST be capitalized
+- MUST NOT have a trailing period
+- MUST be specific: "fix: Handle null pointer when user has no profile photo" not "fix: Fix bug"
+- MUST be plain text only — no backticks, asterisks, or markup of any kind
+- Symbol names MUST be written bare: "fix: Handle FooABC raising ValueError on None input"
+
+### Body
+
+- MUST be separated from subject with a blank line
+- SHOULD explain what and why, not how — the diff shows how
+- MUST wrap at 72 characters
+- MUST be plain text only
+
+### Footer
+
+- Co-author lines MUST NOT be added
+- Issue references — e.g. "Fixes #42", "Closes #38", "References #100", etc. — MUST NOT be added
+- Breaking changes: BREAKING CHANGE: description of the break
+
+### What to avoid
+
+- Vague subjects: "fix", "WIP", "update", "misc", "oops", "changes"
+- Describing what the diff already shows: "change foo to return early"
+- Committing commented-out code
+- Mixing whitespace changes with logic changes
+- Repeating the subject verbatim in the body
+- Any markup (backticks, asterisks, bold, etc.)
+
+### Examples
+
+Good:
+```
+fix: Handle session refresh crash when token has expired
+
+The refresh worker was catching all exceptions as network errors and
+retrying indefinitely. TokenExpiredError needs distinct handling since
+retrying will never succeed — the user must re-authenticate instead.
+
+Fixes #214
+```
+
+Good:
+```
+feat: Add support for Ed25519 signing keys
+```
+
+Bad:
+```
+fix stuff
+```
+
+Bad (mixes concerns, uses markup, past tense, no prefix, too long):
+```
+Updated `parse_config()` to handle missing keys and also reformatted
+the whole file and added a test
+```
+
+---
+
+## Edge Cases
+
+**Untracked files:** The user MUST be asked before staging new files that are not obviously part of the work. Files that MAY be local scratch work MUST NOT be automatically added.
+
+**Binary files:** Binary files MUST be noted explicitly and the user MUST be asked whether to include them.
+
+**Large diffs:** For very large changesets, the commit plan MUST be narrated to the user before executing and confirmation MUST be obtained.
+
+**Merge conflicts or unusual repo state:** Execution MUST stop and the situation MUST be explained rather than worked around. A confused repo state needs human judgment.
+
+**Already-staged changes:** If the user has already staged some changes with git add, those MUST be incorporated into the plan. Already-staged changes MUST NOT be blindly unstaged. `git diff --cached` MUST be run first to see what is already staged.

--- a/llms/skills/implement.md
+++ b/llms/skills/implement.md
@@ -1,0 +1,144 @@
+---
+name: implement
+description: >
+  Implement a planned PR or issue. Use this skill whenever the user says
+  "/implement <number>", "implement #N", "start implementing #N", or similar.
+  Accepts a PR or issue number, resolves it to a draft PR (creating one via
+  the /pr skill if needed), checks out the branch, and enters plan mode to
+  design a concrete execution plan before writing code.
+---
+
+The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
+
+# Implement Skill
+
+Resolve a PR or issue number, check out the branch, read the PR description, and enter plan mode to design a concrete execution plan before writing any code.
+
+## Pipeline Context
+
+This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update). This skill is the **third** stage.
+
+## Arguments
+
+A PR or issue number MUST be provided as the sole argument (e.g., `/implement 103`).
+
+## Workflow
+
+### TL;DR
+
+1. Resolve target repository
+2. Resolve the input to a PR
+3. Assign the PR and issue
+4. Check out the PR branch
+5. Read the PR description
+6. Gather context
+7. Enter plan mode
+8. Execute after approval
+9. Prompt the user to move onto the commit step
+
+### 1. Resolve target repository
+
+```bash
+gh repo view --json isFork,parent
+```
+
+If `isFork` is `true`, extract `parent.owner.login` and `parent.name` to form the upstream repo identifier (`<owner>/<name>`). This upstream identifier becomes the **target repo** for all subsequent `gh` commands that reference issues or pull requests. If the repo is not a fork, the target repo is the current repo and no `--repo` flag is needed.
+
+**User override:** If the user explicitly asks to target the fork — by saying "fork", "on the fork", "fork #N", or similar — the target repo MUST be set to the current (fork) repo instead of upstream. The user's explicit intent always takes precedence.
+
+All `gh` commands in subsequent steps that reference issues or PRs MUST include `--repo <target>` when the target repo differs from the current repo.
+
+### 2. Resolve the input to a PR
+
+Run `gh pr view <number> --repo <target>` to check if the number is a PR.
+
+- **If it is a PR** — use it directly.
+- **If it is not a PR** (the command fails) — run `gh issue view <number> --repo <target>` to confirm it is an issue.
+  - **If it is an issue** — query for linked PRs via the Development sidebar field:
+    ```bash
+    gh issue view <number> --repo <target> --json closedByPullRequestsReferences \
+      --jq '.closedByPullRequestsReferences[].number'
+    ```
+    - If a linked PR exists, use it.
+    - If no linked PR exists, invoke the `/pr` skill to create one. Stop after the PR is created — the user MUST re-run `/implement` once the PR draft is approved.
+- **If the number is neither a PR nor an issue** — inform the user and stop.
+
+The `--repo <target>` flag ensures commands operate against the upstream repo when working from a fork (as resolved in step 1). If the target repo is the current repo, the flag MAY be omitted.
+
+### 3. Assign the PR and issue
+
+Assign both the PR and its linked issue to the current user so that ownership is visible on the board:
+
+```bash
+gh pr edit <number> --repo <target> --add-assignee @me
+```
+
+The linked issue number is already known from the PR's summary (the `Closes #<issue>` reference parsed in step 2). Assign it as well:
+
+```bash
+gh issue edit <issue-number> --repo <target> --add-assignee @me
+```
+
+The `--repo <target>` flag MUST be included when the target repo differs from the current repo.
+
+### 4. Check out the PR branch
+
+Extract the branch name from the PR:
+
+```bash
+gh pr view <number> --repo <target> --json headRefName --jq .headRefName
+```
+
+Fetch and check out the branch:
+
+```bash
+git fetch origin <branch>
+git checkout <branch>
+```
+
+If the local branch is behind the remote, pull to bring it up to date.
+
+### 5. Read the PR description
+
+Fetch the full PR body:
+
+```bash
+gh pr view <number> --repo <target> --json body,title
+```
+
+Parse the four sections: **Summary**, **Proposed changes**, **Test cases**, and **Implementation plan**.
+
+The implementation plan's checkbox list is the primary input for planning. If all items are already checked off, inform the user that the implementation plan appears complete and stop. If the plan is partially checked off, only plan the remaining unchecked items.
+
+### 6. Gather context
+
+Before entering plan mode, read enough of the codebase to plan confidently:
+
+- Read every source file referenced in the PR's "Proposed changes" section.
+- Read existing tests for the affected modules.
+- Read the project test guide (`@llm/guides/testguide-python.md`) to internalize testing conventions.
+- Read project-level instructions (`CLAUDE.md`) for build tooling, documentation style, and architecture context.
+
+### 7. Enter plan mode
+
+Call `EnterPlanMode` to begin the planning phase. The execution plan:
+
+- MUST map each unchecked item from the PR's implementation plan to concrete code changes: exact files, functions, classes, and the nature of each modification.
+- SHOULD prefer test-first ordering when the PR's plan supports it.
+- MUST follow the testing conventions in the project test guide (`@llm/guides/testguide-python.md`). Test case IDs (e.g., WC-001, VP-001) MUST NOT be assigned — the docstring provides sufficient traceability without the maintenance burden of cross-PR ID schemes.
+- MUST include a verification section with the exact command(s) to run the test suite (see the project test guide for the runner command).
+
+### 8. Execute after approval
+
+Once the user approves the plan, implement each step sequentially.
+
+### 9. Prompt the user to move onto the commit step
+
+The user MUST be prompted with the next pipeline step: "Ready to commit? Run `/commit` to stage and commit the changes." DO NOT proceed on your own.
+
+## Edge cases
+
+- **All items already checked off:** Inform the user that the implementation plan appears complete and stop.
+- **Partially checked off:** Only plan the remaining unchecked items.
+- **PR is not a draft:** Proceed normally — the PR may have been marked ready for review before implementation was complete.
+- **Merge conflicts:** Stop and explain the situation rather than trying to resolve automatically.

--- a/llms/skills/issue.md
+++ b/llms/skills/issue.md
@@ -1,0 +1,227 @@
+---
+name: issue
+description: >
+  Draft and push a GitHub issue. Use this skill whenever the user says "/issue",
+  "file an issue", "create an issue", "open a bug report", or similar. If
+  `.issue.md` exists in the repo root, it is used as the source. Otherwise the
+  issue is drafted interactively from the conversation.
+---
+
+The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
+
+# Issue Skill
+
+Create a well-structured GitHub issue, either from a prepared `.issue.md` file or interactively from conversation context.
+
+## Pipeline Context
+
+This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update). This skill is the **first** stage.
+
+## Workflow
+
+### TL;DR
+
+1. Determine the source
+2. Resolve target repository
+3. Draft interactively
+4. Suggest labels
+5. Show draft for approval
+6. Push the issue
+7. Clean up `.issue.md` (if applicable)
+8. Return the issue URL
+9. Prompt the user to move onto the PR step
+
+### 1. Determine the source
+
+Check whether `.issue.md` exists in the repository root:
+
+```bash
+test -f .issue.md && echo "exists" || echo "missing"
+```
+
+- **If `.issue.md` exists** — read it. The first `# heading` MUST be parsed as the issue title and the remaining content as the body. Proceed to step 3.
+- **If `.issue.md` does not exist** — draft the issue interactively (step 2).
+
+### 2. Resolve target repository
+
+```bash
+gh repo view --json isFork,parent
+```
+
+If `isFork` is `true`, extract `parent.owner.login` and `parent.name` to form the upstream repo identifier (`<owner>/<name>`). This upstream identifier becomes the **target repo** for all subsequent `gh` commands that reference issues or pull requests. If the repo is not a fork, the target repo is the current repo and no `--repo` flag is needed.
+
+**User override:** If the user explicitly asks to target the fork — by saying "fork", "on the fork", "fork #N", or similar — the target repo MUST be set to the current (fork) repo instead of upstream. The user's explicit intent always takes precedence.
+
+All `gh` commands in subsequent steps that reference issues or PRs MUST include `--repo <target>` when the target repo differs from the current repo.
+
+### 3. Draft interactively
+
+Based on conversation context, determine the issue type and draft using the matching template. All templates share the same structure — only the field names and auto-label differ.
+
+Issue titles MUST be written in the imperative mood. Issue body prose SHOULD use the imperative mood for proposed actions and present tense for descriptions of current system state.
+
+Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write each sentence or logical phrase as a single unwrapped line. Markdown renderers handle line wrapping automatically — manual line breaks inside paragraphs create unnecessary diffs and awkward rendering.
+
+**Bug** (label: `bug`):
+
+```markdown
+# <title>
+
+## Summary
+
+<What is the bug? Steps to reproduce if applicable.>
+
+## Root cause
+
+<What is causing the bug? Include relevant code snippets.>
+
+## Affected code
+
+<Which files, modules, or components are affected?>
+```
+
+**Feature** (label: `feature`):
+
+```markdown
+# <title>
+
+## Summary
+
+<What is the feature? Describe the desired behavior.>
+
+## Motivation
+
+<Why is this feature needed? What problem does it solve?>
+
+## Affected code
+
+<Which files, modules, or components would be affected?>
+```
+
+**Refactor** (label: `refactor`):
+
+```markdown
+# <title>
+
+## Summary
+
+<What should be restructured and what does the end state look like?>
+
+## Motivation
+
+<Why is this restructuring needed?>
+
+## Affected code
+
+<Which files, modules, or components are affected?>
+```
+
+**Test** (label: `test`):
+
+```markdown
+# <title>
+
+## Summary
+
+<What needs to be tested or what test infrastructure is needed?>
+
+## Motivation
+
+<Why is this test work needed? What gap does it fill?>
+
+## Affected code
+
+<Which files, modules, or components are affected?>
+```
+
+**CI/CD** (label: `cicd`):
+
+```markdown
+# <title>
+
+## Summary
+
+<What CI/CD change is needed?>
+
+## Motivation
+
+<Why is this change needed? What does it improve?>
+
+## Affected code
+
+<Which workflows, pipelines, or config files are affected?>
+```
+
+**Build** (label: `build`):
+
+```markdown
+# <title>
+
+## Summary
+
+<What build system or dependency change is needed?>
+
+## Motivation
+
+<Why is this change needed?>
+
+## Affected code
+
+<Which build files, configs, or dependencies are affected?>
+```
+
+The **Affected code** section MAY be omitted if it is not relevant.
+
+The draft MUST be shown to the user and iterated until they approve.
+
+### 4. Suggest labels
+
+The issue content MUST be analyzed and one or more labels suggested from the repository's label set:
+
+| Label | Use when |
+|-------|----------|
+| `bug` | Something isn't working |
+| `feature` | New feature or capability |
+| `refactor` | Code restructuring without behavior change |
+| `test` | The core focus is test coverage or test infrastructure |
+| `cicd` | CI/CD pipeline changes |
+| `build` | Build system or dependency changes |
+
+Each label SHOULD only be applied when the issue's **primary focus** matches that category. For example, a bug fix will naturally include tests as part of its implementation — that MUST NOT warrant the `test` label. The `test` label is reserved for issues whose core purpose is adding, fixing, or improving tests or test infrastructure.
+
+The suggested labels MUST be shown alongside the draft for user approval.
+
+### 5. Show draft for approval
+
+The full issue (title, body, labels) MUST be presented to the user. The issue MUST NOT be pushed until the user explicitly approves.
+
+### 6. Push the issue
+
+A heredoc MUST be used for the body to avoid shell escaping issues:
+
+```bash
+gh issue create --repo <target> --title "<title>" --label "<label1>,<label2>" --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+The `--repo <target>` flag MUST be included when the target repo differs from the current repo (as resolved in step 2). The `--assignee` flag MUST NOT be used — issues are not auto-assigned.
+
+### 7. Clean up `.issue.md`
+
+If the issue was created from `.issue.md`, the user MUST be asked whether to delete the file now that the issue has been pushed. If they agree:
+
+```bash
+rm .issue.md
+```
+
+### 8. Return the issue URL
+
+The issue URL returned by `gh issue create` MUST be printed so the user can access it directly.
+
+The user SHOULD be prompted with the next pipeline step: "Ready to plan this? Run `/pr <number>` to create a branch and draft PR."
+
+### 9. Prompt the user to move onto the PR step
+
+The user MUST be prompted with the next pipeline step: "Ready to plan this? Run `/pr <number>` to create a branch and draft PR." When working from a fork, note that `<number>` refers to the issue on the upstream repo. DO NOT proceed on your own.

--- a/llms/skills/pr.md
+++ b/llms/skills/pr.md
@@ -1,0 +1,182 @@
+---
+name: pr
+description: >
+  Create a branch and draft PR from a GitHub issue. Use this skill whenever the
+  user says "/pr <number>", "create a PR for issue #N", "start working on #N",
+  or similar. Takes an issue number as argument, fetches the issue, creates a
+  branch, and opens a draft PR with an implementation plan. Also use this skill
+  to update an existing draft PR when the implementation plan changes or code
+  is committed.
+---
+
+The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
+
+# PR Skill
+
+Create a branch and draft pull request from an existing GitHub issue. The PR serves as the implementation plan — no code is written yet.
+
+## Pipeline Context
+
+This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update). This skill is the **second** stage, and is also invoked at the end to update the PR after implementation.
+
+## Arguments
+
+An issue number MUST be provided as the sole argument (e.g., `/pr 96`).
+
+## Workflow
+
+### TL;DR
+
+1. Resolve target repository
+2. Fetch the issue
+3. Generate a branch name
+4. Create and checkout the branch
+5. Draft the PR description
+6. Show draft for approval
+7. Push and create the draft PR
+8. Return the PR URL
+9. Prompt the user to move onto the implementation step
+
+### 1. Resolve target repository
+
+```bash
+gh repo view --json isFork,parent
+```
+
+If `isFork` is `true`, extract `parent.owner.login` and `parent.name` to form the upstream repo identifier (`<owner>/<name>`). This upstream identifier becomes the **target repo** for all subsequent `gh` commands that reference issues or pull requests. The default PR base becomes the upstream repo's default branch and the PR will be opened against the upstream repo. If the repo is not a fork, the target repo is the current repo and no `--repo` flag is needed.
+
+**User override:** If the user explicitly asks to target the fork — by saying "fork", "on the fork", "fork #N", or similar — the target repo MUST be set to the current (fork) repo instead of upstream. The user's explicit intent always takes precedence.
+
+All `gh` commands in subsequent steps that reference issues or PRs MUST include `--repo <target>` when the target repo differs from the current repo.
+
+### 2. Fetch the issue
+
+```bash
+gh issue view <number> --repo <target>
+```
+
+Read the issue title, body, and labels. If the issue does not exist or is closed, inform the user and stop. The `--repo <target>` flag ensures the issue is fetched from the upstream repo when working from a fork (as resolved in step 1). If the target repo is the current repo, the flag MAY be omitted.
+
+### 3. Generate a branch name
+
+Derive a short, descriptive branch name from the issue number and title:
+
+```
+<number>-<kebab-case-summary>
+```
+
+Examples:
+- `96-fix-worker-factory-credentials`
+- `102-add-retry-logic-to-discovery`
+
+The branch name MUST be under 50 characters. Filler words SHOULD be stripped.
+
+### 4. Create and checkout the branch
+
+```bash
+git checkout -b <branch-name> main
+```
+
+If the branch already exists, the user MUST be asked whether to switch to it or recreate it.
+
+### 5. Draft the PR
+
+The PR title should match its associated issue exactly with `— Closes #<number>` appended to the end.
+
+All PR description prose MUST be written in the imperative mood — "Add retry logic" not "Adds retry logic" or "Added retry logic". This applies to the title, summary, proposed changes, and implementation plan steps. The imperative mood MUST be maintained even when updating the description after work has been completed. Descriptions of the current state of the system are exempt and SHOULD use present tense — "The registry stores entries in memory" not "Store entries in memory".
+
+Prose in PR descriptions MUST NOT be hard-wrapped at a fixed column width. Write each sentence or logical phrase as a single unwrapped line. Markdown renderers handle line wrapping automatically — manual line breaks inside paragraphs create unnecessary diffs and awkward rendering.
+
+The PR description MUST contain exactly four sections:
+
+**Summary** — A quick recap of the issue, the high-level approach, and any trade-offs worth noting. The summary MUST end with `Closes #<number>` to link the issue.
+
+**Proposed changes** — Subsections for each logical change. Design rationale and before/after code snippets SHOULD be included where useful.
+
+**Test cases** — The `/test` skill MUST be used to generate a Given-When-Then test case table for the affected modules. The table MUST be included in the PR description so reviewers can see expected behavior at a glance. The table format:
+
+| Test Suite | Test ID | Given | When | Then | Coverage Target |
+|------------|---------|-------|------|------|-----------------|
+| `TestParser` | PA-001 | A parser with default config | Empty input is processed | Returns an empty result | Default behavior |
+
+The first word of every plain-language table entry MUST be capitalized. Table entries MUST NOT end with punctuation (no trailing periods, commas, etc.). Code spans in entries (e.g., `` `foo.bar()` is called ``) are exempt from the capitalization rule.
+
+**Implementation plan** — Sequenced steps for the implementation, formatted as an ordered checkbox list. Test-first ordering SHOULD be preferred when applicable. Each step MUST describe a concrete output (writing code, tests, documentation, schema changes, etc.). Steps MUST NOT include running tests, linting, or other verification tasks — these are handled automatically by CI/CD. Example format:
+
+```markdown
+1. - [ ] Add `version` field to `Ack` in `worker.proto`; regenerate bindings
+2. - [ ] Write discovery-time version filter tests (VP-001 through VP-004)
+3. - [ ] Implement major-version filter in `proxy.py`
+```
+
+When code is committed and the PR description is updated to reflect the implemented state, completed steps MUST be checked off:
+
+```markdown
+1. - [x] Add `version` field to `Ack` in `worker.proto`; regenerate bindings
+2. - [x] Write discovery-time version filter tests (VP-001 through VP-004)
+3. - [ ] Implement major-version filter in `proxy.py`
+```
+
+### 6. Show draft for approval
+
+The full PR (title, body, branch name) MUST be presented to the user. The PR MUST NOT be created until the user explicitly approves.
+
+### 7. Push and create the draft PR
+
+GitHub requires at least one commit of difference between the base and head branches to create a PR. Since the branch has no code yet, an empty commit MUST be created as a placeholder (it can be rebased away when real work starts):
+
+```bash
+git commit --allow-empty -m "chore: Open draft PR for #<number>"
+git push -u origin <branch-name>
+gh pr create --draft --title "<title>" --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+When the repo is a fork (detected in step 2), add `--repo <upstream-owner>/<upstream-name>` so the PR is opened against the upstream repo:
+
+```bash
+gh pr create --draft --repo <upstream-owner>/<upstream-name> --title "<title>" --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+The PR MUST be created as a **draft** since no code has been written yet.
+
+After the PR is created, explicitly link the issue to the PR so the Development sidebar is populated immediately. The `Closes #<number>` keyword in the body is only processed on merge and does not always create the sidebar link:
+
+```bash
+gh issue develop <issue-number> --repo <target> --branch <branch-name>
+```
+
+If the command is not available in the installed `gh` version, the `Closes #<number>` reference in the PR body serves as the fallback.
+
+### 8. Return the PR URL
+
+The PR URL returned by `gh pr create` MUST be printed so the user can access it directly.
+
+The user SHOULD be prompted with the next pipeline step: "Ready to implement? Run `/implement <number>` to start coding against this plan."
+
+## Keeping the PR consistent
+
+The PR description is a living document. It MUST be re-evaluated and updated when:
+
+- **The user requests changes to the proposed implementation plan.** The test cases table MUST be regenerated to reflect the revised plan before showing the updated draft for approval.
+- **Code is committed to the branch.** This skill MUST be re-run against the actual code being pushed: update the summary, proposed changes, and test cases to match what was implemented rather than what was planned. Use `gh pr edit` to update the existing PR body:
+
+  ```bash
+  gh pr edit <number> --repo <target> --body "$(cat <<'EOF'
+  <updated body>
+  EOF
+  )"
+  ```
+
+  The `--repo <target>` flag MUST be included when the target repo differs from the current repo (as resolved in step 1).
+
+The PR description MUST always accurately reflect the current state — planned or implemented — and MUST NOT drift from reality.
+
+### 9. Prompt the user to move onto the implementation step
+
+The user MUST be prompted with the next pipeline step: "Ready to implement? Run `/implement <number>` to start coding against this plan." DO NOT proceed on your own.

--- a/llms/skills/review.md
+++ b/llms/skills/review.md
@@ -1,0 +1,181 @@
+---
+name: review
+description: >
+  Review an open pull request for guide compliance, correctness, and code
+  quality. Use this skill whenever the user says "/review <number>",
+  "review PR #N", "review this PR", or similar. Fetches the PR diff and
+  metadata, reads the project guides and source files under review, analyzes
+  findings by severity, presents them for approval, and posts an inline
+  review via the GitHub API.
+---
+
+The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
+
+# Review Skill
+
+Fetch a pull request, analyze its diff against project guides and source context, categorize findings by severity, present them for user approval, and post an inline GitHub review.
+
+## Pipeline Context
+
+This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update) → `/review`. This skill is the **sixth** stage, invoked after the PR has been updated and is ready for review.
+
+## Arguments
+
+A PR number MUST be provided as the sole argument (e.g., `/review 146`).
+
+## Workflow
+
+### TL;DR
+
+1. Resolve target repository
+2. Fetch the PR metadata and diff
+3. Read project guides and styles
+4. Read source files under review
+5. Analyze the diff
+6. Categorize findings
+7. Present findings for approval
+8. Post the review
+9. Prompt the user with next steps
+
+### 1. Resolve target repository
+
+```bash
+gh repo view --json isFork,parent
+```
+
+If `isFork` is `true`, extract `parent.owner.login` and `parent.name` to form the upstream repo identifier (`<owner>/<name>`). This upstream identifier becomes the **target repo** for all subsequent `gh` commands that reference issues or pull requests. Also extract the `<owner>` and `<repo>` values separately — these are needed for the GitHub API call in step 8. If the repo is not a fork, the target repo is the current repo, `<owner>` and `<repo>` are derived from the current repo, and no `--repo` flag is needed.
+
+**User override:** If the user explicitly asks to target the fork — by saying "fork", "on the fork", "fork #N", or similar — the target repo MUST be set to the current (fork) repo instead of upstream. The user's explicit intent always takes precedence.
+
+All `gh` commands in subsequent steps that reference issues or PRs MUST include `--repo <target>` when the target repo differs from the current repo.
+
+### 2. Fetch the PR metadata and diff
+
+```bash
+gh pr view <number> --repo <target> --json title,body,headRefName,baseRefName,changedFiles
+gh pr diff <number> --repo <target>
+```
+
+If the PR does not exist, inform the user and stop. Parse the PR title, body, branch names, and the list of changed files. The `--repo <target>` flag ensures commands operate against the upstream repo when working from a fork (as resolved in step 1). If the target repo is the current repo, the flag MAY be omitted.
+
+### 3. Read project guides and styles
+
+Read the following files to establish the review baseline:
+
+- `CLAUDE.md` — project-level instructions, architecture context, docstring conventions.
+- `llm/guides/testguide-python.md` — Python testing conventions (if the PR touches test files).
+- Every file in `llm/styles/` — active authoring conventions.
+
+Only the guides relevant to the changed files need to be read. For example, the test guide is only needed if the PR modifies or adds test files.
+
+### 4. Read source files under review
+
+For each changed file in the PR:
+
+- Read the full file at its current HEAD revision so that surrounding context is available.
+- If the changed file is a test file, also read the corresponding source module it tests (and vice versa).
+
+### 5. Analyze the diff
+
+Review every hunk in the diff against the guides read in step 3 and the source context read in step 4. Check for:
+
+- **Guide compliance** — violations of MUST/SHALL/SHOULD rules from `CLAUDE.md`, the test guide, and style guides. Cite the specific guide rule being violated.
+- **Naming and conventions** — inconsistent naming, style drift from the surrounding codebase, or departures from documented conventions.
+- **Coverage regressions** — new public APIs without corresponding tests, removed tests without justification, or test gaps relative to the PR's own test cases table.
+- **Correctness bugs** — logic errors, race conditions, missing error handling at system boundaries, incorrect use of APIs or libraries.
+- **Code quality** — unnecessary complexity, dead code, duplicated logic, or poor separation of concerns.
+
+Each finding MUST reference the specific file and line range in the diff where the issue occurs.
+
+### 6. Categorize findings
+
+Every finding MUST be assigned exactly one severity:
+
+- **Blocking** — Violations of MUST or SHALL requirements from any project guide. These MUST be resolved before the PR can be approved.
+- **Non-blocking** — Violations of SHOULD or RECOMMENDED requirements, style suggestions, or minor quality improvements. These are advisory and do not block approval.
+
+Present findings grouped by severity, with blocking findings first.
+
+### 7. Present findings for approval
+
+The complete list of findings MUST be presented to the user before posting. For each finding, show:
+
+- Severity (blocking / non-blocking)
+- File and line range
+- Description of the issue
+- The comment text that will be posted
+
+The user MUST be given the opportunity to:
+
+- **Remove** any finding they disagree with.
+- **Edit** the comment text of any finding.
+- **Add** new findings the agent missed.
+- **Change** the severity of any finding.
+
+The review MUST NOT be posted until the user explicitly approves the final set of findings.
+
+### 8. Post the review
+
+Construct a review payload and post it via the GitHub API. The payload MUST be written to a temporary file to avoid shell escaping issues:
+
+```bash
+cat > /tmp/review_payload.json << 'EOF'
+{
+  "event": "<APPROVE|REQUEST_CHANGES|COMMENT>",
+  "body": "",
+  "comments": [
+    {
+      "path": "relative/path/to/file.py",
+      "line": 42,
+      "body": "Comment text here."
+    }
+  ]
+}
+EOF
+gh api repos/<owner>/<repo>/pulls/<number>/reviews \
+  --method POST --input /tmp/review_payload.json
+```
+
+**Review event selection:**
+
+- If there are any **blocking** findings remaining after user approval, the event MUST be `REQUEST_CHANGES`.
+- If there are only **non-blocking** findings, the event SHOULD be `COMMENT`.
+- If there are no findings, the event SHOULD be `APPROVE`.
+
+**Review body:** The top-level review `body` SHOULD be an empty string when all findings are line-specific inline comments. A non-empty body is acceptable for findings that cannot be associated with a specific changed line — for example, something from the issue that the PR completely missed, or an architectural concern that spans the entire diff. The user decides whether to use a top-level comment — defer to them.
+
+**Comment text:** Each inline comment MUST contain only the substantive feedback. Comments MUST NOT include pseudo-headers, severity labels, category tags, or other metadata — just the review feedback itself.
+
+**Multi-line comments:** When a finding spans multiple lines, use the `start_line` and `line` fields to highlight the full range:
+
+```json
+{
+  "path": "relative/path/to/file.py",
+  "start_line": 10,
+  "line": 15,
+  "body": "Comment text here."
+}
+```
+
+The `<owner>` and `<repo>` values MUST be resolved from step 1. When working from a fork, these refer to the upstream repo's owner and name (unless the user explicitly targeted the fork).
+
+### 9. Prompt the user with next steps
+
+After the review is posted, prompt the user with the appropriate next step:
+
+- If the review event was `REQUEST_CHANGES` or `COMMENT`: "Review posted. Run `/audit review` to verify compliance, or address the findings with `/implement <number>` and re-run `/review <number>` after pushing fixes."
+- If the review event was `APPROVE`: "PR approved. Run `gh pr ready <number>` to mark it ready for merge, or `/audit review` to verify the review was thorough."
+
+DO NOT proceed on your own.
+
+## Edge Cases
+
+**PR is already merged or closed:** Inform the user that the PR is not open and stop.
+
+**No findings:** If the diff passes all checks cleanly, post an `APPROVE` review with an empty body and no inline comments. Inform the user that no issues were found.
+
+**Binary files in diff:** Binary files MUST be skipped during analysis. Note their presence to the user but do not attempt to review them.
+
+**Very large diffs:** For PRs with more than 20 changed files or more than 1000 lines changed, the agent SHOULD summarize the scope to the user and ask whether to review the full diff or focus on specific files.
+
+**Files outside the repository's guide coverage:** If changed files are in a language or domain not covered by any project guide, review them for general correctness and code quality only. Do not fabricate guide requirements that do not exist.

--- a/llms/skills/test.md
+++ b/llms/skills/test.md
@@ -1,0 +1,174 @@
+---
+name: test
+description: >
+  Generate comprehensive test specifications for source modules with 100%
+  coverage of public APIs. Use this skill whenever the user says "/test",
+  "generate test specs", "create test plan", "write test specifications", or
+  similar. Analyzes module structure and produces Given-When-Then test case
+  tables organized by public class and function.
+---
+
+The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
+
+# Test Skill
+
+Generate comprehensive test specifications for source modules with 100% coverage of public APIs.
+
+## Pipeline Context
+
+This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update). This skill is a **supporting tool** invoked by `/pr` to generate test case tables.
+
+## Arguments
+
+A list of target modules or file references MUST be provided as arguments (e.g., `/test src/wool/worker/service.py`). If no arguments are provided, the user MUST be asked which modules to analyze.
+
+> **Test guide:** Determine the language of the target modules from their file extensions, then read the corresponding test guide before generating test specifications:
+>
+> | Language | Guide |
+> |----------|-------|
+> | Python (`.py`) | `@llm/guides/testguide-python.md` |
+>
+> If no guide exists for the detected language, inform the user and stop.
+
+## Workflow
+
+### 1. Identify target modules
+
+Analyze referenced files or use the provided arguments to determine which source modules need test specifications.
+
+### 2. Analyze module structure
+
+For each module:
+
+- **CRITICAL**: MUST NOT consider any existing tests when creating the test plan. Analyze only the source module itself.
+- Identify all public classes (no underscore prefix).
+- Identify all public functions (no underscore prefix).
+- Identify all public methods in each class.
+- Note language-specific idioms that need idiomatic testing (per the project test guide).
+
+### 3. Generate test specifications
+
+For each source module, create a test specification file using the naming convention from the project test guide:
+
+- Module header: `## Module: <module_name>`
+- For each public class:
+  - Section header: `### Public Class: <ClassName>`
+  - Test table (see Table Format below)
+  - Include: basic cases, variations, edge cases, property-based tests
+- For each public function:
+  - Section header: `### Public Function: <function_name>()`
+  - Test table (see Table Format below)
+- Test Implementation Notes section
+- Test Organization section (showing test file structure)
+- Summary Statistics section
+
+Create `specs/QUICK_REFERENCE.md` with an at-a-glance summary:
+
+- Test spec file locations (links to each spec file)
+- Test suite class names per module
+- Coverage statistics per module
+- Quick navigation to each module/class/function
+
+### 4. Validate test specifications
+
+- All tests focus on public APIs only (no underscore-prefixed symbols).
+- All tests use Given-When-Then format.
+- Language idioms tested idiomatically (not by calling special methods directly).
+- Edge cases grouped with normal cases.
+- Property-based tests grouped with their target object.
+- 100% coverage of public APIs achieved.
+
+### 5. Report completion
+
+Provide paths to generated files and summary statistics.
+
+## Table Format
+
+Each test table MUST have these columns:
+
+| Test Suite | Test ID | Given | When | Then | Coverage Target |
+|------------|---------|-------|------|------|-----------------|
+
+**Column descriptions**:
+
+- **Test Suite**: Test class name (e.g., `TestParser`). Property-based tests use the SAME test class, not a separate properties class.
+- **Test ID**: Sequential ID (e.g., PA-001, PA-002, PBT-001 for property-based).
+- **Given**: Setup conditions (public state only).
+- **When**: Action taken (public API only, using language idioms).
+- **Then**: Observable outcome (public behavior only).
+- **Coverage Target**: What this test covers.
+
+## Testing Requirements
+
+### Coverage and Scope
+
+- MUST achieve 100% test coverage of all public APIs.
+- MUST test ONLY public functions, methods, and classes (no underscore prefix).
+- MUST NOT manipulate or validate any private/internal state.
+- MUST NOT reference private functions/methods/variables in test specifications.
+- Private functions SHOULD achieve coverage naturally through public API usage.
+
+### Test Design Principles
+
+- Tests MUST focus on observable behavior, not implementation details.
+- Tests SHOULD remain valid even if internal implementation is completely refactored.
+- MUST use "Given-When-Then" format for all test cases.
+- Similar behaviors with many scenarios SHOULD use property-based tests.
+- SHOULD avoid excessive test case overlap in assertions.
+
+### Idiomatic Testing
+
+MUST test language idioms using their natural syntax, not by calling special methods directly. Consult the project test guide for language-specific rules.
+
+### Test Organization
+
+- MUST group tests by module.
+- MUST organize within test file by public API (class/function).
+- MUST group property-based tests with their target object IN THE SAME test class.
+  - BAD: Separate properties class (e.g., `TestParserProperties`).
+  - GOOD: Property-based tests in the same class with PBT-xxx test IDs.
+- MUST group edge cases with their target function/class.
+- SHOULD follow progression: basic cases, variations, edge cases, property-based tests.
+
+## Good and Bad Examples
+
+See the project test guide for language-specific good/bad examples.
+
+### Good Examples
+
+| Test Suite | Test ID | Given | When | Then | Coverage Target |
+|------------|---------|-------|------|------|-----------------|
+| TestParser | PA-001 | Valid parameters for a Parser | Parser is instantiated | A "parser-created" event is emitted | Instantiation and event emission |
+| TestParser | PA-004 | A Parser is used as a context manager | Context is entered using the language's context manager syntax | Context manager provides access to parser execution | Context manager entry |
+| TestParser | PBT-001 | Any Parser with valid serializable data | Serialize then deserialize | Original object equals deserialized object in all public attributes | Serialization round-trip property |
+
+### Bad Examples
+
+| Test Suite | Test ID | Given | When | Then | Coverage Target |
+|------------|---------|-------|------|------|-----------------|
+| TestParser | BAD-001 | _internal_state is set to None | Constructor hook is called directly | Field is None | Private state |
+| TestParser | BAD-002 | _dispatch is called with args | _resolve strips self parameter | Args are modified | Private function |
+| TestParser | BAD-003 | A Parser | Context manager entry method is called directly | Returns run method | Calling special method directly |
+| TestParserProperties | PBT-001 | Any Parser with valid data | Serialize then deserialize | Original equals deserialized | Separate property test class |
+
+## Validation Checklist
+
+A test specification is valid if and only if:
+
+- Describes only publicly observable behavior.
+- Uses natural language idioms (context managers, instantiation, etc.).
+- Groups related tests together (by module, then by API).
+- Includes edge cases with normal cases.
+- Has clear Given-When-Then structure.
+- Would remain valid even if all private code is rewritten.
+- Focuses on "what" not "how".
+
+## Key Rules
+
+- **Ignore existing tests**: MUST NOT consider any existing test files when creating test specifications.
+- **Public APIs only**: No underscore-prefixed symbols in test specs.
+- **Behavior not implementation**: Tests validate what, not how.
+- **Idiomatic testing**: Use language idioms, not direct special method calls.
+- **Comprehensive coverage**: 100% of public APIs must be covered.
+- **Clear organization**: Group by module, class/function, test progression.
+- **Separate files**: One spec file per source module in `specs/` directory.

--- a/llms/style-guides/markdown.md
+++ b/llms/style-guides/markdown.md
@@ -1,0 +1,29 @@
+# Markdown Style Guide
+
+Key words MUST, MUST NOT, SHOULD, and SHOULD NOT are interpreted as described in RFC 2119. This guide covers Markdown authoring conventions. It is format-specific but project-agnostic — project-level details belong in `CLAUDE.md`.
+
+## 1. Line Wrapping
+
+MUST NOT arbitrarily hard-wrap prose in Markdown files. Each paragraph, list item, or block-level element MUST be a single long line. Only break lines where Markdown syntax requires it (e.g., inside fenced code blocks or tables).
+
+**Rationale:** Hard-wrapping at a fixed column (e.g., 80 characters) creates noisy diffs when text is edited — a single word change can reflow an entire paragraph. Soft-wrapping (one logical line per block element) keeps diffs minimal and makes version-control history easier to review.
+
+### Do
+
+```markdown
+This is a paragraph that explains something in detail. It keeps going on a single line regardless of length, because the editor and renderer handle wrapping.
+
+- This list item contains a full sentence of explanation and stays on one line even though it is quite long.
+```
+
+### Don't
+
+```markdown
+This is a paragraph that explains something
+in detail. It keeps going but has been
+hard-wrapped at 50 columns for no reason.
+
+- This list item contains a full sentence
+  of explanation and has been hard-wrapped
+  even though Markdown does not require it.
+```

--- a/llms/test-guides/python.md
+++ b/llms/test-guides/python.md
@@ -1,0 +1,248 @@
+# Python Test Guide
+
+Key words MUST, MUST NOT, SHOULD, and SHOULD NOT are interpreted as described in RFC 2119. This guide covers Python testing conventions using pytest, pytest-asyncio, pytest-mock, and Hypothesis. It is language-specific but project-agnostic — project-level details (runner commands, architecture) belong in `CLAUDE.md`.
+
+## 1. Core Philosophy
+
+Test behavior, not implementation.
+
+## 2. Coverage Scope
+
+- MUST achieve 100% test coverage of all public APIs.
+- MUST test ONLY public functions, methods, and classes (no underscore prefix).
+- MUST NOT manipulate or validate any private/internal state.
+- MUST NOT reference private functions/methods/variables in tests.
+- Private functions SHOULD achieve coverage naturally through public API usage.
+
+## 3. Idiomatic Testing
+
+MUST test dunder methods idiomatically, MUST NOT call them directly:
+
+- `__init__`/`__post_init__`: Test via class instantiation.
+- `__enter__`/`__exit__`: Test via `with` statements.
+- `__call__`: Test by calling the object as a function.
+- Other dunder methods: Use their natural Python idiom.
+
+## 4. File and Class Organization
+
+- Test files: `test_<module_name>.py` — mirrors the module under test.
+- Test classes mirror production classes: `class Test<ClassName>:` where `<ClassName>` is the exact `__name__` of the class under test.
+- Tests for class methods live in the corresponding test class.
+- Tests for module-level functions are module-level test functions.
+- Tests MUST be grouped by the behavior they exercise, not by implementation detail. For example, property-based tests for a method live alongside example-based tests for the same method in the same class — do NOT create separate classes by test technique.
+- Within a test class or module, order tests from foundational to derived: test `__init__` before methods that require a constructed instance, and test simple methods before methods that compose them. This ensures `pytest -x` stops at the most fundamental failure first.
+
+## 5. Test Naming
+
+Test methods mirror the qualified name of their subject:
+
+```
+test_<method_name>_<brief_scenario>
+```
+
+The scenario portion is derived from the Given and When — it describes the condition and action, not the expected outcome:
+
+```
+test_dispatch_with_stopping_service
+test_to_protobuf_with_unpicklable_callable
+test___init___outside_task_context
+```
+
+Rules:
+- `<method_name>` MUST match the method's `__name__` exactly, including dunder prefixes (e.g., `test___init___...`).
+- `<brief_scenario>` SHOULD be 2-5 words in snake_case.
+- Do NOT encode the expected outcome in the name — that belongs in the `Then` section of the docstring.
+
+## 6. Docstrings (Given-When-Then)
+
+Scope: test functions and methods only — NOT fixtures or helpers.
+
+**Standard test:**
+
+```python
+"""Test <summary of what is being tested>.
+
+Given:
+    <preconditions>
+When:
+    <action under test>
+Then:
+    It should <expected outcome>
+"""
+```
+
+**Property-based test:**
+
+Same format. The `Given` describes the generated input space, not a specific value:
+
+```python
+"""Test <property being verified>.
+
+Given:
+    <description of generated input domain>
+When:
+    <action under test>
+Then:
+    <invariant that must hold>
+"""
+```
+
+Rules:
+- First line MUST start with `Test` and describe what is being tested.
+- Blank line after the first line.
+- `Given:`, `When:`, `Then:` each on their own line, followed by a colon.
+- Content under each section indented 4 spaces.
+- Each section's content starts with a capital letter.
+- `Then` content typically starts with "It should...".
+- One `Given`/`When`/`Then` block per docstring (no bullet lists within).
+
+## 7. Test Body (AAA)
+
+Every test MUST use Arrange-Act-Assert phase comments. One behavior per test.
+
+**Full 3-phase (default):**
+
+```python
+def test_<method>_<scenario>(self, ...):
+    """..."""
+    # Arrange
+    <set up preconditions>
+
+    # Act
+    <call the method under test>
+
+    # Assert
+    <verify the outcome>
+```
+
+**Combined phases:**
+
+When phases are inseparable, combine the comments:
+
+*No arrangement needed:*
+
+```python
+# Act
+result = SomeClass()
+
+# Assert
+assert result.field == expected
+```
+
+*Action and assertion are the same expression:*
+
+```python
+# Arrange
+<set up preconditions>
+
+# Act & assert
+with pytest.raises(SomeError, match="expected message"):
+    unit.method()
+```
+
+*Trivial one-liner:*
+
+```python
+# Arrange, act, & assert
+async with SomePool(size=3) as pool:
+    assert pool is not None
+```
+
+The combined forms are acceptable but the full 3-phase form is preferred. When in doubt, use the full form.
+
+## 8. Mocking
+
+- MUST use the `mocker` fixture (pytest-mock), not `unittest.mock` directly.
+- Mock at system boundaries only: external services, I/O, network.
+- MUST NOT mock internal/private methods.
+- MUST NOT mock the unit under test.
+- SHOULD prefer `mocker.patch.object(module, "attr")` over `mocker.patch("dotted.string.path")`. Object-style patches let IDE AST indexing resolve mock targets, making references findable and rename-safe.
+
+```python
+# Preferred — IDE can resolve the target
+import grpc.aio
+from mypackage import some_module
+
+mocker.patch.object(some_module, "SomeClass", return_value=mock)
+mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock)
+
+# Discouraged — opaque string, invisible to AST tooling
+mocker.patch("mypackage.some_module.SomeClass", return_value=mock)
+```
+
+## 9. Async Testing
+
+- Use `pytest-asyncio` with `@pytest.mark.asyncio`.
+- Async mocks via `mocker.AsyncMock()`.
+
+```python
+@pytest.mark.asyncio
+async def test_fetch_data_with_valid_endpoint(self, mocker):
+    """..."""
+    # Arrange
+    mock_response = mocker.AsyncMock(return_value={"key": "value"})
+    mocker.patch.object(http_client, "get", mock_response)
+
+    # Act
+    result = await unit.fetch_data("/endpoint")
+
+    # Assert
+    assert result == {"key": "value"}
+```
+
+## 10. Fixtures
+
+- Use fixtures for shared setup that multiple tests need.
+- Fixtures MUST NOT have Given-When-Then docstrings. Plain reST docstrings are fine.
+- Prefer narrowest scope: function > class > module > session.
+
+## 11. Property-Based Testing (Hypothesis)
+
+Property-based testing is a peer of example-based testing, not an afterthought. Property tests live in the same class as example tests, grouped by the method they exercise.
+
+MUST be used for:
+- Invariants.
+- Roundtrip/serialization.
+- Edge-case discovery.
+- Any function with a wide input domain.
+
+Rules:
+- Use `@given` with appropriate strategies.
+- Use `@settings` to control `max_examples` and suppress health checks when justified.
+- Property tests get Given-When-Then docstrings (the `Given` describes the generated domain, not a specific value).
+
+```python
+@given(st.binary())
+def test_roundtrip_with_arbitrary_payload(self, payload):
+    """Test serialization roundtrip with arbitrary payloads.
+
+    Given:
+        Any binary payload.
+    When:
+        The payload is serialized and deserialized.
+    Then:
+        It should equal the original payload.
+    """
+    # Act
+    result = deserialize(serialize(payload))
+
+    # Assert
+    assert result == payload
+```
+
+## 12. Test Independence
+
+- Tests MUST be independent. Each test sets up its own preconditions.
+- When a foundation behavior breaks, many tests fail. The blast radius IS the information — it tells you which behaviors depend on the broken one.
+- Use `pytest -x` (stop on first failure), `--maxfail=N`, or `-lf` (last failed) to manage noise.
+- Dependency markers (`@pytest.mark.dependency`) MUST NOT be used in new tests.
+
+## 13. Verification Commands
+
+```
+pytest <path> -x
+pytest <path> --maxfail=3
+pytest <path> -lf
+```
+
+If your project uses a runner wrapper (e.g., `uv run`, `poetry run`), prefix accordingly — see project instructions.


### PR DESCRIPTION
## Summary

Add an `llms/` directory containing seven SDLC pipeline skills, a Python testing guide, and a Markdown style guide. These define structured, human-in-the-loop workflows for issue creation, PR management, implementation planning, test generation, atomic commits, code review, and compliance auditing.

Closes #1

## Proposed changes

### Pipeline skills (`llms/skills/`)

Add seven skill definitions that form a sequential development pipeline:

- `issue.md` — Draft and push GitHub issues interactively or from `.issue.md`. Support bug, feature, refactor, test, CI/CD, and build templates.
- `pr.md` — Create feature branches and draft PRs from issues with four-section descriptions (summary, proposed changes, test cases, implementation plan). Also handle updating the PR description after implementation.
- `implement.md` — Resolve a PR or issue to a draft PR, check out the branch, and enter plan mode to design and execute the implementation.
- `test.md` — Generate Given-When-Then test case tables targeting 100% coverage of public APIs, organized by public class and function.
- `commit.md` — Analyze working tree diffs, group changes by logical kind (feature, fix, refactor, etc.), and create atomic commits with conventional-commit messages. Include a commit message style guide.
- `review.md` — Fetch PR diffs, analyze against project guides, categorize findings by severity (blocking vs. non-blocking), and post inline GitHub reviews.
- `audit.md` — Spawn an independent subagent to verify whether a skill's MUST/SHALL requirements were met using binary checklist decomposition.

### Python testing guide (`llms/test-guides/python.md`)

Add a comprehensive testing conventions guide covering pytest, pytest-asyncio, pytest-mock, and Hypothesis. Key conventions: test behavior not implementation, 100% coverage of public APIs only, Given-When-Then docstrings, AAA test body structure, property-based testing as a peer to example-based testing.

### Markdown style guide (`llms/style-guides/markdown.md`)

Add a Markdown authoring conventions guide. Primary rule: never hard-wrap prose — each paragraph or list item stays on a single long line to minimize diff noise.

### README (`llms/README.md`)

Add meta-documentation introducing the human-in-the-loop philosophy, directory layout, pipeline sequence diagram (Mermaid), and a reference table of all skills and guides.

## Test cases

No test cases apply — this change adds Markdown documentation only, with no Python modules or public APIs.

## Implementation plan

1. - [x] Write `llms/style-guides/markdown.md` with line-wrapping conventions
2. - [x] Write `llms/test-guides/python.md` with pytest, pytest-asyncio, pytest-mock, and Hypothesis conventions
3. - [x] Write pipeline skills: `llms/skills/issue.md`, `pr.md`, `implement.md`, `test.md`, `commit.md`, `review.md`, `audit.md`
4. - [x] Write `llms/README.md` with pipeline overview, directory layout, and skill reference table