### PR TITLE
Add CI/CD utility scripts — Closes #5

### DIFF
--- a/.github/.githubrc
+++ b/.github/.githubrc
@@ -1,0 +1,1 @@
+alias cicd="$PWD/scripts/git-cicd.sh"

--- a/.github/.gitignore
+++ b/.github/.gitignore
@@ -1,0 +1,5 @@
+.*
+
+!.gitignore
+!.githubrc
+!.github/

--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+USAGE="Usage: $0 major|minor|patch VERSION"
+
+# Evaluate arguments
+case $# in
+    2)
+        ;;
+    *)
+        echo $USAGE
+        exit 1
+        ;;
+esac
+
+# Evaluate version segment
+case $1 in
+    major|minor|patch)
+        SEGMENT=$1
+        ;;
+    *)
+        echo "ERROR: Invalid version segment: $1" >&2
+        echo $USAGE
+        exit 1
+        ;;
+esac
+
+# Determine release cycle
+VERSION=$2
+case $VERSION in
+    *-a*)
+        CYCLE="-a"
+        PRE_RELEASE=true
+        ;;
+    *-b*)
+        CYCLE="-b"
+        PRE_RELEASE=true
+        ;;
+    *-rc*)
+        CYCLE="-rc"
+        PRE_RELEASE=true
+        ;;
+    *)
+        CYCLE=""
+        PRE_RELEASE=false
+        ;;
+esac
+
+if [ "$PRE_RELEASE" = true ] && [[ "$SEGMENT" == "major" ]]; then
+    echo "ERROR: Cannot bump major version segment of a pre-release version" >&2
+    exit 1
+fi
+
+#Split version
+read MAJOR MINOR PATCH <<< $(.github/scripts/split-version.sh $VERSION)
+
+case $SEGMENT in
+    major)
+        MAJOR=$((MAJOR + 1))
+        MINOR=0
+        PATCH=0
+        ;;
+    minor)
+        case $CYCLE in
+            "")
+                MINOR=$((MINOR + 1))
+                ;;
+            "-a")
+                MINOR=$((MINOR))
+                CYCLE="-b"
+            ;;
+            "-b")
+                MINOR=$((MINOR))
+                CYCLE="-rc"
+            ;;
+            "-rc")
+                MINOR=$((MINOR))
+                CYCLE=""
+            ;;
+        esac
+        PATCH=0
+        ;;
+    patch)
+        if [ -z "$PATCH" ]; then
+            PATCH=0
+        fi
+        PATCH=$((PATCH + 1))
+        ;;
+esac
+
+if [[ -n "$CYCLE" ]]; then
+    echo "v$MAJOR.$MINOR.0$CYCLE$PATCH"
+else
+    echo "v$MAJOR.$MINOR.$PATCH"
+fi

--- a/.github/scripts/cut-release.sh
+++ b/.github/scripts/cut-release.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+USAGE="Usage: $0 major|minor [BRANCH=release]"
+
+# Evaluate arguments
+case $1 in
+    major|minor)
+        RELEASE_TYPE=$1
+        ;;
+    *)
+        echo "ERROR: Invalid release type: $1" >&2
+        echo $USAGE
+        exit 1
+        ;;
+esac
+case $# in
+    1)
+        BRANCH="release"
+        ;;
+    2)
+        BRANCH=$2
+        ;;
+    *)
+        echo $USAGE
+        exit 1
+        ;;
+esac
+
+git fetch --unshallow >/dev/null 2>&1
+git checkout main >/dev/null 2>&1
+git pull >/dev/null 2>&1
+
+# Check if the release branch already exists
+if git show-ref --verify --quiet refs/heads/$BRANCH; then
+    echo "ERROR: Branch '$BRANCH' already exists." >&2
+    exit 1
+fi
+
+# Get the latest version tag, default to 0.0.0
+VERSION=$(git describe --tags --abbrev=0)
+
+# Verify no active release candidates exist
+if [[ $VERSION == *-rc* ]]; then
+    echo "ERROR: An active release candidate already exists: $VERSION" >&2
+    exit 1
+fi
+
+read MAJOR MINOR PATCH <<< $(.github/scripts/split-version.sh $VERSION)
+
+# Bump the version
+case $RELEASE_TYPE in
+    major)
+        RELEASE_VERSION="$((MAJOR + 1)).0.0-rc0"
+        ;;
+    minor)
+        RELEASE_VERSION="${MAJOR}.$((MINOR + 1)).0-rc0"
+        ;;
+esac
+
+RELEASE_TAG="v$RELEASE_VERSION"
+
+# Create a new branch for the release candidate
+OUTPUT=$(git checkout -b $BRANCH >/dev/null 2>&1)
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to create branch '$BRANCH'." >&2
+    echo "$OUTPUT" >&2
+    exit 1
+fi
+OUTPUT=$(git push origin $BRANCH 2>&1)
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to push branch '$BRANCH' to origin." >&2
+    echo "$OUTPUT" >&2
+    exit 1
+fi
+
+echo $RELEASE_TAG

