### PR TITLE
Add task execution layer — Closes #16

### DIFF
--- a/wool/src/wool/runtime/routine/task.py
+++ b/wool/src/wool/runtime/routine/task.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import traceback
+from collections.abc import Callable
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from inspect import isasyncgenfunction
+from inspect import iscoroutinefunction
+from types import TracebackType
+from typing import AsyncGenerator
+from typing import ContextManager
+from typing import Coroutine
+from typing import Dict
+from typing import Generic
+from typing import Protocol
+from typing import SupportsInt
+from typing import Tuple
+from typing import TypeAlias
+from typing import TypeVar
+from typing import cast
+from typing import overload
+from typing import runtime_checkable
+from uuid import UUID
+
+import cloudpickle
+
+import wool
+from wool import protocol
+
+Args = Tuple
+Kwargs = Dict
+Timeout = SupportsInt
+Routine: TypeAlias = Coroutine | AsyncGenerator
+W = TypeVar("W", bound=Routine)
+
+
+_do_dispatch: ContextVar[bool] = ContextVar("_do_dispatch", default=True)
+
+
+@contextmanager
+def _do_dispatch_context_manager(flag: bool, /):
+    token = _do_dispatch.set(flag)
+    try:
+        yield
+    finally:
+        _do_dispatch.reset(token)
+
+
+@overload
+def do_dispatch() -> bool: ...
+
+
+@overload
+def do_dispatch(flag: bool, /) -> ContextManager[None]: ...
+
+
+def do_dispatch(flag: bool | None = None, /) -> bool | ContextManager[None]:
+    if flag is None:
+        return _do_dispatch.get()
+    else:
+        return _do_dispatch_context_manager(flag)
+
+
+# public
+@runtime_checkable
+class WorkerProxyLike(Protocol):
+    """Protocol defining the interface required by Task for proxy objects.
+
+    This allows both the actual WorkerProxy and test doubles to be used
+    with Task without requiring inheritance.
+    """
+
+    @property
+    def id(self) -> UUID: ...
+
+    async def dispatch(
+        self, task: Task, *, timeout: float | None = None
+    ) -> AsyncGenerator: ...
+
+
+# public
+@dataclass
+class Task(Generic[W]):
+    """
+    Represents a distributed task to be executed in the worker pool.
+
+    Each task encapsulates a function call along with its arguments and
+    execution context. Tasks are created when decorated functions are
+    invoked and contain all necessary information for remote execution
+    including serialization, routing, and result handling.
+
+    :param id:
+        Unique identifier for this task instance.
+    :param callable:
+        The asynchronous function to execute.
+    :param args:
+        Positional arguments for the function.
+    :param kwargs:
+        Keyword arguments for the function.
+    :param proxy:
+        Proxy object for task dispatch and routing (satisfies WorkerProxyLike).
+    :param timeout:
+        Task timeout in seconds (0 means no timeout).
+    :param caller:
+        UUID of the calling task if this is a nested task.
+    :param exception:
+        Exception information if task execution failed.
+    :param filename:
+        Source filename where the task was defined.
+    :param function:
+        Name of the function being executed.
+    :param line_no:
+        Line number where the task was defined.
+    :param tag:
+        Optional descriptive tag for the task.
+    """
+
+    id: UUID
+    callable: Callable[..., W]
+    args: Args
+    kwargs: Kwargs
+    proxy: WorkerProxyLike
+    timeout: Timeout = 0
+    caller: UUID | None = None
+    exception: TaskException | None = None
+    filename: str | None = None
+    function: str | None = None
+    line_no: int | None = None
+    tag: str | None = None
+
+    def __post_init__(self, **kwargs):
+        """
+        Initialize the task and set up caller tracking.
+
+        :param kwargs:
+            Additional keyword arguments (unused).
+        """
+        if not isinstance(self.proxy, WorkerProxyLike):
+            raise TypeError(
+                f"proxy must conform to WorkerProxyLike, got {type(self.proxy).__name__}"
+            )
+        if caller := _current_task.get():
+            self.caller = caller.id
+
+    def __enter__(self) -> Callable[[], Coroutine | AsyncGenerator]:
+        """
+        Enter the task context for execution.
+
+        :returns:
+            The task's run method as a callable coroutine.
+        """
+        logging.debug(f"Entering {self.__class__.__name__} with ID {self.id}")
+        self._task_token = _current_task.set(self)
+        if iscoroutinefunction(self.callable):
+            return self._run
+        elif isasyncgenfunction(self.callable):
+            return self._stream
+        else:
+            raise ValueError("Expected coroutine function or async generator function")
+
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception_value: BaseException | None,
+        exception_traceback: TracebackType | None,
+    ):
+        """Exit the task context and handle any exceptions.
+
+        Captures exception information for later processing and allows
+        exceptions to propagate normally for proper error handling.
+
+        :param exception_type:
+            Type of exception that occurred, if any.
+        :param exception_value:
+            Exception instance that occurred, if any.
+        :param exception_traceback:
+            Traceback of the exception, if any.
+        :returns:
+            False to allow exceptions to propagate.
+        """
+        logging.debug(f"Exiting {self.__class__.__name__} with ID {self.id}")
+        if exception_value:
+            self.exception = TaskException(
+                exception_type.__qualname__,
+                traceback=[
+                    y
+                    for x in traceback.format_exception(
+                        exception_type, exception_value, exception_traceback
+                    )
+                    for y in x.split("\n")
+                ],
+            )
+        _current_task.reset(self._task_token)
+        # Return False to allow exceptions to propagate
+        return False
+
+    @classmethod
+    def from_protobuf(cls, task: protocol.Task) -> Task:
+        return cls(
+            id=UUID(task.id),
+            callable=cloudpickle.loads(task.callable),
+            args=cloudpickle.loads(task.args),
+            kwargs=cloudpickle.loads(task.kwargs),
+            caller=UUID(task.caller) if task.caller else None,
+            proxy=cloudpickle.loads(task.proxy),
+            timeout=task.timeout if task.timeout else 0,
+            tag=task.tag if task.tag else None,
+        )
+
+    def to_protobuf(self) -> protocol.Task:
+        return protocol.Task(
+            version=protocol.__version__,
+            id=str(self.id),
+            callable=cloudpickle.dumps(self.callable),
+            args=cloudpickle.dumps(self.args),
+            kwargs=cloudpickle.dumps(self.kwargs),
+            caller=str(self.caller) if self.caller else "",
+            proxy=cloudpickle.dumps(self.proxy),
+            proxy_id=str(self.proxy.id),
+            timeout=int(self.timeout) if self.timeout else 0,
+            tag=self.tag if self.tag else "",
+        )
+
+    def dispatch(self) -> W:
+        if isasyncgenfunction(self.callable):
+            return cast(W, self._stream())
+        elif iscoroutinefunction(self.callable):
+            return cast(W, self._run())
+        else:
+            raise ValueError("Expected routine to be coroutine or async generator")
+
+    async def _run(self):
+        """
+        Execute the task's callable with its arguments in proxy context.
+
+        :returns:
+            The result of executing the callable.
+        :raises RuntimeError:
+            If no proxy pool is available for task execution.
+        """
+        assert iscoroutinefunction(self.callable), "Expected coroutine function"
+        proxy_pool = wool.__proxy_pool__.get()
+        if not proxy_pool:
+            raise RuntimeError("No proxy pool available for task execution")
+        async with proxy_pool.get(self.proxy) as proxy:
+            # Set the proxy in context variable for nested task dispatch
+            token = wool.__proxy__.set(proxy)
+            try:
+                with self:
+                    with do_dispatch(False):
+                        await asyncio.sleep(0)
+                        return await self.callable(*self.args, **self.kwargs)
+            finally:
+                wool.__proxy__.reset(token)
+
+    async def _stream(self):
+        """
+        Execute the task's callable with its arguments in proxy context.
+
+        :returns:
+            An async generator that yields values from the callable.
+        :raises RuntimeError:
+            If no proxy pool is available for task execution.
+        """
+        assert isasyncgenfunction(self.callable), "Expected async generator function"
+        proxy_pool = wool.__proxy_pool__.get()
+        if not proxy_pool:
+            raise RuntimeError("No proxy pool available for task execution")
+        async with proxy_pool.get(self.proxy) as proxy:
+            await asyncio.sleep(0)
+            gen = self.callable(*self.args, **self.kwargs)
+            try:
+                while True:
+                    # Set the proxy in context variable for nested task dispatch
+                    token = wool.__proxy__.set(proxy)
+                    try:
+                        with self:
+                            with do_dispatch(False):
+                                try:
+                                    result = await anext(gen)
+                                except StopAsyncIteration:
+                                    break
+                    finally:
+                        wool.__proxy__.reset(token)
+
+                    yield result
+            finally:
+                await gen.aclose()
+
+
+# public
+@dataclass
+class TaskException:
+    """
+    Represents an exception that occurred during distributed task execution.
+
+    Captures exception information from remote task execution for proper
+    error reporting and debugging. The exception details are serialized
+    and transmitted back to the calling context.
+
+    :param type:
+        Qualified name of the exception class.
+    :param traceback:
+        List of formatted traceback lines from the exception.
+    """
+
+    type: str
+    traceback: list[str]
+
+
+_current_task: ContextVar[Task | None] = ContextVar("_current_task", default=None)
+
+
+# public
+def current_task() -> Task | None:
+    """
+    Get the current task from the context variable if we are inside a task
+    context, otherwise return None.
+
+    :returns:
+        The current task or None if no task is active.
+    """
+    return _current_task.get()

