### PR TITLE
Add worker service and orchestration — Closes #20

### DIFF
--- a/wool/src/wool/runtime/worker/interceptor.py
+++ b/wool/src/wool/runtime/worker/interceptor.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import grpc
+import grpc.aio
+
+from wool import protocol
+from wool.runtime.worker.proxy import is_version_compatible
+from wool.runtime.worker.proxy import parse_version
+
+
+class VersionInterceptor(grpc.aio.ServerInterceptor):
+    """gRPC server interceptor for wire protocol version checking.
+
+    Intercepts the ``dispatch`` RPC to extract the client version from
+    field 1 of the raw request bytes using
+    :class:`~wool.protocol.TaskEnvelope`.  A client is accepted
+    when its protocol version is less than or equal to the local
+    worker version within the same major version.  Requests with
+    empty, missing, or unparseable version fields are rejected.
+    """
+
+    async def intercept_service(self, continuation, handler_call_details):
+        handler = await continuation(handler_call_details)
+        if handler is None or not handler_call_details.method.endswith("/dispatch"):
+            return handler
+
+        original_handler = handler.stream_stream
+        original_deserializer = handler.request_deserializer
+        assert original_handler is not None
+        assert original_deserializer is not None
+
+        async def version_checked_handler(request_iterator, context):
+            # Read the first raw request to extract the version envelope
+            first_bytes = await anext(aiter(request_iterator))
+
+            # The first Request message wraps a Task; parse the Task
+            # envelope from the nested task bytes.
+            request_msg = protocol.Request()
+            request_msg.ParseFromString(first_bytes)
+            task_bytes = request_msg.task.SerializeToString()
+
+            envelope = protocol.TaskEnvelope()
+            try:
+                envelope.ParseFromString(task_bytes)
+            except Exception:
+                yield protocol.Response(
+                    nack=protocol.Nack(reason="Failed to parse version envelope")
+                )
+                return
+
+            client_version = parse_version(envelope.version)
+            local_version = parse_version(protocol.__version__)
+
+            if client_version is None or local_version is None:
+                yield protocol.Response(
+                    nack=protocol.Nack(
+                        reason=(
+                            f"Unparseable version: "
+                            f"client={envelope.version!r}, "
+                            f"worker={protocol.__version__!r}"
+                        )
+                    )
+                )
+                return
+
+            if not is_version_compatible(client_version, local_version):
+                yield protocol.Response(
+                    nack=protocol.Nack(
+                        reason=(
+                            f"Incompatible version: "
+                            f"client={envelope.version}, "
+                            f"worker={protocol.__version__}"
+                        )
+                    )
+                )
+                return
+
+            # Re-assemble a chained iterator: yield the deserialized
+            # first request, then the rest of the stream.
+            first_request = original_deserializer(first_bytes)
+
+            async def chained_iterator():
+                yield first_request
+                async for raw in request_iterator:
+                    yield original_deserializer(raw)
+
+            async for response in original_handler(chained_iterator(), context):  # pyright: ignore[reportArgumentType, reportGeneralTypeIssues]
+                yield response
+
+        return grpc.stream_stream_rpc_method_handler(
+            version_checked_handler,
+            request_deserializer=None,
+            response_serializer=handler.response_serializer,
+        )

