### PR TITLE
Add integration test suite and extend test skill to cover integration specs — Closes #58

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -66,5 +66,6 @@ jobs:
         env:
           NAMESPACE: ${{ matrix.namespace }}
         run: |
+          ulimit -n 65536
           cd ${{ env.NAMESPACE }}
           uv run pytest

--- a/llms/test-guides/python.md
+++ b/llms/test-guides/python.md
@@ -246,3 +246,175 @@ pytest <path> -lf
 ```
 
 If your project uses a runner wrapper (e.g., `uv run`, `poetry run`), prefix accordingly — see project instructions.
+
+## 14. Integration Testing
+
+Integration tests exercise real cross-boundary interactions — real subprocesses, real network I/O, real serialization — and MUST NOT mock the system under test. They complement unit tests by validating that assembled subsystems work together correctly.
+
+### Marker
+
+All integration tests MUST be marked with a dedicated marker (e.g., `@pytest.mark.integration`) to enable selective execution:
+
+```sh
+# Run only integration tests
+pytest -m integration -x
+
+# Run everything except integration tests
+pytest -m "not integration" -x
+```
+
+The marker MUST be registered in `pyproject.toml` under `[tool.pytest.ini_options]`.
+
+### Test Style
+
+Integration tests follow the same conventions as unit tests: Given-When-Then docstrings on test functions and methods (not fixtures or helpers), AAA phase comments, and `@pytest.mark.asyncio` for async tests.
+
+### File Layout
+
+Integration tests live in a dedicated `tests/integration/` package:
+
+```
+tests/integration/
+    __init__.py         (empty)
+    conftest.py         (scenario model, enums, filter, builder, fixtures)
+    routines.py         (decorated functions exercised by integration tests)
+    test_scenario.py    (unit tests for the Scenario model itself)
+    test_pool_composition.py (builder tests — one per pool/discovery mode)
+    test_integration.py (pairwise parametrized + Hypothesis exploration)
+```
+
+### Routine Module
+
+Test routines — functions decorated with the project's dispatch decorator — MUST live in a non-test module (e.g., `routines.py`, no `test_` prefix) so pytest does not collect them. This module defines all the callable targets that integration tests dispatch through the real runtime. Organize routines by the dimensions they exercise (e.g., coroutine vs async generator, module function vs instance method vs classmethod vs staticmethod).
+
+### Dimensions and Enums
+
+Each orthogonal axis identified by the test skill (see `llms/skills/test.md` section 6) becomes a separate `Enum`:
+
+```python
+class RoutineShape(Enum):
+    COROUTINE = auto()
+    ASYNC_GEN = auto()
+    # ...
+
+class PoolMode(Enum):
+    DEFAULT = auto()
+    EPHEMERAL = auto()
+    DURABLE = auto()
+    # ...
+```
+
+### Composable Scenario Model
+
+Model each scenario as a frozen dataclass with one field per dimension, all defaulting to `None`. Implement `__or__` for algebraic merge (right side wins on `None` fields, raises `ValueError` on conflicting non-`None` values), `is_complete` to check all fields are set, and `__str__` returning dash-separated enum member names for pytest IDs:
+
+```python
+@dataclass(frozen=True)
+class Scenario:
+    shape: RoutineShape | None = None
+    pool_mode: PoolMode | None = None
+    # ...
+
+    def __or__(self, other: Scenario) -> Scenario:
+        """Merge two partial scenarios; raise on conflicts."""
+
+    @property
+    def is_complete(self) -> bool:
+        """True when all dimensions are set."""
+```
+
+Write unit tests for the Scenario model itself (`__or__` with disjoint fields, conflicting fields, identical values, empty merge, completeness checks). These are fast, synchronous tests that validate the test infrastructure before trusting it for real integration tests.
+
+### Filter Function
+
+A `filter_func` encodes cross-dimension constraints — combinations that are structurally invalid and MUST be excluded from generation:
+
+- **Structural constraints** — e.g., discovery protocol is required for durable modes, forbidden for ephemeral modes.
+- **Permanent exclusions** — combinations that are documented limitations (not bugs). For example, factory forms that are not picklable when the runtime requires serialization. These MUST be excluded in the filter with a comment referencing the issue or documentation.
+
+Bugs expected to be fixed MUST NOT be filtered — use `xfail` instead (see below).
+
+### Builder
+
+Implement a builder — typically an async context manager — that takes a complete `Scenario` and resolves each dimension to its concrete runtime value:
+
+```python
+@asynccontextmanager
+async def build_from_scenario(scenario, shared_fixtures):
+    """Resolve all dimensions and yield the running system."""
+    assert scenario.is_complete
+    # Resolve each dimension to concrete values...
+    async with system:
+        yield system
+```
+
+Some modes may require special handling. For example, a "durable" mode where the system only discovers external processes (doesn't spawn them) needs a helper that manually starts processes and registers them before creating the durable system under test.
+
+Implement a separate `invoke` function that maps the scenario's callable shape and binding to the correct invocation protocol (await, async for, asend, athrow, aclose) and asserts the expected result.
+
+Write builder tests — one per major mode — that construct a complete scenario, build the system, dispatch a simple call, and assert the result. These validate that each mode works in isolation before combining them in the pairwise suite.
+
+### Pairwise Covering Arrays
+
+Use `allpairspy.AllPairs` with the `filter_func` to generate a deterministic covering array that exercises all pairwise dimension combinations:
+
+```python
+from allpairspy import AllPairs
+
+PAIRWISE_SCENARIOS = [
+    Scenario(shape=row[0], pool_mode=row[1], ...)
+    for row in AllPairs(
+        [list(Dim1), list(Dim2), ...],
+        filter_func=my_filter,
+    )
+]
+```
+
+Parametrize with `@pytest.mark.parametrize("scenario", PAIRWISE_SCENARIOS, ids=str)`.
+
+### Hypothesis Exploration
+
+Use `@st.composite` strategies that draw from per-dimension `st.sampled_from(Enum)` with conditional filtering matching the `filter_func` logic. Apply the same permanent exclusions as the filter. Decorate tests with:
+
+```python
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[
+        HealthCheck.function_scoped_fixture,
+        HealthCheck.too_slow,
+    ],
+)
+@example(scenario=Scenario(...))  # Smoke test with known-good config
+@given(scenario=scenarios_strategy())
+```
+
+`deadline=None` prevents false positives from subprocess startup latency. `suppress_health_check` allows function-scoped fixtures and slow tests inherent to integration testing.
+
+### xfail for Known Bugs
+
+Scenarios that hit known bugs MUST use `pytest.xfail()` in the test body (not `skip`, not filtered out) with a reference to the issue number:
+
+```python
+def _xfail_known_bugs(scenario):
+    if scenario.credential is not CredentialType.INSECURE:
+        pytest.xfail("credential pickling across subprocess boundary (#60)")
+    if scenario.pool_mode in _NESTED_MODES:
+        pytest.xfail("resource collision with nested pools (#62)")
+```
+
+This keeps the scenarios visible in the test output (as `xfail`, not silently missing) and automatically surfaces when a bug fix causes them to pass unexpectedly (`xpass`).
+
+The distinction from permanent filter exclusions: filtered combinations are documented limitations that will not be fixed. `xfail` combinations are bugs with open issues that will eventually pass.
+
+### Cleanup
+
+Autouse fixtures MUST clear shared state between tests — connection pools, context variables, cached singletons, temporary files. These fixtures live in the integration `conftest.py` and mirror any equivalent cleanup fixtures from the unit test suite to prevent cross-test contamination.
+
+### Three Test Layers
+
+Integration test files SHOULD follow this progression:
+
+1. **Scenario model unit tests** — fast, synchronous tests for `__or__`, `is_complete`, `__str__`. Validate the test infrastructure itself.
+2. **Builder/composition tests** — one async test per major system mode. Validate that each mode works in isolation before combining.
+3. **Pairwise + Hypothesis** — combinatorial tests covering all pairwise dimension interactions and random exploration. These are the main integration tests.

--- a/wool/pyproject.toml
+++ b/wool/pyproject.toml
@@ -39,6 +39,7 @@ requires-python = ">=3.11"
 
 [project.optional-dependencies]
 dev = [
+    "allpairspy",
     "cryptography",
     "debugpy",
     "hypothesis",
@@ -83,6 +84,9 @@ path = "../build-hooks/metadata.py"
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
 addopts = "--cov --cov-config=.coveragerc"
+markers = [
+    "integration: end-to-end integration tests against real WorkerPool",
+]
 
 [tool.ruff]
 line-length = 89

--- a/wool/src/wool/runtime/worker/local.py
+++ b/wool/src/wool/runtime/worker/local.py
@@ -141,5 +141,8 @@ class LocalWorker(Worker):
             else:
                 channel = grpc.aio.insecure_channel(self.address)
 
-            stub = protocol.WorkerStub(channel)
-            await stub.stop(protocol.StopRequest(timeout=timeout))
+            try:
+                stub = protocol.WorkerStub(channel)
+                await stub.stop(protocol.StopRequest(timeout=timeout))
+            finally:
+                await channel.close()

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -1,0 +1,716 @@
+"""Integration test infrastructure.
+
+Provides the scenario model, dimension enums, pairwise covering array,
+fixtures, and builder functions for composable integration tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import ipaddress
+import uuid
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from dataclasses import fields
+from enum import Enum
+from enum import auto
+
+import pytest
+import pytest_asyncio
+from allpairspy import AllPairs
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from hypothesis import strategies as st
+
+import wool
+from wool.runtime.context import RuntimeContext
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
+from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.local import LocalWorker
+from wool.runtime.worker.pool import WorkerPool
+
+from . import routines
+
+
+class RoutineShape(Enum):
+    COROUTINE = auto()
+    ASYNC_GEN_ANEXT = auto()
+    ASYNC_GEN_ASEND = auto()
+    ASYNC_GEN_ATHROW = auto()
+    ASYNC_GEN_ACLOSE = auto()
+    NESTED_COROUTINE = auto()
+    NESTED_ASYNC_GEN = auto()
+
+
+class PoolMode(Enum):
+    DEFAULT = auto()
+    EPHEMERAL = auto()
+    DURABLE = auto()
+    HYBRID = auto()
+    NESTED_DEFAULT_IN_EPHEMERAL = auto()
+    NESTED_EPHEMERAL_IN_EPHEMERAL = auto()
+
+
+class DiscoveryFactory(Enum):
+    NONE = auto()
+    LOCAL_DIRECT = auto()
+    LOCAL_CALLABLE = auto()
+    LOCAL_SYNC_CM = auto()
+    LOCAL_ASYNC_CM = auto()
+    LAN_DIRECT = auto()
+    LAN_CALLABLE = auto()
+    LAN_ASYNC_CM = auto()
+
+
+class LbFactory(Enum):
+    CLASS_REF = auto()
+    INSTANCE = auto()
+    CALLABLE = auto()
+    ASYNC_CM = auto()
+
+
+class CredentialType(Enum):
+    INSECURE = auto()
+    MTLS = auto()
+    ONE_WAY = auto()
+
+
+class WorkerOptionsKind(Enum):
+    DEFAULT = auto()
+    RESTRICTIVE = auto()
+
+
+class TimeoutKind(Enum):
+    NONE = auto()
+    VIA_RUNTIME_CONTEXT = auto()
+
+
+class RoutineBinding(Enum):
+    MODULE_FUNCTION = auto()
+    INSTANCE_METHOD = auto()
+    CLASSMETHOD = auto()
+    STATICMETHOD = auto()
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """Composable scenario describing one integration test configuration.
+
+    Each field corresponds to one dimension. Partial scenarios (some fields
+    ``None``) can be merged with ``|`` to build complete configurations.
+    """
+
+    shape: RoutineShape | None = None
+    pool_mode: PoolMode | None = None
+    discovery: DiscoveryFactory | None = None
+    lb: LbFactory | None = None
+    credential: CredentialType | None = None
+    options: WorkerOptionsKind | None = None
+    timeout: TimeoutKind | None = None
+    binding: RoutineBinding | None = None
+
+    def __or__(self, other: Scenario) -> Scenario:
+        """Merge two partial scenarios. Right side wins on ``None`` fields.
+
+        Raises ValueError if both sides set the same field to different
+        non-None values.
+        """
+        kwargs = {}
+        for f in fields(self):
+            left = getattr(self, f.name)
+            right = getattr(other, f.name)
+            if left is not None and right is not None and left != right:
+                raise ValueError(
+                    f"Conflicting values for {f.name}: {left!r} vs {right!r}"
+                )
+            kwargs[f.name] = right if right is not None else left
+        return Scenario(**kwargs)
+
+    @property
+    def is_complete(self) -> bool:
+        """True when all 8 dimensions are set."""
+        return all(getattr(self, f.name) is not None for f in fields(self))
+
+    def __str__(self) -> str:
+        parts = []
+        for f in fields(self):
+            val = getattr(self, f.name)
+            if val is not None:
+                parts.append(val.name)
+            else:
+                parts.append("_")
+        return "-".join(parts)
+
+
+class _DirectDiscovery:
+    """Wraps an already-entered discovery service as a plain object.
+
+    Does NOT implement ``__enter__``/``__exit__``/``__aenter__``/
+    ``__aexit__``, forcing ``WorkerPool._enter_context`` to take the
+    passthrough path. Used for the ``*_DIRECT`` factory form arrangements.
+    """
+
+    def __init__(self, discovery):
+        self._discovery = discovery
+
+    @property
+    def publisher(self):
+        return self._discovery.publisher
+
+    @property
+    def subscriber(self):
+        return self._discovery.subscriber
+
+    def subscribe(self, filter=None):
+        return self._discovery.subscribe(filter)
+
+
+@asynccontextmanager
+async def build_pool_from_scenario(scenario, credentials_map):
+    """Build and enter a WorkerPool from a complete Scenario.
+
+    Resolves each dimension to its concrete runtime value and yields the
+    entered pool context.
+    """
+    assert scenario.is_complete
+
+    creds = credentials_map[scenario.credential]
+
+    if scenario.options is WorkerOptionsKind.RESTRICTIVE:
+        options = WorkerOptions(
+            max_receive_message_length=64 * 1024,
+            max_send_message_length=64 * 1024,
+        )
+    else:
+        options = None
+
+    lb: object
+    match scenario.lb:
+        case LbFactory.CLASS_REF:
+            lb = RoundRobinLoadBalancer
+        case LbFactory.INSTANCE:
+            lb = RoundRobinLoadBalancer()
+        case LbFactory.CALLABLE:
+            lb = lambda: RoundRobinLoadBalancer()  # noqa: E731
+        case LbFactory.ASYNC_CM:
+
+            @asynccontextmanager
+            async def _lb_cm():
+                yield RoundRobinLoadBalancer()
+
+            lb = _lb_cm()
+
+    discovery_obj = None
+    _local_cm = None
+
+    if scenario.discovery is not DiscoveryFactory.NONE:
+        namespace = f"integration-{uuid.uuid4().hex[:12]}"
+
+        match scenario.discovery:
+            case DiscoveryFactory.LOCAL_SYNC_CM:
+                discovery_obj = LocalDiscovery(namespace)
+            case DiscoveryFactory.LOCAL_CALLABLE:
+                discovery_obj = lambda: LocalDiscovery(namespace)  # noqa: E731
+            case DiscoveryFactory.LOCAL_DIRECT:
+                _local_cm = LocalDiscovery(namespace)
+                _local_cm.__enter__()
+                discovery_obj = _DirectDiscovery(_local_cm)
+            case DiscoveryFactory.LOCAL_ASYNC_CM:
+
+                @asynccontextmanager
+                async def _local_async_cm():
+                    with LocalDiscovery(namespace) as d:
+                        yield d
+
+                discovery_obj = _local_async_cm()
+
+            case DiscoveryFactory.LAN_DIRECT:
+                from wool.runtime.discovery.lan import LanDiscovery
+
+                discovery_obj = LanDiscovery()
+            case DiscoveryFactory.LAN_CALLABLE:
+                from wool.runtime.discovery.lan import LanDiscovery
+
+                discovery_obj = lambda: LanDiscovery()  # noqa: E731
+            case DiscoveryFactory.LAN_ASYNC_CM:
+                from wool.runtime.discovery.lan import LanDiscovery
+
+                @asynccontextmanager
+                async def _lan_async_cm():
+                    discovery = LanDiscovery()
+                    yield discovery
+
+                discovery_obj = _lan_async_cm()
+
+    runtime_ctx = None
+    if scenario.timeout is TimeoutKind.VIA_RUNTIME_CONTEXT:
+        runtime_ctx = RuntimeContext(dispatch_timeout=30.0)
+
+    try:
+        if runtime_ctx is not None:
+            runtime_ctx.__enter__()
+
+        try:
+            if scenario.pool_mode is PoolMode.DURABLE:
+                async with _durable_pool_context(lb, creds, options) as pool:
+                    yield pool
+            else:
+                pool_kwargs = {
+                    "loadbalancer": lb,
+                    "credentials": creds,
+                    "options": options,
+                }
+                match scenario.pool_mode:
+                    case PoolMode.DEFAULT:
+                        pool_kwargs["size"] = 1
+                    case PoolMode.EPHEMERAL:
+                        pool_kwargs["size"] = 2
+                    case PoolMode.HYBRID:
+                        pool_kwargs["size"] = 1
+                        pool_kwargs["discovery"] = discovery_obj
+                    case PoolMode.NESTED_DEFAULT_IN_EPHEMERAL:
+                        pool_kwargs["size"] = 1
+                    case PoolMode.NESTED_EPHEMERAL_IN_EPHEMERAL:
+                        pool_kwargs["size"] = 1
+
+                pool = WorkerPool(**pool_kwargs)
+                async with pool:
+                    if scenario.pool_mode in (
+                        PoolMode.NESTED_DEFAULT_IN_EPHEMERAL,
+                        PoolMode.NESTED_EPHEMERAL_IN_EPHEMERAL,
+                    ):
+                        # Nested pool modes verify that entering a second
+                        # WorkerPool context doesn't break the outer pool.
+                        # Dispatch still goes through the outer pool.
+                        nested_size = (
+                            2
+                            if scenario.pool_mode
+                            is PoolMode.NESTED_EPHEMERAL_IN_EPHEMERAL
+                            else 1
+                        )
+                        nested_pool = WorkerPool(
+                            size=nested_size,
+                            credentials=creds,
+                            options=options,
+                        )
+                        async with nested_pool:
+                            yield pool
+                    else:
+                        yield pool
+        finally:
+            if runtime_ctx is not None:
+                runtime_ctx.__exit__(None, None, None)
+    finally:
+        if _local_cm is not None:
+            _local_cm.__exit__(None, None, None)
+
+
+@asynccontextmanager
+async def _durable_pool_context(lb, creds, options):
+    """Manually start a worker, register it, then create a DURABLE pool.
+
+    DURABLE pools don't spawn workers — they only discover external
+    ones. This helper starts a LocalWorker, registers it via a
+    LocalDiscovery publisher, and creates a DURABLE WorkerPool that
+    discovers it. Discovery is always LocalDiscovery (managed
+    internally); the D3 dimension is constrained to NONE for DURABLE
+    mode in the pairwise filter.
+    """
+    namespace = f"durable-{uuid.uuid4().hex[:12]}"
+    with LocalDiscovery(namespace) as discovery:
+        worker = LocalWorker(credentials=creds, options=options)
+        await worker.start()
+        try:
+            publisher = discovery.publisher
+            async with publisher:
+                await publisher.publish("worker-added", worker.metadata)
+                try:
+                    pool = WorkerPool(
+                        discovery=_DirectDiscovery(discovery),
+                        loadbalancer=lb,
+                        credentials=creds,
+                        options=options,
+                    )
+                    async with pool:
+                        yield pool
+                finally:
+                    await publisher.publish("worker-dropped", worker.metadata)
+        finally:
+            await worker.stop()
+
+
+async def invoke_routine(scenario):
+    """Invoke the appropriate routine for the given scenario and return results."""
+    binding = scenario.binding
+    shape = scenario.shape
+
+    obj = routines.Routines() if binding is not RoutineBinding.MODULE_FUNCTION else None
+
+    routine = _select_routine(shape, binding)
+
+    match shape:
+        case RoutineShape.COROUTINE:
+            if binding is RoutineBinding.INSTANCE_METHOD:
+                result = await routine(obj, 1, 2)
+            else:
+                result = await routine(1, 2)
+            assert result == 3
+            return result
+
+        case RoutineShape.ASYNC_GEN_ANEXT:
+            collected = []
+            if binding is RoutineBinding.INSTANCE_METHOD:
+                gen = routine(obj, 3)
+            else:
+                gen = routine(3)
+            async for item in gen:
+                collected.append(item)
+            assert collected == [0, 1, 2]
+            return collected
+
+        case RoutineShape.ASYNC_GEN_ASEND:
+            if binding is RoutineBinding.INSTANCE_METHOD:
+                gen = routine(obj, 2)
+            else:
+                gen = routine(2)
+            first = await gen.__anext__()
+            assert first == "ready"
+            echoed = await gen.asend(42)
+            assert echoed == 42
+            await gen.aclose()
+            return echoed
+
+        case RoutineShape.ASYNC_GEN_ATHROW:
+            if binding is RoutineBinding.INSTANCE_METHOD:
+                gen = routine(obj, 10)
+            else:
+                gen = routine(10)
+            first = await gen.__anext__()
+            assert first == 10
+            reset = await gen.athrow(ValueError)
+            assert reset == 0
+            await gen.aclose()
+            return reset
+
+        case RoutineShape.ASYNC_GEN_ACLOSE:
+            if binding is RoutineBinding.INSTANCE_METHOD:
+                gen = routine(obj)
+            else:
+                gen = routine()
+            first = await gen.__anext__()
+            assert first == "alive"
+            await gen.aclose()
+            return first
+
+        case RoutineShape.NESTED_COROUTINE:
+            result = await routines.nested_add(1, 2)
+            assert result == 3
+            return result
+
+        case RoutineShape.NESTED_ASYNC_GEN:
+            collected = []
+            async for item in routines.nested_gen(3):
+                collected.append(item)
+            assert collected == [0, 1, 2]
+            return collected
+
+
+def _select_routine(shape, binding):
+    """Return the routine callable for the given shape and binding."""
+    match (shape, binding):
+        case (RoutineShape.COROUTINE, RoutineBinding.MODULE_FUNCTION):
+            return routines.add
+        case (RoutineShape.COROUTINE, RoutineBinding.INSTANCE_METHOD):
+            return routines.Routines.instance_add
+        case (RoutineShape.COROUTINE, RoutineBinding.CLASSMETHOD):
+            return routines.Routines.class_add
+        case (RoutineShape.COROUTINE, RoutineBinding.STATICMETHOD):
+            return routines.Routines.static_add
+
+        case (RoutineShape.ASYNC_GEN_ANEXT, RoutineBinding.MODULE_FUNCTION):
+            return routines.gen_range
+        case (RoutineShape.ASYNC_GEN_ANEXT, RoutineBinding.INSTANCE_METHOD):
+            return routines.Routines.instance_gen
+        case (RoutineShape.ASYNC_GEN_ANEXT, RoutineBinding.CLASSMETHOD):
+            return routines.Routines.class_gen
+        case (RoutineShape.ASYNC_GEN_ANEXT, RoutineBinding.STATICMETHOD):
+            return routines.Routines.static_gen
+
+        case (RoutineShape.ASYNC_GEN_ASEND, RoutineBinding.MODULE_FUNCTION):
+            return routines.echo_send
+        case (RoutineShape.ASYNC_GEN_ASEND, RoutineBinding.INSTANCE_METHOD):
+            return routines.Routines.instance_echo_send
+        case (RoutineShape.ASYNC_GEN_ASEND, _):
+            return routines.echo_send
+
+        case (RoutineShape.ASYNC_GEN_ATHROW, RoutineBinding.MODULE_FUNCTION):
+            return routines.resilient_counter
+        case (RoutineShape.ASYNC_GEN_ATHROW, RoutineBinding.INSTANCE_METHOD):
+            return routines.Routines.instance_resilient_counter
+        case (RoutineShape.ASYNC_GEN_ATHROW, _):
+            return routines.resilient_counter
+
+        case (RoutineShape.ASYNC_GEN_ACLOSE, RoutineBinding.MODULE_FUNCTION):
+            return routines.closeable_gen
+        case (RoutineShape.ASYNC_GEN_ACLOSE, RoutineBinding.INSTANCE_METHOD):
+            return routines.Routines.instance_closeable_gen
+        case (RoutineShape.ASYNC_GEN_ACLOSE, _):
+            return routines.closeable_gen
+
+        case (RoutineShape.NESTED_COROUTINE, _):
+            return routines.nested_add
+        case (RoutineShape.NESTED_ASYNC_GEN, _):
+            return routines.nested_gen
+
+        case _:
+            raise ValueError(f"Unsupported shape/binding: {shape}, {binding}")
+
+
+_ASEND_ATHROW_ACLOSE = (
+    RoutineShape.ASYNC_GEN_ASEND,
+    RoutineShape.ASYNC_GEN_ATHROW,
+    RoutineShape.ASYNC_GEN_ACLOSE,
+)
+_NESTED_SHAPES = (
+    RoutineShape.NESTED_COROUTINE,
+    RoutineShape.NESTED_ASYNC_GEN,
+)
+
+
+def _pairwise_filter(row):
+    """Filter invalid dimension combinations.
+
+    - D3 must be NONE when D2 is DEFAULT, EPHEMERAL, DURABLE, or NESTED_*
+      (DURABLE manages its own LocalDiscovery internally)
+    - D3 must NOT be NONE when D2 is HYBRID
+    - D4 must not be ASYNC_CM (pre-called async CM instances are not
+      picklable inside WorkerProxy.__reduce__; documented limitation,
+      see #61)
+    - D8 must be MODULE_FUNCTION or INSTANCE_METHOD when D1 is ASEND,
+      ATHROW, or ACLOSE (no classmethod/staticmethod routines defined
+      for these shapes)
+    - D8 must be MODULE_FUNCTION when D1 is NESTED_* (nested dispatch
+      always uses module-level routines)
+    """
+    if len(row) > 2:
+        pool_mode = row[1]
+        discovery = row[2]
+        needs_discovery = pool_mode in (PoolMode.HYBRID,)
+        forbids_discovery = pool_mode in (
+            PoolMode.DEFAULT,
+            PoolMode.EPHEMERAL,
+            PoolMode.DURABLE,
+            PoolMode.NESTED_DEFAULT_IN_EPHEMERAL,
+            PoolMode.NESTED_EPHEMERAL_IN_EPHEMERAL,
+        )
+        if needs_discovery and discovery is DiscoveryFactory.NONE:
+            return False
+        if forbids_discovery and discovery is not DiscoveryFactory.NONE:
+            return False
+    if len(row) > 3:
+        lb = row[3]
+        if lb is LbFactory.ASYNC_CM:
+            return False
+    if len(row) > 7:
+        shape = row[0]
+        binding = row[7]
+        if shape in _ASEND_ATHROW_ACLOSE and binding in (
+            RoutineBinding.CLASSMETHOD,
+            RoutineBinding.STATICMETHOD,
+        ):
+            return False
+        if shape in _NESTED_SHAPES and binding is not RoutineBinding.MODULE_FUNCTION:
+            return False
+    return True
+
+
+PAIRWISE_SCENARIOS = [
+    Scenario(
+        shape=row[0],
+        pool_mode=row[1],
+        discovery=row[2],
+        lb=row[3],
+        credential=row[4],
+        options=row[5],
+        timeout=row[6],
+        binding=row[7],
+    )
+    for row in AllPairs(
+        [
+            list(RoutineShape),
+            list(PoolMode),
+            list(DiscoveryFactory),
+            list(LbFactory),
+            list(CredentialType),
+            list(WorkerOptionsKind),
+            list(TimeoutKind),
+            list(RoutineBinding),
+        ],
+        filter_func=_pairwise_filter,
+    )
+]
+
+
+@st.composite
+def scenarios_strategy(draw):
+    """Hypothesis composite strategy that draws valid Scenarios."""
+    shape = draw(st.sampled_from(RoutineShape))
+    pool_mode = draw(st.sampled_from(PoolMode))
+
+    needs_discovery = pool_mode in (PoolMode.HYBRID,)
+    forbids_discovery = pool_mode in (
+        PoolMode.DEFAULT,
+        PoolMode.EPHEMERAL,
+        PoolMode.DURABLE,
+        PoolMode.NESTED_DEFAULT_IN_EPHEMERAL,
+        PoolMode.NESTED_EPHEMERAL_IN_EPHEMERAL,
+    )
+
+    if needs_discovery:
+        discovery = draw(
+            st.sampled_from(
+                [d for d in DiscoveryFactory if d is not DiscoveryFactory.NONE]
+            )
+        )
+    elif forbids_discovery:
+        discovery = DiscoveryFactory.NONE
+    else:
+        discovery = draw(st.sampled_from(DiscoveryFactory))
+
+    # ASYNC_CM lb excluded: pre-called CM instances are not picklable
+    # inside WorkerProxy.__reduce__ (documented limitation, see #61)
+    lb = draw(st.sampled_from([f for f in LbFactory if f is not LbFactory.ASYNC_CM]))
+    credential = draw(st.sampled_from(CredentialType))
+    options = draw(st.sampled_from(WorkerOptionsKind))
+    timeout = draw(st.sampled_from(TimeoutKind))
+
+    if shape in _NESTED_SHAPES:
+        binding = RoutineBinding.MODULE_FUNCTION
+    elif shape in _ASEND_ATHROW_ACLOSE:
+        binding = draw(
+            st.sampled_from(
+                [
+                    RoutineBinding.MODULE_FUNCTION,
+                    RoutineBinding.INSTANCE_METHOD,
+                ]
+            )
+        )
+    else:
+        binding = draw(st.sampled_from(RoutineBinding))
+
+    return Scenario(
+        shape=shape,
+        pool_mode=pool_mode,
+        discovery=discovery,
+        lb=lb,
+        credential=credential,
+        options=options,
+        timeout=timeout,
+        binding=binding,
+    )
+
+
+def _generate_test_certificates():
+    """Generate self-signed test certificates for SSL/TLS testing."""
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COMMON_NAME, "localhost"),
+        ]
+    )
+
+    now = datetime.datetime.now(datetime.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [
+                    x509.DNSName("localhost"),
+                    x509.IPAddress(ipaddress.IPv4Address("127.0.0.1")),
+                ]
+            ),
+            critical=False,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage(
+                [
+                    x509.oid.ExtendedKeyUsageOID.SERVER_AUTH,
+                    x509.oid.ExtendedKeyUsageOID.CLIENT_AUTH,
+                ]
+            ),
+            critical=False,
+        )
+        .sign(private_key, hashes.SHA256(), default_backend())
+    )
+
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+
+    return private_key_pem, cert_pem, cert_pem
+
+
+@pytest.fixture(scope="session")
+def test_certificates():
+    """Provide test certificates for the session."""
+    return _generate_test_certificates()
+
+
+@pytest.fixture(scope="session")
+def credentials_map(test_certificates):
+    """Map CredentialType enum values to WorkerCredentials or None."""
+    key_pem, cert_pem, ca_pem = test_certificates
+    return {
+        CredentialType.INSECURE: None,
+        CredentialType.MTLS: WorkerCredentials(
+            ca_cert=ca_pem,
+            worker_key=key_pem,
+            worker_cert=cert_pem,
+            mutual=True,
+        ),
+        CredentialType.ONE_WAY: WorkerCredentials(
+            ca_cert=ca_pem,
+            worker_key=key_pem,
+            worker_cert=cert_pem,
+            mutual=False,
+        ),
+    }
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_channel_pool():
+    """Clear the module-level gRPC channel pool after each test."""
+    yield
+    import wool.runtime.worker.connection as _conn
+
+    await _conn._channel_pool.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_proxy_context():
+    """Reset proxy context vars between tests."""
+    proxy_token = wool.__proxy__.set(None)
+    pool_token = wool.__proxy_pool__.set(None)
+    yield
+    wool.__proxy__.reset(proxy_token)
+    wool.__proxy_pool__.reset(pool_token)

--- a/wool/tests/integration/routines.py
+++ b/wool/tests/integration/routines.py
@@ -1,0 +1,140 @@
+"""Test routines for integration tests.
+
+This module defines all ``@wool.routine`` decorated functions used by the
+integration test suite. It is NOT a test file — no ``test_`` prefix — so
+pytest will not collect it directly.
+
+Routines are organized by dimension:
+- D1 (RoutineShape): coroutine vs async generator vs nested variants
+- D8 (RoutineBinding): module function vs instance/class/static method
+"""
+
+import wool
+
+
+@wool.routine
+async def add(a: int, b: int) -> int:
+    """Simple coroutine that returns the sum of two integers."""
+    return a + b
+
+
+@wool.routine
+async def gen_range(n: int):
+    """Async generator that yields integers 0..n-1."""
+    for i in range(n):
+        yield i
+
+
+@wool.routine
+async def echo_send(n: int):
+    """Async generator with asend support.
+
+    Yields "ready" first, then echoes back any value sent via asend().
+    """
+    value = yield "ready"
+    for _ in range(n):
+        value = yield value
+
+
+@wool.routine
+async def resilient_counter(start: int):
+    """Async generator with athrow support.
+
+    Yields incrementing integers from *start*. When a ValueError is
+    thrown, resets the counter to 0 and continues.
+    """
+    counter = start
+    while True:
+        try:
+            yield counter
+            counter += 1
+        except ValueError:
+            counter = 0
+
+
+@wool.routine
+async def closeable_gen():
+    """Async generator for aclose testing.
+
+    Yields "alive" in a loop until closed.
+    """
+    while True:
+        yield "alive"
+
+
+@wool.routine
+async def nested_add(a: int, b: int) -> int:
+    """Coroutine that dispatches to ``add``, triggering nested dispatch."""
+    return await add(a, b)
+
+
+@wool.routine
+async def nested_gen(n: int):
+    """Async generator that yields from ``gen_range``, nested streaming."""
+    async for item in gen_range(n):
+        yield item
+
+
+class Routines:
+    """Test class providing instance, class, and static method bindings."""
+
+    @wool.routine
+    async def instance_add(self, a: int, b: int) -> int:
+        """Instance method coroutine."""
+        return a + b
+
+    @wool.routine
+    async def instance_gen(self, n: int):
+        """Instance method async generator."""
+        for i in range(n):
+            yield i
+
+    @wool.routine
+    async def instance_echo_send(self, n: int):
+        """Instance method async generator with asend."""
+        value = yield "ready"
+        for _ in range(n):
+            value = yield value
+
+    @wool.routine
+    async def instance_resilient_counter(self, start: int):
+        """Instance method async generator with athrow."""
+        counter = start
+        while True:
+            try:
+                yield counter
+                counter += 1
+            except ValueError:
+                counter = 0
+
+    @wool.routine
+    async def instance_closeable_gen(self):
+        """Instance method async generator for aclose."""
+        while True:
+            yield "alive"
+
+    @wool.routine
+    @classmethod
+    async def class_add(cls, a: int, b: int) -> int:
+        """Class method coroutine."""
+        return a + b
+
+    @wool.routine
+    @classmethod
+    async def class_gen(cls, n: int):
+        """Class method async generator."""
+        for i in range(n):
+            yield i
+
+    @wool.routine
+    @staticmethod
+    async def static_add(a: int, b: int) -> int:
+        """Static method coroutine."""
+        return a + b
+
+    @wool.routine
+    @staticmethod
+    async def static_gen(n: int):
+        """Static method async generator."""
+        for i in range(n):
+            yield i

--- a/wool/tests/integration/test_integration.py
+++ b/wool/tests/integration/test_integration.py
@@ -1,0 +1,109 @@
+"""Full integration tests — pairwise parametrized and Hypothesis exploration."""
+
+import asyncio
+
+import pytest
+from hypothesis import HealthCheck
+from hypothesis import example
+from hypothesis import given
+from hypothesis import settings
+
+from .conftest import PAIRWISE_SCENARIOS
+from .conftest import CredentialType
+from .conftest import DiscoveryFactory
+from .conftest import LbFactory
+from .conftest import PoolMode
+from .conftest import RoutineBinding
+from .conftest import RoutineShape
+from .conftest import Scenario
+from .conftest import TimeoutKind
+from .conftest import WorkerOptionsKind
+from .conftest import build_pool_from_scenario
+from .conftest import invoke_routine
+from .conftest import scenarios_strategy
+
+_INTEGRATION_TIMEOUT = 30
+
+_NESTED_SHAPES = {RoutineShape.NESTED_COROUTINE, RoutineShape.NESTED_ASYNC_GEN}
+
+
+def _xfail_known_bugs(scenario):
+    if scenario.shape in _NESTED_SHAPES:
+        pytest.xfail(
+            "grpcio 1.78 PollerCompletionQueue thundering herd race "
+            "(https://github.com/grpc/grpc/pull/41483)"
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scenario", PAIRWISE_SCENARIOS, ids=str)
+async def test_dispatch_pairwise(scenario, credentials_map):
+    """Test routine dispatch across pairwise scenario combinations.
+
+    Given:
+        A complete scenario from the pairwise covering array.
+    When:
+        A pool is built and the appropriate routine is dispatched.
+    Then:
+        It should return the expected result for the given routine shape.
+    """
+    _xfail_known_bugs(scenario)
+
+    # Arrange, act, & assert
+    async with asyncio.timeout(_INTEGRATION_TIMEOUT):
+        async with build_pool_from_scenario(scenario, credentials_map):
+            await invoke_routine(scenario)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[
+        HealthCheck.function_scoped_fixture,
+        HealthCheck.too_slow,
+    ],
+)
+@example(
+    scenario=Scenario(
+        RoutineShape.COROUTINE,
+        PoolMode.DEFAULT,
+        DiscoveryFactory.NONE,
+        LbFactory.CLASS_REF,
+        CredentialType.INSECURE,
+        WorkerOptionsKind.DEFAULT,
+        TimeoutKind.NONE,
+        RoutineBinding.MODULE_FUNCTION,
+    )
+)
+@example(
+    scenario=Scenario(
+        RoutineShape.ASYNC_GEN_ANEXT,
+        PoolMode.EPHEMERAL,
+        DiscoveryFactory.NONE,
+        LbFactory.INSTANCE,
+        CredentialType.INSECURE,
+        WorkerOptionsKind.DEFAULT,
+        TimeoutKind.NONE,
+        RoutineBinding.MODULE_FUNCTION,
+    )
+)
+@given(scenario=scenarios_strategy())
+async def test_dispatch_hypothesis(scenario, credentials_map):
+    """Test routine dispatch with Hypothesis-generated scenarios.
+
+    Given:
+        A randomly generated valid scenario from the Hypothesis strategy.
+    When:
+        A pool is built and the appropriate routine is dispatched.
+    Then:
+        It should return the expected result for the given routine shape.
+    """
+    _xfail_known_bugs(scenario)
+
+    # Arrange, act, & assert
+    async with asyncio.timeout(_INTEGRATION_TIMEOUT):
+        async with build_pool_from_scenario(scenario, credentials_map):
+            await invoke_routine(scenario)

--- a/wool/tests/integration/test_pool_composition.py
+++ b/wool/tests/integration/test_pool_composition.py
@@ -1,0 +1,203 @@
+"""Tests for pool composition via build_pool_from_scenario."""
+
+import pytest
+
+from .conftest import CredentialType
+from .conftest import DiscoveryFactory
+from .conftest import LbFactory
+from .conftest import PoolMode
+from .conftest import RoutineBinding
+from .conftest import RoutineShape
+from .conftest import Scenario
+from .conftest import TimeoutKind
+from .conftest import WorkerOptionsKind
+from .conftest import build_pool_from_scenario
+from .conftest import invoke_routine
+
+
+@pytest.mark.integration
+class TestPoolComposition:
+    @pytest.mark.asyncio
+    async def test_build_pool_from_scenario_with_default_mode(self, credentials_map):
+        """Test building a pool with DEFAULT mode.
+
+        Given:
+            A complete scenario using DEFAULT pool mode with insecure
+            credentials.
+        When:
+            A pool is built and a coroutine routine is dispatched.
+        Then:
+            It should return the correct result (add(1, 2) == 3).
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DEFAULT,
+            discovery=DiscoveryFactory.NONE,
+            lb=LbFactory.CLASS_REF,
+            credential=CredentialType.INSECURE,
+            options=WorkerOptionsKind.DEFAULT,
+            timeout=TimeoutKind.NONE,
+            binding=RoutineBinding.MODULE_FUNCTION,
+        )
+
+        # Act
+        async with build_pool_from_scenario(scenario, credentials_map):
+            result = await invoke_routine(scenario)
+
+        # Assert
+        assert result == 3
+
+    @pytest.mark.asyncio
+    async def test_build_pool_from_scenario_with_ephemeral_mode(self, credentials_map):
+        """Test building a pool with EPHEMERAL mode and size=2.
+
+        Given:
+            A complete scenario using EPHEMERAL pool mode with 2 workers.
+        When:
+            A pool is built and a coroutine routine is dispatched.
+        Then:
+            It should return the correct result.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.EPHEMERAL,
+            discovery=DiscoveryFactory.NONE,
+            lb=LbFactory.INSTANCE,
+            credential=CredentialType.INSECURE,
+            options=WorkerOptionsKind.DEFAULT,
+            timeout=TimeoutKind.NONE,
+            binding=RoutineBinding.MODULE_FUNCTION,
+        )
+
+        # Act
+        async with build_pool_from_scenario(scenario, credentials_map):
+            result = await invoke_routine(scenario)
+
+        # Assert
+        assert result == 3
+
+    @pytest.mark.asyncio
+    async def test_build_pool_from_scenario_with_durable_mode(self, credentials_map):
+        """Test building a pool with DURABLE mode.
+
+        Given:
+            A complete scenario using DURABLE pool mode with internally
+            managed LocalDiscovery and externally started workers.
+        When:
+            A pool is built and a coroutine routine is dispatched.
+        Then:
+            It should return the correct result.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DURABLE,
+            discovery=DiscoveryFactory.NONE,
+            lb=LbFactory.CLASS_REF,
+            credential=CredentialType.INSECURE,
+            options=WorkerOptionsKind.DEFAULT,
+            timeout=TimeoutKind.NONE,
+            binding=RoutineBinding.MODULE_FUNCTION,
+        )
+
+        # Act
+        async with build_pool_from_scenario(scenario, credentials_map):
+            result = await invoke_routine(scenario)
+
+        # Assert
+        assert result == 3
+
+    @pytest.mark.asyncio
+    async def test_build_pool_from_scenario_with_hybrid_mode(self, credentials_map):
+        """Test building a pool with HYBRID mode and LOCAL_CALLABLE discovery.
+
+        Given:
+            A complete scenario using HYBRID pool mode with local
+            callable discovery factory.
+        When:
+            A pool is built and a coroutine routine is dispatched.
+        Then:
+            It should return the correct result.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.HYBRID,
+            discovery=DiscoveryFactory.LOCAL_CALLABLE,
+            lb=LbFactory.CLASS_REF,
+            credential=CredentialType.INSECURE,
+            options=WorkerOptionsKind.DEFAULT,
+            timeout=TimeoutKind.NONE,
+            binding=RoutineBinding.MODULE_FUNCTION,
+        )
+
+        # Act
+        async with build_pool_from_scenario(scenario, credentials_map):
+            result = await invoke_routine(scenario)
+
+        # Assert
+        assert result == 3
+
+    @pytest.mark.asyncio
+    async def test_build_pool_from_scenario_with_restrictive_opts(self, credentials_map):
+        """Test building a pool with restrictive message size options.
+
+        Given:
+            A complete scenario using RESTRICTIVE worker options (64KB
+            message limits).
+        When:
+            A pool is built and a small-payload coroutine is dispatched.
+        Then:
+            It should return the correct result within the size limits.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DEFAULT,
+            discovery=DiscoveryFactory.NONE,
+            lb=LbFactory.CLASS_REF,
+            credential=CredentialType.INSECURE,
+            options=WorkerOptionsKind.RESTRICTIVE,
+            timeout=TimeoutKind.NONE,
+            binding=RoutineBinding.MODULE_FUNCTION,
+        )
+
+        # Act
+        async with build_pool_from_scenario(scenario, credentials_map):
+            result = await invoke_routine(scenario)
+
+        # Assert
+        assert result == 3
+
+    @pytest.mark.asyncio
+    async def test_build_pool_from_scenario_with_dispatch_timeout(self, credentials_map):
+        """Test building a pool with dispatch_timeout via RuntimeContext.
+
+        Given:
+            A complete scenario using VIA_RUNTIME_CONTEXT timeout.
+        When:
+            A pool is built within a RuntimeContext and a coroutine is
+            dispatched.
+        Then:
+            It should return the correct result with the timeout active.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DEFAULT,
+            discovery=DiscoveryFactory.NONE,
+            lb=LbFactory.CLASS_REF,
+            credential=CredentialType.INSECURE,
+            options=WorkerOptionsKind.DEFAULT,
+            timeout=TimeoutKind.VIA_RUNTIME_CONTEXT,
+            binding=RoutineBinding.MODULE_FUNCTION,
+        )
+
+        # Act
+        async with build_pool_from_scenario(scenario, credentials_map):
+            result = await invoke_routine(scenario)
+
+        # Assert
+        assert result == 3

--- a/wool/tests/integration/test_scenario.py
+++ b/wool/tests/integration/test_scenario.py
@@ -1,0 +1,166 @@
+"""Unit tests for the Scenario model."""
+
+import pytest
+
+from .conftest import CredentialType
+from .conftest import DiscoveryFactory
+from .conftest import LbFactory
+from .conftest import PoolMode
+from .conftest import RoutineBinding
+from .conftest import RoutineShape
+from .conftest import Scenario
+from .conftest import TimeoutKind
+from .conftest import WorkerOptionsKind
+
+
+class TestScenario:
+    def test___or___with_disjoint_fields(self):
+        """Test merging two partial scenarios with disjoint fields.
+
+        Given:
+            Two partial scenarios with non-overlapping dimensions set.
+        When:
+            They are merged with the ``|`` operator.
+        Then:
+            It should produce a combined scenario with both sides' fields.
+        """
+        # Arrange
+        left = Scenario(shape=RoutineShape.COROUTINE)
+        right = Scenario(pool_mode=PoolMode.DEFAULT)
+
+        # Act
+        merged = left | right
+
+        # Assert
+        assert merged.shape is RoutineShape.COROUTINE
+        assert merged.pool_mode is PoolMode.DEFAULT
+
+    def test___or___with_conflicting_fields(self):
+        """Test merging two scenarios that set the same field differently.
+
+        Given:
+            Two scenarios that both set ``shape`` to different values.
+        When:
+            They are merged with the ``|`` operator.
+        Then:
+            It should raise ValueError.
+        """
+        # Arrange
+        left = Scenario(shape=RoutineShape.COROUTINE)
+        right = Scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+
+        # Act & assert
+        with pytest.raises(ValueError, match="Conflicting values for shape"):
+            left | right
+
+    def test___or___with_identical_values(self):
+        """Test merging two scenarios that set the same field identically.
+
+        Given:
+            Two scenarios that both set ``shape`` to the same value.
+        When:
+            They are merged with the ``|`` operator.
+        Then:
+            It should merge without error and preserve the value.
+        """
+        # Arrange
+        left = Scenario(shape=RoutineShape.COROUTINE)
+        right = Scenario(shape=RoutineShape.COROUTINE)
+
+        # Act
+        merged = left | right
+
+        # Assert
+        assert merged.shape is RoutineShape.COROUTINE
+
+    def test___or___with_empty_scenario(self):
+        """Test merging a partial scenario with an all-None scenario.
+
+        Given:
+            A partial scenario and a default empty scenario.
+        When:
+            They are merged with the ``|`` operator.
+        Then:
+            It should return the original non-None fields unchanged.
+        """
+        # Arrange
+        left = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DEFAULT,
+        )
+        right = Scenario()
+
+        # Act
+        merged = left | right
+
+        # Assert
+        assert merged.shape is RoutineShape.COROUTINE
+        assert merged.pool_mode is PoolMode.DEFAULT
+        assert merged.discovery is None
+
+    def test_is_complete_with_all_fields(self):
+        """Test that a fully populated scenario reports complete.
+
+        Given:
+            A scenario with all 8 dimensions set.
+        When:
+            ``is_complete`` is checked.
+        Then:
+            It should return True.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DEFAULT,
+            discovery=DiscoveryFactory.NONE,
+            lb=LbFactory.CLASS_REF,
+            credential=CredentialType.INSECURE,
+            options=WorkerOptionsKind.DEFAULT,
+            timeout=TimeoutKind.NONE,
+            binding=RoutineBinding.MODULE_FUNCTION,
+        )
+
+        # Act & assert
+        assert scenario.is_complete is True
+
+    def test_is_complete_with_missing_field(self):
+        """Test that a partial scenario reports incomplete.
+
+        Given:
+            A scenario with only some dimensions set.
+        When:
+            ``is_complete`` is checked.
+        Then:
+            It should return False.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DEFAULT,
+        )
+
+        # Act & assert
+        assert scenario.is_complete is False
+
+    def test___str___with_partial_fields(self):
+        """Test string representation with some fields set.
+
+        Given:
+            A partial scenario with two dimensions set.
+        When:
+            Converted to string.
+        Then:
+            It should return dash-separated names with underscores
+            for unset fields.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DEFAULT,
+        )
+
+        # Act
+        result = str(scenario)
+
+        # Assert
+        assert result == "COROUTINE-DEFAULT-_-_-_-_-_-_"

--- a/wool/tests/runtime/worker/test_local.py
+++ b/wool/tests/runtime/worker/test_local.py
@@ -365,6 +365,7 @@ class TestLocalWorker:
         await worker.start()
 
         mock_channel = mocker.MagicMock()
+        mock_channel.close = mocker.AsyncMock()
         mock_stub = mocker.MagicMock()
         mock_stub.stop = mocker.AsyncMock()
 
@@ -432,6 +433,7 @@ class TestLocalWorker:
         await worker.start()
 
         mock_channel = mocker.MagicMock()
+        mock_channel.close = mocker.AsyncMock()
         mock_stub = mocker.MagicMock()
         mock_stub.stop = mocker.AsyncMock(side_effect=Exception("gRPC error"))
 
@@ -558,6 +560,7 @@ class TestLocalWorker:
         await worker.start()
 
         mock_channel = mocker.MagicMock()
+        mock_channel.close = mocker.AsyncMock()
         mock_stub = mocker.MagicMock()
         mock_stub.stop = mocker.AsyncMock()
 
@@ -598,6 +601,7 @@ class TestLocalWorker:
         await worker.start()
 
         mock_channel = mocker.MagicMock()
+        mock_channel.close = mocker.AsyncMock()
         mock_stub = mocker.MagicMock()
         mock_stub.stop = mocker.AsyncMock()
 
@@ -638,6 +642,7 @@ class TestLocalWorker:
         assert worker.metadata is not None
 
         mock_channel = mocker.MagicMock()
+        mock_channel.close = mocker.AsyncMock()
         mock_stub = mocker.MagicMock()
         mock_stub.stop = mocker.AsyncMock()
 
@@ -682,6 +687,7 @@ class TestLocalWorker:
         mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
 
         mock_channel = mocker.MagicMock()
+        mock_channel.close = mocker.AsyncMock()
         mock_stub = mocker.MagicMock()
         mock_stub.stop = mocker.AsyncMock()
         mocker.patch.object(grpc.aio, "secure_channel", return_value=mock_channel)


### PR DESCRIPTION
## Summary

Add an integration test suite that exercises Wool's distributed runtime end-to-end — real `WorkerPool` contexts, real discovery, real gRPC, real `@wool.routine` dispatch — without mocking internal boundaries. The suite is structured around 8 orthogonal dimensions with composable test arrangements, using `allpairspy` pairwise covering arrays for deterministic CI and Hypothesis for random exploration.

Extend the Python test guide with section 14 on integration testing conventions, generalized to be replicable beyond this project.

Fix a gRPC channel leak in `LocalWorker._stop()` discovered during integration testing — the one-off channel used to send the stop RPC was never closed, leaking a completion queue file descriptor per worker teardown.

53 pairwise scenarios pass across all 8 dimensions including TLS credentials, nested routines, nested pool modes, LAN discovery, and all routine bindings. Pre-called CM loadbalancers (#61) are permanently excluded from the pairwise array as a documented limitation. Nested dispatch scenarios are xfailed due to a grpcio 1.78 bug (see Known issues).

Closes #58

## Proposed changes

### Build: allpairspy dependency and integration marker

Add `allpairspy` to `[project.optional-dependencies] dev` in `pyproject.toml` and register the `integration` marker under `[tool.pytest.ini_options]` for selective test execution (`-m integration` / `-m "not integration"`).

### Docs: Integration testing conventions

Add section 14 to `llms/test-guides/python.md` covering the full integration testing process: routine module conventions, dimension enums, filter functions for structural constraints vs permanent exclusions, the composable Scenario model, builder pattern with mode-specific helpers, pairwise covering arrays, Hypothesis exploration, xfail vs filter distinction for known bugs vs documented limitations, cleanup fixtures, and the three test layer progression.

### Fix: Close gRPC channel after worker stop request

`LocalWorker._stop()` creates a one-off gRPC channel to send the stop RPC but never calls `channel.close()`. Each unclosed channel leaks a completion queue file descriptor. Under rapid test cycling where many workers are started and stopped in sequence, this exhausts the process FD limit. Wrap the stop call in `try/finally` to ensure `await channel.close()` runs.

### CI: Raise file descriptor limit for integration tests

Add `ulimit -n 65536` before the test run in the CI workflow. gRPC C-core completion queue cleanup is asynchronous — FDs from torn-down worker subprocesses may not be fully reclaimed before the next test starts. The higher limit provides sufficient headroom on CI runners.

### Test: Integration test suite

**File layout:**

```
wool/tests/integration/
    __init__.py              (empty)
    conftest.py              (Scenario model, enums, pairwise array, fixtures, builder)
    routines.py              (all @wool.routine test functions for D1/D8)
    test_scenario.py         (TestScenario — 6 tests)
    test_pool_composition.py (TestPoolComposition — 6 tests)
    test_integration.py      (pairwise parametrized + Hypothesis exploration)
