### PR TITLE
Add discovery system — Closes #14

### DIFF
--- a/wool/src/wool/runtime/discovery/base.py
+++ b/wool/src/wool/runtime/discovery/base.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import uuid
+from abc import ABC
+from abc import abstractmethod
+from dataclasses import dataclass
+from dataclasses import field
+from types import MappingProxyType
+from typing import AsyncIterator
+from typing import Callable
+from typing import Final
+from typing import Literal
+from typing import Protocol
+from typing import TypeAlias
+from typing import TypeVar
+from typing import runtime_checkable
+
+from wool.protocol import WorkerMetadata as WorkerMetadataProtobuf
+T: Final = TypeVar("T")
+
+# public
+PredicateFunction: TypeAlias = Callable[[T], bool]
+
+
+# public
+@dataclass(frozen=True)
+class WorkerMetadata:
+    """Properties and metadata for a worker instance.
+
+    Contains identifying information and capabilities of a worker that
+    can be used for discovery, filtering, and routing decisions.
+
+    :param uid:
+        Unique identifier for the worker instance (UUID).
+    :param address:
+        gRPC target address (e.g. ``"host:port"``,
+        ``"unix:path"``).
+    :param pid:
+        Process ID of the worker.
+    :param version:
+        Version string of the worker software.
+    :param tags:
+        Frozenset of capability tags for worker filtering and
+        selection.
+    :param extra:
+        Additional arbitrary metadata as immutable key-value pairs.
+    :param secure:
+        Whether the worker requires secure TLS/mTLS connections.
+    """
+
+    uid: uuid.UUID
+    address: str = field(hash=False)
+    pid: int = field(hash=False)
+    version: str = field(hash=False)
+    tags: frozenset[str] = field(default_factory=frozenset, hash=False)
+    extra: MappingProxyType = field(
+        default_factory=lambda: MappingProxyType({}), hash=False
+    )
+    secure: bool = field(default=False, hash=False)
+
+    @classmethod
+    def from_protobuf(cls, protobuf: WorkerMetadataProtobuf) -> WorkerMetadata:
+        """Create a WorkerMetadata instance from a protobuf message.
+
+        :param protobuf:
+            The protobuf WorkerMetadata message to deserialize.
+        :returns:
+            A new WorkerMetadata instance with data from the protobuf message.
+        :raises ValueError:
+            If the UID in the protobuf message is not a valid UUID.
+        """
+
+        return cls(
+            uid=uuid.UUID(protobuf.uid),
+            address=protobuf.address,
+            pid=protobuf.pid,
+            version=protobuf.version,
+            tags=frozenset(protobuf.tags),
+            extra=MappingProxyType(dict(protobuf.extra)),
+            secure=protobuf.secure,
+        )
+
+    def to_protobuf(self) -> WorkerMetadataProtobuf:
+        """Convert this WorkerMetadata instance to a protobuf message.
+
+        :returns:
+            A protobuf WorkerMetadata message containing this instance's data.
+        """
+
+        return WorkerMetadataProtobuf(
+            uid=str(self.uid),
+            address=self.address,
+            pid=self.pid,
+            version=self.version,
+            tags=list(self.tags),
+            extra=dict(self.extra),
+            secure=self.secure,
+        )
+
+
+# public
+DiscoveryEventType: TypeAlias = Literal[
+    "worker-added", "worker-dropped", "worker-updated"
+]
+
+
+# public
+class DiscoveryEvent:
+    """Event representing a change in worker availability.
+
+    Used by discovery services when workers are added, updated, or
+    dropped from the pool. Contains both the event type and the
+    affected worker's metadata.
+
+    :param type:
+        The type of discovery event.
+    :param metadata:
+        Information about the worker that triggered the event.
+    """
+
+    type: DiscoveryEventType
+    metadata: WorkerMetadata
+
+    def __init__(self, type: DiscoveryEventType, /, metadata: WorkerMetadata) -> None:
+        self.type = type
+        self.metadata = metadata
+
+
+# public
+@runtime_checkable
+class DiscoveryPublisherLike(Protocol):
+    """Protocol for publishing worker discovery events.
+
+    Implementations must provide a publish method that broadcasts
+    worker lifecycle events (added, updated, dropped) to subscribers.
+    """
+
+    async def publish(self, type: DiscoveryEventType, metadata: WorkerMetadata) -> None:
+        """Publish a worker discovery event.
+
+        :param type:
+            The type of discovery event.
+        :param metadata:
+            Information about the worker.
+        """
+        ...
+
+
+# public
+@runtime_checkable
+class DiscoverySubscriberLike(Protocol):
+    """Protocol for receiving worker discovery events.
+
+    Implementations must provide an async iterator that yields
+    discovery events as workers join, leave, or update their status.
+    """
+
+    def __aiter__(self) -> AsyncIterator[DiscoveryEvent]:
+        """Return an async iterator of discovery events.
+
+        :returns:
+            An async iterator yielding discovery events.
+        """
+        ...
+
+
+# public
+@runtime_checkable
+class DiscoveryLike(Protocol):
+    """Structural type for custom discovery backends.
+
+    See :py:class:`Discovery` for a convenience abstract base class.
+    """
+
+    @property
+    def publisher(self) -> DiscoveryPublisherLike:
+        """Get the publisher component.
+
+        :returns:
+            A publisher instance for broadcasting events.
+        """
+        ...
+
+    @property
+    def subscriber(self) -> DiscoverySubscriberLike:
+        """Get the default subscriber component.
+
+        :returns:
+            A subscriber instance for receiving events.
+        """
+        ...
+
+    def subscribe(
+        self, filter: PredicateFunction | None = None
+    ) -> DiscoverySubscriberLike:
+        """Create a filtered subscriber.
+
+        :param filter:
+            Optional predicate to filter discovered workers.
+        :returns:
+            A subscriber instance for receiving filtered events.
+        """
+        ...
+
+
+# public
+class Discovery(ABC):
+    """Convenience base class for discovery implementations.
+
+    Conforming to :py:class:`DiscoveryLike` via structural subtyping
+    is sufficient; inheriting from this class is optional.
+    """
+
+    @property
+    @abstractmethod
+    def publisher(self) -> DiscoveryPublisherLike: ...
+
+    @property
+    @abstractmethod
+    def subscriber(self) -> DiscoverySubscriberLike: ...
+
+    @abstractmethod
+    def subscribe(
+        self, filter: PredicateFunction | None = None
+    ) -> DiscoverySubscriberLike: ...