--- a/wool/src/wool/runtime/worker/local.py
+++ b/wool/src/wool/runtime/worker/local.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import asyncio
+from types import MappingProxyType
+from typing import Any
+
+import grpc.aio
+
+from wool import protocol
+from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.base import ChannelCredentialsType
+from wool.runtime.worker.base import ServerCredentialsType
+from wool.runtime.worker.base import Worker
+from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.base import resolve_channel_credentials
+from wool.runtime.worker.process import WorkerProcess
+
+
+# public
+class LocalWorker(Worker):
+    """Worker running in a local subprocess.
+
+    Spawns a dedicated process hosting a gRPC server for task execution.
+    Handles multiple concurrent tasks in an isolated asyncio event loop.
+
+    **Basic usage:**
+
+    .. code-block:: python
+
+        worker = LocalWorker("gpu-capable")
+        await worker.start()
+        # Worker is now accepting tasks
+        await worker.stop()
+
+    **Custom configuration:**
+
+    .. code-block:: python
+
+        worker = LocalWorker(
+            "production",
+            "high-memory",
+            host="0.0.0.0",  # Listen on all interfaces
+            port=50051,  # Fixed port
+            shutdown_grace_period=30.0,
+        )
+
+    :param tags:
+        Capability tags for filtering and selection.
+    :param host:
+        Host address to bind. Defaults to localhost.
+    :param port:
+        Port to bind. 0 for random available port.
+    :param shutdown_grace_period:
+        Graceful shutdown timeout in seconds.
+    :param proxy_pool_ttl:
+        Proxy pool TTL in seconds.
+    :param credentials:
+        Optional credentials for TLS/mTLS authentication:
+
+        - :class:`WorkerCredentials`: Provides both server and client
+          credentials for mutual TLS. Enables secure worker-to-worker
+          communication.
+        - ``None``: Worker uses insecure connections.
+    :param options:
+        gRPC message size options. Defaults to
+        :class:`WorkerOptions` with 100 MB limits.
+    :param extra:
+        Additional metadata as key-value pairs.
+    """
+
+    _worker_process: WorkerProcess
+    _server_credentials: ServerCredentialsType
+    _client_credentials: ChannelCredentialsType
+
+    def __init__(
+        self,
+        *tags: str,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        shutdown_grace_period: float = 60.0,
+        proxy_pool_ttl: float = 60.0,
+        credentials: WorkerCredentials | None = None,
+        options: WorkerOptions | None = None,
+        **extra: Any,
+    ):
+        super().__init__(*tags, **extra)
+
+        # Extract server and client credentials
+        if credentials is not None:
+            self._server_credentials = credentials.server_credentials
+            self._client_credentials = credentials.client_credentials
+        else:
+            self._server_credentials = None
+            self._client_credentials = None
+
+        self._worker_process = WorkerProcess(
+            host=host,
+            port=port,
+            shutdown_grace_period=shutdown_grace_period,
+            proxy_pool_ttl=proxy_pool_ttl,
+            server_credentials=self._server_credentials,
+            options=options,
+        )
+
+    @property
+    def address(self) -> str | None:
+        """The network address where the worker is listening.
+
+        :returns:
+            The address in "host:port" format, or None if not started.
+        """
+        return self._worker_process.address
+
+    async def _start(self, timeout: float | None):
+        """Start the worker process and register it with the pool.
+
+        Initializes the registrar service, starts the worker process
+        with its gRPC server, and registers the worker's network
+        address with the registrar for discovery by client sessions.
+
+        :param timeout:
+            Maximum time in seconds to wait for worker process startup.
+        """
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None, lambda t: self._worker_process.start(timeout=t), timeout
+        )
+        if not self._worker_process.address:
+            raise RuntimeError("Worker process failed to start - no address")
+        if not self._worker_process.pid:
+            raise RuntimeError("Worker process failed to start - no PID")
+
+        self._info = WorkerMetadata(
+            uid=self._uid,
+            address=self._worker_process.address,
+            pid=self._worker_process.pid,
+            version=protocol.__version__,
+            tags=frozenset(self._tags),
+            extra=MappingProxyType(self._extra),
+            secure=self._server_credentials is not None,
+        )
+
+    async def _stop(self, timeout: float | None):
+        """Stop the worker process and unregister it from the pool.
+
+        Unregisters the worker from the registrar service, gracefully
+        shuts down the worker process using a gRPC stop request, and cleans
+        up the registrar service. If graceful shutdown fails, the process
+        is forcefully terminated.
+
+        For workers configured with :class:`WorkerCredentials`, uses
+        the client credentials to establish a secure connection for the
+        stop operation. For insecure workers, uses an insecure channel.
+        """
+        if self._worker_process.is_alive():
+            assert self.address
+
+            # Create appropriate channel based on available credentials
+            credentials = resolve_channel_credentials(self._client_credentials)
+            if credentials is not None:
+                # Secure worker with mTLS: use client credentials
+                channel = grpc.aio.secure_channel(self.address, credentials)
+            else:
+                # Insecure worker: use insecure channel
+                channel = grpc.aio.insecure_channel(self.address)
+
+            stub = protocol.WorkerStub(channel)
+            await stub.stop(protocol.StopRequest(timeout=timeout))

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import uuid
+from contextlib import asynccontextmanager
+from typing import AsyncContextManager
+from typing import Awaitable
+from typing import ContextManager
+from typing import Coroutine
+from typing import Final
+from typing import overload
+
+from wool.runtime.context import RuntimeContext
+from wool.runtime.discovery.base import DiscoveryLike
+from wool.runtime.discovery.base import DiscoveryPublisherLike
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.typing import Factory
+from wool.runtime.typing import Undefined
+from wool.runtime.typing import UndefinedType
+from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.base import WorkerFactory
+from wool.runtime.worker.base import WorkerLike
+from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.local import LocalWorker
+from wool.runtime.worker.proxy import LoadBalancerLike
+from wool.runtime.worker.proxy import RoundRobinLoadBalancer
+from wool.runtime.worker.proxy import WorkerProxy
+
+
+# public
+class WorkerPool:
+    """Orchestrates distributed workers for task execution.
+
+    The core of wool's distributed runtime. Manages worker lifecycle,
+    discovery, and load balancing across two modes:
+
+    - **Ephemeral pools** spawn local workers managed within the pool's
+    lifecycle. Perfect for development and single-machine deployments.
+
+    - **Durable pools** connect to existing remote workers through discovery
+    services. Workers run independently, serving multiple clients across
+    distributed deployments.
+
+    **Basic ephemeral pool:**
+
+    .. code-block:: python
+
+        @wool.routine
+        async def fibonacci(n: int) -> int:
+            if n <= 1:
+                return n
+            a = await fibonacci(n - 1)
+            b = await fibonacci(n - 2)
+            return a + b
+
+
+        async with wool.WorkerPool():
+            result = await fibonacci(10)
+
+    **Ephemeral with tags:**
+
+    .. code-block:: python
+
+        async with WorkerPool("gpu-capable", size=4):
+            result = await gpu_task()
+
+    **Custom worker factory:**
+
+    .. code-block:: python
+
+        from functools import partial
+
+        worker_factory = partial(LocalWorker, host="0.0.0.0")
+
+        async with WorkerPool(size=8, worker=worker_factory):
+            result = await task()
+
+    **Durable pool:**
+
+    .. code-block:: python
+
+        from wool.runtime.discovery.lan import LanDiscovery
+
+        async with WorkerPool(discovery=LanDiscovery()):
+            result = await task()
+
+    **Filtered discovery:**
+
+    .. code-block:: python
+
+        discovery = LanDiscovery().subscribe(filter=lambda w: "production" in w.tags)
+        async with WorkerPool(discovery=discovery):
+            result = await task()
+
+    **Hybrid pool:**
+
+    .. code-block:: python
+
+        # Spawn local workers AND discover remote workers
+        async with WorkerPool(size=4, discovery=LanDiscovery()):
+            result = await task()
+
+    **Custom load balancer:**
+
+    .. code-block:: python
+
+        from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
+
+
+        class PriorityBalancer(RoundRobinLoadBalancer):
+            async def dispatch(self, task, context, timeout=None):
+                # Custom routing logic
+                ...
+
+
+        async with WorkerPool(loadbalancer=PriorityBalancer()):
+            result = await task()
+
+    **Custom discovery:**
+
+    .. code-block:: python
+
+        from contextlib import asynccontextmanager
+
+
+        @asynccontextmanager
+        async def custom_discovery():
+            svc = await DatabaseDiscovery.connect()
+            try:
+                yield svc.subscribe()
+            finally:
+                await svc.close()
+
+
+        async with WorkerPool(discovery=custom_discovery):
+            result = await task()
+
+    :param tags:
+        Capability tags for spawned workers.
+    :param size:
+        Number of workers to spawn (0 = CPU count).
+    :param worker:
+        Worker factory callable. Defaults to :class:`LocalWorker`.
+    :param loadbalancer:
+        Load balancer instance, factory, or context manager.
+    :param discovery:
+        Discovery service instance, factory, or context manager.
+    :param credentials:
+        Optional channel credentials for TLS/mTLS connections to workers.
+    :raises ValueError:
+        If configuration is invalid or CPU count unavailable.
+    """
+
+    _workers: Final[dict[WorkerLike, Coroutine]]
+
+    @overload
+    def __init__(
+        self,
+        *tags: str,
+        size: int = 0,
+        worker: WorkerFactory = LocalWorker,
+        discovery: None = None,
+        loadbalancer: (
+            LoadBalancerLike | Factory[LoadBalancerLike]
+        ) = RoundRobinLoadBalancer,
+        credentials: WorkerCredentials | None | UndefinedType = Undefined,
+        options: WorkerOptions | None = None,
+    ):
+        """
+        Create an ephemeral pool of workers, spawning the specified
+        quantity of workers using the specified worker factory.
+        """
+        ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        discovery: DiscoveryLike | Factory[DiscoveryLike],
+        loadbalancer: (
+            LoadBalancerLike | Factory[LoadBalancerLike]
+        ) = RoundRobinLoadBalancer,
+        credentials: WorkerCredentials | None | UndefinedType = Undefined,
+    ):
+        """
+        Connect to an existing pool of workers discovered by the
+        specified discovery protocol.
+        """
+        ...
+
+    @overload
+    def __init__(
+        self,
+        *tags: str,
+        size: int = 0,
+        worker: WorkerFactory = LocalWorker,
+        discovery: DiscoveryLike | Factory[DiscoveryLike],
+        loadbalancer: (
+            LoadBalancerLike | Factory[LoadBalancerLike]
+        ) = RoundRobinLoadBalancer,
+        credentials: WorkerCredentials | None | UndefinedType = Undefined,
+        options: WorkerOptions | None = None,
+    ):
+        """
+        Create a hybrid pool that spawns local workers and discovers
+        remote workers through the specified discovery protocol.
+        """
+        ...
+
+    def __init__(
+        self,
+        *tags: str,
+        size: int | None = None,
+        worker: WorkerFactory | None = None,
+        discovery: DiscoveryLike | Factory[DiscoveryLike] | None = None,
+        loadbalancer: (
+            LoadBalancerLike | Factory[LoadBalancerLike]
+        ) = RoundRobinLoadBalancer,
+        credentials: WorkerCredentials | None | UndefinedType = Undefined,
+        options: WorkerOptions | None = None,
+    ):
+        self._workers = {}
+        self._options = options
+
+        # Resolve credentials: explicit parameter overrides runtime context
+        if credentials is Undefined:
+            ctx = RuntimeContext.get_current()
+            credentials = ctx.credentials
+        else:
+            credentials = credentials
+
+        if credentials is not None:
+            self._credentials = credentials
+            self._client_credentials = credentials.client_credentials
+        else:
+            self._credentials = None
+            self._client_credentials = None
+
+        match (size, discovery):
+            case (size, discovery) if size is not None and discovery is not None:
+                if size == 0:
+                    cpu_count = os.cpu_count()
+                    if cpu_count is None:
+                        raise ValueError("Unable to determine CPU count")
+                    size = cpu_count
+                elif size < 0:
+                    raise ValueError("Size must be non-negative")
+
+                @asynccontextmanager
+                async def create_proxy():
+                    discovery_svc, discovery_ctx = await self._enter_context(discovery)
+                    if not isinstance(discovery_svc, DiscoveryLike):
+                        raise TypeError(
+                            f"Expected DiscoveryLike, got: {type(discovery_svc)}"
+                        )
+
+                    try:
+                        async with self._worker_context(
+                            *tags,
+                            size=size,
+                            factory=worker,
+                            publisher=discovery_svc.publisher,
+                        ):
+                            async with WorkerProxy(
+                                discovery=discovery_svc.subscribe(_predicate(tags)),
+                                loadbalancer=loadbalancer,
+                                credentials=self._client_credentials,
+                                options=self._options,
+                            ):
+                                yield
+                    finally:
+                        await self._exit_context(discovery_ctx)
+
+            case (size, None) if size is not None:
+                if size == 0:
+                    cpu_count = os.cpu_count()
+                    if cpu_count is None:
+                        raise ValueError("Unable to determine CPU count")
+                    size = cpu_count
+                elif size < 0:
+                    raise ValueError("Size must be non-negative")
+
+                namespace = f"pool-{uuid.uuid4().hex}"
+
+                @asynccontextmanager
+                async def create_proxy():
+                    with LocalDiscovery(namespace) as discovery:
+                        async with self._worker_context(
+                            *tags,
+                            size=size,
+                            factory=worker,
+                            publisher=discovery.publisher,
+                        ):
+                            async with WorkerProxy(
+                                discovery=discovery.subscribe(_predicate(tags)),
+                                loadbalancer=loadbalancer,
+                                credentials=self._client_credentials,
+                                options=self._options,
+                            ):
+                                yield
+
+            case (None, discovery) if discovery is not None:
+
+                @asynccontextmanager
+                async def create_proxy():
+                    discovery_svc, discovery_ctx = await self._enter_context(discovery)
+                    if not isinstance(discovery_svc, DiscoveryLike):
+                        raise ValueError
+                    try:
+                        async with WorkerProxy(
+                            discovery=discovery_svc.subscriber,
+                            loadbalancer=loadbalancer,
+                            credentials=self._client_credentials,
+                            options=self._options,
+                        ):
+                            yield
+                    finally:
+                        await self._exit_context(discovery_ctx)
+
+            case (None, None):
+                cpu_count = os.cpu_count()
+                if cpu_count is None:
+                    raise ValueError("Unable to determine CPU count")
+                size = cpu_count
+
+                namespace = f"pool-{uuid.uuid4().hex}"
+
+                @asynccontextmanager
+                async def create_proxy():
+                    with LocalDiscovery(namespace) as discovery:
+                        async with self._worker_context(
+                            *tags,
+                            size=size,
+                            factory=worker,
+                            publisher=discovery.publisher,
+                        ):
+                            async with WorkerProxy(
+                                discovery=discovery.subscriber,
+                                loadbalancer=loadbalancer,
+                                credentials=self._client_credentials,
+                                options=self._options,
+                            ):
+                                yield
+
+            case _:
+                raise RuntimeError
+
+        self._proxy_factory = create_proxy
+
+    async def __aenter__(self) -> WorkerPool:
+        """Starts the worker pool and its services, returning a session.
+
+        This method starts the worker registrar, creates a connection,
+        launches all worker processes, and registers them.
+
+        :returns:
+            The :class:`WorkerPool` instance itself for method chaining.
+        """
+        self._proxy_context = self._proxy_factory()
+        await self._proxy_context.__aenter__()
+        return self
+
+    async def __aexit__(self, *args):
+        """Stops all workers and tears down the pool and its services."""
+        await self._proxy_context.__aexit__(*args)
+
+    @asynccontextmanager
+    async def _worker_context(
+        self,
+        *tags: str,
+        size: int,
+        factory: WorkerFactory | None,
+        publisher: DiscoveryPublisherLike,
+    ):
+        if factory is None:
+            factory = self._default_worker_factory()
+        publisher_svc, publisher_ctx = await self._enter_context(publisher)
+        if not isinstance(publisher_svc, DiscoveryPublisherLike):
+            raise ValueError
+
+        tasks = []
+        for _ in range(size):
+            worker = factory(
+                *tags, credentials=self._credentials, options=self._options
+            )
+
+            async def start(worker):
+                await worker.start()
+                await publisher.publish("worker-added", worker.metadata)
+
+            async def stop(worker):
+                await publisher.publish("worker-dropped", worker.metadata)
+                await worker.stop()
+
+            task = asyncio.create_task(start(worker))
+            tasks.append(task)
+            self._workers[worker] = stop(worker)
+
+        try:
+            await asyncio.gather(*tasks, return_exceptions=True)
+            yield [w.metadata for w in self._workers if w.metadata]
+        finally:
+            tasks = [asyncio.create_task(stop) for stop in self._workers.values()]
+            await asyncio.gather(*tasks, return_exceptions=True)
+            await self._exit_context(publisher_ctx)
+
+    def _default_worker_factory(self):
+        def factory(*tags, credentials=None, options=None):
+            return LocalWorker(*tags, credentials=credentials, options=options)
+
+        return factory
+
+    async def _enter_context(self, factory):
+        ctx = None
+        if isinstance(factory, ContextManager):
+            ctx = factory
+            obj = ctx.__enter__()
+        elif isinstance(factory, AsyncContextManager):
+            ctx = factory
+            obj = await ctx.__aenter__()
+        elif callable(factory):
+            return await self._enter_context(factory())
+        elif isinstance(factory, Awaitable):
+            obj = await factory
+        else:
+            obj = factory
+        return obj, ctx
+
+    async def _exit_context(self, ctx: AsyncContextManager | ContextManager | None):
+        if isinstance(ctx, AsyncContextManager):
+            await ctx.__aexit__(*sys.exc_info())
+        elif isinstance(ctx, ContextManager):
+            ctx.__exit__(*sys.exc_info())
+
+
+def _predicate(tags):
+    return lambda w: bool(w.tags & set(tags)) if tags else True

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import sys
+from contextlib import contextmanager
+from functools import partial
+from multiprocessing import Pipe
+from multiprocessing import Process
+from multiprocessing.connection import Connection
+from typing import TYPE_CHECKING
+
+import grpc.aio
+
+import wool
+from wool import protocol
+from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.worker.base import ServerCredentialsType
+from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.base import resolve_server_credentials
+from wool.runtime.worker.interceptor import VersionInterceptor
+from wool.runtime.worker.service import WorkerService
+
+if TYPE_CHECKING:
+    from wool.runtime.worker.proxy import WorkerProxy
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerProcess(Process):
+    """Subprocess hosting a gRPC worker server.
+
+    Isolated Python process running a gRPC server for task execution.
+    Maintains its own event loop and serves as an independent worker node.
+
+    Communicates the bound port back to the parent process via pipe after
+    startup. Handles SIGTERM and SIGINT for graceful shutdown.
+
+    :param host:
+        Host address to bind.
+    :param port:
+        Port to bind. 0 for random available port.
+    :param shutdown_grace_period:
+        Graceful shutdown timeout in seconds.
+    :param proxy_pool_ttl:
+        Proxy pool TTL in seconds.
+    :param server_credentials:
+        Optional gRPC server credentials for TLS/mTLS.
+    :param options:
+        gRPC message size options. Defaults to
+        :class:`WorkerOptions` with 100 MB limits.
+    :param args:
+        Additional args for :class:`multiprocessing.Process`.
+    :param kwargs:
+        Additional kwargs for :class:`multiprocessing.Process`.
+    """
+
+    _port: int | None
+    _get_port: Connection
+    _set_port: Connection
+    _shutdown_grace_period: float
+    _proxy_pool_ttl: float
+    _credentials: ServerCredentialsType
+    _options: WorkerOptions
+
+    def __init__(
+        self,
+        *args,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        shutdown_grace_period: float = 60.0,
+        proxy_pool_ttl: float = 60.0,
+        server_credentials: ServerCredentialsType = None,
+        options: WorkerOptions | None = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        if not host:
+            raise ValueError("Host must be a non-blank string")
+        self._host = host
+        if port < 0 or port > 65535:
+            raise ValueError("Port must be a positive integer")
+        self._port = port
+        if shutdown_grace_period <= 0:
+            raise ValueError("Shutdown grace period must be positive")
+        self._shutdown_grace_period = shutdown_grace_period
+        if proxy_pool_ttl <= 0:
+            raise ValueError("Proxy pool TTL must be positive")
+        self._proxy_pool_ttl = proxy_pool_ttl
+        self._credentials = server_credentials
+        self._options = options or WorkerOptions()
+        self._get_port, self._set_port = Pipe(duplex=False)
+
+    @property
+    def address(self) -> str | None:
+        """The network address where the gRPC server is listening.
+
+        :returns:
+            The address in "host:port" format, or None if not started.
+        """
+        return self._address(self._host, self._port) if self._port else None
+
+    @property
+    def host(self) -> str | None:
+        """The host where the gRPC server is listening.
+
+        :returns:
+            The host address, or None if not started.
+        """
+        return self._host
+
+    @property
+    def port(self) -> int | None:
+        """The port where the gRPC server is listening.
+
+        :returns:
+            The port number, or None if not started.
+        """
+        return self._port or None
+
+    def start(self, *, timeout: float | None = None):
+        """Start the worker process.
+
+        Launches the worker process and waits until it has started
+        listening on a port. After starting, the :attr:`address`
+        property will contain the actual network address.
+
+        :param timeout:
+            Maximum time in seconds to wait for worker process startup.
+        :raises RuntimeError:
+            If the worker process fails to start within the timeout.
+        :raises ValueError:
+            If the timeout is not positive.
+        """
+        if timeout is not None and timeout <= 0:
+            raise ValueError("Timeout must be positive")
+        super().start()
+        if self._get_port.poll(timeout=timeout):
+            self._port = self._get_port.recv()
+        else:
+            self.terminate()
+            self.join()
+            raise RuntimeError(
+                f"Worker process failed to start within {timeout} seconds"
+            )
+        self._get_port.close()
+
+    def run(self) -> None:
+        """Run the worker process.
+
+        Sets the event loop for this process and starts the gRPC server,
+        blocking until the server is stopped.
+        """
+        # Configure logging for this subprocess
+        logging.basicConfig(
+            level=logging.INFO,
+            format=f"%(asctime)s - WORKER[{self.pid}] - %(name)s - %(levelname)s - %(message)s",
+            stream=sys.stderr,
+        )
+        logger.info(f"Worker process starting on {self._host}:{self._port}")
+
+        wool.__proxy_pool__.set(
+            ResourcePool(
+                factory=_proxy_factory,
+                finalizer=_proxy_finalizer,
+                ttl=self._proxy_pool_ttl,
+            )
+        )
+        try:
+            asyncio.run(self._serve())
+        except Exception as e:
+            logger.exception(f"Worker process crashed: {type(e).__name__}: {e}")
+            raise
+
+    async def _serve(self):
+        """Start the gRPC server in this worker process.
+
+        This method is called by the event loop to start serving
+        requests. It creates a gRPC server, adds the worker service, and
+        starts listening for incoming connections.
+        """
+        grpc_options = [
+            ("grpc.max_receive_message_length", self._options.max_receive_message_length),
+            ("grpc.max_send_message_length", self._options.max_send_message_length),
+        ]
+        server = grpc.aio.server(interceptors=[VersionInterceptor()], options=grpc_options)
+        credentials = resolve_server_credentials(self._credentials)
+        address = self._address(self._host, self._port)
+
+        if credentials is not None:
+            port = server.add_secure_port(address, credentials)
+        else:
+            port = server.add_insecure_port(address)
+
+        service = WorkerService()
+        protocol.add_to_server[protocol.WorkerServicer](service, server)
+
+        with _signal_handlers(service):
+            try:
+                await server.start()
+                logger.info(f"Worker gRPC server started on port {port}")
+                try:
+                    self._set_port.send(port)
+                finally:
+                    self._set_port.close()
+                await service.stopped.wait()
+                logger.info("Worker service stopped, shutting down server")
+            except Exception as e:
+                logger.exception(f"Worker server error: {type(e).__name__}: {e}")
+                raise
+            finally:
+                logger.info("Worker server stopping with grace period")
+                await server.stop(grace=self._shutdown_grace_period)
+
+    def _address(self, host, port) -> str:
+        """Format network address for the given port.
+
+        :param port:
+            Port number to include in the address.
+        :returns:
+            Address string in "host:port" format.
+        """
+        return f"{host}:{port}"
+
+
+@contextmanager
+def _signal_handlers(service: WorkerService):
+    """Context manager for setting up signal handlers for graceful shutdown.
+
+    Installs SIGTERM and SIGINT handlers that gracefully shut down the worker
+    service when the process receives termination signals.
+
+    :param service:
+        The :class:`WorkerService` instance to shut down on signal receipt.
+    :yields:
+        Control to the calling context with signal handlers installed.
+    """
+    loop = asyncio.get_running_loop()
+
+    old_sigterm = signal.signal(signal.SIGTERM, partial(_sigterm_handler, loop, service))
+    old_sigint = signal.signal(signal.SIGINT, partial(_sigint_handler, loop, service))
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGTERM, old_sigterm)
+        signal.signal(signal.SIGINT, old_sigint)
+
+
+def _sigterm_handler(loop, service, signum, frame):
+    if loop.is_running():
+        loop.call_soon_threadsafe(
+            lambda: asyncio.create_task(
+                service.stop(protocol.StopRequest(timeout=0), None)
+            )
+        )
+
+
+def _sigint_handler(loop, service, signum, frame):
+    if loop.is_running():
+        loop.call_soon_threadsafe(
+            lambda: asyncio.create_task(
+                service.stop(protocol.StopRequest(timeout=-1), None)
+            )
+        )
+
+
+async def _proxy_factory(proxy: WorkerProxy):
+    """Factory function for WorkerProxy instances in ResourcePool.
+
+    Starts the proxy if not already started and returns it.
+    The proxy object itself is used as the cache key.
+
+    :param proxy:
+        The WorkerProxy instance to start (passed as key from
+        ResourcePool).
+    :returns:
+        The started WorkerProxy instance.
+    """
+    if not proxy.started:
+        await proxy.start()
+    return proxy
+
+
+async def _proxy_finalizer(proxy: WorkerProxy):
+    """Finalizer function for WorkerProxy instances in ResourcePool.
+
+    Stops the proxy when it's being cleaned up from the resource pool.
+    Based on the cleanup logic from WorkerProxyCache._delayed_cleanup.
+
+    :param proxy:
+        The WorkerProxy instance to clean up.
+    """
+    try:
+        await proxy.stop()
+    except Exception:
+        pass

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import TYPE_CHECKING
+from typing import AsyncContextManager
+from typing import AsyncGenerator
+from typing import AsyncIterator
+from typing import Awaitable
+from typing import Callable
+from typing import ContextManager
+from typing import Generic
+from typing import Sequence
+from typing import TypeAlias
+from typing import TypeVar
+from typing import overload
+
+from packaging.version import InvalidVersion
+from packaging.version import Version
+
+import wool
+from wool.runtime.discovery.base import DiscoveryEvent
+from wool.runtime.discovery.base import DiscoverySubscriberLike
+from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.loadbalancer.base import LoadBalancerContext
+from wool.runtime.loadbalancer.base import LoadBalancerLike
+from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
+from wool.runtime.typing import Factory
+from wool.runtime.worker.base import ChannelCredentialsType
+from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.connection import WorkerConnection
+
+if TYPE_CHECKING:
+    from wool.runtime.routine.task import Task
+
+T = TypeVar("T")
+
+
+def parse_version(version: str) -> Version | None:
+    """Parse a PEP 440 version string.
+
+    :param version:
+        A version string (e.g. ``"1.2.3"``).
+    :returns:
+        A :class:`~packaging.version.Version` instance, or
+        ``None`` if unparseable.
+    """
+    try:
+        return Version(version)
+    except InvalidVersion:
+        return None
+
+
+def is_version_compatible(client: Version, server: Version) -> bool:
+    """Check whether a client version is compatible with a server.
+
+    A server accepts requests from any client whose protocol
+    version is less than or equal to its own within the same major
+    version.  There is no forward-compatibility guarantee.
+
+    :param client:
+        The client's protocol version.
+    :param server:
+        The server's protocol version.
+    :returns:
+        ``True`` if compatible, ``False`` otherwise.
+    """
+    return client.major == server.major and client <= server
+
+
+class ReducibleAsyncIterator(Generic[T]):
+    """An async iterator that can be pickled via __reduce__.
+
+    Converts a sequence into an async iterator while maintaining
+    picklability for distributed task execution contexts.
+
+    :param items:
+        Sequence of items to convert to async iterator.
+    """
+
+    def __init__(self, items: Sequence[T]):
+        self._items = items
+        self._index = 0
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        return self
+
+    async def __anext__(self) -> T:
+        if self._index >= len(self._items):
+            raise StopAsyncIteration
+        item = self._items[self._index]
+        self._index += 1
+        return item
+
+    def __reduce__(self) -> tuple:
+        """Return constructor args for unpickling."""
+        return (self.__class__, (self._items,))
+
+
+WorkerUri: TypeAlias = str
+
+
+class WorkerProxy:
+    """Client-side proxy for dispatching tasks to distributed workers.
+
+    Manages worker discovery, connection pooling, and load-balanced task
+    routing. The bridge between :func:`@wool.routine <wool.routine>` decorated
+    functions and the worker pool.
+
+    Connects to workers through discovery services, pool URIs, or static
+    worker lists. Handles connection lifecycle and fault tolerance
+    automatically.
+
+    **Connect via pool URI:**
+
+    .. code-block:: python
+
+        async with WorkerProxy("pool-abc123") as proxy:
+            result = await task()
+
+    **Connect via discovery:**
+
+    .. code-block:: python
+
+        from wool.runtime.discovery.lan import LanDiscovery
+
+        discovery = LanDiscovery().subscribe()
+        async with WorkerProxy(discovery=discovery) as proxy:
+            result = await task()
+
+    **Connect to static workers:**
+
+    .. code-block:: python
+
+        workers = [
+            WorkerMetadata(address="10.0.0.1:50051", ...),
+            WorkerMetadata(address="10.0.0.2:50051", ...),
+        ]
+        async with WorkerProxy(workers=workers) as proxy:
+            result = await task()
+
+    **Custom load balancer:**
+
+    .. code-block:: python
+
+        from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
+
+
+        class CustomBalancer(RoundRobinLoadBalancer):
+            async def dispatch(self, task, context, timeout=None):
+                # Custom routing strategy
+                ...
+
+
+        async with WorkerProxy(
+            discovery=discovery,
+            loadbalancer=CustomBalancer(),
+        ) as proxy:
+            result = await task()
+
+    :param pool_uri:
+        Pool identifier for discovery-based connection.
+    :param tags:
+        Additional tags for filtering discovered workers.
+    :param discovery:
+        Discovery service or event stream.
+    :param workers:
+        Static worker list for direct connection.
+    :param loadbalancer:
+        Load balancer instance, factory, or context manager.
+    :param credentials:
+        Optional channel credentials for TLS/mTLS connections to workers.
+    """
+
+    _discovery: DiscoverySubscriberLike | Factory[DiscoverySubscriberLike]
+    _discovery_manager: (
+        AsyncContextManager[DiscoverySubscriberLike]
+        | ContextManager[DiscoverySubscriberLike]
+    )
+
+    _loadbalancer = LoadBalancerLike | Factory[LoadBalancerLike]
+    _loadbalancer_manager: (
+        AsyncContextManager[LoadBalancerLike] | ContextManager[LoadBalancerLike]
+    )
+    _credentials: ChannelCredentialsType
+
+    @overload
+    def __init__(
+        self,
+        *,
+        discovery: DiscoverySubscriberLike | Factory[DiscoverySubscriberLike],
+        loadbalancer: (
+            LoadBalancerLike | Factory[LoadBalancerLike]
+        ) = RoundRobinLoadBalancer,
+        credentials: ChannelCredentialsType | None = None,
+        options: WorkerOptions | None = None,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        workers: Sequence[WorkerMetadata],
+        loadbalancer: (
+            LoadBalancerLike | Factory[LoadBalancerLike]
+        ) = RoundRobinLoadBalancer,
+        credentials: ChannelCredentialsType | None = None,
+        options: WorkerOptions | None = None,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        pool_uri: str,
+        *tags: str,
+        loadbalancer: (
+            LoadBalancerLike | Factory[LoadBalancerLike]
+        ) = RoundRobinLoadBalancer,
+        credentials: ChannelCredentialsType | None = None,
+        options: WorkerOptions | None = None,
+    ): ...
+
+    def __init__(
+        self,
+        pool_uri: str | None = None,
+        *tags: str,
+        discovery: (
+            DiscoverySubscriberLike | Factory[DiscoverySubscriberLike] | None
+        ) = None,
+        workers: Sequence[WorkerMetadata] | None = None,
+        loadbalancer: (
+            LoadBalancerLike | Factory[LoadBalancerLike]
+        ) = RoundRobinLoadBalancer,
+        credentials: ChannelCredentialsType | None = None,
+        options: WorkerOptions | None = None,
+    ):
+        if not (pool_uri or discovery or workers):
+            raise ValueError(
+                "Must specify either a workerpool URI, discovery event stream, or a "
+                "sequence of workers"
+            )
+
+        self._id: uuid.UUID = uuid.uuid4()
+        self._started = False
+        self._loadbalancer = loadbalancer
+        self._credentials = credentials
+        self._options = options
+
+        # Create security filter based on resolved credentials
+        security_filter = self._create_security_filter(self._credentials)
+        version_filter = self._create_version_filter()
+
+        def compatible(w):
+            return security_filter(w) and version_filter(w)
+
+        match (pool_uri, discovery, workers):
+            case (pool_uri, None, None) if pool_uri is not None:
+                # Combine tag and compatibility filters
+                def combined_filter(w):
+                    return bool({pool_uri, *tags} & w.tags) and compatible(w)
+
+                self._discovery = LocalDiscovery(pool_uri).subscribe(
+                    filter=combined_filter
+                )
+            case (None, discovery, None) if discovery is not None:
+                self._discovery = discovery
+            case (None, None, workers) if workers is not None:
+                compatible_workers = [w for w in workers if compatible(w)]
+                self._discovery = ReducibleAsyncIterator(
+                    [
+                        DiscoveryEvent("worker-added", metadata=w)
+                        for w in compatible_workers
+                    ]
+                )
+            case _:
+                raise ValueError(
+                    "Must specify exactly one of: "
+                    "pool_uri, discovery_event_stream, or workers"
+                )
+        self._sentinel_task: asyncio.Task[None] | None = None
+        self._loadbalancer_context: LoadBalancerContext | None = None
+
+    async def __aenter__(self):
+        """Starts the proxy and sets it as the active context."""
+        await self.start()
+        return self
+
+    async def __aexit__(self, *args):
+        """Stops the proxy and resets the active context."""
+        await self.stop(*args)
+
+    def __hash__(self) -> int:
+        return hash(str(self.id))
+
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, WorkerProxy) and hash(self) == hash(value)
+
+    def __reduce__(self) -> tuple:
+        """Return constructor args for unpickling with proxy ID preserved.
+
+        Creates a new WorkerProxy instance with the same discovery stream and
+        load balancer type, then sets the preserved proxy ID on the new object.
+        Workers will be re-discovered on the new instance.
+
+        :returns:
+            Tuple of (callable, args, state) for unpickling.
+        """
+
+        def _restore_proxy(discovery, loadbalancer, proxy_id):
+            proxy = WorkerProxy(discovery=discovery, loadbalancer=loadbalancer)
+            proxy._id = proxy_id
+            return proxy
+
+        return (
+            _restore_proxy,
+            (self._discovery, self._loadbalancer, self._id),
+        )
+
+    @property
+    def id(self) -> uuid.UUID:
+        return self._id
+
+    @property
+    def started(self) -> bool:
+        return self._started
+
+    @property
+    def workers(self) -> list[WorkerMetadata]:
+        """A list of the currently discovered worker gRPC stubs."""
+        if self._loadbalancer_context:
+            return list(self._loadbalancer_context.workers.keys())
+        else:
+            return []
+
+    async def start(self) -> None:
+        """Starts the proxy by initiating the worker discovery process.
+
+        :raises RuntimeError:
+            If the proxy has already been started.
+        """
+        if self._started:
+            raise RuntimeError("Proxy already started")
+
+        (
+            self._loadbalancer_service,
+            self._loadbalancer_context_manager,
+        ) = await self._enter_context(self._loadbalancer)
+        if not isinstance(self._loadbalancer_service, LoadBalancerLike):
+            raise ValueError
+
+        (
+            self._discovery_stream,
+            self._discovery_context_manager,
+        ) = await self._enter_context(self._discovery)
+        if not isinstance(self._discovery_stream, DiscoverySubscriberLike):
+            raise ValueError
+
+        self._proxy_token = wool.__proxy__.set(self)
+        self._loadbalancer_context = LoadBalancerContext()
+        self._sentinel_task = asyncio.create_task(self._worker_sentinel())
+        self._started = True
+
+    async def stop(self, *args) -> None:
+        """Stops the proxy, terminating discovery and clearing connections.
+
+        :raises RuntimeError:
+            If the proxy was not started first.
+        """
+        if not self._started:
+            raise RuntimeError("Proxy not started - call start() first")
+
+        await self._exit_context(self._discovery_context_manager, *args)
+        await self._exit_context(self._loadbalancer_context_manager, *args)
+
+        wool.__proxy__.reset(self._proxy_token)
+        if self._sentinel_task:
+            self._sentinel_task.cancel()
+            try:
+                await self._sentinel_task
+            except asyncio.CancelledError:
+                pass
+            self._sentinel_task = None
+        self._loadbalancer_context = None
+        self._started = False
+
+    async def dispatch(
+        self, task: Task, *, timeout: float | None = None
+    ) -> AsyncGenerator:
+        """Dispatches a task to an available worker in the pool.
+
+        This method selects a worker using a round-robin strategy. If no
+        workers are available within the timeout period, it raises an
+        exception.
+
+        :param task:
+            The :class:`Task` object to be dispatched.
+        :param timeout:
+            Timeout in seconds for getting a worker.
+        :returns:
+            A protobuf result object from the worker.
+        :raises RuntimeError:
+            If the proxy is not started.
+        :raises asyncio.TimeoutError:
+            If no worker is available within the timeout period.
+        """
+        if not self._started:
+            raise RuntimeError("Proxy not started - call start() first")
+
+        await asyncio.wait_for(self._await_workers(), 60)
+
+        assert isinstance(self._loadbalancer_service, LoadBalancerLike)
+        assert self._loadbalancer_context
+        return await self._loadbalancer_service.dispatch(
+            task, context=self._loadbalancer_context, timeout=timeout
+        )
+
+    async def _enter_context(self, factory):
+        ctx = None
+        if isinstance(factory, ContextManager):
+            ctx = factory
+            obj = ctx.__enter__()
+        elif isinstance(factory, AsyncContextManager):
+            ctx = factory
+            obj = await ctx.__aenter__()
+        elif callable(factory):
+            return await self._enter_context(factory())
+        elif isinstance(factory, Awaitable):
+            obj = await factory
+        else:
+            obj = factory
+        return obj, ctx
+
+    async def _exit_context(
+        self, ctx: AsyncContextManager | ContextManager | None, *args
+    ):
+        if isinstance(ctx, AsyncContextManager):
+            await ctx.__aexit__(*args)
+        elif isinstance(ctx, ContextManager):
+            ctx.__exit__(*args)
+
+    def _create_security_filter(
+        self, credentials: ChannelCredentialsType
+    ) -> Callable[[WorkerMetadata], bool]:
+        """Create discovery filter based on proxy credentials.
+
+        Workers and proxies must have compatible security settings:
+        - Proxy with credentials only discovers workers with secure=True
+        - Proxy without credentials only discovers workers with secure=False
+
+        :param credentials:
+            Channel credentials for this proxy.
+        :returns:
+            Predicate function for filtering workers by security compatibility.
+        """
+        if credentials is not None:
+            # Proxy has credentials: only accept secure workers
+            return lambda metadata: metadata.secure
+        else:
+            # Proxy has no credentials: only accept insecure workers
+            return lambda metadata: not metadata.secure
+
+    @staticmethod
+    def _create_version_filter() -> Callable[[WorkerMetadata], bool]:
+        """Create discovery filter based on major version compatibility.
+
+        A worker is accepted when its version is greater than or
+        equal to the local proxy version within the same major
+        version.  Workers with unparseable versions are rejected.
+
+        :returns:
+            Predicate function for filtering workers by version
+            compatibility.
+        """
+        from wool import protocol
+
+        local_version = parse_version(protocol.__version__)
+
+        def version_filter(metadata: WorkerMetadata) -> bool:
+            worker_version = parse_version(metadata.version)
+            if local_version is None or worker_version is None:
+                return False
+            return is_version_compatible(local_version, worker_version)
+
+        return version_filter
+
+    async def _await_workers(self):
+        while not self._loadbalancer_context or not self._loadbalancer_context.workers:
+            await asyncio.sleep(0)
+
+    async def _worker_sentinel(self):
+        assert self._loadbalancer_context
+        async for event in self._discovery_stream:
+            match event.type:
+                case "worker-added":
+                    self._loadbalancer_context.add_worker(
+                        event.metadata,
+                        WorkerConnection(
+                            event.metadata.address,
+                            credentials=self._credentials,
+                            options=self._options,
+                        ),
+                    )
+                case "worker-updated":
+                    self._loadbalancer_context.update_worker(
+                        event.metadata,
+                        WorkerConnection(
+                            event.metadata.address,
+                            credentials=self._credentials,
+                            options=self._options,
+                        ),
+                    )
+                case "worker-dropped":
+                    self._loadbalancer_context.remove_worker(event.metadata)