```

**D1 — Routine shape**

| # | Arrangement | Exercises |
|---|-------------|-----------|
| 1 | `COROUTINE` (await) | `_execute` → single return value |
| 2 | `ASYNC_GEN_ANEXT` (async for) | `__anext__` pull loop |
| 3 | `ASYNC_GEN_ASEND` | Bidirectional value passing |
| 4 | `ASYNC_GEN_ATHROW` | Remote exception injection |
| 5 | `ASYNC_GEN_ACLOSE` | Early termination, cleanup |
| 6 | `NESTED_COROUTINE` (routine calls routine) | Recursive dispatch, `do_dispatch` context toggle |
| 7 | `NESTED_ASYNC_GEN` (routine yields from routine) | Nested streaming dispatch |

**D2 — WorkerPool mode**

| # | Arrangement | Config |
|---|-------------|--------|
| 1 | `DEFAULT` | `WorkerPool(size=1)` |
| 2 | `EPHEMERAL` | `WorkerPool(size=2)` |
| 3 | `DURABLE` | `WorkerPool(discovery=...)` with externally started workers |
| 4 | `HYBRID` | `WorkerPool(size=1, discovery=...)` |
| 5 | `NESTED_DEFAULT_IN_EPHEMERAL` | Outer ephemeral, routine opens inner default pool |
| 6 | `NESTED_EPHEMERAL_IN_EPHEMERAL` | Outer ephemeral, routine opens inner ephemeral pool |

**D3 — Discovery protocol x factory form** (only applicable to durable and hybrid modes)

| # | Protocol | Factory form |
|---|----------|-------------|
| 1 | None | No discovery (ephemeral/default modes) |
| 2 | `LocalDiscovery` | Direct instance (`_DirectDiscovery` wrapper) |
| 3 | `LocalDiscovery` | Callable returning instance |
| 4 | `LocalDiscovery` | Sync context manager |
| 5 | `LocalDiscovery` | Async context manager |
| 6 | `LanDiscovery` | Direct instance |
| 7 | `LanDiscovery` | Callable returning instance |
| 8 | `LanDiscovery` | Async context manager |

**D4 — Load balancer factory form**

| # | Arrangement | Exercises |
|---|-------------|-----------|
| 1 | `CLASS_REF` (`RoundRobinLoadBalancer`) | `callable(factory)` → instantiation |
| 2 | `INSTANCE` (`RoundRobinLoadBalancer()`) | Direct passthrough |
| 3 | `CALLABLE` (`lambda: RoundRobinLoadBalancer()`) | `callable(factory)` → recursive `_enter_context` |
| 4 | `ASYNC_CM` (`@asynccontextmanager`) | Permanently excluded — pre-called CM not picklable in `__reduce__` (#61) |

**D5 — Credential type**

| # | Arrangement | Exercises |
|---|-------------|-----------|
| 1 | `INSECURE` | No TLS, insecure gRPC channels |
| 2 | `MTLS` | Mutual TLS with self-signed certs |
| 3 | `ONE_WAY` | Server-only TLS |

**D6 — Worker options**

| # | Arrangement | Exercises |
|---|-------------|-----------|
| 1 | `DEFAULT` (100MB limits) | Normal operation |
| 2 | `RESTRICTIVE` (64KB limits) | Message size boundary behavior |

**D7 — Dispatch timeout**

| # | Arrangement | Exercises |
|---|-------------|-----------|
| 1 | `NONE` (no timeout) | Unbounded dispatch |
| 2 | `VIA_RUNTIME_CONTEXT` | `RuntimeContext(dispatch_timeout=30.0)` propagation |

**D8 — Routine binding**

| # | Arrangement | Exercises |
|---|-------------|-----------|
| 1 | `MODULE_FUNCTION` | `parent` is `ModuleType` in `_resolve` |
| 2 | `INSTANCE_METHOD` | `args[1:]` skip for `__self__` |
| 3 | `CLASSMETHOD` | `fn.__func__(parent, *args)` path |
| 4 | `STATICMETHOD` | `fn.__func__(*args)` path |

**Composable Scenario dataclass** with `__or__` algebraic merge, `is_complete` property, and dash-separated `__str__` for pytest IDs.

**Pairwise covering array** via `AllPairs` with `filter_func` excluding invalid combinations (discovery with non-durable pools, pre-called CM loadbalancers).

**Hypothesis `@st.composite` strategy** with conditional dimension filtering and `@example` smoke tests.

**`build_pool_from_scenario` async context manager** resolving all 8 dimensions to concrete runtime values, including a dedicated `_durable_pool_context` helper that manually starts workers for DURABLE mode.

**`invoke_routine`** mapping (shape, binding) pairs to the correct routine and invocation protocol (await, async for, asend, athrow, aclose).

### Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestScenario` | Two partial scenarios from different dimensions | Composed with `\|` | Result contains both dimensions' values | Algebraic merge |
| 2 | `TestScenario` | Two partial scenarios setting the same field differently | Composed with `\|` | ValueError is raised | Conflict detection |
| 3 | `TestScenario` | Two partial scenarios setting the same field identically | Composed with `\|` | Merge succeeds with value preserved | Identical-value merge |
| 4 | `TestScenario` | A partial scenario and an empty scenario | Composed with `\|` | Original fields unchanged | Empty merge identity |
| 5 | `TestScenario` | A scenario with all 8 fields set | `is_complete` checked | Returns True | Completeness check |
| 6 | `TestScenario` | A scenario with missing fields | `is_complete` checked | Returns False | Incompleteness check |
| 7 | `TestPoolComposition` | DEFAULT pool mode, insecure, default options | Pool built and `add(1, 2)` dispatched | Returns 3 | Default ephemeral pool |
| 8 | `TestPoolComposition` | EPHEMERAL pool mode with size=2 | Pool built and `add(1, 2)` dispatched | Returns 3 | Multi-worker ephemeral |
| 9 | `TestPoolComposition` | DURABLE pool mode with LOCAL_SYNC_CM discovery | Pool built with external workers and `add(1, 2)` dispatched | Returns 3 | Durable discovery path |
| 10 | `TestPoolComposition` | HYBRID pool mode with LOCAL_CALLABLE discovery | Pool built and `add(1, 2)` dispatched | Returns 3 | Hybrid spawn + discovery |
| 11 | `TestPoolComposition` | RESTRICTIVE worker options (64KB limits) | Pool built and `add(1, 2)` dispatched | Returns 3 | Small message limits |
| 12 | `TestPoolComposition` | VIA_RUNTIME_CONTEXT timeout | Pool built within RuntimeContext and `add(1, 2)` dispatched | Returns 3 | dispatch_timeout propagation |

