### PR TITLE
Add public API exports — Closes #23

### DIFF
--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -1,0 +1,112 @@
+from contextvars import ContextVar
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version
+from typing import Final
+
+from tblib import pickling_support
+
+from wool.runtime.context import RuntimeContext
+from wool.runtime.discovery.base import Discovery
+from wool.runtime.discovery.base import DiscoveryEvent
+from wool.runtime.discovery.base import DiscoveryEventType
+from wool.runtime.discovery.base import DiscoveryLike
+from wool.runtime.discovery.base import DiscoveryPublisherLike
+from wool.runtime.discovery.base import DiscoverySubscriberLike
+from wool.runtime.discovery.base import PredicateFunction
+from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.discovery.lan import LanDiscovery
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.loadbalancer.base import LoadBalancerContextLike
+from wool.runtime.loadbalancer.base import LoadBalancerLike
+from wool.runtime.loadbalancer.base import NoWorkersAvailable
+from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
+from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.routine.task import Task
+from wool.runtime.routine.task import TaskException
+from wool.runtime.routine.task import current_task
+from wool.runtime.routine.wrapper import routine
+from wool.runtime.typing import Factory
+from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.base import Worker
+from wool.runtime.worker.base import WorkerFactory
+from wool.runtime.worker.base import WorkerLike
+from wool.runtime.worker.connection import RpcError
+from wool.runtime.worker.connection import TransientRpcError
+from wool.runtime.worker.connection import UnexpectedResponse
+from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.local import LocalWorker
+from wool.runtime.worker.pool import WorkerPool
+from wool.runtime.worker.proxy import WorkerProxy
+from wool.runtime.worker.service import WorkerService
+
+pickling_support.install()
+
+try:
+    __version__ = version("wool")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
+__proxy__: Final[ContextVar[WorkerProxy | None]] = ContextVar("__proxy__", default=None)
+
+__proxy_pool__: Final[ContextVar[ResourcePool[WorkerProxy] | None]] = ContextVar(
+    "__proxy_pool__", default=None
+)
+
+__all__ = [
+    # Connection
+    "RpcError",
+    "TransientRpcError",
+    "UnexpectedResponse",
+    "WorkerConnection",
+    # Context
+    "RuntimeContext",
+    # Load balancing
+    "LoadBalancerContextLike",
+    "LoadBalancerLike",
+    "NoWorkersAvailable",
+    "RoundRobinLoadBalancer",
+    # Routines
+    "Task",
+    "TaskException",
+    "current_task",
+    "routine",
+    # Workers
+    "LocalWorker",
+    "Worker",
+    "WorkerCredentials",
+    "WorkerFactory",
+    "WorkerLike",
+    "WorkerPool",
+    "WorkerProxy",
+    "WorkerService",
+    # Discovery
+    "Discovery",
+    "DiscoveryEvent",
+    "DiscoveryEventType",
+    "DiscoveryLike",
+    "DiscoveryPublisherLike",
+    "DiscoverySubscriberLike",
+    "LanDiscovery",
+    "LocalDiscovery",
+    "PredicateFunction",
+    "WorkerMetadata",
+    # Typing
+    "Factory",
+]
+
+for symbol in __all__:
+    attribute = globals().get(symbol)
+    try:
+        if attribute and "wool" in attribute.__module__.split("."):
+            # Set the module to reflect imports of the symbol
+            attribute.__module__ = __name__
+    except AttributeError:
+        continue
+
+# for plugin in entry_points(group="wool_cli_plugins"):
+#     try:
+#         plugin.load()
+#         logging.info(f"Loaded CLI plugin {plugin.name}")
+#     except Exception as e:
+#         logging.error(f"Failed to load CLI plugin {plugin.name}: {e}")
+#         raise


### PR DESCRIPTION
## Summary

Add the top-level `wool` package `__init__.py` that re-exports the public API surface, making key classes and functions available directly from `import wool`. Include version metadata from build metadata, install tblib pickling support, and expose context variables for proxy lifecycle management. Populate `__all__` to declare the public contract and re-attribute module paths so public symbols appear to originate from the top-level package.

Closes #23

## Proposed changes

### Public API module

Add `wool/__init__.py` re-exporting the full public API organized by domain: connection types (`RpcError`, `TransientRpcError`, `UnexpectedResponse`, `WorkerConnection`), runtime context (`RuntimeContext`), load balancing (`LoadBalancerContextLike`, `LoadBalancerLike`, `NoWorkersAvailable`, `RoundRobinLoadBalancer`), routines (`Task`, `TaskException`, `current_task`, `routine`), workers (`LocalWorker`, `Worker`, `WorkerCredentials`, `WorkerFactory`, `WorkerLike`, `WorkerPool`, `WorkerProxy`, `WorkerService`), discovery (`Discovery`, `DiscoveryEvent`, `DiscoveryEventType`, `DiscoveryLike`, `DiscoveryPublisherLike`, `DiscoverySubscriberLike`, `LanDiscovery`, `LocalDiscovery`, `PredicateFunction`, `WorkerMetadata`), typing (`Factory`), and the `ResourcePool` utility.

Define `__proxy__` and `__proxy_pool__` context variables for internal proxy lifecycle management. Install tblib pickling support at import time for traceback serialization across process boundaries.

## Test cases

N/A — Tests are deferred to a follow-up issue.

## Implementation plan

1. - [x] Write the top-level package `__init__.py` with all public API re-exports, version metadata, tblib installation, context variables, and `__all__` declaration