### PR TITLE
Fix coroutine dispatch crash caused by stream over-iteration — Closes #45

### DIFF
--- a/wool/src/wool/runtime/routine/wrapper.py
+++ b/wool/src/wool/runtime/routine/wrapper.py
@@ -305,10 +305,7 @@ async def _execute(fn, parent, *args, **kwargs):
 
 
 async def _stream_to_coroutine(stream):
-    result = None
-    async for result in stream:
-        continue
-    return result
+    return await anext(stream, None)
 
 
 def _resolve(

--- a/wool/tests/runtime/routine/test_wrapper.py
+++ b/wool/tests/runtime/routine/test_wrapper.py
@@ -357,38 +357,6 @@ async def test_routine_with_various_arguments(
         mock_proxy_context.dispatch.assert_called_once()
 
 
-@pytest.mark.asyncio
-async def test_routine_with_multi_value_stream(
-    mocker: MockerFixture,
-    mock_proxy_context,
-):
-    """Test stream with multiple values returns final value.
-
-    Given:
-        A decorated async function returns multiple values via stream.
-    When:
-        Wrapped function is called and awaited.
-    Then:
-        The final value from the execution stream is returned.
-    """
-
-    # Arrange
-    async def mock_dispatch_stream():
-        yield "first"
-        yield "second"
-        yield "final"
-
-    async def mock_dispatch(*args, **kwargs):
-        return mock_dispatch_stream()
-
-    mock_proxy_context.dispatch = mocker.MagicMock(side_effect=mock_dispatch)
-
-    # Act
-    result = await bar()
-
-    # Assert
-    assert result == "final"
-
 
 @pytest.mark.asyncio
 async def test_routine_with_empty_stream(


### PR DESCRIPTION
## Summary

Replace `async for` with `await anext(stream, None)` in `_stream_to_coroutine` to fix a crash when dispatching coroutine-based `@wool.routine` functions. The `async for` loop calls `__anext__` a second time after receiving the result, which writes to the already-closed gRPC stream and raises `AioRpcError(INTERNAL)`. Remove the now-invalid `test_routine_with_multi_value_stream` test that asserted impossible multi-value coroutine stream behavior.

Closes #45

## Proposed changes

### Use single-pull in `_stream_to_coroutine`

Replace the `async for` iteration with `await anext(stream, None)`. Coroutines produce exactly one result — iterating further triggers a write to the closed gRPC stream. The `None` default handles the edge case of a coroutine with no explicit return value.

Before:
```python
async def _stream_to_coroutine(stream):
    result = None
    async for result in stream:
        continue
    return result
```

After:
```python
async def _stream_to_coroutine(stream):
    return await anext(stream, None)
```

### Remove invalid test

Remove `test_routine_with_multi_value_stream` which mocked a multi-value stream for a coroutine — a scenario that cannot occur in practice. The test only passed due to the `async for` implementation detail.

## Test cases

| Test Suite | Test ID | Given | When | Then | Coverage Target |
|------------|---------|-------|------|------|-----------------|
| `test_wrapper` | CW-001 | A `@wool.routine` coroutine returning a value | Dispatched and awaited | Returns the value | Single-result dispatch |
| `test_wrapper` | CW-002 | A `@wool.routine` coroutine with no return | Dispatched and awaited | Returns `None` | Empty stream default |
| `test_wrapper` | CW-003 | A `@wool.routine` coroutine raising an exception | Dispatched and awaited | Re-raises the exception | Error propagation |

All three cases are covered by existing tests (`test_routine_with_single_value_stream`, `test_routine_with_empty_stream`, `test_routine_with_stream_exception`).

## Implementation plan

1. - [ ] Replace `async for` with `await anext(stream, None)` in `_stream_to_coroutine`
2. - [ ] Remove `test_routine_with_multi_value_stream`