### PR TITLE
Clean up formatting with ruff — Closes #31

### DIFF
--- a/wool/src/wool/runtime/discovery/base.py
+++ b/wool/src/wool/runtime/discovery/base.py
@@ -16,6 +16,7 @@ from typing import TypeVar
 from typing import runtime_checkable
 
 from wool.protocol import WorkerMetadata as WorkerMetadataProtobuf
+
 T: Final = TypeVar("T")
 
 # public

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -19,9 +19,7 @@ from wool.runtime.worker.base import ChannelCredentialsType
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.base import resolve_channel_credentials
 
-_DispatchCall: TypeAlias = grpc.aio.StreamStreamCall[
-    protocol.Request, protocol.Response
-]
+_DispatchCall: TypeAlias = grpc.aio.StreamStreamCall[protocol.Request, protocol.Response]
 
 _T = TypeVar("_T")
 

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -382,9 +382,7 @@ class WorkerPool:
 
         tasks = []
         for _ in range(size):
-            worker = factory(
-                *tags, credentials=self._credentials, options=self._options
-            )
+            worker = factory(*tags, credentials=self._credentials, options=self._options)
 
             async def start(worker):
                 await worker.start()

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -181,10 +181,15 @@ class WorkerProcess(Process):
         starts listening for incoming connections.
         """
         grpc_options = [
-            ("grpc.max_receive_message_length", self._options.max_receive_message_length),
+            (
+                "grpc.max_receive_message_length",
+                self._options.max_receive_message_length,
+            ),
             ("grpc.max_send_message_length", self._options.max_send_message_length),
         ]
-        server = grpc.aio.server(interceptors=[VersionInterceptor()], options=grpc_options)
+        server = grpc.aio.server(
+            interceptors=[VersionInterceptor()], options=grpc_options
+        )
         credentials = resolve_server_credentials(self._credentials)
         address = self._address(self._host, self._port)
 

--- a/wool/tests/protocol/test_wire.py
+++ b/wool/tests/protocol/test_wire.py
@@ -2,7 +2,6 @@ import pytest
 
 from wool import protocol
 
-
 EXPECTED_MESSAGE_EXPORTS = [
     "Ack",
     "Message",

--- a/wool/tests/runtime/routine/test_task.py
+++ b/wool/tests/runtime/routine/test_task.py
@@ -163,9 +163,7 @@ def test_do_dispatch_with_nested_contexts():
 
 
 @pytest.mark.asyncio
-async def test_current_task_inside_task_context(
-    sample_task, mock_worker_proxy_cache
-):
+async def test_current_task_inside_task_context(sample_task, mock_worker_proxy_cache):
     """Test current_task returns the active Task during dispatch.
 
     Given:
@@ -236,9 +234,7 @@ async def test_current_task_with_nested_task_contexts(sample_task):
 )
 @given(depth=st.integers(min_value=2, max_value=5))
 @pytest.mark.asyncio
-async def test_current_task_with_variable_nesting_depth(
-    depth, sample_task
-):
+async def test_current_task_with_variable_nesting_depth(depth, sample_task):
     """Test nested task context tracking at variable depth.
 
     Given:
@@ -282,9 +278,7 @@ class TestTask:
     """Tests for :py:class:`Task`."""
 
     @pytest.mark.asyncio
-    async def test___post_init___inside_task_context(
-        self, sample_task
-    ):
+    async def test___post_init___inside_task_context(self, sample_task):
         """Test post-init sets caller inside a task context.
 
         Given:
@@ -322,9 +316,7 @@ class TestTask:
         assert task.caller is None
 
     @pytest.mark.asyncio
-    async def test___enter___with_coroutine_callable(
-        self, sample_task
-    ):
+    async def test___enter___with_coroutine_callable(self, sample_task):
         """Test __enter__ returns a callable for coroutine tasks.
 
         Given:
@@ -343,9 +335,7 @@ class TestTask:
             assert callable(run_method)
 
     @pytest.mark.asyncio
-    async def test___enter___with_async_generator(
-        self, sample_task
-    ):
+    async def test___enter___with_async_generator(self, sample_task):
         """Test __enter__ returns a callable for generator tasks.
 
         Given:
@@ -368,9 +358,7 @@ class TestTask:
             assert callable(run_method)
 
     @pytest.mark.asyncio
-    async def test___enter___with_invalid_callable(
-        self, sample_task
-    ):
+    async def test___enter___with_invalid_callable(self, sample_task):
         """Test __enter__ raises ValueError for non-async callable.
 
         Given:
@@ -666,9 +654,7 @@ class TestTask:
         assert task.timeout == 0
         assert task.tag is None
 
-    def test_to_protobuf_all_fields(
-        self, sample_async_callable, picklable_proxy
-    ):
+    def test_to_protobuf_all_fields(self, sample_async_callable, picklable_proxy):
         """Test to_protobuf serializes all fields correctly.
 
         Given:
@@ -711,9 +697,7 @@ class TestTask:
         assert pb_task.timeout == 30
         assert pb_task.tag == "test_tag"
 
-    def test_to_protobuf_none_optionals(
-        self, sample_async_callable, picklable_proxy
-    ):
+    def test_to_protobuf_none_optionals(self, sample_async_callable, picklable_proxy):
         """Test to_protobuf serializes None optionals as defaults.
 
         Given:
@@ -851,9 +835,7 @@ class TestTask:
         assert result == 8
 
     @pytest.mark.asyncio
-    async def test_dispatch_without_proxy_pool_raises_error(
-        self, sample_task
-    ):
+    async def test_dispatch_without_proxy_pool_raises_error(self, sample_task):
         """Test dispatch raises RuntimeError without a proxy pool.
 
         Given:
@@ -873,9 +855,7 @@ class TestTask:
         ):
             await task.dispatch()
 
-    def test_to_protobuf_with_unpicklable_callable_fails(
-        self, picklable_proxy
-    ):
+    def test_to_protobuf_with_unpicklable_callable_fails(self, picklable_proxy):
         """Test to_protobuf fails with an unpicklable callable.
 
         Given:

--- a/wool/tests/runtime/routine/test_wrapper.py
+++ b/wool/tests/runtime/routine/test_wrapper.py
@@ -927,9 +927,7 @@ async def test_routine_with_coroutine_tag(
     async def mock_stream():
         yield 42
 
-    mock_proxy_context.dispatch = mocker.AsyncMock(
-        return_value=mock_stream()
-    )
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=mock_stream())
 
     # Act
     await foo(1, 2)
@@ -962,9 +960,7 @@ async def test_routine_with_async_generator_tag(
         yield 0
         yield 1
 
-    mock_proxy_context.dispatch = mocker.AsyncMock(
-        return_value=mock_stream()
-    )
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=mock_stream())
 
     # Act
     result = []
@@ -973,10 +969,7 @@ async def test_routine_with_async_generator_tag(
 
     # Assert
     task = mock_proxy_context.dispatch.call_args[0][0]
-    expected = (
-        f"{foo_gen.__module__}.{foo_gen.__qualname__}"
-        f":{expected_lineno}"
-    )
+    expected = f"{foo_gen.__module__}.{foo_gen.__qualname__}:{expected_lineno}"
     assert task.tag == expected
 
 
@@ -995,13 +988,12 @@ async def test_routine_with_large_arguments(
     Then:
         The task tag length should remain under 200 characters.
     """
+
     # Arrange
     async def mock_stream():
         yield 0
 
-    mock_proxy_context.dispatch = mocker.AsyncMock(
-        return_value=mock_stream()
-    )
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=mock_stream())
 
     # Act
     await foo(b"\x00" * 1_000_000, 0)
@@ -1032,9 +1024,7 @@ async def test_routine_with_source_line_in_tag(
     async def mock_stream():
         yield 42
 
-    mock_proxy_context.dispatch = mocker.AsyncMock(
-        return_value=mock_stream()
-    )
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=mock_stream())
 
     # Act
     await foo(1, 2)