--- a/wool/src/wool/runtime/discovery/lan.py
+++ b/wool/src/wool/runtime/discovery/lan.py
@@ -1,0 +1,541 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from asyncio import Queue
+from types import MappingProxyType
+from typing import AsyncIterator
+from typing import Dict
+from typing import Final
+from typing import Literal
+from typing import Tuple
+from uuid import UUID
+
+from zeroconf import IPVersion
+from zeroconf import ServiceInfo
+from zeroconf import ServiceListener
+from zeroconf import Zeroconf
+from zeroconf.asyncio import AsyncServiceBrowser
+from zeroconf.asyncio import AsyncZeroconf
+
+from wool.runtime.discovery.base import Discovery
+from wool.runtime.discovery.base import DiscoveryEvent
+from wool.runtime.discovery.base import DiscoveryEventType
+from wool.runtime.discovery.base import DiscoveryPublisherLike
+from wool.runtime.discovery.base import DiscoverySubscriberLike
+from wool.runtime.discovery.base import PredicateFunction
+from wool.runtime.discovery.base import WorkerMetadata
+
+
+# public
+class LanDiscovery(Discovery):
+    """Zeroconf DNS-SD discovery for network-wide worker pools.
+
+    Workers are advertised as DNS-SD service records
+    (``_wool._tcp.local.``) on the local network. Subscribers
+    browse for these services and receive events as workers come
+    and go. No central coordinator required.
+
+    :param filter:
+        Optional default predicate function to filter workers.
+        Used by :py:attr:`subscriber` and as the default for
+        :py:meth:`subscribe` when no explicit filter is provided.
+
+    Example — publish workers:
+
+    .. code-block:: python
+
+        publisher = LanDiscovery.Publisher()
+        async with publisher:
+            await publisher.publish("worker-added", metadata)
+
+    Example — subscribe to workers:
+
+    .. code-block:: python
+
+        discovery = LanDiscovery()
+        async for event in discovery.subscriber:
+            print(f"Discovered worker: {event.metadata}")
+    """
+
+    _filter: Final[PredicateFunction | None]
+    service_type: Literal["_wool._tcp.local."] = "_wool._tcp.local."
+
+    def __init__(
+        self,
+        *,
+        filter: PredicateFunction | None = None,
+    ):
+        self._filter = filter
+
+    @property
+    def publisher(self) -> DiscoveryPublisherLike:
+        """A new publisher instance for this discovery service.
+
+        :returns:
+            A publisher instance for broadcasting worker events.
+        """
+        return self.Publisher()
+
+    @property
+    def subscriber(self) -> DiscoverySubscriberLike:
+        """A subscriber using the constructor's default filter.
+
+        :returns:
+            A subscriber instance for receiving worker discovery
+            events.
+        """
+        return self.subscribe()
+
+    def subscribe(
+        self, filter: PredicateFunction | None = None
+    ) -> DiscoverySubscriberLike:
+        """Create a new subscriber with optional filtering.
+
+        :param filter:
+            Optional predicate function to filter workers. Only workers
+            for which the predicate returns True will be included in
+            events. Falls back to the constructor's filter if not
+            provided.
+        :returns:
+            A subscriber instance that receives filtered worker
+            discovery events.
+        """
+        return self.Subscriber(filter if filter is not None else self._filter)
+
+    class Publisher:
+        """Publisher for broadcasting worker discovery events.
+
+        Publishes worker :class:`discovery events <~wool.DiscoveryEvent>`
+        by registering and managing DNS-SD service records on the local
+        network. Multiple publishers can safely operate on the same
+        network, each advertising their own set of workers.
+
+        Uses AsyncZeroconf for non-blocking service registration and
+        management. Services are advertised on localhost (127.0.0.1) to
+        avoid network warnings during development.
+        """
+
+        aiozc: AsyncZeroconf | None
+        services: Dict[str, ServiceInfo]
+        service_type: Literal["_wool._tcp.local."] = "_wool._tcp.local."
+
+        def __init__(self):
+            self.aiozc = None
+            self.services = {}
+
+        async def __aenter__(self):
+            """Initialize and start the Zeroconf instance.
+
+            Configures AsyncZeroconf to use localhost only to avoid
+            network warnings during development.
+
+            :returns:
+                Self, for context manager usage.
+            """
+            # Configure zeroconf to use localhost only
+            self.aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
+            return self
+
+        async def __aexit__(self, *_args):
+            """Stop Zeroconf and clean up registered services.
+
+            Closes the AsyncZeroconf instance and releases all registered
+            service records.
+            """
+            if self.aiozc:
+                await self.aiozc.async_close()
+                self.aiozc = None
+
+        async def publish(self, type: DiscoveryEventType, metadata: WorkerMetadata):
+            """Publish a worker discovery event.
+
+            Manages Zeroconf service records based on the event type:
+
+            - worker-added: Registers a new service record
+            - worker-dropped: Unregisters an existing service record
+            - worker-updated: Updates an existing service record
+
+            :param type:
+                The type of discovery event.
+            :param metadata:
+                Worker metadata to publish.
+            :raises RuntimeError:
+                If the publisher is not properly initialized or if an
+                unexpected event type is provided.
+            """
+            if self.aiozc is None:
+                raise RuntimeError("Publisher not properly initialized")
+
+            match type:
+                case "worker-added":
+                    await self._add(metadata)
+                case "worker-dropped":
+                    await self._drop(metadata)
+                case "worker-updated":
+                    await self._update(metadata)
+                case _:
+                    raise RuntimeError(f"Unexpected discovery event type: {type}")
+
+        async def _add(self, metadata: WorkerMetadata) -> None:
+            """Register a worker by publishing its service info.
+
+            :param metadata:
+                The worker details to publish.
+            :raises RuntimeError:
+                If the publisher is not properly initialized.
+            """
+            assert self.aiozc
+
+            ip_address, port = self._resolve_address(metadata.address)
+            service_name = f"{metadata.uid}.{self.service_type}"
+            service_info = ServiceInfo(
+                self.service_type,
+                service_name,
+                addresses=[ip_address],
+                port=port,
+                properties=_serialize_metadata(metadata),
+            )
+            self.services[str(metadata.uid)] = service_info
+            await self.aiozc.async_register_service(service_info)
+
+        async def _drop(self, metadata: WorkerMetadata) -> None:
+            """Unregister a worker by removing its service record.
+
+            :param metadata:
+                The worker to unregister.
+            :raises RuntimeError:
+                If the publisher is not properly initialized.
+            """
+            assert self.aiozc
+
+            uid_str = str(metadata.uid)
+            if uid_str in self.services:
+                service = self.services[uid_str]
+                await self.aiozc.async_unregister_service(service)
+                del self.services[uid_str]
+
+        async def _update(self, metadata: WorkerMetadata) -> None:
+            """Update a worker's properties if they have changed.
+
+            Updates both the Zeroconf service and local cache
+            atomically. If the Zeroconf update fails, the local cache
+            remains unchanged to maintain consistency.
+
+            :param metadata:
+                The updated worker metadata.
+            :raises RuntimeError:
+                If the publisher is not properly initialized.
+            :raises Exception:
+                If the Zeroconf service update fails.
+            """
+            assert self.aiozc
+
+            uid_str = str(metadata.uid)
+            if uid_str not in self.services:
+                # Worker not found, treat as registration
+                await self._add(metadata)
+                return
+
+            service = self.services[uid_str]
+            new_properties = _serialize_metadata(metadata)
+
+            if service.decoded_properties != new_properties:
+                updated_service = ServiceInfo(
+                    service.type,
+                    service.name,
+                    addresses=service.addresses,
+                    port=service.port,
+                    properties=new_properties,
+                    server=service.server,
+                )
+                await self.aiozc.async_update_service(updated_service)
+                self.services[uid_str] = updated_service
+
+        def _resolve_address(self, address: str) -> Tuple[bytes, int]:
+            """Resolve an address string to bytes and validate port.
+
+            :param address:
+                Address in format "host:port".
+            :returns:
+                Tuple of (IPv4/IPv6 address as bytes, port as int).
+            :raises ValueError:
+                If address format is invalid or port is out of range.
+            :raises OSError:
+                If hostname cannot be resolved.
+            """
+            host, port_str = address.split(":")
+            port = int(port_str)
+
+            try:
+                return socket.inet_pton(socket.AF_INET, host), port
+            except OSError:
+                pass
+
+            try:
+                return socket.inet_pton(socket.AF_INET6, host), port
+            except OSError:
+                pass
+
+            return socket.inet_aton(socket.gethostbyname(host)), port
+
+    class Subscriber:
+        """Subscriber for receiving worker discovery events.
+
+        Subscribes to worker :class:`discovery events
+        <~wool.DiscoveryEvent>` by browsing for DNS-SD services on the
+        local network. As workers register and unregister their
+        services, the subscriber yields corresponding events.
+
+        Each call to ``__aiter__`` creates an isolated iterator with its
+        own state. Multiple concurrent iterations from the same
+        subscriber instance are fully independent.
+
+        Uses AsyncZeroconf's service browser to monitor for service
+        changes and converts Zeroconf events into Wool discovery
+        events.
+
+        :param filter:
+            Optional predicate function to filter workers. Only workers
+            for which the predicate returns True will be included in
+            events.
+        """
+
+        _filter: Final[PredicateFunction[WorkerMetadata] | None]
+        service_type: Literal["_wool._tcp.local."] = "_wool._tcp.local."
+
+        def __init__(
+            self,
+            filter: PredicateFunction[WorkerMetadata] | None = None,
+        ) -> None:
+            self._filter = filter
+
+        def __aiter__(self) -> AsyncIterator[DiscoveryEvent]:
+            return self._event_stream()
+
+        async def _event_stream(self) -> AsyncIterator[DiscoveryEvent]:
+            """Stream discovery events from the network.
+
+            Creates isolated state for this iteration including its own
+            Zeroconf instance, service browser, event queue, and service
+            cache. Automatically cleans up all resources when iteration
+            completes or is interrupted.
+
+            :yields:
+                Discovery events as workers are added, updated, or removed.
+            """
+            # Create isolated state for this iterator
+            event_queue: Queue[DiscoveryEvent] = Queue()
+            service_cache: Dict[str, WorkerMetadata] = {}
+
+            # Configure zeroconf to use localhost only to avoid network warnings
+            aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
+
+            try:
+                browser = AsyncServiceBrowser(
+                    aiozc.zeroconf,
+                    self.service_type,
+                    listener=self._Listener(
+                        aiozc=aiozc,
+                        event_queue=event_queue,
+                        service_cache=service_cache,
+                        predicate=self._filter or (lambda _: True),
+                    ),
+                )
+
+                try:
+                    while True:
+                        event = await event_queue.get()
+                        yield event
+                finally:
+                    await browser.async_cancel()
+            finally:
+                await aiozc.async_close()
+
+        class _Listener(ServiceListener):
+            """Zeroconf listener that delivers worker service events.
+
+            :param aiozc:
+                The AsyncZeroconf instance to use for async service
+                info retrieval.
+            :param event_queue:
+                Queue to deliver discovery events to.
+            :param service_cache:
+                Cache to track service properties for pre/post event
+                states.
+            :param predicate:
+                Function to filter which workers to track.
+            """
+
+            aiozc: AsyncZeroconf
+            _event_queue: Queue[DiscoveryEvent]
+            _service_addresses: Dict[str, str]
+            _service_cache: Dict[str, WorkerMetadata]
+
+            def __init__(
+                self,
+                aiozc: AsyncZeroconf,
+                event_queue: Queue[DiscoveryEvent],
+                predicate: PredicateFunction[WorkerMetadata],
+                service_cache: Dict[str, WorkerMetadata],
+            ) -> None:
+                self.aiozc = aiozc
+                self._event_queue = event_queue
+                self._predicate = predicate
+                self._service_addresses = {}
+                self._service_cache = service_cache
+
+            def add_service(self, zc: Zeroconf, type_: str, name: str):  # noqa: ARG002
+                """Called by Zeroconf when a service is added."""
+                if type_ == LanDiscovery.service_type:
+                    asyncio.create_task(self._handle_add_service(type_, name))
+
+            def remove_service(self, zc: Zeroconf, type_: str, name: str):  # noqa: ARG002
+                """Called by Zeroconf when a service is removed."""
+                if type_ == LanDiscovery.service_type:
+                    if worker := self._service_cache.pop(name, None):
+                        asyncio.create_task(
+                            self._event_queue.put(
+                                DiscoveryEvent("worker-dropped", metadata=worker)
+                            )
+                        )
+
+            def update_service(self, zc: Zeroconf, type_, name):  # noqa: ARG002
+                """Called by Zeroconf when a service is updated."""
+                if type_ == LanDiscovery.service_type:
+                    asyncio.create_task(self._handle_update_service(type_, name))
+
+            async def _handle_add_service(self, type_: str, name: str):
+                """Async handler for service addition."""
+                try:
+                    if not (
+                        service_info := await self.aiozc.async_get_service_info(
+                            type_, name
+                        )
+                    ):
+                        return
+
+                    try:
+                        metadata = _deserialize_metadata(service_info)
+                    except ValueError:
+                        return
+
+                    if self._predicate(metadata):
+                        self._service_cache[name] = metadata
+                        event = DiscoveryEvent("worker-added", metadata=metadata)
+                        await self._event_queue.put(event)
+                except Exception:  # pragma: no cover
+                    pass
+
+            async def _handle_update_service(self, type_: str, name: str):
+                """Async handler for service update."""
+                try:
+                    if not (
+                        service_info := await self.aiozc.async_get_service_info(
+                            type_, name
+                        )
+                    ):
+                        return
+
+                    try:
+                        metadata = _deserialize_metadata(service_info)
+                    except ValueError:
+                        return
+
+                    if name not in self._service_cache:
+                        # New worker that wasn't tracked before
+                        if self._predicate(metadata):
+                            self._service_cache[name] = metadata
+                            event = DiscoveryEvent("worker-added", metadata=metadata)
+                            await self._event_queue.put(event)
+                    else:
+                        # Existing tracked worker
+                        old_worker = self._service_cache[name]
+                        if self._predicate(metadata):
+                            # Still satisfies filter, update cache and emit update
+                            self._service_cache[name] = metadata
+                            event = DiscoveryEvent("worker-updated", metadata=metadata)
+                            await self._event_queue.put(event)
+                        else:
+                            # No longer satisfies filter, remove and emit removal
+                            del self._service_cache[name]
+                            removal_event = DiscoveryEvent(
+                                "worker-dropped", metadata=old_worker
+                            )
+                            await self._event_queue.put(removal_event)
+
+                except Exception:  # pragma: no cover
+                    pass
+
+
+def _serialize_metadata(
+    info: WorkerMetadata,
+) -> dict[str, str | None]:
+    """Serialize WorkerMetadata to a flat dict for service properties.
+
+    :param info:
+        WorkerMetadata instance to serialize.
+    :returns:
+        Flat dict with pid, version, tags (JSON), extra (JSON), secure.
+    """
+    properties = {
+        "pid": str(info.pid),
+        "version": info.version,
+        "tags": (json.dumps(list(info.tags)) if info.tags else None),
+        "extra": (json.dumps(dict(info.extra)) if info.extra else None),
+        "secure": "true" if info.secure else "false",
+    }
+    return properties
+
+
+def _deserialize_metadata(info: ServiceInfo) -> WorkerMetadata:
+    """Deserialize ServiceInfo.decoded_properties to WorkerMetadata.
+
+    :param info:
+        ServiceInfo with decoded properties dict (str keys/values).
+    :returns:
+        WorkerMetadata instance.
+    :raises ValueError:
+        If required fields are missing or invalid JSON.
+    """
+    properties = info.decoded_properties
+    if missing := {"pid", "version"} - set(k for k, v in properties.items() if v):
+        missing_fields = ", ".join(missing)
+        raise ValueError(f"Missing required properties: {missing_fields}")
+
+    assert "pid" in properties and properties["pid"]
+    assert "version" in properties and properties["version"]
+
+    pid = int(properties["pid"])
+    version = properties["version"]
+
+    if "tags" in properties and properties["tags"]:
+        tags = frozenset(json.loads(properties["tags"]))
+    else:
+        tags = frozenset()
+
+    if "extra" in properties and properties["extra"]:
+        extra = json.loads(properties["extra"])
+    else:
+        extra = {}
+
+    # Parse security flag (backward compatible - defaults to False)
+    secure = False
+    if "secure" in properties and properties["secure"]:
+        secure = properties["secure"].lower() == "true"
+
+    # Extract UID from service name (format: "<uuid>._wool._tcp.local.")
+    service_name = info.name
+    uid_str = service_name.split(".")[0]
+
+    ip = info.ip_addresses_by_version(IPVersion.V4Only)[0]
+    return WorkerMetadata(
+        uid=UUID(uid_str),
+        address=f"{ip}:{info.port}",
+        pid=pid,
+        version=version,
+        tags=tags,
+        extra=MappingProxyType(extra),
+        secure=secure,
+    )

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -1,0 +1,804 @@
+from __future__ import annotations
+
+import asyncio
+import atexit
+import hashlib
+import struct
+import tempfile
+from contextlib import asynccontextmanager
+from contextlib import contextmanager
+from multiprocessing.shared_memory import SharedMemory
+from pathlib import Path
+from typing import AsyncIterator
+from typing import Callable
+from typing import Final
+from typing import Self
+from uuid import UUID
+from uuid import uuid4
+
+import portalocker
+from watchdog.events import FileSystemEvent
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from wool.protocol import WorkerMetadata as WorkerMetadataProtobuf
+from wool.runtime.discovery.base import Discovery
+from wool.runtime.discovery.base import DiscoveryEvent
+from wool.runtime.discovery.base import DiscoveryEventType
+from wool.runtime.discovery.base import DiscoveryPublisherLike
+from wool.runtime.discovery.base import DiscoverySubscriberLike
+from wool.runtime.discovery.base import PredicateFunction
+from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.resourcepool import ResourcePool
+
+REF_WIDTH: Final = 16
+NULL_REF: Final = b"\x00" * REF_WIDTH
+
+
+class _Watchdog(FileSystemEventHandler):
+    """Filesystem event handler for worker discovery notifications.
+
+    Monitors the notification file for modifications and sets an asyncio
+    Event to wake subscribers when publishers modify the shared memory.
+    Thread-safe for use with watchdog's observer thread.
+
+    Acquires the scan lock before setting the notification event to ensure
+    that notifications are properly synchronized with ongoing scans. This
+    prevents race conditions where a notification arrives while a scan is
+    in progress.
+
+    :param notification:
+        asyncio.Event to set when the notification file is modified.
+    :param watchdog:
+        Path to the notification file to monitor.
+    :param lock:
+        asyncio.Lock to acquire before setting the notification event.
+    :param loop:
+        Event loop where the notification lives.
+    """
+
+    def __init__(
+        self,
+        notification: asyncio.Event,
+        watchdog: Path,
+        lock: asyncio.Lock,
+        loop: asyncio.AbstractEventLoop,
+    ):
+        self._notification = notification
+        self._watchdog = watchdog
+        self._lock = lock
+        self._loop = loop
+
+    def on_modified(self, event: FileSystemEvent):
+        """Handle file modification events.
+
+        :param event:
+            The filesystem event containing the modified file path.
+        """
+        event_path = Path(str(event.src_path))
+        if event_path == self._watchdog:
+            # Schedule the event.set() in the event loop with lock acquired
+            # (thread-safe)
+            self._loop.call_soon_threadsafe(self._set_event_with_lock)
+
+    def _set_event_with_lock(self):
+        """Set the notification event after acquiring the scan lock.
+
+        This ensures that the event is only set when the lock is available,
+        preventing the notification from being lost if a scan is in progress.
+        Must be called from the event loop thread.
+        """
+        asyncio.create_task(self._async_set_event())
+
+    async def _async_set_event(self):
+        """Async helper to acquire lock and set event."""
+        async with self._lock:
+            self._notification.set()
+
+
+class _WorkerReference:
+    """Reference to a worker using its UUID.
+
+    Provides both byte and unicode string representations of a worker's UUID.
+
+    :param uid:
+        The worker's UID to reference.
+    """
+
+    __slots__ = ("_uuid",)
+
+    def __init__(self, uid: UUID):
+        self._uuid = uid
+
+    def __str__(self) -> str:
+        """String representation (32-char hex) for :class:`SharedMemory` names.
+
+        :returns:
+            The UUID as a hex string without dashes.
+        """
+        return _short_hash(self._uuid.hex)
+
+    def __hash__(self) -> int:
+        return hash(self._uuid)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _WorkerReference):
+            return self._uuid == other._uuid
+        return NotImplemented  # pragma: no cover
+
+    def __repr__(self) -> str:
+        return f"_WorkerReference({self._uuid})"  # pragma: no cover
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> _WorkerReference:
+        """Create a reference from its bytes representation.
+
+        :param data:
+            The 16-byte UUID representation.
+        :returns:
+            A new reference instance.
+        :raises ValueError:
+            If data is not 16 bytes or is NULL.
+        """
+        ref = object.__new__(cls)
+        ref._uuid = UUID(bytes=data)
+        return ref
+
+    @property
+    def bytes(self) -> bytes:
+        """The 16-byte representation for address space storage.
+
+        :returns:
+            The UUID as 16 bytes.
+        """
+        return self._uuid.bytes
+
+
+# public
+class LocalDiscovery(Discovery):
+    """Shared-memory discovery for single-machine worker pools.
+
+    The default when a
+    :py:class:`~wool.runtime.worker.pool.WorkerPool` is created
+    without an explicit discovery protocol. Workers and subscribers
+    communicate through a shared memory region identified by a
+    namespace string. File-based locking ensures consistency across
+    processes.
+
+    .. note::
+        Multiple unrelated processes can share the same namespace,
+        enabling automatic worker discovery across process boundaries.
+
+    :param namespace:
+        Unique identifier for the shared memory region. Publishers
+        and subscribers using the same namespace will see each
+        other's workers.
+    :param filter:
+        Optional default predicate function to filter workers.
+        Used by :py:attr:`subscriber` and as the default for
+        :py:meth:`subscribe` when no explicit filter is provided.
+    :param capacity:
+        Maximum number of workers that can be registered
+        simultaneously. Defaults to 128.
+    :param block_size:
+        Size in bytes for each worker's serialized data block.
+        Defaults to 1024.
+
+    Example — publish workers:
+
+    .. code-block:: python
+
+        publisher = LocalDiscovery.Publisher("my-worker-pool")
+        async with publisher:
+            await publisher.publish("worker-added", metadata)
+
+    Example — subscribe to workers:
+
+    .. code-block:: python
+
+        subscriber = LocalDiscovery.Subscriber("my-worker-pool")
+        async for event in subscriber:
+            print(f"Discovered worker: {event.metadata}")
+    """
+
+    _filter: Final[PredicateFunction | None]
+    _namespace: Final[str]
+
+    def __init__(
+        self,
+        namespace: str | None = None,
+        *,
+        filter: PredicateFunction | None = None,
+        capacity: int = 128,
+        block_size: int = 1024,
+    ):
+        self._namespace = namespace or f"workerpool-{uuid4()}"
+        self._filter = filter
+        self._capacity = capacity
+        self._block_size = block_size
+
+    def __enter__(self) -> Self:
+        size = self._capacity * 4
+        self._address_space = SharedMemory(
+            name=_short_hash(self._namespace),
+            create=True,
+            size=size,
+        )
+        assert self._address_space.buf
+        self._cleanup = atexit.register(lambda: self._address_space.unlink())
+        for i in range(size):
+            self._address_space.buf[i] = 0
+        return self
+
+    def __exit__(self, *_):
+        self._address_space.unlink()
+        atexit.unregister(self._cleanup)
+
+    @property
+    def namespace(self):
+        """The namespace identifier for this discovery service.
+
+        :returns:
+            The namespace string.
+        """
+        return self._namespace
+
+    @property
+    def publisher(self) -> DiscoveryPublisherLike:
+        """A new publisher instance for this discovery service.
+
+        :returns:
+            A publisher instance for broadcasting worker events.
+        """
+        return self.Publisher(self._namespace, block_size=self._block_size)
+
+    @property
+    def subscriber(self) -> DiscoverySubscriberLike:
+        """A subscriber using the constructor's default filter.
+
+        :returns:
+            A subscriber instance for receiving worker discovery
+            events.
+        """
+        return self.subscribe()
+
+    def subscribe(
+        self,
+        filter: PredicateFunction | None = None,
+        *,
+        poll_interval: float | None = None,
+    ) -> DiscoverySubscriberLike:
+        """Create a new subscriber with optional filtering.
+
+        :param filter:
+            Optional predicate function to filter workers. Only workers
+            for which the predicate returns True will be included in
+            events. Falls back to the constructor's filter if not
+            provided.
+        :param poll_interval:
+            Optional interval in seconds between shared memory polls.
+            If not specified, uses filesystem notifications for
+            efficient updates.
+        :returns:
+            A subscriber instance that receives filtered worker
+            discovery events.
+        """
+        return self.Subscriber(
+            self._namespace,
+            filter if filter is not None else self._filter,
+            poll_interval=poll_interval,
+        )
+
+    class Publisher:
+        """Publisher for broadcasting worker discovery events.
+
+        Publishes worker :class:`discovery events
+        <~wool.DiscoveryEvent>` to a shared memory region where
+        subscribers can discover them. Multiple publishers in different
+        processes can safely write to the same namespace using
+        cross-platform file locking for synchronization.
+
+        :param namespace:
+            The namespace identifier for the shared memory region.
+        :param block_size:
+            Size in bytes for worker metadata storage blocks. Defaults
+            to 512 bytes, which accommodates typical worker
+            metadata including tags and extra metadata.
+        :raises ValueError:
+            If block_size is negative.
+        """
+
+        _block_size: int
+        _cleanups: dict[str, Callable]
+        _namespace: Final[str]
+        _shared_memory_pool: ResourcePool[SharedMemory]
+
+        def __init__(self, namespace: str, *, block_size: int = 512):
+            if block_size < 0:
+                raise ValueError("Block size must be positive")
+            self._namespace = namespace
+            self._block_size = block_size
+            self._cleanups = {}
+            self._shared_memory_pool = ResourcePool(
+                factory=self._shared_memory_factory,
+                finalizer=self._shared_memory_finalizer,
+                ttl=0,
+            )
+
+        async def __aenter__(self) -> Self:
+            await self._shared_memory_pool.__aenter__()
+            return self
+
+        async def __aexit__(self, *args):
+            await self._shared_memory_pool.__aexit__(*args)
+
+        @property
+        def namespace(self):
+            """The namespace identifier for this publisher.
+
+            :returns:
+                The namespace string.
+            """
+            return self._namespace
+
+        async def publish(self, type: DiscoveryEventType, metadata: WorkerMetadata):
+            """Publish a worker discovery event.
+
+            Writes the event to shared memory where subscribers can
+            discover it. The operation is synchronized across processes
+            using file locking to ensure consistency. After publishing,
+            touches a notification file to wake subscribers via
+            filesystem events.
+
+            :param type:
+                The type of discovery event.
+            :param metadata:
+                Worker metadata to publish.
+            :raises RuntimeError:
+                If an unexpected event type is provided or if the
+                shared memory is not properly initialized.
+            """
+            async with _lock(self._namespace):
+                with _shared_memory(_short_hash(self._namespace)) as address_space:
+                    match type:
+                        case "worker-added":
+                            await self._add(metadata, address_space)
+                        case "worker-dropped":
+                            await self._drop(metadata, address_space)
+                        case "worker-updated":
+                            await self._update(metadata, address_space)
+                        case _:
+                            raise RuntimeError(
+                                f"Unexpected discovery event type: {type}"
+                            )
+
+                # Notify subscribers by touching the notification file
+                _watchdog_path(self._namespace).touch()
+
+        async def _add(self, metadata: WorkerMetadata, address_space: SharedMemory):
+            """Register a worker by adding it to shared memory.
+
+            :param metadata:
+                The worker to publish to the namespace's shared memory.
+            :raises RuntimeError:
+                If the shared memory region is not properly initialized or no
+                slots are available.
+            :raises ValueError:
+                If the worker UID is not specified.
+            """
+            if address_space.buf is None:
+                raise RuntimeError(
+                    "Registrar service not properly initialized"
+                )  # pragma: no cover
+
+            ref = _WorkerReference(metadata.uid)
+            serialized = metadata.to_protobuf().SerializeToString()
+            size = len(serialized)
+
+            for i in range(0, len(address_space.buf), REF_WIDTH):
+                slot = struct.unpack_from("16s", address_space.buf, i)[0]
+                if slot == NULL_REF:
+                    try:
+                        memory_block = await self._shared_memory_pool.acquire(str(ref))
+                        assert memory_block.buf is not None
+                        struct.pack_into(
+                            f"I{size}s", memory_block.buf, 0, size, serialized
+                        )
+                        struct.pack_into("16s", address_space.buf, i, ref.bytes)
+                    except Exception:
+                        await self._drop(metadata, address_space)
+                        raise
+                    break
+            else:
+                raise RuntimeError("No available slots in shared memory registrar")
+
+        async def _drop(self, metadata: WorkerMetadata, address_space: SharedMemory):
+            """Unregister a worker by removing it from shared memory.
+
+            :param metadata:
+                The worker to unpublish from the namespace's shared memory.
+            :raises RuntimeError:
+                If the registrar service is not properly initialized.
+            """
+            if address_space.buf is None:
+                raise RuntimeError(
+                    "Registrar service not properly initialized"
+                )  # pragma: no cover
+
+            target_ref = _WorkerReference(metadata.uid)
+
+            for i in range(0, len(address_space.buf), REF_WIDTH):
+                slot = struct.unpack_from("16s", address_space.buf, i)[0]
+                if slot != NULL_REF:
+                    ref = _WorkerReference.from_bytes(slot)
+                    if ref == target_ref:
+                        struct.pack_into("16s", address_space.buf, i, NULL_REF)
+                        await self._shared_memory_pool.release(str(ref))
+                        break
+
+        async def _update(self, metadata: WorkerMetadata, address_space: SharedMemory):
+            """Update a worker's properties in shared memory.
+
+            :param metadata:
+                The updated worker to publish to the namespace's shared memory.
+            :raises RuntimeError:
+                If the registrar service is not properly initialized.
+            :raises KeyError:
+                If the worker is not found in the address space.
+            """
+            if address_space.buf is None:
+                raise RuntimeError(
+                    "Registrar service not properly initialized"
+                )  # pragma: no cover
+
+            target_ref = _WorkerReference(metadata.uid)
+            serialized = metadata.to_protobuf().SerializeToString()
+            size = len(serialized)
+
+            for i in range(0, len(address_space.buf), REF_WIDTH):
+                slot = struct.unpack_from("16s", address_space.buf, i)[0]
+                if slot != NULL_REF:
+                    ref = _WorkerReference.from_bytes(slot)
+                    if ref == target_ref:
+                        memory_block = await self._shared_memory_pool.acquire(str(ref))
+                        assert memory_block.buf is not None
+                        # Save prior state before updating
+                        prior_size = struct.unpack_from("I", memory_block.buf, 0)[0]
+                        prior_serialized = struct.unpack_from(
+                            f"{prior_size}s", memory_block.buf, 4
+                        )[0]
+                        try:
+                            struct.pack_into(
+                                f"I{size}s", memory_block.buf, 0, size, serialized
+                            )
+                        except Exception:
+                            # Restore prior state on failure
+                            struct.pack_into(
+                                f"I{prior_size}s",
+                                memory_block.buf,
+                                0,
+                                prior_size,
+                                prior_serialized,
+                            )
+                            raise
+                        return
+
+            # Worker not found in address space
+            raise KeyError(f"Worker {metadata.uid} not found in address space")
+
+        def _shared_memory_factory(self, name: str):
+            """Create a new shared memory block for worker metadata storage.
+
+            Creates a shared memory region with the specified name and
+            registers an atexit handler to ensure cleanup on process
+            termination. Used by the resource pool to allocate memory blocks
+            for individual worker metadata.
+
+            :param name:
+                The name for the shared memory block (typically a worker UUID
+                hex string).
+            :returns:
+                A new SharedMemory instance.
+            """
+            shared_memory = SharedMemory(
+                name=name,
+                create=True,
+                size=self._block_size,
+            )
+
+            def cleanup():  # pragma: no cover
+                try:
+                    shared_memory.unlink()
+                except OSError:
+                    pass
+
+            self._cleanups[name] = atexit.register(cleanup)
+            return shared_memory
+
+        def _shared_memory_finalizer(self, shared_memory: SharedMemory):
+            """Clean up a shared memory block when released from the pool.
+
+            Unlinks the shared memory region and unregisters the atexit
+            handler. Errors during unlink are silently ignored to handle
+            Windows platforms where unlink may fail if other processes still
+            have the memory file open.
+
+            :param shared_memory:
+                The SharedMemory instance to finalize.
+            """
+            try:
+                shared_memory.unlink()
+            except OSError:
+                pass  # pragma: no cover
+            atexit.unregister(self._cleanups.pop(shared_memory.name))
+
+    class Subscriber:
+        """Subscriber for receiving worker discovery events.
+
+        Subscribes to worker :class:`discovery events <~wool.DiscoveryEvent>`
+        from a shared memory region, monitoring for changes via filesystem
+        notifications and yielding events as workers are added, updated, or
+        dropped. Multiple subscribers in different processes can read from
+        the same namespace independently.
+
+        Uses watchdog to monitor a notification file that publishers touch
+        when modifying the shared memory, providing near-instant notification
+        of changes. Falls back to periodic polling if notifications are
+        delayed or missed.
+
+        :param namespace:
+            The namespace identifier for the shared memory region.
+        :param filter:
+            Optional predicate function to filter workers. Only workers for
+            which the predicate returns True will be included in events.
+        :param poll_interval:
+            Maximum polling interval in seconds for when filesystem
+            notifications are delayed or missed.
+        """
+
+        _filter: Final[PredicateFunction | None]
+        _namespace: Final[str]
+        _poll_interval: Final[float | None]
+
+        def __init__(
+            self,
+            namespace: str,
+            filter: PredicateFunction | None = None,
+            *,
+            poll_interval: float | None = None,
+        ):
+            self._namespace = namespace
+            self._filter = filter
+            if poll_interval is not None and poll_interval < 0:
+                raise ValueError(f"Expected positive poll interval, got {poll_interval}")
+            self._poll_interval = poll_interval
+
+        def __reduce__(self):
+            return type(self), (self._namespace, self._filter)
+
+        def __aiter__(self) -> AsyncIterator[DiscoveryEvent]:
+            return self._event_stream(self._filter)
+
+        @property
+        def namespace(self):
+            """The namespace identifier for this subscriber."""
+            return self._namespace
+
+        async def _event_stream(
+            self, filter: PredicateFunction | None = None
+        ) -> AsyncIterator[DiscoveryEvent]:
+            """Monitor shared memory for worker changes via filesystem notifications.
+
+            Sets up a watchdog filesystem observer to monitor the notification
+            file for modifications. When publishers touch the file (after
+            updating shared memory), the observer triggers scanning of the
+            shared memory address space. Falls back to periodic polling in
+            case notifications are delayed or missed.
+
+            :param filter:
+                Optional predicate function to filter workers. Only workers for
+                which the predicate returns True will be included in events.
+            :yields:
+                Discovery events as changes are detected in shared memory.
+            """
+            cached_workers: dict[str, WorkerMetadata] = {}
+            notification = asyncio.Event()
+            lock = asyncio.Lock()
+            loop = asyncio.get_running_loop()
+            if not (watchdog := _watchdog_path(self._namespace)).exists():
+                watchdog.touch()
+            handler = _Watchdog(notification, watchdog, lock, loop)
+            observer = Observer()
+            observer.schedule(handler, path=str(watchdog.parent), recursive=False)
+            observer.start()
+
+            try:
+                with _shared_memory(_short_hash(self._namespace)) as address_space:
+                    assert address_space.buf is not None
+
+                    while True:
+                        async with lock:
+                            notification.clear()
+                            discovered_workers: dict[str, WorkerMetadata] = {}
+                            for i in range(0, len(address_space.buf), REF_WIDTH):
+                                slot = struct.unpack_from("16s", address_space.buf, i)[0]
+                                if slot != NULL_REF:
+                                    ref = _WorkerReference.from_bytes(slot)
+                                    metadata = self._deserialize_metadata(str(ref))
+                                    if filter is None or filter(metadata):
+                                        discovered_workers[str(metadata.uid)] = metadata
+
+                            for event in self._diff(cached_workers, discovered_workers):
+                                yield event
+                        try:
+                            await asyncio.wait_for(
+                                notification.wait(), timeout=self._poll_interval
+                            )
+                        except asyncio.TimeoutError:
+                            pass
+            finally:
+                observer.stop()
+                observer.join()
+
+        def _deserialize_metadata(self, ref: str):
+            """Load and deserialize worker metadata from shared memory.
+
+            Opens the shared memory block identified by the reference string
+            (worker UUID hex), reads the size header and serialized protobuf
+            data, and reconstructs the WorkerMetadata instance.
+
+            :param ref:
+                The worker reference string (UUID hex) identifying the shared
+                memory block containing the worker's metadata.
+            :returns:
+                The deserialized WorkerMetadata instance.
+            """
+            with _shared_memory(ref) as memory_block:
+                assert memory_block.buf is not None
+                size = struct.unpack_from("I", memory_block.buf, 0)[0]
+                serialized = struct.unpack_from(f"{size}s", memory_block.buf, 4)[0]
+                protobuf = WorkerMetadataProtobuf.FromString(serialized)
+                return WorkerMetadata.from_protobuf(protobuf)
+
+        def _diff(
+            self,
+            cached_workers: dict[str, WorkerMetadata],
+            discovered_workers: dict[str, WorkerMetadata],
+        ):
+            """Detect and emit events for worker changes.
+
+            Performs a three-way comparison between the cached worker state and
+            the newly discovered workers, identifying which workers have been
+            added, dropped, or updated. Updates the cache in-place and yields
+            appropriate discovery events for each change.
+
+            :param cached_workers:
+                Dictionary of previously discovered workers (UID string ->
+                WorkerMetadata). Modified in-place to reflect current state.
+            :param discovered_workers:
+                Dictionary of workers found in the current scan (UID string ->
+                WorkerMetadata).
+            :yields:
+                Discovery events for each detected change (worker-added,
+                worker-dropped, worker-updated).
+            """
+
+            # Identify added workers
+            for uid in set(discovered_workers) - set(cached_workers):
+                cached_workers[uid] = discovered_workers[uid]
+                event = DiscoveryEvent("worker-added", metadata=discovered_workers[uid])
+                yield event
+
+            # Identify removed workers
+            for uid in set(cached_workers) - set(discovered_workers):
+                discovered_worker = cached_workers.pop(uid)
+                event = DiscoveryEvent("worker-dropped", metadata=discovered_worker)
+                yield event
+
+            # Identify updated workers
+            for uid in set(cached_workers) & set(discovered_workers):
+                cached_workers[uid] = discovered_workers[uid]
+                event = DiscoveryEvent(
+                    "worker-updated", metadata=discovered_workers[uid]
+                )
+                yield event
+
+
+def _short_hash(s: str, n: int = 30) -> str:
+    """Create a shortened hash of a string for use as a system identifier.
+
+    Generates a SHA-256 hash of the input string and returns the first n
+    characters of a URL-safe base64 encoding. This encoding provides 50% more
+    entropy than hexadecimal in the same space (180 bits vs 120 bits for 30
+    chars). Used to create platform-safe names for shared memory regions and
+    lock files that fit within system limits (31 chars on macOS, 255 on Linux).
+
+    :param s:
+        The string to abbreviate (typically a namespace identifier).
+    :param n:
+        Number of base64 characters to return. Defaults to 30 for macOS
+        compatibility.
+    :returns:
+        The first n characters of the URL-safe base64-encoded SHA-256 hash.
+        Uses character set: A-Za-z0-9-_
+    """
+    import base64
+
+    hash_bytes = hashlib.sha256(s.encode()).digest()
+    # URL-safe base64 encoding (replaces + with -, / with _)
+    b64_str = base64.urlsafe_b64encode(hash_bytes).decode("utf-8")
+    # Remove padding characters and truncate to n chars
+    return b64_str.rstrip("=")[:n]
+
+
+@contextmanager
+def _shared_memory(name):
+    """Open an existing shared memory region by name.
+
+    Context manager that opens a shared memory region for reading or writing
+    and ensures it is properly closed on exit. Does not create new memory
+    regions (use SharedMemory with create=True for that).
+
+    :param name:
+        The name of the shared memory region to open.
+    :yields:
+        An open SharedMemory instance.
+
+    .. note::
+        Close errors are silently ignored to handle cases where the memory
+        region has been unlinked by another process.
+    """
+    shared_memory = SharedMemory(name=name)
+    try:
+        yield shared_memory
+    finally:
+        try:
+            shared_memory.close()
+        except Exception:
+            pass  # pragma: no cover
+
+
+@asynccontextmanager
+async def _lock(namespace: str):
+    """Acquire an exclusive lock for the address space identified by namespace.
+
+    Uses cross-platform file locking (via portalocker) to synchronize access
+    across unrelated processes that may be publishing to the same shared
+    memory region. Works on Windows, Linux, and macOS.
+
+    Uses non-blocking lock attempts with async sleep to avoid blocking the
+    event loop while waiting for lock acquisition. Retries every 1ms until
+    the lock is acquired.
+
+    :param namespace:
+        The namespace identifying the shared memory region to lock.
+    """
+    lock_name = _short_hash(namespace)
+    lock_path = Path(tempfile.gettempdir()) / f"wool-lock-{lock_name}"
+
+    with open(lock_path, "w") as lock_file:
+        while True:
+            try:
+                portalocker.lock(lock_file, portalocker.LOCK_EX | portalocker.LOCK_NB)
+                break
+            except portalocker.LockException:
+                await asyncio.sleep(0)
+
+        try:
+            yield
+        finally:
+            portalocker.unlock(lock_file)
+
+
+def _watchdog_path(namespace: str) -> Path:
+    """Get the path to the notification file for a namespace.
+
+    Returns the path to a temporary file that publishers touch when modifying
+    the shared memory region, signaling subscribers to scan for changes.
+
+    :param namespace:
+        The namespace identifying the shared memory region.
+    :returns:
+        Path to the notification file for this namespace.
+    """
+    return Path(tempfile.gettempdir()) / f"wool-notify-{namespace}"


