### PR TITLE
Add CI/CD composite actions — Closes #7

### DIFF
--- a/.github/actions/add-label/action.yaml
+++ b/.github/actions/add-label/action.yaml
@@ -1,0 +1,22 @@
+name: Add label
+description: Add specified label to pull request.
+inputs:
+  label:
+    description: Label to add to the pull request.
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Verify event
+      if: ${{ github.event_name != 'pull_request' }}
+      shell: bash
+      run: |
+        echo "Error: This action can only be used on pull request events."
+        exit 1
+
+    - name: Add label
+      shell: bash
+      run: |
+        gh pr edit "${{ github.event.number }}" --add-label "${{ inputs.label }}"

--- a/.github/actions/build-release/action.yaml
+++ b/.github/actions/build-release/action.yaml
@@ -1,0 +1,34 @@
+name: Build release
+description: Build distribution for the target version.
+inputs:
+  source:
+    required: true
+    type: string
+  version:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-tags: true
+        persist-credentials: false
+        ref: ${{ inputs.version }}
+
+    - name: Install uv & prepare python
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: false
+
+    - name: Build distribution artifacts
+      shell: bash
+      run: uv build ${{ inputs.source }} --sdist --wheel --out-dir ${{ inputs.source }}-dist-${{ inputs.version }}
+
+    - name: Store distribution artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.source }}-dist-${{ inputs.version }}
+        path: ${{ inputs.source }}-dist-${{ inputs.version }}/