@@ -1058,13 +1048,12 @@ async def test_routine_with_instance_method_tag(
     Then:
         The task tag should include the class-qualified name.
     """
+
     # Arrange
     async def mock_stream():
         yield 10
 
-    mock_proxy_context.dispatch = mocker.AsyncMock(
-        return_value=mock_stream()
-    )
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=mock_stream())
 
     # Act
     await Foo().foo(5)
@@ -1088,13 +1077,12 @@ async def test_routine_with_classmethod_tag(
     Then:
         The task tag should include the class-qualified name.
     """
+
     # Arrange
     async def mock_stream():
         yield 15
 
-    mock_proxy_context.dispatch = mocker.AsyncMock(
-        return_value=mock_stream()
-    )
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=mock_stream())
 
     # Act
     await Foo.bar(5)
@@ -1118,13 +1106,12 @@ async def test_routine_with_staticmethod_tag(
     Then:
         The task tag should include the class-qualified name.
     """
+
     # Arrange
     async def mock_stream():
         yield 20
 
-    mock_proxy_context.dispatch = mocker.AsyncMock(
-        return_value=mock_stream()
-    )
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=mock_stream())
 
     # Act
     await Foo.baz(5)
@@ -1148,14 +1135,13 @@ async def test_routine_with_async_generator_method_tag(
     Then:
         The task tag should include the class-qualified name.
     """
+
     # Arrange
     async def mock_stream():
         yield 0
         yield 2
 
-    mock_proxy_context.dispatch = mocker.AsyncMock(
-        return_value=mock_stream()
-    )
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=mock_stream())
 
     # Act
     async for _ in Foo().foo_gen(2):