--- a/wool/src/wool/runtime/worker/service.py
+++ b/wool/src/wool/runtime/worker/service.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import contextvars
+import threading
+from contextlib import contextmanager
+from inspect import isasyncgen
+from inspect import isasyncgenfunction
+from inspect import iscoroutinefunction
+from typing import AsyncGenerator
+from typing import AsyncIterator
+
+import cloudpickle
+from grpc import StatusCode
+from grpc.aio import ServicerContext
+
+import wool
+from wool import protocol
+from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.routine.task import Task
+from wool.runtime.routine.task import do_dispatch
+
+# Sentinel to mark end of async generator stream
+_SENTINEL = object()
+
+
+class _Task:
+    def __init__(self, task: asyncio.Task):
+        self._work = task
+
+    async def cancel(self):
+        self._work.cancel()
+        await self._work
+
+
+class _AsyncGen:
+    def __init__(self, task: AsyncGenerator):
+        self._work = task
+
+    async def cancel(self):
+        await self._work.aclose()
+
+
+class _ReadOnlyEvent:
+    """A read-only wrapper around :class:`asyncio.Event`.
+
+    Provides access to check if an event is set and wait for it to be
+    set, but prevents external code from setting or clearing the event.
+
+    :param event:
+        The underlying :class:`asyncio.Event` to wrap.
+    """
+
+    def __init__(self, event: asyncio.Event):
+        self._event = event
+
+    def is_set(self) -> bool:
+        """Check if the event is set.
+
+        :returns:
+            ``True`` if the event is set, ``False`` otherwise.
+        """
+        return self._event.is_set()
+
+    async def wait(self) -> None:
+        """Wait until the underlying event is set."""
+        await self._event.wait()
+
+
+class WorkerService(protocol.WorkerServicer):
+    """gRPC service for task execution.
+
+    Implements the worker gRPC interface for receiving and executing
+    tasks. Runs tasks in the current asyncio event loop and streams
+    results back to the client.
+
+    Handles graceful shutdown by rejecting new tasks while allowing
+    in-flight tasks to complete. Exposes :attr:`stopping` and
+    :attr:`stopped` events for lifecycle monitoring.
+    """
+
+    _docket: set[_Task | _AsyncGen]
+    _stopped: asyncio.Event
+    _stopping: asyncio.Event
+    _task_completed: asyncio.Event
+    _loop_pool: ResourcePool[tuple[asyncio.AbstractEventLoop, threading.Thread]]
+
+    def __init__(self):
+        self._stopped = asyncio.Event()
+        self._stopping = asyncio.Event()
+        self._task_completed = asyncio.Event()
+        self._docket = set()
+        self._loop_pool = ResourcePool(
+            factory=self._create_worker_loop,
+            finalizer=self._destroy_worker_loop,
+            ttl=0,
+        )
+
+    @property
+    def stopping(self) -> _ReadOnlyEvent:
+        """Read-only event signaling that the service is stopping.
+
+        :returns:
+            A :class:`_ReadOnlyEvent`.
+        """
+        return _ReadOnlyEvent(self._stopping)
+
+    @property
+    def stopped(self) -> _ReadOnlyEvent:
+        """Read-only event signaling that the service has stopped.
+
+        :returns:
+            A :class:`_ReadOnlyEvent`.
+        """
+        return _ReadOnlyEvent(self._stopped)
+
+    async def dispatch(
+        self,
+        request_iterator: AsyncIterator[protocol.Request],
+        context: ServicerContext,
+    ) -> AsyncIterator[protocol.Response]:
+        """Execute a task in the current event loop.
+
+        Reads the first :class:`~wool.protocol.Request` from
+        the bidirectional stream to obtain the :class:`Task`, then
+        schedules it for execution. For async generators, subsequent
+        ``Message`` frames are forwarded into the generator via
+        ``asend()``.
+
+        :param request_iterator:
+            The incoming bidirectional request stream.
+        :param context:
+            The :class:`grpc.aio.ServicerContext` for this request.
+        :yields:
+            First yields an Ack Response when task processing begins,
+            then yields Response(s) containing the task result(s).
+
+        """
+        if self._stopping.is_set():
+            await context.abort(
+                StatusCode.UNAVAILABLE, "Worker service is shutting down"
+            )
+
+        response = await anext(aiter(request_iterator))
+        with self._tracker(Task.from_protobuf(response.task), request_iterator) as task:
+            ack = protocol.Ack(version=protocol.__version__)
+            yield protocol.Response(ack=ack)
+            try:
+                if isasyncgen(task):
+                    async for result in task:
+                        result = protocol.Message(dump=cloudpickle.dumps(result))
+                        yield protocol.Response(result=result)
+                elif isinstance(task, asyncio.Task):
+                    result = protocol.Message(dump=cloudpickle.dumps(await task))
+                    yield protocol.Response(result=result)
+            except (Exception, asyncio.CancelledError) as e:
+                exception = protocol.Message(dump=cloudpickle.dumps(e))
+                yield protocol.Response(exception=exception)
+
+    async def stop(
+        self, request: protocol.StopRequest, context: ServicerContext | None
+    ) -> protocol.Void:
+        """Stop the worker service and its thread.
+
+        Gracefully shuts down the worker thread and signals the server
+        to stop accepting new requests. This method is idempotent and
+        can be called multiple times safely.
+
+        :param request:
+            The protobuf stop request containing the wait timeout.
+        :param context:
+            The :class:`grpc.aio.ServicerContext` for this request.
+        :returns:
+            An empty protobuf response indicating completion.
+        """
+        if self._stopping.is_set():
+            return protocol.Void()
+        await self._stop(timeout=request.timeout)
+        return protocol.Void()
+
+    @staticmethod
+    def _create_worker_loop(
+        key,
+    ) -> tuple[asyncio.AbstractEventLoop, threading.Thread]:
+        """Create a new event loop running on a dedicated daemon thread.
+
+        :param key:
+            The :class:`ResourcePool` cache key (unused).
+        :returns:
+            A tuple of the event loop and the thread running it.
+        """
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+        return loop, thread
+
+    @staticmethod
+    def _destroy_worker_loop(
+        loop_thread: tuple[asyncio.AbstractEventLoop, threading.Thread],
+    ) -> None:
+        """Stop the worker event loop and join its thread.
+
+        Cancels all pending tasks on the worker loop before stopping,
+        ensuring cleanup code runs in each task's own context.
+
+        :param loop_thread:
+            A tuple of the event loop and the thread running it.
+        """
+        loop, thread = loop_thread
+
+        async def _shutdown():
+            current = asyncio.current_task()
+            tasks = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            loop.stop()
+
+        loop.call_soon_threadsafe(lambda: loop.create_task(_shutdown()))
+        thread.join(timeout=5)
+        loop.close()
+
+    async def _run_on_worker(self, work_task: Task):
+        """Run a task on the shared worker event loop.
+
+        Offloads task execution to a dedicated worker event loop to
+        prevent blocking the main gRPC event loop. Context variables
+        are propagated from the calling context to the worker loop.
+
+        :param work_task:
+            The :class:`Task` instance to execute.
+        :returns:
+            The result of the task execution.
+        """
+        ctx = contextvars.copy_context()
+        future: concurrent.futures.Future = concurrent.futures.Future()
+        worker_task = None
+
+        async with self._loop_pool.get("worker") as (worker_loop, _):
+
+            def _schedule():
+                nonlocal worker_task
+                task = worker_loop.create_task(work_task._run(), context=ctx)
+                worker_task = task
+
+                def _done(t: asyncio.Task):
+                    if future.done():
+                        return
+                    if t.cancelled():
+                        future.cancel()
+                    elif t.exception() is not None:
+                        future.set_exception(t.exception())
+                    else:
+                        future.set_result(t.result())
+
+                task.add_done_callback(_done)
+
+            worker_loop.call_soon_threadsafe(_schedule)
+
+            try:
+                return await asyncio.wrap_future(future)
+            except asyncio.CancelledError:
+                if worker_task is not None:
+                    worker_loop.call_soon_threadsafe(worker_task.cancel)
+                raise
+
+    async def _stream_from_worker(
+        self,
+        work_task: Task,
+        request_iterator: AsyncIterator[protocol.Request],
+    ):
+        """Run a streaming task on the shared worker event loop.
+
+        Offloads async generator execution to a dedicated worker event
+        loop. Client requests (``next``, ``send``, ``throw``) are read
+        from *request_iterator* on the main loop, forwarded to the
+        worker loop via a queue, and the resulting values are returned
+        to the main loop for yielding.
+
+        :param work_task:
+            The :class:`Task` instance containing an async
+            generator.
+        :param request_iterator:
+            The incoming bidirectional request stream for reading
+            client-driven iteration commands.
+        :yields:
+            Values yielded by the async generator, streamed from
+            the worker loop.
+        """
+        main_loop = asyncio.get_running_loop()
+        ctx = contextvars.copy_context()
+        request_queue: asyncio.Queue = asyncio.Queue()
+        result_queue: asyncio.Queue = asyncio.Queue()
+
+        async with self._loop_pool.get("worker") as (worker_loop, _):
+
+            async def worker_dispatch():
+                proxy_pool = wool.__proxy_pool__.get()
+                proxy_ctx = proxy_pool.get(work_task.proxy) if proxy_pool else None
+                proxy = await proxy_ctx.__aenter__() if proxy_ctx else None
+                token = wool.__proxy__.set(proxy) if proxy else None
+                try:
+                    gen = work_task.callable(*work_task.args, **work_task.kwargs)
+                    try:
+                        while True:
+                            cmd = await request_queue.get()
+                            if cmd is _SENTINEL:
+                                break
+                            action, payload = cmd
+                            try:
+                                with do_dispatch(False):
+                                    match action:
+                                        case "next":
+                                            value = await gen.asend(None)
+                                        case "send":
+                                            value = await gen.asend(payload)
+                                        case "throw":
+                                            value = await gen.athrow(
+                                                type(payload), payload
+                                            )
+                                        case _:
+                                            continue
+                            except StopAsyncIteration:
+                                main_loop.call_soon_threadsafe(
+                                    result_queue.put_nowait, _SENTINEL
+                                )
+                                return
+                            except BaseException as e:
+                                main_loop.call_soon_threadsafe(
+                                    result_queue.put_nowait, ("error", e)
+                                )
+                                return
+                            else:
+                                main_loop.call_soon_threadsafe(
+                                    result_queue.put_nowait,
+                                    ("value", value),
+                                )
+                    finally:
+                        await gen.aclose()
+                finally:
+                    if token is not None:
+                        wool.__proxy__.reset(token)
+                    if proxy_ctx is not None:
+                        await proxy_ctx.__aexit__(None, None, None)
+
+            worker_loop.call_soon_threadsafe(
+                lambda: worker_loop.create_task(worker_dispatch(), context=ctx)
+            )
+
+            try:
+                async for request in request_iterator:
+                    match request.WhichOneof("payload"):
+                        case "next":
+                            worker_loop.call_soon_threadsafe(
+                                request_queue.put_nowait,
+                                ("next", None),
+                            )
+                        case "send":
+                            value = cloudpickle.loads(request.send.dump)
+                            worker_loop.call_soon_threadsafe(
+                                request_queue.put_nowait,
+                                ("send", value),
+                            )
+                        case "throw":
+                            exc = cloudpickle.loads(request.throw.dump)
+                            worker_loop.call_soon_threadsafe(
+                                request_queue.put_nowait,
+                                ("throw", exc),
+                            )
+                        case _:
+                            continue
+
+                    result = await result_queue.get()
+
+                    if result is _SENTINEL:
+                        break
+                    tag, payload = result
+                    if tag == "error":
+                        raise payload
+                    yield payload
+            finally:
+                worker_loop.call_soon_threadsafe(request_queue.put_nowait, _SENTINEL)
+
+    @contextmanager
+    def _tracker(
+        self,
+        work_task: Task,
+        request_iterator: AsyncIterator[protocol.Request],
+    ):
+        """Context manager for tracking running tasks.
+
+        Manages the lifecycle of a task execution, adding it to the
+        active tasks set. Ensures proper cleanup when the task
+        completes or fails.
+
+        Tasks are executed in a thread pool to prevent blocking the
+        main gRPC event loop, allowing the worker to remain responsive
+        to health checks and new task dispatches.
+
+        :param work_task:
+            The :class:`Task` instance to execute and track.
+        :param request_iterator:
+            The incoming bidirectional request stream.
+        :yields:
+            The :class:`asyncio.Task` or async generator for the
+            wool task.
+
+        """
+        if iscoroutinefunction(work_task.callable):
+            # Regular async function -> run on worker loop
+            task = asyncio.create_task(self._run_on_worker(work_task))
+            watcher = _Task(task)
+        elif isasyncgenfunction(work_task.callable):
+            # Async generator -> stream from worker loop via queue
+            task = self._stream_from_worker(work_task, request_iterator)
+            watcher = _AsyncGen(task)
+        else:
+            raise ValueError("Expected coroutine function or async generator function")
+
+        self._docket.add(watcher)
+        try:
+            yield task
+        finally:
+            self._docket.discard(watcher)
+
+    async def _stop(self, *, timeout: float | None = 0) -> None:
+        if timeout is not None and timeout < 0:
+            timeout = None
+        self._stopping.set()
+        await self._await_or_cancel(timeout=timeout)
+        try:
+            if proxy_pool := wool.__proxy_pool__.get():
+                await proxy_pool.clear()
+        finally:
+            await self._loop_pool.clear()
+            self._stopped.set()
+
+    async def _await_or_cancel(self, *, timeout: float | None = 0) -> None:
+        """Stop the worker service gracefully.
+
+        Gracefully shuts down the worker service by canceling or waiting
+        for running tasks. This method is idempotent and can be called
+        multiple times safely.
+
+        :param timeout:
+            Maximum time to wait for tasks to complete. If 0 (default),
+            tasks are canceled immediately. If None, waits indefinitely.
+            If a positive number, waits for that many seconds before
+            canceling tasks.
+
+        .. note::
+            If a timeout occurs while waiting for tasks to complete,
+            the method recursively calls itself with a timeout of 0
+            to cancel all remaining tasks immediately.
+        """
+        if self._docket and timeout == 0:
+            await self._cancel()
+        elif self._docket:
+            try:
+                await asyncio.wait_for(self._await(), timeout=timeout)
+            except asyncio.TimeoutError:
+                return await self._await_or_cancel(timeout=0)
+
+    async def _await(self):
+        while self._docket:
+            await asyncio.sleep(0)
+
+    async def _cancel(self):
+        """Cancel multiple tasks safely.
+
+        Cancels the provided tasks while performing safety checks to
+        avoid canceling the current task or already completed tasks.
+        Waits for all cancelled tasks to complete in parallel and handles
+        cancellation exceptions.
+
+        :param tasks:
+            The :class:`asyncio.Task` instances to cancel.
+
+        .. note::
+            This method performs the following safety checks:
+            - Avoids canceling the current task (would cause deadlock)
+            - Only cancels tasks that are not already done
+            - Properly handles :exc:`asyncio.CancelledError`
+              exceptions.
+        """
+        await asyncio.gather(*(w.cancel() for w in self._docket), return_exceptions=True)