--- a/.github/actions/get-touched-files/action.yaml
+++ b/.github/actions/get-touched-files/action.yaml
@@ -1,0 +1,33 @@
+name: Get touched files
+description: Get a list of files that have been modified in a pull request.
+inputs:
+  pathspec:
+    description: 'Optional pathspec(s) to filter files. E.g., "src/**" will only get files in the src directory.'
+    required: false
+    type: string
+outputs:
+  touched:
+    description: 'List of files that have been modified in a pull request.'
+    value: ${{ steps.get-touched-files.outputs.touched }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Get touched files
+      id: get-touched-files
+      shell: bash
+      env:
+        INPUT_PATHSPEC: ${{ inputs.pathspec }}
+      run: |
+        IFS=' ' read -ra pathspec <<< "$INPUT_PATHSPEC"
+        echo "pathspec: '${pathspec[@]}'"
+        touched=$(git diff --name-only HEAD origin/master -- "${pathspec[@]}")
+        touched=$(echo "$touched" | tr '\n' ' ' | xargs)
+        echo "touched: '$touched'"
+        echo "touched=$touched" >> $GITHUB_OUTPUT

--- a/.github/actions/get-wool-labs-app-token/action.yaml
+++ b/.github/actions/get-wool-labs-app-token/action.yaml
@@ -1,0 +1,38 @@
+name: get-wool-labs-app-token
+description: "Obtain a GitHub App installation access token to use in place of a PAT"
+inputs:
+  app-id:
+    description: "The ID of the GitHub App"
+    required: true
+  app-installation-id:
+    description: "The installation ID of the GitHub App"
+    required: true
+  app-private-key:
+    description: "The private key of the GitHub App"
+    required: true
+outputs:
+  access-token:
+    description: "Access token to use in place of a PAT"
+    value: ${{ steps.generate-access-token.outputs.access-token }}
+
+runs:
+  using: "composite"
+  steps:
+  - name: Generate Access Token
+    id: generate-access-token
+    shell: bash
+    env:
+      INPUT_PRIVATE_KEY: ${{ inputs.app-private-key }}
+      INPUT_INSTALLATION_ID: ${{ inputs.app-installation-id }}
+      INPUT_APP_ID: ${{ inputs.app-id }}
+    run: |
+      key_file=$(mktemp)
+      chmod 600 "$key_file"
+      printf '%s' "$INPUT_PRIVATE_KEY" > "$key_file"
+      trap 'rm -f "$key_file"' EXIT
+      access_token="$(APP_INSTALLATION_ID="$INPUT_INSTALLATION_ID" \
+            APP_ID="$INPUT_APP_ID" \
+            SIGNING_KEY_PATH="$key_file" \
+            .github/scripts/generate-github-access-token.sh)"
+      echo "::add-mask::$access_token"
+      echo "access-token=$access_token" >> $GITHUB_OUTPUT

--- a/.github/actions/publish-github-release/action.yaml
+++ b/.github/actions/publish-github-release/action.yaml
@@ -1,0 +1,30 @@
+name: Publish release to GitHub
+description: Publish the target version to GitHub.
+
+inputs:
+  source:
+    required: true
+    type: string
+  version:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Download distribution artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.source }}-dist-${{ inputs.version }}
+        path: ${{ inputs.source }}-dist-${{ inputs.version }}/
+
+    - name: Sign the artifacts with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: ./${{ inputs.source }}-dist-${{ inputs.version }}/*.tar.gz ./${{ inputs.source }}-dist-${{ inputs.version }}/*.whl
+ 
+    - name: Upload artifact signatures to GitHub release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: gh release upload ${{ inputs.version }} ${{ inputs.source }}-dist-${{ inputs.version }}/** --repo ${{ github.repository }}

--- a/.github/actions/publish-pypi-release/action.yaml
+++ b/.github/actions/publish-pypi-release/action.yaml
@@ -1,0 +1,32 @@
+name: Publish release to PyPI
+description: Publish the target version to PyPI.
+
+inputs:
+  source:
+    required: true
+    type: string
+  version:
+    required: true
+    type: string
+  pypi-token:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Download distribution artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.source }}-dist-${{ inputs.version }}
+        path: ${{ inputs.source }}-dist-${{ inputs.version }}/
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Upload distribution to PyPI
+      shell: bash
+      env:
+        PYPI_TOKEN: ${{ inputs.pypi-token }}
+      run: |
+        .github/scripts/publish-distribution.sh --source "${{ inputs.source }}-dist-${{ inputs.version }}"


### PR DESCRIPTION
## Summary

Add six reusable GitHub Actions composite actions under `.github/actions/` that encapsulate common CI/CD operations. These actions depend on the utility scripts from #5 and will be consumed by the CI/CD workflows.

Closes #7

## Proposed changes

### PR labeling (`add-label/`)

Add a composite action that applies a specified label to a pull request using `gh pr edit`.

### Release building (`build-release/`)

Add a composite action that checks out code at a version tag, installs `uv`, and builds sdist and wheel artifacts using `uv build`. Upload the artifacts for downstream consumption.

### Changed file detection (`get-touched-files/`)

Add a composite action that compares HEAD against `origin/master` to produce a list of modified files, with optional glob filtering via a `pathspec` input.

### GitHub App authentication (`get-wool-labs-app-token/`)

Add a composite action that generates a GitHub App installation access token by calling `generate-github-access-token.sh`. Accept app ID, installation ID, and private key as inputs.

### GitHub release publishing (`publish-github-release/`)

Add a composite action that downloads build artifacts, signs them with Sigstore, and uploads them to a GitHub release.

### PyPI release publishing (`publish-pypi-release/`)

Add a composite action that publishes a distribution to PyPI by calling `publish-distribution.sh`.

## Test cases

No test cases apply — this change adds GitHub Actions YAML configuration only, with no executable code.

## Implementation plan

1. - [x] Write `add-label/action.yaml` for PR labeling
2. - [x] Write `build-release/action.yaml` for building sdist and wheel artifacts
3. - [x] Write `get-touched-files/action.yaml` for changed file detection
4. - [x] Write `get-wool-labs-app-token/action.yaml` for GitHub App token generation
5. - [x] Write `publish-github-release/action.yaml` for GitHub release publishing with Sigstore signing
6. - [x] Write `publish-pypi-release/action.yaml` for PyPI publishing