### PR TITLE
Fix cut-release workflow to use app token for git operations — Closes #33

### DIFF
--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -64,6 +64,11 @@ jobs:
             echo "Error: main is not up to date with master" >&2
             exit 1
           fi
+      - name: Configure git with app token
+        env:
+          APP_TOKEN: ${{ steps.get-wool-labs-app-token.outputs.access-token }}
+        run: |
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${APP_TOKEN}" | base64)"
       - name: Create release branch
         id: cut-release-branch
         env:
@@ -76,6 +81,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: release
+          token: ${{ steps.get-wool-labs-app-token.outputs.access-token }}
       - name: Tag version
         env:
           VERSION: ${{ steps.cut-release-branch.outputs.version }}


### PR DESCRIPTION
## Summary

Fix the cut-release workflow to use the wool-labs app token for git push operations so the release branch can be created and tags pushed despite repository rulesets restricting branch operations. The app token is already fetched but only used for PR creation — the `git push` inside `cut-release.sh` and the tag push after checkout still use the default `GITHUB_TOKEN`, which lacks ruleset bypass permissions.

Closes #33

## Proposed changes

### Configure git credentials before release branch creation

Add a step before `cut-release.sh` that configures the git HTTP extra header with the app token, so the push inside the script authenticates as the wool-labs app (which is a bypass actor on both rulesets).

### Use app token for release branch checkout

Pass the app token to `actions/checkout` when checking out the release branch, so the subsequent tag push also authenticates as the wool-labs app.

## Test cases

N/A — CI workflow fix verified by re-running the cut-release workflow.

## Implementation plan

1. - [x] Add a "Configure git with app token" step before the release branch creation step
2. - [x] Pass the app token to `actions/checkout` for the release branch checkout