### PR TITLE
Add GitHub issue templates — Closes #3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,25 @@
+name: Bug Report
+description: Report something that isn't working correctly.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is the bug? Include steps to reproduce if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: root-cause
+    attributes:
+      label: Root cause
+      description: What is causing the bug? Include relevant code snippets.
+    validations:
+      required: true
+  - type: textarea
+    id: affected-code
+    attributes:
+      label: Affected code
+      description: Which files, modules, or components are affected?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,25 @@
+name: Feature Request
+description: Propose a new feature or capability.
+labels: ["feature"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is the feature? Describe the desired behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this feature needed? What problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: affected-code
+    attributes:
+      label: Affected code
+      description: Which files, modules, or components would be affected?
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

Add YAML-based GitHub issue form templates for bug reports and feature requests under `.github/ISSUE_TEMPLATE/`. Each template defines structured fields with required/optional validation so contributors provide consistent, actionable information.

Closes #3

## Proposed changes

### Bug report template

`.github/ISSUE_TEMPLATE/bug.yaml`

Add an issue form with three fields: summary (required), root cause (required), and affected code (optional). Use `textarea` inputs so contributors can provide multi-line descriptions with Markdown support.

### Feature request template

`.github/ISSUE_TEMPLATE/feature.yaml`

Add an issue form with three fields: summary (required), motivation (required), and affected code (optional). Mirror the bug template structure for consistency.

## Test cases

No test cases apply — this change adds GitHub configuration files only, with no executable code.

## Implementation plan

1. - [x] Write `.github/ISSUE_TEMPLATE/bug.yaml` with summary, root cause, and affected code fields
2. - [x] Write `.github/ISSUE_TEMPLATE/feature.yaml` with summary, motivation, and affected code fields