--- a/.github/scripts/find-cicd.sh
+++ b/.github/scripts/find-cicd.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -d "$(pwd)/..git" ]; then
+    echo "$(pwd)"
+elif [ -d "$(pwd)/.github" ]; then
+    echo "$(pwd)/.github"
+else
+    echo "."
+fi

--- a/.github/scripts/generate-github-access-token.sh
+++ b/.github/scripts/generate-github-access-token.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Inspired by implementation by Will Haley at:
+#   http://willhaley.com/blog/generate-jwt-with-bash/
+
+# Stolen from
+#   https://stackoverflow.com/questions/46657001/how-do-you-create-an-rs256-jwt-assertion-with-bash-shell-scripting
+# and simplified to suit our needs
+
+set -euo pipefail
+
+app_id=${APP_ID?"Need to set APP_ID"}                                        # The app id of the app
+app_installation_id=${APP_INSTALLATION_ID?"Need to set APP_INSTALLATION_ID"} # The installation id of the app
+siging_key_path=${SIGNING_KEY_PATH?"Need to set SIGNING_KEY_PATH"}           # Path to the private key used to sign the JWT as a pem file
+
+header_template='{
+    "typ": "JWT",
+    "kid": "0001",
+    "iss": "https://gist.github.com/Nastaliss/7f8466f59072d744540190721a63672d"
+}'
+
+build_header() {
+    jq -c \
+        --arg iat_str "$(date +%s)" \
+        --arg alg RS256 \
+        '
+        ($iat_str | tonumber) as $iat
+        | .alg = $alg
+        | .iat = $iat
+        | .exp = ($iat + 1)
+        ' <<<"$header_template" | tr -d '\n'
+}
+
+b64enc() { openssl enc -base64 -A | tr '+/' '-_' | tr -d '='; }
+json() { jq -c . | LC_CTYPE=C tr -d '\n'; }
+
+sign() {
+    local payload header sig secret=$2
+    header=$(build_header) || return
+    payload=${1}
+    signed_content="$(json <<<"$header" | b64enc).$(json <<<"$payload" | b64enc)"
+    sig=$(printf %s "$signed_content" | openssl dgst -binary -sha256 -sign <(printf '%s\n' "$secret") | b64enc)
+    printf '%s.%s\n' "${signed_content}" "${sig}"
+}
+
+# Construct the payload
+# Max duration is one hour, account for clock skew by subtracting 10 seconds
+payload="{\"iat\": $(($(date +%s) - 10)),\"exp\": $(($(date +%s) - 10 + 10 * 60)),\"iss\": \"${app_id}\"}"
+
+# Get the secret from a file
+# The secret needs to be a pem file with line breaks, with or without leading/trailing line break
+secret=$(cat "$siging_key_path")
+
+# Generate a jwt, according to https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app
+# and https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#generating-a-json-web-token-jwt
+jwt=$(sign "$payload" "$secret")
+
+# Actually get an access token from the github api
+curl -s --location --request POST "https://api.github.com/app/installations/$app_installation_id/access_tokens" \
+    --header "Authorization: Bearer $jwt" \
+    --header 'Accept: application/vnd.github+json' \
+    --header 'X-GitHub-Api-Version: 2022-11-28' | jq ".token" | tr -d '"'