### PR DESCRIPTION
## Summary

Add the worker service and orchestration layer: a gRPC service for executing dispatched tasks, a version interceptor for wire protocol compatibility, a client-side proxy for load-balanced task dispatch, subprocess worker hosting, a local worker abstraction, and the top-level WorkerPool orchestrator that ties discovery, proxying, and worker lifecycle management together.

Closes #20

## Proposed changes

### gRPC worker service

Add the Worker gRPC servicer implementing `dispatch` and `stop` RPCs. Dispatch handles both coroutine and async generator tasks via bidirectional streaming, supporting next/send/throw client requests. Stop performs graceful shutdown with configurable timeout, cancelling in-flight tasks after the deadline.

### Worker proxy and version interceptor

Add WorkerProxy for client-side proxy pool management, discovery event subscription, and load-balanced task dispatch across available workers. Include version parsing and major-version compatibility checking.

Add VersionInterceptor as a gRPC server interceptor that validates wire protocol versions on incoming dispatch requests, rejecting incompatible major versions with FAILED_PRECONDITION.

### Worker process and local worker

Add WorkerProcess for hosting a gRPC server in a subprocess with the version interceptor, TLS/mTLS credential support, and graceful shutdown. Bind to a random available port and manage the server lifecycle.

Add LocalWorker wrapping WorkerProcess as a Worker implementation for same-machine workers, handling subprocess start/stop and publishing worker metadata to the discovery service.

### WorkerPool orchestrator

Add the top-level orchestrator tying together discovery, worker lifecycle, and proxy-based task dispatch. Manage a configurable number of local workers, subscribe to discovery events, and expose an async context manager that starts workers, initializes the proxy pool, and tears everything down on exit.

## Test cases

N/A — Tests are deferred to a follow-up issue.

## Implementation plan

1. - [x] Implement the gRPC worker service with dispatch and stop RPCs, bidirectional streaming, and graceful shutdown
2. - [x] Implement the worker proxy with discovery subscription, load-balanced dispatch, and version compatibility checking
3. - [x] Implement the version interceptor for wire protocol major-version gating
4. - [x] Implement the worker process for subprocess gRPC server hosting with TLS support
5. - [x] Implement the local worker wrapping worker process with discovery publishing
6. - [x] Implement the WorkerPool orchestrator with configurable worker count, discovery integration, and async context manager lifecycle