### PR TITLE
Add runtime core utilities — Closes #13

### DIFF
--- a/wool/src/wool/runtime/context.py
+++ b/wool/src/wool/runtime/context.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+from contextvars import Token
+from typing import TYPE_CHECKING
+from typing import Final
+
+from wool.runtime.typing import Undefined
+from wool.runtime.typing import UndefinedType
+
+if TYPE_CHECKING:
+    from wool.runtime.worker.auth import WorkerCredentials
+
+dispatch_timeout: Final[ContextVar[float | None]] = ContextVar(
+    "dispatch_timeout", default=None
+)
+credentials: Final[ContextVar[WorkerCredentials | None]] = ContextVar(
+    "credentials", default=None
+)
+
+
+# public
+class RuntimeContext:
+    """Runtime context for configuring Wool behavior.
+
+    Provides context-managed configuration for dispatch timeout and
+    worker credentials, allowing defaults to be set for all workers
+    within a context.
+
+    :param dispatch_timeout:
+        Default timeout for task dispatch operations.
+    :param credentials:
+        Default WorkerCredentials for secure worker connections.
+    """
+
+    _dispatch_timeout: float | None | UndefinedType
+    _dispatch_timeout_token: Token | UndefinedType
+    _credentials: WorkerCredentials | None | UndefinedType
+    _credentials_token: Token | UndefinedType
+
+    def __init__(
+        self,
+        *,
+        dispatch_timeout: float | None | UndefinedType = Undefined,
+        credentials: WorkerCredentials | None | UndefinedType = Undefined,
+    ):
+        self._dispatch_timeout = dispatch_timeout
+        self._credentials = credentials
+
+    def __enter__(self):
+        if self._dispatch_timeout is not Undefined:
+            self._dispatch_timeout_token = dispatch_timeout.set(self._dispatch_timeout)
+        else:
+            self._dispatch_timeout_token = Undefined
+
+        if self._credentials is not Undefined:
+            self._credentials_token = credentials.set(self._credentials)
+        else:
+            self._credentials_token = Undefined
+
+        return self
+
+    def __exit__(self, *_):
+        if self._dispatch_timeout_token is not Undefined:
+            dispatch_timeout.reset(self._dispatch_timeout_token)
+
+        if self._credentials_token is not Undefined:
+            credentials.reset(self._credentials_token)
+
+    @classmethod
+    def get_current(cls) -> "RuntimeContext":
+        """Get the current runtime context.
+
+        Returns a RuntimeContext instance with the current context values.
+
+        :returns:
+            RuntimeContext with current context variable values.
+        """
+        ctx = cls()
+        ctx._dispatch_timeout = dispatch_timeout.get()
+        ctx._credentials = credentials.get()
+        return ctx
+
+    @property
+    def credentials(self) -> WorkerCredentials | None:
+        """Get the current worker credentials.
+
+        :returns:
+            The WorkerCredentials instance, or None if not set.
+        """
+        return credentials.get() if self._credentials is Undefined else self._credentials