--- a/wool/src/wool/runtime/routine/wrapper.py
+++ b/wool/src/wool/runtime/routine/wrapper.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import wraps
+from inspect import getsourcelines
+from inspect import isasyncgen
+from inspect import isasyncgenfunction
+from inspect import iscoroutinefunction
+from sys import modules
+from types import ModuleType
+from typing import TYPE_CHECKING
+from typing import AsyncGenerator
+from typing import Coroutine
+from typing import ParamSpec
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+from typing import cast
+from uuid import uuid4
+
+import wool
+from wool.runtime import context as ctx
+from wool.runtime.routine.task import Task
+from wool.runtime.routine.task import do_dispatch
+
+if TYPE_CHECKING:
+    from wool.runtime.worker.proxy import WorkerProxy
+
+C = TypeVar("C", bound=Callable[..., Coroutine | AsyncGenerator])
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+# public
+def routine(fn: C) -> C:
+    """Decorator to declare an asynchronous function as remotely executable.
+
+    Converts an asynchronous coroutine or generator into a distributed
+    task that can be executed by a worker pool. When the decorated function
+    is invoked, it is dispatched to the worker pool associated with the
+    current worker pool session context.
+
+    :param fn:
+        The asynchronous function or async generator to convert into a
+        distributed routine.
+    :returns:
+        The decorated function that dispatches to the worker pool when
+        called.
+    :raises ValueError:
+        If the decorated function is not a coroutine function or async
+        generator function.
+
+    .. note::
+        Decorated functions behave like regular coroutines or async
+        generators and can be awaited, iterated over, and cancelled
+        normally. Task execution occurs transparently across the
+        distributed worker pool.
+
+    **Async Generator Support:**
+
+    For async generators, the decorator supports pull-based streaming
+    where the worker pauses at each ``yield`` until the client requests
+    the next value. This enables efficient processing of large or
+    infinite sequences without server-side buffering.
+
+    - **Supported operations**:
+      ``anext()``, ``asend()``, ``athrow()``, ``aclose()``
+    - **Cleanup**:
+      Calling ``aclose()`` or breaking out of iteration properly cancels
+      the remote worker task
+
+    Best practices and considerations for designing tasks:
+
+    1. **Picklability**: Arguments, return values, and yielded values
+       must be picklable for serialization between processes. Avoid
+       unpicklable objects like open file handles, database connections,
+       or lambda functions. Custom objects should implement
+       ``__getstate__`` and ``__setstate__`` methods if needed.
+
+    2. **Synchronization**: Tasks are not guaranteed to execute on the
+       same process between invocations. Standard :mod:`asyncio`
+       synchronization primitives will not work across processes.
+       Use file-based or other distributed synchronization utilities.
+
+    3. **Statelessness**: Design tasks to be stateless and idempotent.
+       Avoid global variables or shared mutable state to ensure
+       predictable behavior and enable safe retries.
+
+    4. **Cancellation**: Task cancellation behaves like standard Python
+       coroutine cancellation and is properly propagated across the
+       distributed system. For async generators, cancellation or calling
+       ``aclose()`` triggers proper cleanup.
+
+    5. **Error propagation**: Unhandled exceptions raised within tasks are
+       transparently propagated to the caller as they would be normally.
+
+    6. **Performance**: Minimize argument, return value, and yielded value
+       sizes to reduce serialization overhead. For large datasets,
+       consider using shared memory or passing references instead of the
+       data itself.
+
+    Example usage with coroutines:
+
+    .. code-block:: python
+
+        import asyncio, wool
+
+
+        @wool.routine
+        async def fibonacci(n: int) -> int:
+            if n <= 1:
+                return n
+            async with asyncio.TaskGroup() as tg:
+                a = tg.create_task(fibonacci(n - 1))
+                b = tg.create_task(fibonacci(n - 2))
+            return a.result() + b.result()
+
+
+        async def main():
+            async with wool.WorkerPool():
+                print(await fibonacci(10))  # 34
+
+    Example usage with async generators:
+
+    .. code-block:: python
+
+        import wool
+
+
+        @wool.routine
+        async def fibonacci_series(n: int):
+            a, b = 0, 1
+            for _ in range(n):
+                yield a
+                a, b = b, a + b
+
+
+        async def main():
+            async with wool.WorkerPool():
+                async for value in fibonacci_series(10):
+                    print(value)  # 0, 1, 1, 2, 3, 5, 8, 13, 21, 34
+    """
+    # Check if function is a coroutine or async generator
+    is_valid = (
+        iscoroutinefunction(fn)
+        or isasyncgenfunction(fn)
+        or (
+            isinstance(fn, (classmethod, staticmethod))
+            and (iscoroutinefunction(fn.__func__) or isasyncgenfunction(fn.__func__))
+        )
+    )
+    if not is_valid:
+        raise ValueError("Expected a coroutine function or async generator function")
+
+    if isinstance(fn, (classmethod, staticmethod)):
+        wrapped_fn = fn.__func__
+    else:
+        wrapped_fn = fn
+
+    try:
+        _, lineno = getsourcelines(wrapped_fn)
+    except OSError:
+        lineno = 0
+
+    if isasyncgenfunction(wrapped_fn):
+
+        @wraps(wrapped_fn)
+        async def async_generator_wrapper(*args, **kwargs):
+            # Handle static and class methods in a picklable way.
+            parent, function = _resolve(fn)
+            assert parent is not None
+            assert callable(function)
+
+            if do_dispatch():
+                proxy = wool.__proxy__.get()
+                assert proxy
+                stream = await _dispatch(
+                    proxy,
+                    async_generator_wrapper.__module__,
+                    async_generator_wrapper.__qualname__,
+                    lineno,
+                    function,
+                    *args,
+                    **kwargs,
+                )
+            else:
+                stream = _stream(fn, parent, *args, **kwargs)
+                assert isasyncgen(stream)
+
+            try:
+                sent = None
+                result = await stream.__anext__()
+                while True:
+                    try:
+                        sent = yield result
+                    except GeneratorExit:
+                        await stream.aclose()
+                        return
+                    except BaseException as exc:
+                        result = await stream.athrow(type(exc), exc)
+                    else:
+                        if sent is None:
+                            result = await stream.__anext__()
+                        else:
+                            result = await stream.asend(sent)
+            except StopAsyncIteration:
+                return
+            finally:
+                await stream.aclose()
+
+        return cast(C, async_generator_wrapper)
+
+    else:
+
+        @wraps(wrapped_fn)
+        async def coroutine_wrapper(*args, **kwargs):
+            # Handle static and class methods in a picklable way.
+            parent, function = _resolve(fn)
+            assert parent is not None
+            assert callable(function)
+
+            if do_dispatch():
+                proxy = wool.__proxy__.get()
+                assert proxy
+                stream = await _dispatch(
+                    proxy,
+                    coroutine_wrapper.__module__,
+                    coroutine_wrapper.__qualname__,
+                    lineno,
+                    function,
+                    *args,
+                    **kwargs,
+                )
+                coro = _stream_to_coroutine(stream)
+            else:
+                coro = _execute(fn, parent, *args, **kwargs)
+
+            return await coro
+
+        return cast(C, coroutine_wrapper)
+
+
+def _dispatch(
+    proxy: WorkerProxy,
+    module: str,
+    qualname: str,
+    lineno: int,
+    function: Callable[..., Coroutine | AsyncGenerator],
+    *args,
+    **kwargs,
+):
+    # Skip self argument if function is a method.
+    args = args[1:] if hasattr(function, "__self__") else args
+    task = Task(
+        id=uuid4(),
+        callable=function,
+        args=args,
+        kwargs=kwargs,
+        tag=f"{module}.{qualname}:{lineno}",
+        proxy=proxy,
+    )
+    return proxy.dispatch(task, timeout=ctx.dispatch_timeout.get())
+
+
+async def _stream(fn, parent, *args, **kwargs):
+    if isinstance(fn, classmethod):
+        gen = fn.__func__(parent, *args, **kwargs)
+    elif isinstance(fn, staticmethod):
+        gen = fn.__func__(*args, **kwargs)
+    else:
+        gen = fn(*args, **kwargs)
+    try:
+        sent = None
+        with do_dispatch(True):
+            result = await gen.__anext__()
+        while True:
+            try:
+                sent = yield result
+            except GeneratorExit:
+                await gen.aclose()
+                return
+            except BaseException as exc:
+                with do_dispatch(True):
+                    result = await gen.athrow(type(exc), exc)
+            else:
+                with do_dispatch(True):
+                    if sent is None:
+                        result = await gen.__anext__()
+                    else:
+                        result = await gen.asend(sent)
+    except StopAsyncIteration:
+        return
+    finally:
+        await gen.aclose()
+
+
+async def _execute(fn, parent, *args, **kwargs):
+    with do_dispatch(True):
+        if isinstance(fn, classmethod):
+            return await fn.__func__(parent, *args, **kwargs)
+        elif isinstance(fn, staticmethod):
+            return await fn.__func__(*args, **kwargs)
+        else:
+            return await fn(*args, **kwargs)
+
+
+async def _stream_to_coroutine(stream):
+    result = None
+    async for result in stream:
+        continue
+    return result
+
+
+def _resolve(
+    method: Callable[P, R] | classmethod | staticmethod,
+) -> Tuple[Type | ModuleType | None, Callable[P, R]]:
+    scope = modules[method.__module__]
+    parent = None
+    for name in method.__qualname__.split("."):
+        parent = scope
+        scope = getattr(scope, name)
+        assert scope
+    assert isinstance(parent, (Type, ModuleType))
+    return parent, cast(Callable[P, R], scope)