--- a/.github/scripts/git-cicd.sh
+++ b/.github/scripts/git-cicd.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ -d "$(pwd)/..git" ]; then
+    GIT_DIR="$(pwd)/..git"
+    WORK_TREE="$(pwd)"
+elif [ -d "$(pwd)/.github" ]; then
+    GIT_DIR="$(pwd)/.github/..git"
+    WORK_TREE="$(pwd)/.github"
+else
+    echo "Neither '.git' nor '.github' directory found."
+    exit 1
+fi
+# Execute the git command with all the provided arguments
+git --git-dir="$GIT_DIR" --work-tree="$WORK_TREE" "$@"

--- a/.github/scripts/init.sh
+++ b/.github/scripts/init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mv .github/.git .github/..git
+source .github/.githubrc

--- a/.github/scripts/install-python-packages.sh
+++ b/.github/scripts/install-python-packages.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Install all Python namespace packages in the current directory
+for dir in */; do
+    if [ -d "$dir" ] && [ -f "$dir/pyproject.toml" ]; then
+        (cd "$dir" && uv pip install --no-deps .)
+    fi
+done

--- a/.github/scripts/install-tools.sh
+++ b/.github/scripts/install-tools.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Check if Homebrew (brew) is installed
+if ! command -v brew &> /dev/null; then
+
+    # Prompt the user to install Homebrew (defaults to "yes")
+    read -p "Homebrew (brew) is not installed. Do you want to install it now? (Y/n): " brew_choice
+    brew_choice=${brew_choice:-Y}
+    if [[ "$brew_choice" == "y" || "$brew_choice" == "Y" ]]; then
+
+        # Install Homebrew using the official installation script
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+        # Confirm the installation
+        if ! command -v brew &> /dev/null; then
+            echo "Error: Homebrew installation failed."
+            exit 1
+        fi
+    else
+        echo "Homebrew is required. Please install it manually."
+        exit 1
+    fi
+else
+    echo "Homebrew is already installed."
+fi
+
+# Check if UV is installed
+if ! command -v uv &> /dev/null; then
+
+    # Prompt the user to install UV (defaults to "yes")
+    read -p "UV is required but not installed. Do you want to install it now? (Y/n): " gh_choice
+    uv_choice=${uv_choice:-Y}
+    if [[ "$uv_choice" == "y" || "$uv_choice" == "Y" ]]; then
+        
+        # Install UV using Homebrew
+        brew install uv
+
+        # Confirm the installation
+        if ! command -v uv &> /dev/null; then
+            echo "Error: UV installation failed."
+            exit 1
+        fi
+    else
+        echo "UV is required. Please install it manually."
+        exit 1
+    fi
+else    
+    echo "UV is already installed."
+fi
+
+# Check if the GitHub CLI is installed
+if ! command -v gh &> /dev/null; then
+
+    # Prompt the user to install GitHub CLI (defaults to "yes")
+    read -p "GitHub CLI (gh) is required but not installed. Do you want to install it now? (Y/n): " gh_choice
+    gh_choice=${gh_choice:-Y}
+    if [[ "$gh_choice" == "y" || "$gh_choice" == "Y" ]]; then
+        
+        # Install GitHub CLI using Homebrew
+        brew install gh
+
+        # Confirm the installation
+        if ! command -v gh &> /dev/null; then
+            echo "Error: GitHub CLI installation failed."
+            exit 1
+        fi
+    else
+        echo "GitHub CLI is required. Please install it manually."
+        exit 1
+    fi
+else    
+    echo "GitHub CLI is already installed."
+fi
+
+# Check if the keychain secrets manager (ks) is installed
+if ! command -v ks &> /dev/null; then
+
+    # Prompt the user to install ks (defaults to "yes")
+    read -p "Keychain secrets manager is required but not installed. Do you want to install it now? (Y/n): " ks_choice
+    ks_choice=${ks_choice:-Y}
+    if [[ "$ks_choice" == "y" || "$ks_choice" == "Y" ]]; then
+        
+        # Install keychain secrets manager using Homebrew
+        brew tap loteoo/formulas
+        brew install ks
+
+        # Confirm the installation
+        if ! command -v ks &> /dev/null; then
+            echo "Error: Keychain secrets manager installation failed."
+            exit 1
+        fi
+    else
+        echo "Keychain secrets manager is required. Please install it manually."
+        exit 1
+    fi
+else
+    echo "Keychain secrets manager is already installed."
+fi