--- a/wool/src/wool/runtime/resourcepool.py
+++ b/wool/src/wool/runtime/resourcepool.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+from typing import Awaitable
+from typing import Callable
+from typing import Generic
+from typing import TypeVar
+from typing import cast
+
+from wool.runtime.typing import Undefined
+from wool.runtime.typing import UndefinedType
+
+T = TypeVar("T")
+
+
+class Resource(Generic[T]):
+    """
+    A single-use async context manager for resource acquisition.
+
+    This class can only be used once as an async context manager. After
+    acquisition, it cannot be reacquired, and after release, it cannot be
+    released again.
+
+    :param pool:
+        The :class:`ResourcePool` this resource belongs to.
+    :param key:
+        The cache key for this resource.
+    """
+
+    def __init__(self, pool: ResourcePool[T], key):
+        self._pool = pool
+        self._key = key
+        self._resource = None
+        self._acquired = False
+        self._released = False
+
+    async def __aenter__(self) -> T:
+        """
+        Context manager entry - acquire resource.
+
+        :returns:
+            The cached resource object.
+        :raises RuntimeError:
+            If called on a resource that was previously acquired.
+        """
+        if self._acquired:
+            raise RuntimeError(
+                "Cannot re-acquire a resource that has already been acquired"
+            )
+
+        self._acquired = True
+        try:
+            self._resource = await self._pool.acquire(self._key)
+            return cast(T, self._resource)
+        except Exception:
+            self._acquired = False
+            raise
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """
+        Context manager exit - release resource.
+
+        :param exc_type:
+            Exception type if an exception occurred, None otherwise.
+        :param exc_val:
+            Exception value if an exception occurred, None otherwise.
+        :param exc_tb:
+            Exception traceback if an exception occurred, None otherwise.
+        """
+        await self._release()
+
+    async def _release(self):
+        """
+        Release the resource.
+
+        :raises RuntimeError:
+            If attempting to release a resource that was not acquired or
+            already released.
+        """
+        if not self._acquired:
+            raise RuntimeError("Cannot release a resource that was not acquired")
+        if self._released:
+            raise RuntimeError(
+                "Cannot release a resource that has already been released"
+            )
+
+        self._released = True
+        if self._resource:
+            await self._pool.release(self._key)
+
+
+class ResourcePool(Generic[T]):
+    """
+    An asynchronous reference-counted cache with TTL-based cleanup.
+
+    Objects are created on-demand via a factory function (sync or async) and
+    automatically cleaned up after all references are released and the TTL
+    expires.
+
+    :param factory:
+        Function to create new objects (sync or async).
+    :param finalizer:
+        Optional cleanup function (sync or async).
+    :param ttl:
+        Time-to-live in seconds after last reference is released.
+    """
+
+    @dataclass
+    class CacheEntry:
+        """
+        Internal cache entry tracking an object and its metadata.
+
+        :param obj:
+            The cached object.
+        :param reference_count:
+            Number of active references to this object.
+        :param cleanup:
+            Optional cleanup task scheduled when reference count reaches zero.
+        """
+
+        obj: Any
+        reference_count: int
+        cleanup: asyncio.Task | None = None
+
+    @dataclass
+    class Stats:
+        """
+        Statistics about the current state of the resource pool.
+
+        :param total_entries:
+            Total number of cached entries.
+        :param referenced_entries:
+            Number of entries currently being referenced (reference_count > 0).
+        :param pending_cleanup:
+            Number of cleanup tasks currently pending execution.
+        """
+
+        total_entries: int
+        referenced_entries: int
+        pending_cleanup: int
+
+    def __init__(
+        self,
+        factory: Callable[[Any], T | Awaitable[T]],
+        *,
+        finalizer: Callable[[T], None | Awaitable[None]] | None = None,
+        ttl: float = 0,
+    ):
+        self._factory = factory
+        self._finalizer = finalizer
+        self._ttl = ttl
+        self._cache: dict[Any, ResourcePool.CacheEntry] = {}
+        self._lock = asyncio.Lock()
+
+    async def __aenter__(self):
+        """Async context manager entry.
+
+        :returns:
+            The ResourcePool instance itself.
+        """
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit - cleanup all resources.
+
+        :param exc_type:
+            Exception type if an exception occurred, None otherwise.
+        :param exc_val:
+            Exception value if an exception occurred, None otherwise.
+        :param exc_tb:
+            Exception traceback if an exception occurred, None otherwise.
+        """
+        await self.clear()
+
+    @property
+    def stats(self) -> Stats:
+        """
+        Return cache statistics.
+
+        .. note::
+            This is synchronous for convenience, but should only be called
+            when not concurrently modifying the cache.
+
+        :returns:
+            :class:`ResourcePool.Stats` containing current statistics.
+        """
+        pending_cleanup = sum(
+            1 for c in self.pending_cleanup.values() if c is not None and not c.done()
+        )
+        return self.Stats(
+            total_entries=len(self._cache),
+            referenced_entries=sum(
+                1 for e in self._cache.values() if e.reference_count > 0
+            ),
+            pending_cleanup=pending_cleanup,
+        )
+
+    @property
+    def pending_cleanup(self):
+        """Dictionary of cache keys with pending cleanup tasks.
+
+        :returns:
+            Dictionary mapping cache keys to their cleanup tasks.
+        """
+        return {
+            k: v.cleanup
+            for k, v in self._cache.items()
+            if v.cleanup is not None and not v.cleanup.done()
+        }
+
+    def get(self, key: Any) -> Resource[T]:
+        """
+        Get a resource acquisition that can be awaited or used as context
+        manager.
+
+        :param key:
+            The cache key.
+        :returns:
+            :class:`Resource` that can be awaited or used with 'async with'.
+        """
+        return Resource(self, key)
+
+    async def acquire(self, key: Any) -> T:
+        """
+        Internal acquire method - acquires a reference to the cached object.
+
+        Creates a new object via the factory if not cached. Increments
+        reference count and cancels any pending cleanup.
+
+        :param key:
+            The cache key.
+        :returns:
+            The cached or newly created object.
+        """
+        async with self._lock:
+            if key in self._cache:
+                entry = self._cache[key]
+                entry.reference_count += 1
+
+                # Cancel pending cleanup task if it exists
+                if entry.cleanup is not None and not entry.cleanup.done():
+                    current_loop = asyncio.get_running_loop()
+                    task_loop = entry.cleanup.get_loop()
+
+                    if task_loop is current_loop:
+                        # Same event loop - safe to cancel and await
+                        entry.cleanup.cancel()
+                        try:
+                            await entry.cleanup
+                        except asyncio.CancelledError:
+                            pass
+                    else:
+                        # Different event loop - cancel from correct loop, don't await
+                        try:
+                            task_loop.call_soon_threadsafe(entry.cleanup.cancel)
+                        except RuntimeError:
+                            pass
+                    entry.cleanup = None
+
+                return entry.obj
+            else:
+                # Cache miss - create new object
+                obj = await self._await(self._factory, key)
+                self._cache[key] = self.CacheEntry(obj=obj, reference_count=1)
+                return obj
+
+    async def release(self, key: Any) -> None:
+        """
+        Release a reference to the cached object.
+
+        Decrements reference count. If count reaches 0, schedules cleanup
+        after TTL expires (if TTL > 0).
+
+        :param key:
+            The cache key.
+        :raises KeyError:
+            If key not in cache.
+        """
+        async with self._lock:
+            if key not in self._cache:
+                return
+            entry = self._cache[key]
+
+            if entry.reference_count <= 0:
+                raise ValueError(f"Reference count for key '{key}' is already 0")
+
+            entry.reference_count -= 1
+
+            if entry.reference_count <= 0:
+                if self._ttl > 0:
+                    # Schedule cleanup after TTL
+                    entry.cleanup = asyncio.create_task(self._schedule_cleanup(key))
+                else:
+                    # Immediate cleanup
+                    await self._cleanup(key)
+
+    async def clear(self, key: Any | UndefinedType = Undefined) -> None:
+        """Clear cache entries and cancel pending cleanups.
+
+        :param key:
+            Specific key to clear (clears all entries if not specified).
+        """
+        async with self._lock:
+            # Clean up all entries
+            if key is Undefined:
+                keys = list(self._cache.keys())
+            else:
+                keys = [key]
+            for key in keys:
+                await self._cleanup(key)
+
+    async def _schedule_cleanup(self, key: Any) -> None:
+        """
+        Schedule cleanup after TTL delay.
+
+        Only cleans up if the reference count is still 0 when TTL expires.
+
+        :param key:
+            The cache key to schedule cleanup for.
+        """
+        try:
+            await asyncio.sleep(self._ttl)
+
+            async with self._lock:
+                # Double-check conditions - reference might have been re-acquired
+                if key in self._cache:
+                    entry = self._cache[key]
+                    if entry.reference_count == 0:
+                        await self._cleanup(key)
+
+        except asyncio.CancelledError:
+            # Cleanup was cancelled due to new reference - this is expected
+            pass
+
+    async def _cleanup(self, key: Any) -> None:
+        """
+        Remove entry from cache and call finalizer.
+
+        .. warning::
+            Must be called while holding the lock.
+
+        :param key:
+            The cache key to cleanup.
+        """
+        entry = self._cache[key]
+        try:
+            # Cancel cleanup task if running
+            if entry.cleanup is not None and not entry.cleanup.done():
+                current_loop = asyncio.get_running_loop()
+                task_loop = entry.cleanup.get_loop()
+
+                if task_loop is current_loop:
+                    # Same event loop - safe to cancel and await
+                    entry.cleanup.cancel()
+                    try:
+                        await entry.cleanup
+                    except asyncio.CancelledError:
+                        pass
+                else:
+                    # Different event loop (e.g., task created in worker thread)
+                    # Cancel from the correct loop, don't await cross-loop
+                    try:
+                        task_loop.call_soon_threadsafe(entry.cleanup.cancel)
+                    except RuntimeError:
+                        pass
+        finally:
+            # Call finalizer
+            if self._finalizer:
+                try:
+                    await self._await(self._finalizer, entry.obj)
+                except Exception:
+                    pass
+            del self._cache[key]
+
+    async def _await(self, func: Callable, *args) -> Any:
+        """
+        Call a function that might be sync or async.
+
+        If the function is a coroutine function, await it. Otherwise, call it
+        synchronously. If the result is a coroutine, await that as well.
+
+        :param func:
+            The function to call.
+        :param args:
+            Arguments to pass to the function.
+        :returns:
+            The result of the function call.
+        """
+        if asyncio.iscoroutinefunction(func):
+            return await func(*args)
+        else:
+            result = func(*args)
+            # Check if the result is a coroutine and await it if so
+            if asyncio.iscoroutine(result):
+                return await result
+            return result

--- a/wool/src/wool/runtime/typing.py
+++ b/wool/src/wool/runtime/typing.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import AsyncContextManager
+from typing import Awaitable
+from typing import Callable
+from typing import ContextManager
+from typing import Final
+from typing import TypeAlias
+from typing import TypeVar
+from typing import final
+
+F = TypeVar("F", bound=Callable)
+W = TypeVar("W", bound=Callable)
+Wrapper = Callable[[F], W]
+PassthroughWrapper = Callable[[F], F]
+
+
+@final
+class UndefinedType(Enum):
+    Undefined = "Undefined"
+
+
+Undefined: Final = UndefinedType.Undefined
+
+
+T_CO: Final = TypeVar("T_CO", covariant=True)
+
+# public
+Factory: TypeAlias = (
+    Awaitable[T_CO]
+    | AsyncContextManager[T_CO]
+    | ContextManager[T_CO]
+    | Callable[
+        [], T_CO | Awaitable[T_CO] | AsyncContextManager[T_CO] | ContextManager[T_CO]
+    ]
+)


### PR DESCRIPTION
## Summary

Add runtime utility modules providing type aliases, an `Undefined` sentinel value, runtime context management for dispatch configuration (timeout, credentials), and an async reference-counted resource pool with TTL-based cleanup. These utilities are cross-cutting concerns used by discovery, worker connections, and the task execution layer. Extracting them into standalone modules avoids circular dependencies and keeps higher-level modules focused on their domain logic.

Closes #13

## Proposed changes

### Typing utilities module

Add a typing module with generic `TypeVar`-based wrapper aliases (`F`, `W`, `Wrapper`, `PassthroughWrapper`), a singleton `Undefined` sentinel backed by a `@final` enum (`UndefinedType`), and a covariant `Factory` type alias unifying `Awaitable`, `AsyncContextManager`, `ContextManager`, and callable variants for flexible resource creation.

### Context management module

Add a `RuntimeContext` class that wraps `contextvars.ContextVar` instances for `dispatch_timeout` and `credentials`. Implement `__enter__`/`__exit__` to set and reset context variables using token-based restoration. Skip setting variables left as `Undefined` so nested contexts can selectively override only specific fields. Expose a `get_current()` classmethod returning a snapshot of the active context and a `credentials` property for reading the current value.

### Resource pool module

Add a `ResourcePool` generic class implementing an async reference-counted cache with TTL-based cleanup. On `acquire`, create objects on-demand via a sync-or-async factory and increment the reference count, cancelling any pending cleanup task. On `release`, decrement the reference count and either clean up immediately (TTL=0) or schedule deferred cleanup via `asyncio.create_task`. Provide `clear()` for bulk or per-key teardown, a `stats` property returning `total_entries`, `referenced_entries`, and `pending_cleanup` counts, and an `async with` interface that calls `clear()` on exit. Add a companion `Resource` single-use async context manager that enforces acquire-once, release-once semantics and delegates lifecycle to the pool.

## Test plan

N/A – Tests are deferred to a later issue.

## Implementation plan

1. - [x] Write the typing utilities module with wrapper type aliases, `Undefined` sentinel, and `Factory` type alias
2. - [x] Write the context management module with `RuntimeContext`, `dispatch_timeout` and `credentials` context variables
3. - [x] Write the resource pool module with `ResourcePool`, `Resource`, reference counting, and TTL-based cleanup