### PR DESCRIPTION
## Summary

Add the task execution subsystem for Wool's distributed runtime. Introduce a `Task` dataclass representing a distributable unit of work — with serialization via cloudpickle, execution context propagation through context variables, and protobuf conversion for wire transport — alongside a `TaskException` dataclass for capturing remote error information. Provide a `@routine` decorator that converts async functions and async generators into distributable routines with transparent local/remote dispatch semantics, including bilateral streaming support (asend, athrow, aclose) and source-metadata tagging. Include the `__init__.py` package marker for the routine subpackage.

Closes #16

## Proposed changes

### Task dataclass

- Define a `WorkerProxyLike` protocol specifying the `id` property and async `dispatch` method required by `Task` for proxy objects
- Implement the `Task` generic dataclass with fields for id, callable, args, kwargs, proxy, timeout, caller, exception, filename, function, line_no, and tag
- Validate proxy conformance in `__post_init__` and auto-set the `caller` field from the active task context
- Implement `__enter__`/`__exit__` context manager protocol for execution context tracking, returning the appropriate run/stream method based on callable type and capturing exceptions as `TaskException`
- Implement `from_protobuf`/`to_protobuf` for wire-format conversion using cloudpickle and the protocol module
- Implement `dispatch` to route to `_run` (coroutine) or `_stream` (async generator) based on callable type
- Implement `_run` and `_stream` methods that acquire a proxy from the pool, set context variables, and execute the callable with dispatch disabled
- Define `TaskException` dataclass storing the exception type name and formatted traceback lines
- Expose `current_task()` and `do_dispatch()` module-level helpers backed by context variables

