### PR TITLE
Remove task lifecycle event documentation from README — Closes #37

### DIFF
--- a/wool/README.md
+++ b/wool/README.md
@@ -148,18 +148,6 @@ async with wool.WorkerPool(size=4, credentials=creds):
     result = await my_routine()
 ```
 
-## Task lifecycle events
-
-Wool emits events at each stage of a task's lifecycle. Register handlers to observe execution without modifying task code:
-
-```python
-@wool.TaskEvent.handler("task-created", "task-completed")
-def on_task(event: wool.TaskEvent, timestamp: int, context=None) -> None:
-    ...
-```
-
-Available event types: `task-created`, `task-scheduled`, `task-started`, `task-stopped`, `task-completed`, `task-iteration-initiated`, `task-iteration-started`, `task-iteration-completed`.
-
 ## Error handling
 
 Exceptions raised within a routine are captured as a `TaskException` and re-raised on the caller side, preserving the original exception type and traceback:


### PR DESCRIPTION
## Summary

Remove the "Task lifecycle events" section from the README. The `TaskEvent` API was removed from the codebase in favor of a future OpenTelemetry integration, but the README still documents it. Remove the section so the documentation only covers APIs that exist.

Closes #37

## Proposed changes

### Remove task lifecycle events section

Delete the "Task lifecycle events" section from the root README, including the code example showing `@wool.TaskEvent.handler` and the list of event types.

## Test cases

N/A — Documentation-only change.

## Implementation plan

1. - [x] Remove the "Task lifecycle events" section from the README