## Known issues

### Nested dispatch xfail: grpcio 1.78 PollerCompletionQueue race

Scenarios with `NESTED_COROUTINE` and `NESTED_ASYNC_GEN` shapes are marked `xfail`. These scenarios dispatch a routine from within a worker subprocess, which creates a gRPC client channel on the worker's task execution thread. This results in two event loops with gRPC completion queue fd readers in the same process — the main gRPC server loop and the worker task loop on a daemon thread.

grpcio 1.78.0 has a thundering herd bug in `PollerCompletionQueue._handle_events`: the C-core poller writes a single byte to a socket pair to wake all registered event loops, and multiple loops race to `recv(1)` on the same non-blocking socket. The losers get `BlockingIOError` (EAGAIN), which is unhandled and causes `execute_batch` failures surfacing as `AioRpcError(INTERNAL, "Internal error from Core")`.

This is a test-only manifestation — in production, worker processes are long-lived and the two event loops reach steady state before nested dispatches occur. The tight startup-dispatch-teardown cycle in tests hits the narrow window where both loops are freshly registered and idle simultaneously.

Fixed upstream in [grpc/grpc#41483](https://github.com/grpc/grpc/pull/41483) but not yet available in a stable grpcio release (1.78.1 was yanked; 1.80.0 is rc-only). The xfail will automatically surface as `xpass` when a fixed release is available.