### @routine decorator

- Validate that the decorated function is a coroutine function or async generator function (including classmethod/staticmethod wrappers), raising `ValueError` otherwise
- Capture the source line number via `inspect.getsourcelines` for tag metadata
- For async generators, build a wrapper that supports bilateral streaming (asend, athrow, aclose, GeneratorExit) and delegates to either `_dispatch` (remote) or `_stream` (local) based on `do_dispatch()`
- For coroutines, build a wrapper that delegates to either `_dispatch` then `_stream_to_coroutine` (remote) or `_execute` (local)
- Implement `_dispatch` to construct a `Task`, attach the source-metadata tag, and call `proxy.dispatch`
- Implement `_stream` for local async generator execution with `do_dispatch(True)` restored inside each yield
- Implement `_execute` for local coroutine execution with `do_dispatch(True)` restored
- Implement `_resolve` to look up the callable from its module and qualname for picklable dispatch of methods

### Package init

- Add the `__init__.py` package marker for the `wool.runtime.routine` subpackage

## Test cases

N/A – Tests are deferred to a follow-up issue.

## Implementation plan

- [x] Define the `WorkerProxyLike` runtime-checkable protocol with `id` property and async `dispatch` method
- [x] Implement the `Task` generic dataclass with all fields, `__post_init__` validation, and caller tracking via context variable
- [x] Implement `Task.__enter__` and `Task.__exit__` for execution context management and exception capture
- [x] Implement `Task.from_protobuf` and `Task.to_protobuf` for wire-format conversion
- [x] Implement `Task.dispatch`, `Task._run`, and `Task._stream` for coroutine and async generator execution with proxy pool integration
- [x] Implement the `TaskException` dataclass with type and traceback fields
- [x] Implement `current_task()` and `do_dispatch()` module-level context variable helpers
- [x] Implement the `@routine` decorator with validation, source line capture, and separate wrappers for coroutines and async generators
- [x] Implement `_dispatch` to construct a `Task` with source-metadata tag and call `proxy.dispatch`
- [x] Implement `_stream`, `_execute`, `_stream_to_coroutine`, and `_resolve` helper functions for local execution and method resolution
- [x] Add the `__init__.py` package marker for the routine subpackage