--- a/.github/scripts/publish-distribution.sh
+++ b/.github/scripts/publish-distribution.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+USAGE="Usage: $0 [-s|--source=dist] [[KEYCHAIN=dev SECRET=pypi-token] | [TOKEN]]"
+SOURCE="dist"
+KEYCHAIN="dev"
+SECRET="pypi-token"
+
+# Parse options
+ARGS=()
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -s|--source) 
+            # Set source directory
+            if [[ -z "$2" ]]; then
+                echo "Error: --source requires a value."
+                echo $USAGE
+                exit 1
+            fi
+            SOURCE="$2"
+            shift
+            ;;
+        *)
+            # Collect arguments
+            ARGS+=("$1")
+            ;;
+    esac
+    shift
+done
+echo "Publishing artifacts in '$SOURCE' directory..."
+
+# Parse arguments
+case ${#ARGS[@]} in
+    0)
+        # Check for PYPI_TOKEN env var first, then fall back to keychain
+        if [[ -n "${PYPI_TOKEN:-}" ]]; then
+            echo "Publishing with token from environment..."
+            TOKEN="$PYPI_TOKEN"
+        elif command -v ks &> /dev/null; then
+            if [[ -n $(ks -k $KEYCHAIN ls | grep "\b$SECRET\b") ]]; then
+                echo "Publishing with token from keychain..."
+                TOKEN=$(ks -k $KEYCHAIN show $SECRET)
+            else
+                echo "Warning: Keychain does not contain 'pypi-token' secret."
+                echo "Publishing without token..."
+            fi
+        else
+            echo "Warning: Keychain secrets manager (ks) is not installed. Please install it to use keychain secrets."
+            echo "Publishing without token..."
+        fi
+        ;;
+    1)
+        # Use the specified token
+        echo "Publishing with provided token..."
+        TOKEN="${ARGS[0]}"
+        ;;
+    2)
+        # Attempt to retrieve token from the specified keychain
+        echo "Publishing with token from keychain..."
+        KEYCHAIN="${ARGS[0]}"
+        SECRET="${ARGS[1]}"
+        TOKEN=$(ks -k $KEYCHAIN show $SECRET)
+        ;;
+    *)
+        # Improper usage
+        echo $USAGE
+        exit 1
+        ;;
+esac
+
+# Publish the package
+if [ -n "$TOKEN" ]; then
+    uv publish --username "__token__" --password "$TOKEN" "$SOURCE"/*
+else
+    uv publish "$SOURCE/*"
+fi

--- a/.github/scripts/release-pr-exists.sh
+++ b/.github/scripts/release-pr-exists.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Check for the existence of a PR with the label "release" and state "open"
+gh pr list --label release --state open --json number --jq '. | length > 0'

--- a/.github/scripts/set-secrets.sh
+++ b/.github/scripts/set-secrets.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+USAGE="Usage: $0 [-k|--keychain <keychain-name>] [-l|--logout]"
+
+if [[ "$1" == "--help" ]]; then
+    echo $USAGE
+    exit 0
+fi
+
+LOGOUT=false
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -l|--logout) LOGOUT=true;;
+        -k|--keychain) KEYCHAIN="$2"; shift ;;
+        *) echo $USAGE; exit 1 ;;
+    esac
+    shift
+done
+
+if [[ ! $(gh auth status) ]]; then
+    gh auth login
+fi
+for KEY in "pypi-token" "wool-labs-app-id" "wool-labs-installation-id" "wool-labs-private-key"; do
+    if [[ -n "$KEYCHAIN" && -n $(ks -k $KEYCHAIN ls | grep "\b$KEY\b") ]]; then
+        echo "Using $KEY from keychain"
+        SECRET=$(ks -k $KEYCHAIN show $KEY)
+    else
+        read -sp "Enter a value for $KEY: " SECRET
+        if [[ -z "$SECRET" ]]; then
+            echo ""
+            echo "Error: A value for $KEY is required."
+            exit 1
+        fi
+    fi
+    gh secret set $(echo $KEY | tr '-' '_' | tr '[:lower:]' '[:upper:]') --app actions --body $SECRET
+done
+if [[ "$LOGOUT" == true ]]; then
+    gh auth logout
+fi

--- a/.github/scripts/split-version.sh
+++ b/.github/scripts/split-version.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+USAGE="Usage: $0 [VERSION=0.0.0]"
+
+# Evaluate arguments
+case $# in
+    1)
+        VERSION=$1
+        ;;
+    *)
+        VERSION="0.0.0"
+        ;;
+esac
+
+# Strip the leading "v" if there is one
+if [[ $VERSION == v* ]]; then
+    VERSION=${VERSION#v}
+fi
+
+# Extract pre-release number if present (-rc, -b, -a)
+if [[ $VERSION == *-rc* ]]; then
+    PRE=${VERSION##*-rc}
+    BASE=${VERSION%-rc*}
+elif [[ $VERSION == *-b* ]]; then
+    PRE=${VERSION##*-b}
+    BASE=${VERSION%-b*}
+elif [[ $VERSION == *-a* ]]; then
+    PRE=${VERSION##*-a}
+    BASE=${VERSION%-a*}
+else
+    PRE=""
+    BASE=$VERSION
+fi
+
+# Split the base version into its components
+IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+
+if [[ -n "$PRE" ]]; then
+    echo "$MAJOR $MINOR $PRE"
+else
+    echo "$MAJOR $MINOR ${PATCH:-0}"
+fi


### PR DESCRIPTION
## Summary

Add shell utility scripts under `.github/scripts/` for version management, release cutting, environment bootstrapping, GitHub App authentication, and PyPI publishing. Include the `.github/.gitignore` and `.github/.githubrc` configuration files that support the scripts. These scripts form the foundation layer that CI/CD composite actions and workflows will build on.

Closes #5

## Proposed changes

### Version management scripts

- `split-version.sh` — Parse a semantic version string into its major, minor, patch, and pre-release components.
- `bump-version.sh` — Increment a semantic version by major, minor, or patch, with support for pre-release variants (alpha, beta, RC).

### Release scripts

- `cut-release.sh` — Create a release branch from main and tag a release candidate.
- `release-pr-exists.sh` — Check whether an open release PR already exists.
- `publish-distribution.sh` — Publish a Python distribution to PyPI using `uv publish`.

### Environment and tooling scripts

- `init.sh` — Initialize the CI/CD environment (move git directory, source shell config).
- `install-tools.sh` — Install required development tools (brew, uv, gh, ks).
- `install-python-packages.sh` — Install all namespace packages found in the repository.
- `find-cicd.sh` — Locate the `.github` directory from any working directory.
- `git-cicd.sh` — Wrapper for git commands in CI/CD environments with proper directory/work-tree setup.

### Authentication scripts

- `generate-github-access-token.sh` — Generate a JWT and exchange it for a GitHub App installation access token.
- `set-secrets.sh` — Set GitHub repository secrets from keychain or manual input.

### Configuration files

- `.github/.gitignore` — Ignore patterns for the `.github` directory.
- `.github/.githubrc` — Shell alias configuration for CI/CD commands.

## Test cases

No test cases apply — this change adds shell scripts and configuration files only, with no Python modules or public APIs.

## Implementation plan

1. - [x] Write `.github/.gitignore` and `.github/.githubrc` configuration files
2. - [x] Write version management scripts: `split-version.sh`, `bump-version.sh`
3. - [x] Write environment and tooling scripts: `find-cicd.sh`, `git-cicd.sh`, `init.sh`, `install-tools.sh`, `install-python-packages.sh`
4. - [x] Write authentication scripts: `generate-github-access-token.sh`, `set-secrets.sh`
5. - [x] Write release scripts: `cut-release.sh`, `release-pr-exists.sh`, `publish-distribution.sh`