### PR TITLE
Fix watchdog collision when multiple LocalDiscovery instances share the same temp directory — Closes #62

### DIFF
--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -801,4 +801,6 @@ def _watchdog_path(namespace: str) -> Path:
     :returns:
         Path to the notification file for this namespace.
     """
-    return Path(tempfile.gettempdir()) / f"wool-notify-{namespace}"
+    directory = Path(tempfile.gettempdir()) / f"wool-{namespace}"
+    directory.mkdir(exist_ok=True)
+    return directory / "notify"

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -1146,3 +1146,146 @@ class TestLocalDiscoverySubscriber:
 
         # Assert
         assert unpickled.namespace == namespace
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_concurrent_namespaces(self):
+        """Test concurrent subscribers on different namespaces do not collide.
+
+        Given:
+            Two LocalDiscovery instances with different namespaces
+        When:
+            Both subscribers async-iterate simultaneously
+        Then:
+            It should deliver events to both without RuntimeError or
+            BlockingIOError.
+        """
+        # Arrange
+        ns_a = f"test-concurrent-a-{uuid.uuid4()}"
+        ns_b = f"test-concurrent-b-{uuid.uuid4()}"
+        worker_a = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="host-a:50051",
+            pid=111,
+            version="1.0",
+        )
+        worker_b = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="host-b:50052",
+            pid=222,
+            version="1.0",
+        )
+
+        events_a: list = []
+        events_b: list = []
+        received_a = asyncio.Event()
+        received_b = asyncio.Event()
+        started_a = asyncio.Event()
+        started_b = asyncio.Event()
+
+        async def collect(subscriber, events, received, started):
+            started.set()
+            async for event in subscriber:
+                events.append(event)
+                received.set()
+                break
+
+        with LocalDiscovery(ns_a) as discovery_a, LocalDiscovery(ns_b) as discovery_b:
+            publisher_a = discovery_a.publisher
+            publisher_b = discovery_b.publisher
+            subscriber_a = discovery_a.subscribe(poll_interval=0.05)
+            subscriber_b = discovery_b.subscribe(poll_interval=0.05)
+
+            async with publisher_a, publisher_b:
+                task_a = asyncio.create_task(collect(subscriber_a, events_a, received_a, started_a))
+                task_b = asyncio.create_task(collect(subscriber_b, events_b, received_b, started_b))
+                await asyncio.gather(started_a.wait(), started_b.wait())
+
+                # Act
+                await publisher_a.publish("worker-added", worker_a)
+                await publisher_b.publish("worker-added", worker_b)
+
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(received_a.wait(), received_b.wait()),
+                        timeout=2.0,
+                    )
+                except asyncio.TimeoutError:
+                    pytest.fail("Concurrent subscribers did not both receive events")
+                finally:
+                    for t in (task_a, task_b):
+                        t.cancel()
+                        try:
+                            await t
+                        except asyncio.CancelledError:
+                            pass
+
+        # Assert
+        assert len(events_a) == 1
+        assert events_a[0].metadata.uid == worker_a.uid
+        assert len(events_b) == 1
+        assert events_b[0].metadata.uid == worker_b.uid
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_multiple_subscribers_same_namespace(
+        self, namespace, metadata
+    ):
+        """Test two subscribers on the same namespace receive events independently.
+
+        Given:
+            Two Subscribers on the same namespace
+        When:
+            A worker is published
+        Then:
+            It should deliver the worker-added event to both subscribers
+            independently.
+        """
+        # Arrange
+        events_1: list = []
+        events_2: list = []
+        received_1 = asyncio.Event()
+        received_2 = asyncio.Event()
+        started_1 = asyncio.Event()
+        started_2 = asyncio.Event()
+
+        async def collect(subscriber, events, received, started):
+            started.set()
+            async for event in subscriber:
+                events.append(event)
+                received.set()
+                break
+
+        with LocalDiscovery(namespace) as discovery:
+            publisher = discovery.publisher
+            subscriber_1 = discovery.subscribe(poll_interval=0.05)
+            subscriber_2 = discovery.subscribe(poll_interval=0.05)
+
+            async with publisher:
+                task_1 = asyncio.create_task(collect(subscriber_1, events_1, received_1, started_1))
+                task_2 = asyncio.create_task(collect(subscriber_2, events_2, received_2, started_2))
+                await asyncio.gather(started_1.wait(), started_2.wait())
+
+                # Act
+                await publisher.publish("worker-added", metadata)
+
+                try:
+                    await asyncio.wait_for(
+                        asyncio.gather(received_1.wait(), received_2.wait()),
+                        timeout=2.0,
+                    )
+                except asyncio.TimeoutError:
+                    pytest.fail("Both subscribers did not receive the event")
+                finally:
+                    for t in (task_1, task_2):
+                        t.cancel()
+                        try:
+                            await t
+                        except asyncio.CancelledError:
+                            pass
+
+        # Assert
+        assert len(events_1) == 1
+        assert events_1[0].type == "worker-added"
+        assert events_1[0].metadata.uid == metadata.uid
+        assert len(events_2) == 1
+        assert events_2[0].type == "worker-added"
+        assert events_2[0].metadata.uid == metadata.uid


### PR DESCRIPTION
## Summary

When multiple `LocalDiscovery` instances are active concurrently (e.g., nested `WorkerPool` contexts), their watchdog observers all schedule watches on the same parent directory (`/tmp` or equivalent). This causes `RuntimeError: Cannot add watch - it is already scheduled` and `BlockingIOError` from file descriptor exhaustion.

Move each namespace's notification file into its own subdirectory (e.g., `/tmp/wool-<namespace>/notify`) so each subscriber's watchdog `Observer` watches an isolated directory instead of the shared system temp dir.

Closes #62

## Proposed changes

### Namespace the watchdog notification path

`_watchdog_path()` previously returned `/tmp/wool-notify-<namespace>`, placing all notification files directly in the system temp directory. Every `Observer` then watched `/tmp`, colliding when multiple instances coexist.

`_watchdog_path()` now returns `<tmpdir>/wool-<namespace>/notify`, creating a per-namespace subdirectory. The `Observer` watches only that subdirectory, eliminating the collision.

**Before:**
```python
def _watchdog_path(namespace: str) -> Path:
    return Path(tempfile.gettempdir()) / f"wool-notify-{namespace}"
```

**After:**
```python
def _watchdog_path(namespace: str) -> Path:
    directory = Path(tempfile.gettempdir()) / f"wool-{namespace}"
    directory.mkdir(exist_ok=True)
    return directory / "notify"
```

## Test cases

| Test Suite | Test ID | Given | When | Then | Coverage Target |
|------------|---------|-------|------|------|-----------------|
| `TestLocalDiscovery` | LD-001 | A LocalDiscovery with an explicit namespace | It is instantiated | It should store the provided namespace | `__init__` with explicit namespace |
| `TestLocalDiscovery` | LD-002 | A LocalDiscovery with no namespace | It is instantiated | It should generate a unique namespace | `__init__` default namespace |
| `TestLocalDiscovery` | LD-003 | A LocalDiscovery instance | It is used as a context manager | It should enter and exit without error | `__enter__`/`__exit__` |
| `TestLocalDiscovery` | LD-004 | A LocalDiscovery context manager | The `namespace` property is accessed | It should return the namespace string | `namespace` property |
| `TestLocalDiscovery` | LD-005 | A LocalDiscovery context manager | The `publisher` property is accessed | It should return a Publisher with the same namespace | `publisher` property |
| `TestLocalDiscovery` | LD-006 | A LocalDiscovery context manager | The `subscriber` property is accessed | It should return a Subscriber with the same namespace | `subscriber` property |
| `TestLocalDiscovery` | LD-007 | A LocalDiscovery context manager | `subscribe()` is called with a filter | It should return a Subscriber with that filter applied | `subscribe()` with filter |
| `TestLocalDiscovery` | LD-008 | A LocalDiscovery context manager | `subscribe()` is called with a poll_interval | It should return a Subscriber configured with that interval | `subscribe()` with poll_interval |
| `TestPublisher` | PB-001 | A Publisher with an explicit namespace | It is instantiated | It should store the provided namespace | `__init__` basic |
| `TestPublisher` | PB-002 | A Publisher with a negative block_size | It is instantiated | It should raise `ValueError` | `__init__` validation |
| `TestPublisher` | PB-003 | A Publisher instance | It is used as an async context manager | It should enter and exit without error | `__aenter__`/`__aexit__` |
| `TestPublisher` | PB-004 | A Publisher within a LocalDiscovery context | `publish("worker-added", metadata)` is called | It should write the worker to shared memory | `publish()` add |
| `TestPublisher` | PB-005 | A Publisher with a published worker | `publish("worker-dropped", metadata)` is called | It should remove the worker from shared memory | `publish()` drop |
| `TestPublisher` | PB-006 | A Publisher with a published worker | `publish("worker-updated", metadata)` is called | It should update the worker in shared memory | `publish()` update |
| `TestPublisher` | PB-007 | A Publisher within a LocalDiscovery context | `publish()` is called with an unknown event type | It should raise `RuntimeError` | `publish()` unknown type |
| `TestPublisher` | PB-008 | A Publisher with a full address space (capacity=1, one worker registered) | `publish("worker-added", new_metadata)` is called | It should raise `RuntimeError` for no available slots | `publish()` capacity exhaustion |
| `TestPublisher` | PB-009 | A Publisher with a published worker | `publish("worker-updated", unknown_metadata)` is called for an unregistered UID | It should raise `KeyError` | `publish()` update missing worker |
| `TestSubscriber` | SB-001 | A Subscriber with an explicit namespace | It is instantiated | It should store the provided namespace | `__init__` basic |
| `TestSubscriber` | SB-002 | A Subscriber with a negative poll_interval | It is instantiated | It should raise `ValueError` | `__init__` validation |
| `TestSubscriber` | SB-003 | A Subscriber instance | It is pickled and unpickled | It should reconstruct with the same namespace | `__reduce__` pickling |
| `TestSubscriber` | SB-004 | A Subscriber within a LocalDiscovery context with a published worker | It is async-iterated | It should yield a `worker-added` event for the published worker | `__aiter__` add detection |
| `TestSubscriber` | SB-005 | A Subscriber iterating after a worker is dropped | A second scan occurs | It should yield a `worker-dropped` event | `__aiter__` drop detection |
| `TestSubscriber` | SB-006 | A Subscriber with a filter predicate | Workers are published | It should yield events only for workers matching the filter | `__aiter__` with filter |
| `TestSubscriber` | SB-007 | Two LocalDiscovery instances with different namespaces used concurrently | Both subscribers async-iterate simultaneously | Both should receive their respective events without `RuntimeError` or `BlockingIOError` | Concurrent subscriber isolation (issue #62 regression) |
| `TestSubscriber` | SB-008 | Two Subscribers on the same namespace | A worker is published | Both should independently yield the `worker-added` event | Multiple subscriber independence |

## Implementation plan

1. - [x] Write regression test SB-007 — two concurrent `LocalDiscovery` instances with different namespaces, both subscribing simultaneously, asserting no `RuntimeError` or `BlockingIOError`
2. - [x] Update `_watchdog_path()` in `local.py` to place notification files in per-namespace subdirectories
3. - [x] Write remaining test case SB-008 — two subscribers on the same namespace independently receiving events