@@ -1204,13 +1190,12 @@ async def test_routine_with_keyword_arguments(
     Then:
         The task tag should not contain ``=``.
     """
+
     # Arrange
     async def mock_stream():
         yield 42
 
-    mock_proxy_context.dispatch = mocker.AsyncMock(
-        return_value=mock_stream()
-    )
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=mock_stream())
 
     # Act
     await foo(x=1, y=2)
@@ -1241,16 +1226,12 @@ async def test_routine_with_no_arguments(
     async def mock_stream():
         yield "async_result"
 
-    mock_proxy_context.dispatch = mocker.AsyncMock(
-        return_value=mock_stream()
-    )
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=mock_stream())
 
     # Act
     await bar()
 
     # Assert
     task = mock_proxy_context.dispatch.call_args[0][0]
-    expected = (
-        f"{bar.__module__}.{bar.__qualname__}:{expected_lineno}"
-    )
+    expected = f"{bar.__module__}.{bar.__qualname__}:{expected_lineno}"
     assert task.tag == expected

--- a/wool/tests/runtime/worker/test_connection.py
+++ b/wool/tests/runtime/worker/test_connection.py
@@ -457,9 +457,7 @@ class TestWorkerConnection:
         responses = (
             protocol.Response(ack=protocol.Ack()),
             asyncio.sleep(10),
-            protocol.Response(
-                result=protocol.Message(dump=cloudpickle.dumps("done"))
-            ),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("done"))),
         )
 
         long_running_call = mock_grpc_call(async_stream(responses))
@@ -582,9 +580,7 @@ class TestWorkerConnection:
             protocol.Response(ack=protocol.Ack()),
             execution_started.set,
             asyncio.sleep(10),
-            protocol.Response(
-                result=protocol.Message(dump=cloudpickle.dumps("done"))
-            ),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("done"))),
         )
 
         mock_call = mock_grpc_call(async_stream(responses), cancel_raises=cancel_raises)
@@ -850,9 +846,7 @@ class TestWorkerConnection:
         # Arrange
         responses = (
             protocol.Response(ack=protocol.Ack()),
-            protocol.Response(
-                result=protocol.Message(dump=cloudpickle.dumps("first"))
-            ),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("first"))),
             protocol.Response(
                 result=protocol.Message(dump=cloudpickle.dumps("recovered"))
             ),
@@ -893,9 +887,7 @@ class TestWorkerConnection:
         # Arrange
         responses = (
             protocol.Response(ack=protocol.Ack()),
-            protocol.Response(
-                result=protocol.Message(dump=cloudpickle.dumps("value"))
-            ),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("value"))),
         )
         mock_call = mock_grpc_call(async_stream(responses))
 
@@ -935,9 +927,7 @@ class TestWorkerConnection:
 
         responses = (
             protocol.Response(ack=protocol.Ack()),
-            protocol.Response(
-                result=protocol.Message(dump=cloudpickle.dumps("done"))
-            ),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("done"))),
         )
         mock_call = mock_grpc_call(async_stream(responses))
 
@@ -979,9 +969,7 @@ class TestWorkerConnection:
         responses = (
             protocol.Response(ack=protocol.Ack()),
             protocol.Response(
-                exception=protocol.Message(
-                    dump=cloudpickle.dumps(RuntimeError("boom"))
-                )
+                exception=protocol.Message(dump=cloudpickle.dumps(RuntimeError("boom")))
             ),
         )
         mock_call = mock_grpc_call(async_stream(responses))
@@ -1022,9 +1010,7 @@ class TestWorkerConnection:
 
         responses = (
             protocol.Response(ack=protocol.Ack()),
-            protocol.Response(
-                result=protocol.Message(dump=cloudpickle.dumps("done"))
-            ),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("done"))),
         )
         mock_call = mock_grpc_call(async_stream(responses))
 
@@ -1063,9 +1049,7 @@ class TestWorkerConnection:
         def make_call():
             responses = (
                 protocol.Response(ack=protocol.Ack()),
-                protocol.Response(
-                    result=protocol.Message(dump=cloudpickle.dumps("ok"))
-                ),
+                protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("ok"))),
             )
             return mock_grpc_call(async_stream(responses))
 
@@ -1108,9 +1092,7 @@ class TestWorkerConnection:
 
         responses = (
             protocol.Response(ack=protocol.Ack()),
-            protocol.Response(
-                result=protocol.Message(dump=cloudpickle.dumps("ok"))
-            ),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("ok"))),
         )
         mock_call = mock_grpc_call(async_stream(responses))
 
@@ -1161,9 +1143,7 @@ class TestWorkerConnection:
 
         responses = (
             protocol.Response(ack=protocol.Ack()),
-            protocol.Response(
-                result=protocol.Message(dump=cloudpickle.dumps("ok"))
-            ),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("ok"))),
         )
         mock_call = mock_grpc_call(async_stream(responses))
 

--- a/wool/tests/runtime/worker/test_local.py
+++ b/wool/tests/runtime/worker/test_local.py
@@ -195,9 +195,7 @@ class TestLocalWorker:
         mock_process.pid = 12345
         mock_process.start.return_value = None
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker()
 
@@ -224,9 +222,7 @@ class TestLocalWorker:
         mock_process.pid = 12345
         mock_process.start.return_value = None
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker()
 
@@ -253,9 +249,7 @@ class TestLocalWorker:
         mock_process.pid = 12345
         mock_process.start.return_value = None
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker("gpu", "ml", region="us-west")
 
@@ -288,9 +282,7 @@ class TestLocalWorker:
         mock_process.pid = 12345
         mock_process.start.return_value = None
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker()
 
@@ -315,9 +307,7 @@ class TestLocalWorker:
         mock_process.pid = None
         mock_process.start.return_value = None
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker()
 
@@ -342,9 +332,7 @@ class TestLocalWorker:
         mock_process.pid = 99999
         mock_process.start.return_value = None
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker()
 
@@ -372,9 +360,7 @@ class TestLocalWorker:
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = True
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker()
         await worker.start()
@@ -384,9 +370,7 @@ class TestLocalWorker:
         mock_stub.stop = mocker.AsyncMock()
 
         mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
-        mocker.patch.object(
-            protocol, "WorkerStub", return_value=mock_stub
-        )
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
         # Act
         await worker.stop()
@@ -412,9 +396,7 @@ class TestLocalWorker:
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = False
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker()
         await worker.start()
@@ -445,9 +427,7 @@ class TestLocalWorker:
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = True
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker()
         await worker.start()
@@ -457,9 +437,7 @@ class TestLocalWorker:
         mock_stub.stop = mocker.AsyncMock(side_effect=Exception("gRPC error"))
 
         mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
-        mocker.patch.object(
-            protocol, "WorkerStub", return_value=mock_stub
-        )
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
         # Act & assert
         with pytest.raises(Exception, match="gRPC error"):
@@ -517,9 +495,7 @@ class TestLocalWorker:
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = False
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker(credentials=worker_credentials)
 
@@ -547,9 +523,7 @@ class TestLocalWorker:
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = False
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker()
 
@@ -579,9 +553,7 @@ class TestLocalWorker:
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = True
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker(credentials=worker_credentials)
         await worker.start()
@@ -593,9 +565,7 @@ class TestLocalWorker:
         mock_secure_channel = mocker.patch.object(
             grpc.aio, "secure_channel", return_value=mock_channel
         )
-        mocker.patch.object(
-            protocol, "WorkerStub", return_value=mock_stub
-        )
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
         # Act
         await worker.stop()
@@ -623,9 +593,7 @@ class TestLocalWorker:
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = True
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker()
         await worker.start()
@@ -637,9 +605,7 @@ class TestLocalWorker:
         mock_insecure_channel = mocker.patch.object(
             grpc.aio, "insecure_channel", return_value=mock_channel
         )
-        mocker.patch.object(
-            protocol, "WorkerStub", return_value=mock_stub
-        )
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
         # Act
         await worker.stop()
@@ -665,9 +631,7 @@ class TestLocalWorker:
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = True
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker(credentials=worker_credentials_one_way)
         await worker.start()
@@ -681,9 +645,7 @@ class TestLocalWorker:
         mock_secure_channel = mocker.patch.object(
             grpc.aio, "secure_channel", return_value=mock_channel
         )
-        mocker.patch.object(
-            protocol, "WorkerStub", return_value=mock_stub
-        )
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
         # Act
         await worker.stop()
@@ -712,9 +674,7 @@ class TestLocalWorker:
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = True
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         worker = LocalWorker(credentials=worker_credentials_callable)
         await worker.start()
@@ -726,9 +686,7 @@ class TestLocalWorker:
         mock_secure_channel = mocker.patch.object(
             grpc.aio, "secure_channel", return_value=mock_channel
         )
-        mocker.patch.object(
-            protocol, "WorkerStub", return_value=mock_stub
-        )
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
         # Act
         await worker.stop()
@@ -762,18 +720,14 @@ class TestLocalWorker:
         mock_process.start.return_value = None
         mock_process.is_alive.side_effect = [True, False]
 
-        mocker.patch.object(
-            local_module, "WorkerProcess", return_value=mock_process
-        )
+        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         mock_channel = mocker.MagicMock()
         mock_stub = mocker.MagicMock()
         mock_stub.stop = mocker.AsyncMock()
         mocker.patch.object(grpc.aio, "secure_channel", return_value=mock_channel)
         mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
-        mocker.patch.object(
-            protocol, "WorkerStub", return_value=mock_stub
-        )
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
         # Act
         worker = LocalWorker(credentials=creds)

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -1679,9 +1679,7 @@ class TestWorkerPool:
         mock_proxy_cls = mocker.patch.object(
             wp, "WorkerProxy", return_value=mock_worker_proxy
         )
-        pool = WorkerPool(
-            worker=mock_worker_factory, size=1, options=custom_options
-        )
+        pool = WorkerPool(worker=mock_worker_factory, size=1, options=custom_options)
 
         # Act
         async with pool:

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -1388,9 +1388,7 @@ class TestWorkerProcess:
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
-        mock_grpc_server = mocker.patch(
-            "grpc.aio.server", return_value=mock_server
-        )
+        mock_grpc_server = mocker.patch("grpc.aio.server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.stopped.wait = mocker.AsyncMock()
@@ -1438,9 +1436,7 @@ class TestWorkerProcess:
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
-        mock_grpc_server = mocker.patch(
-            "grpc.aio.server", return_value=mock_server
-        )
+        mock_grpc_server = mocker.patch("grpc.aio.server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.stopped.wait = mocker.AsyncMock()

--- a/wool/tests/runtime/worker/test_service.py
+++ b/wool/tests/runtime/worker/test_service.py
@@ -329,9 +329,7 @@ class TestWorkerService:
         async with service_fixture as (service, event, stub):
             # Initiate stop (service enters stopping state)
             # Use wait=0 to immediately cancel tasks, but we'll check before tasks finish
-            stop_task = asyncio.ensure_future(
-                stub.stop(protocol.StopRequest(timeout=5))
-            )
+            stop_task = asyncio.ensure_future(stub.stop(protocol.StopRequest(timeout=5)))
 
             await asyncio.wait_for(service.stopping.wait(), 1)
             assert not service.stopped.is_set()
@@ -693,9 +691,7 @@ class TestWorkerService:
         # Arrange
         async with service_fixture as (service, event, stub):
             # Initiate stop (service enters stopping state)
-            stop_task = asyncio.ensure_future(
-                stub.stop(protocol.StopRequest(timeout=5))
-            )
+            stop_task = asyncio.ensure_future(stub.stop(protocol.StopRequest(timeout=5)))
 
             # Wait for service to enter stopping state
             await asyncio.wait_for(service.stopping.wait(), 1)
@@ -1522,9 +1518,7 @@ class TestWorkerService:
             assert cloudpickle.loads(response.result.dump) == "echo:world"
 
             # Send None to terminate the generator
-            msg = protocol.Request(
-                send=protocol.Message(dump=cloudpickle.dumps(None))
-            )
+            msg = protocol.Request(send=protocol.Message(dump=cloudpickle.dumps(None)))
             await stream.write(msg)
             await stream.done_writing()
 
@@ -1586,9 +1580,7 @@ class TestWorkerService:
             assert cloudpickle.loads(response.result.dump) == 0
 
             # Send 2 to jump the counter
-            msg = protocol.Request(
-                send=protocol.Message(dump=cloudpickle.dumps(2))
-            )
+            msg = protocol.Request(send=protocol.Message(dump=cloudpickle.dumps(2)))
             await stream.write(msg)
             response = await anext(aiter(stream))
             assert response.HasField("result")
@@ -1771,9 +1763,7 @@ class TestWorkerService:
             assert cloudpickle.loads(response.result.dump) == 0
 
             # send 10 -> yields 10
-            msg = protocol.Request(
-                send=protocol.Message(dump=cloudpickle.dumps(10))
-            )
+            msg = protocol.Request(send=protocol.Message(dump=cloudpickle.dumps(10)))
             await stream.write(msg)
             response = await anext(aiter(stream))
             assert cloudpickle.loads(response.result.dump) == 10
@@ -1784,9 +1774,7 @@ class TestWorkerService:
             assert cloudpickle.loads(response.result.dump) == 11
 
             # send 5 -> yields 16
-            msg = protocol.Request(
-                send=protocol.Message(dump=cloudpickle.dumps(5))
-            )
+            msg = protocol.Request(send=protocol.Message(dump=cloudpickle.dumps(5)))
             await stream.write(msg)
             response = await anext(aiter(stream))
             assert cloudpickle.loads(response.result.dump) == 16
@@ -1843,9 +1831,7 @@ class TestWorkerService:
 
             # Throw ValueError into the generator
             throw_request = protocol.Request(
-                throw=protocol.Message(
-                    dump=cloudpickle.dumps(ValueError("injected"))
-                )
+                throw=protocol.Message(dump=cloudpickle.dumps(ValueError("injected")))
             )
             await stream.write(throw_request)
             response = await anext(aiter(stream))
@@ -2104,9 +2090,7 @@ class TestWorkerService:
             result2 = cloudpickle.loads(response.result.dump)
 
             # Send None to terminate
-            msg = protocol.Request(
-                send=protocol.Message(dump=cloudpickle.dumps(None))
-            )
+            msg = protocol.Request(send=protocol.Message(dump=cloudpickle.dumps(None)))
             await stream.write(msg)
             await stream.done_writing()
             [r async for r in stream]


### PR DESCRIPTION
## Summary

Run `ruff format` and `ruff check --fix` across the wool codebase to enforce the project's configured style rules (line-length 89, double quotes, force-single-line imports). This is a formatting-only change with no behavior modifications.

Closes #31

## Proposed changes

### Formatting pass

Apply `ruff format` to all Python source and test files under `wool/` to normalize whitespace, quote style, and line length to the project configuration in `pyproject.toml`.

### Lint auto-fixes

Apply `ruff check --fix` to auto-correct any linting violations (unused imports, import ordering, etc.) that ruff can resolve without manual intervention.

## Test cases

N/A — Formatting-only change with no behavior modifications.

## Implementation plan

1. - [x] Run `ruff check --fix` to auto-correct linting violations
2. - [x] Run `ruff format` to normalize formatting across all source and test files