### PR TITLE
Fix publish-release tagging wrong commit on PR merge — Closes #48

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -94,6 +94,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
       - uses: ./.github/actions/get-wool-labs-app-token
         id: get-wool-labs-app-token
         with:


### PR DESCRIPTION
## Summary

Fix the `tag-version` job in `publish-release.yaml` to tag the actual merge commit instead of the pre-merge base branch tip. Use `github.event.pull_request.merge_commit_sha` for PR merges, falling back to `github.sha` for `workflow_dispatch` triggers.

Closes #48

## Proposed changes

### Checkout merge commit in tag-version job

Add `ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}` to the `actions/checkout@v4` step in the `tag-version` job. For `pull_request_target` events, `github.sha` defaults to the base branch tip before the merge — not the merge commit. The `merge_commit_sha` field from the PR event payload points to the correct commit.

## Test cases

No automated tests — verify by merging a PR to master and checking that the resulting tag points to the merge commit (`git log <tag> --oneline -1`).

## Implementation plan

1. - [x] Add `ref` to checkout step in `tag-version` job