### PR DESCRIPTION
## Summary

Add the worker discovery subsystem with an abstract base defining the discovery protocol (register, deregister, event subscription) and two concrete implementations: a local discovery service using shared-memory and filesystem-based coordination for same-machine workers, and a LAN discovery service using Zeroconf DNS-SD for network-wide worker advertisement and resolution.

The abstract protocol defines three runtime-checkable structural types (`DiscoveryPublisherLike`, `DiscoverySubscriberLike`, `DiscoveryLike`) plus a convenience ABC (`Discovery`), allowing custom backends to conform via either inheritance or duck typing. A frozen `WorkerMetadata` dataclass carries worker identity, address, capabilities, and a protobuf serialization round-trip. `DiscoveryEvent` pairs an event type literal (`worker-added`, `worker-dropped`, `worker-updated`) with the affected metadata.

Closes #14

## Proposed changes

### Abstract discovery protocol

- Define `WorkerMetadata` as a frozen dataclass with UID-based hashing, protobuf round-trip (`to_protobuf` / `from_protobuf`), and immutable collection fields (`frozenset` tags, `MappingProxyType` extra).
- Define `DiscoveryEvent` carrying a `DiscoveryEventType` literal and the affected `WorkerMetadata`.
- Define `DiscoveryPublisherLike` (async `publish`), `DiscoverySubscriberLike` (`__aiter__`), and `DiscoveryLike` (`publisher`, `subscriber`, `subscribe`) as `@runtime_checkable` protocols.
- Provide `Discovery` ABC as a convenience base class that enforces the three abstract members.
- Export `PredicateFunction` type alias for subscriber filter callbacks.

### Local discovery implementation

- Implement `LocalDiscovery` extending `Discovery`, parameterized by namespace, capacity, and block size.
- Use a synchronous context manager (`__enter__` / `__exit__`) to create and unlink the address-space `SharedMemory` region, with `atexit` safety net.
- Implement `LocalDiscovery.Publisher` with an async context manager that manages a `ResourcePool[SharedMemory]` for per-worker metadata blocks. Publish operations acquire a cross-process file lock (via `portalocker`), write serialized protobuf into the slot, and touch a notification file to wake subscribers.
- Implement `LocalDiscovery.Subscriber` as an async iterator that uses `watchdog` filesystem monitoring on the notification file, falling back to configurable polling. On each notification, scan the address space, deserialize worker metadata from individual shared-memory blocks, diff against a local cache, and yield `DiscoveryEvent` instances for additions, removals, and updates.
- Support predicate-based filtering at the subscriber level, pickle-safe `__reduce__`, and negative-poll-interval validation.
- Use a SHA-256-based short hash for platform-safe shared-memory and lock-file names (30-char base64, fitting macOS 31-char limit).

### LAN discovery implementation

- Implement `LanDiscovery` extending `Discovery`, advertising workers as `_wool._tcp.local.` DNS-SD service records via Zeroconf.
- Implement `LanDiscovery.Publisher` with an async context manager managing an `AsyncZeroconf` instance. Map `worker-added` to `async_register_service`, `worker-dropped` to `async_unregister_service`, and `worker-updated` to `async_update_service` with atomic cache updates and rollback on failure.
- Implement `LanDiscovery.Subscriber` as an async iterator that creates an isolated `AsyncZeroconf` + `AsyncServiceBrowser` per iteration. A nested `_Listener` (implementing `ServiceListener`) converts Zeroconf callbacks into `DiscoveryEvent` items placed on an `asyncio.Queue`.
- Handle filter-based dynamic transitions: when an update causes a tracked worker to fail the predicate, emit `worker-dropped`; when an untracked worker passes after update, emit `worker-added`.
- Serialize worker metadata to flat DNS-SD TXT properties (JSON for tags/extra, string for pid/version/secure) and deserialize with missing-field validation.
- Resolve `host:port` addresses to raw IPv4/IPv6 bytes for `ServiceInfo` registration.

## Test cases

NA – Tests are deferred to a follow-up issue.

## Implementation plan

- [x] Define `WorkerMetadata` frozen dataclass with UID, address, pid, version, tags, extra, and secure fields, plus protobuf round-trip methods
- [x] Define `DiscoveryEventType` literal and `DiscoveryEvent` class pairing event type with worker metadata
- [x] Define `DiscoveryPublisherLike`, `DiscoverySubscriberLike`, and `DiscoveryLike` as `@runtime_checkable` protocols
- [x] Define `Discovery` ABC with abstract `publisher`, `subscriber`, and `subscribe` members
- [x] Define `PredicateFunction` type alias for subscriber filter callbacks
- [x] Implement `LocalDiscovery` with namespace, capacity, block-size parameters and synchronous context manager for address-space shared memory lifecycle
- [x] Implement `LocalDiscovery.Publisher` with async context manager, `ResourcePool`-backed per-worker shared-memory blocks, cross-process file locking via `portalocker`, and notification-file touch on publish
- [x] Implement `LocalDiscovery.Subscriber` with `watchdog` filesystem monitoring, configurable poll-interval fallback, shared-memory scanning, cache diffing, predicate filtering, and pickle support
- [x] Implement SHA-256 short-hash utility for platform-safe shared-memory and lock-file names
- [x] Implement `LanDiscovery` with optional default filter and `_wool._tcp.local.` service type
- [x] Implement `LanDiscovery.Publisher` with `AsyncZeroconf` context management and service registration/unregistration/update methods with atomic cache rollback
- [x] Implement `LanDiscovery.Subscriber` with per-iteration isolated `AsyncZeroconf` and `AsyncServiceBrowser`, queue-based event delivery, and dynamic filter transitions (promotion and demotion)
- [x] Implement DNS-SD TXT property serialization/deserialization helpers with missing-field validation
- [x] Implement address resolution utility mapping `host:port` strings to raw IPv4/IPv6 bytes
- [x] Wire up `__init__.py` exports for the discovery subpackage