### PR TITLE
Fix LocalWorker TLS credential pickling — Closes #60

### DIFF
--- a/wool/src/wool/runtime/worker/auth.py
+++ b/wool/src/wool/runtime/worker/auth.py
@@ -101,9 +101,8 @@ class WorkerCredentials:
             mutual=mutual,
         )
 
-    @property
     def server_credentials(self) -> grpc.ServerCredentials:
-        """Server credentials for accepting connections.
+        """Build server credentials for accepting connections.
 
         Returns server credentials configured based on the ``mutual`` flag.
         Use when the worker is acting as a server accepting connections.
@@ -135,9 +134,8 @@ class WorkerCredentials:
             require_client_auth=self.mutual,
         )
 
-    @property
     def client_credentials(self) -> grpc.ChannelCredentials:
-        """Client credentials for making connections.
+        """Build client credentials for making connections.
 
         Returns client credentials configured based on the ``mutual`` flag.
         Use when the worker is acting as a client connecting to servers.

--- a/wool/src/wool/runtime/worker/base.py
+++ b/wool/src/wool/runtime/worker/base.py
@@ -21,13 +21,6 @@ from wool.runtime.discovery.base import WorkerMetadata
 if TYPE_CHECKING:
     from wool.runtime.worker.auth import WorkerCredentials
 
-# Type aliases for credentials
-ServerCredentialsType: TypeAlias = Union[
-    grpc.ServerCredentials,
-    Callable[[], grpc.ServerCredentials],
-    None,
-]
-
 ChannelCredentialsType: TypeAlias = Union[
     grpc.ChannelCredentials,
     Callable[[], grpc.ChannelCredentials],
@@ -52,32 +45,6 @@ class WorkerOptions:
 
     max_receive_message_length: int = 100 * 1024 * 1024
     max_send_message_length: int = 100 * 1024 * 1024
-
-
-def resolve_server_credentials(
-    credentials: ServerCredentialsType,
-) -> grpc.ServerCredentials | None:
-    """Resolve server credentials from object or callable.
-
-    :param credentials:
-        Server credentials object, callable, or None.
-    :returns:
-        Resolved server credentials or None.
-    :raises TypeError:
-        If callable doesn't return proper credentials type.
-    """
-    if credentials is None:
-        return None
-    elif callable(credentials):
-        result = credentials()
-        if result is not None and not isinstance(result, grpc.ServerCredentials):
-            raise TypeError(
-                f"Server credentials callable must return grpc.ServerCredentials "
-                f"or None, got {type(result)}"
-            )
-        return result
-    else:
-        return credentials
 
 
 def resolve_channel_credentials(

--- a/wool/src/wool/runtime/worker/local.py
+++ b/wool/src/wool/runtime/worker/local.py
@@ -9,11 +9,8 @@ import grpc.aio
 from wool import protocol
 from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.worker.auth import WorkerCredentials
-from wool.runtime.worker.base import ChannelCredentialsType
-from wool.runtime.worker.base import ServerCredentialsType
 from wool.runtime.worker.base import Worker
 from wool.runtime.worker.base import WorkerOptions
-from wool.runtime.worker.base import resolve_channel_credentials
 from wool.runtime.worker.process import WorkerProcess
 
 
@@ -70,8 +67,7 @@ class LocalWorker(Worker):
     """
 
     _worker_process: WorkerProcess
-    _server_credentials: ServerCredentialsType
-    _client_credentials: ChannelCredentialsType
+    _credentials: WorkerCredentials | None
 
     def __init__(
         self,
@@ -85,21 +81,13 @@ class LocalWorker(Worker):
         **extra: Any,
     ):
         super().__init__(*tags, **extra)
-
-        # Extract server and client credentials
-        if credentials is not None:
-            self._server_credentials = credentials.server_credentials
-            self._client_credentials = credentials.client_credentials
-        else:
-            self._server_credentials = None
-            self._client_credentials = None
-
+        self._credentials = credentials
         self._worker_process = WorkerProcess(
             host=host,
             port=port,
             shutdown_grace_period=shutdown_grace_period,
             proxy_pool_ttl=proxy_pool_ttl,
-            server_credentials=self._server_credentials,
+            credentials=credentials,
             options=options,
         )
 
@@ -138,7 +126,7 @@ class LocalWorker(Worker):
             version=protocol.__version__,
             tags=frozenset(self._tags),
             extra=MappingProxyType(self._extra),
-            secure=self._server_credentials is not None,
+            secure=self._credentials is not None,
         )
 
     async def _stop(self, timeout: float | None):
@@ -157,12 +145,10 @@ class LocalWorker(Worker):
             assert self.address
 
             # Create appropriate channel based on available credentials
-            credentials = resolve_channel_credentials(self._client_credentials)
-            if credentials is not None:
-                # Secure worker with mTLS: use client credentials
+            if self._credentials is not None:
+                credentials = self._credentials.client_credentials()
                 channel = grpc.aio.secure_channel(self.address, credentials)
             else:
-                # Insecure worker: use insecure channel
                 channel = grpc.aio.insecure_channel(self.address)
 
             stub = protocol.WorkerStub(channel)

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -231,12 +231,12 @@ class WorkerPool:
         else:
             credentials = credentials
 
-        if credentials is not None:
-            self._credentials = credentials
-            self._client_credentials = credentials.client_credentials
-        else:
-            self._credentials = None
-            self._client_credentials = None
+        self._credentials = credentials
+        self._client_credentials = (
+            credentials.client_credentials()
+            if credentials is not None
+            else None
+        )
 
         match (size, discovery):
             case (size, discovery) if size is not None and discovery is not None:

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -15,9 +15,8 @@ import grpc.aio
 import wool
 from wool import protocol
 from wool.runtime.resourcepool import ResourcePool
-from wool.runtime.worker.base import ServerCredentialsType
+from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerOptions
-from wool.runtime.worker.base import resolve_server_credentials
 from wool.runtime.worker.interceptor import VersionInterceptor
 from wool.runtime.worker.service import WorkerService
 
@@ -48,8 +47,8 @@ class WorkerProcess(Process):
         Graceful shutdown timeout in seconds.
     :param proxy_pool_ttl:
         Proxy pool TTL in seconds.
-    :param server_credentials:
-        Optional gRPC server credentials for TLS/mTLS.
+    :param credentials:
+        Optional worker credentials for TLS/mTLS.
     :param options:
         gRPC message size options. Defaults to
         :class:`WorkerOptions` with 100 MB limits.
@@ -64,7 +63,7 @@ class WorkerProcess(Process):
     _set_port: Connection
     _shutdown_grace_period: float
     _proxy_pool_ttl: float
-    _credentials: ServerCredentialsType
+    _credentials: WorkerCredentials | None
     _options: WorkerOptions
 
     def __init__(
@@ -74,7 +73,7 @@ class WorkerProcess(Process):
         port: int = 0,
         shutdown_grace_period: float = 60.0,
         proxy_pool_ttl: float = 60.0,
-        server_credentials: ServerCredentialsType = None,
+        credentials: WorkerCredentials | None = None,
         options: WorkerOptions | None = None,
         **kwargs,
     ):
@@ -91,7 +90,7 @@ class WorkerProcess(Process):
         if proxy_pool_ttl <= 0:
             raise ValueError("Proxy pool TTL must be positive")
         self._proxy_pool_ttl = proxy_pool_ttl
-        self._credentials = server_credentials
+        self._credentials = credentials
         self._options = options or WorkerOptions()
         self._get_port, self._set_port = Pipe(duplex=False)
 
@@ -193,7 +192,11 @@ class WorkerProcess(Process):
         server = grpc.aio.server(
             interceptors=[VersionInterceptor()], options=grpc_options
         )
-        credentials = resolve_server_credentials(self._credentials)
+        credentials = (
+            self._credentials.server_credentials()
+            if self._credentials is not None
+            else None
+        )
         address = self._address(self._host, self._port)
 
         if credentials is not None:

--- a/wool/tests/runtime/worker/conftest.py
+++ b/wool/tests/runtime/worker/conftest.py
@@ -585,31 +585,3 @@ def worker_credentials_one_way(test_certificates):
     return WorkerCredentials(
         ca_cert=ca_pem, worker_key=key_pem, worker_cert=cert_pem, mutual=False
     )
-
-
-@pytest.fixture
-def worker_credentials_callable(test_certificates):
-    """Provide WorkerCredentials with callable credentials for testing.
-
-    Returns:
-        WorkerCredentials with callable server and client credentials
-    """
-    key_pem, cert_pem, ca_pem = test_certificates
-
-    def server_factory():
-        return grpc.ssl_server_credentials(
-            private_key_certificate_chain_pairs=[(key_pem, cert_pem)],
-            root_certificates=ca_pem,
-            require_client_auth=True,
-        )
-
-    def client_factory():
-        return grpc.ssl_channel_credentials(
-            root_certificates=ca_pem, private_key=key_pem, certificate_chain=cert_pem
-        )
-
-    # Create a WorkerCredentials-like object with callable properties
-    # Since WorkerCredentials is frozen, we need to create it differently
-    return WorkerCredentials(
-        ca_cert=ca_pem, worker_key=key_pem, worker_cert=cert_pem, mutual=True
-    )

--- a/wool/tests/runtime/worker/test_auth.py
+++ b/wool/tests/runtime/worker/test_auth.py
@@ -1,4 +1,5 @@
 import datetime
+import pickle
 from dataclasses import FrozenInstanceError
 
 import grpc
@@ -122,8 +123,6 @@ def temp_cert_files(test_certificates, tmp_path):
 
 class TestWorkerCredentials:
     """Test suite for WorkerCredentials credential management."""
-
-    # === WTC-001 through WTC-006: Basic instantiation tests ===
 
     def test___init___with_mtls(self, test_certificates):
         """Test basic instantiation with mTLS.
@@ -258,8 +257,6 @@ class TestWorkerCredentials:
         # Assert
         assert creds.mutual is True
 
-    # === WTC-007 through WTC-010: Error handling ===
-
     def test_from_files_missing_ca_cert(self, temp_cert_files):
         """Test missing CA file error handling.
 
@@ -343,15 +340,13 @@ class TestWorkerCredentials:
             # Restore permissions for cleanup
             restricted_file.chmod(0o644)
 
-    # === WTC-011 through WTC-017: Credential property tests ===
-
     def test_server_credentials_with_mtls(self, test_certificates):
         """Test server credentials property for mTLS.
 
         Given:
             WorkerCredentials with mutual=True.
         When:
-            server_credentials property is accessed.
+            server_credentials() method is called.
         Then:
             Returns grpc.ServerCredentials configured for mTLS.
         """
@@ -362,7 +357,7 @@ class TestWorkerCredentials:
         )
 
         # Act
-        server_creds = creds.server_credentials
+        server_creds = creds.server_credentials()
 
         # Assert
         assert isinstance(server_creds, grpc.ServerCredentials)
@@ -373,7 +368,7 @@ class TestWorkerCredentials:
         Given:
             WorkerCredentials with mutual=False.
         When:
-            server_credentials property is accessed.
+            server_credentials() method is called.
         Then:
             Returns grpc.ServerCredentials configured for one-way TLS.
         """
@@ -384,7 +379,7 @@ class TestWorkerCredentials:
         )
 
         # Act
-        server_creds = creds.server_credentials
+        server_creds = creds.server_credentials()
 
         # Assert
         assert isinstance(server_creds, grpc.ServerCredentials)
@@ -395,7 +390,7 @@ class TestWorkerCredentials:
         Given:
             WorkerCredentials with mutual=True.
         When:
-            client_credentials property is accessed.
+            client_credentials() method is called.
         Then:
             Returns grpc.ChannelCredentials with worker cert and key.
         """
@@ -406,7 +401,7 @@ class TestWorkerCredentials:
         )
 
         # Act
-        client_creds = creds.client_credentials
+        client_creds = creds.client_credentials()
 
         # Assert
         assert isinstance(client_creds, grpc.ChannelCredentials)
@@ -417,7 +412,7 @@ class TestWorkerCredentials:
         Given:
             WorkerCredentials with mutual=False.
         When:
-            client_credentials property is accessed.
+            client_credentials() method is called.
         Then:
             Returns grpc.ChannelCredentials without worker cert (anonymous).
         """
@@ -428,7 +423,7 @@ class TestWorkerCredentials:
         )
 
         # Act
-        client_creds = creds.client_credentials
+        client_creds = creds.client_credentials()
 
         # Assert
         assert isinstance(client_creds, grpc.ChannelCredentials)
@@ -441,8 +436,8 @@ class TestWorkerCredentials:
         Given:
             Same certificate files used for server and client.
         When:
-            Both server_credentials and client_credentials properties
-            are accessed.
+            Both server_credentials() and client_credentials() methods
+            are called.
         Then:
             Both return valid credentials using the same underlying
             certificates.
@@ -454,20 +449,20 @@ class TestWorkerCredentials:
         )
 
         # Act
-        server_creds = creds.server_credentials
-        client_creds = creds.client_credentials
+        server_creds = creds.server_credentials()
+        client_creds = creds.client_credentials()
 
         # Assert
         assert isinstance(server_creds, grpc.ServerCredentials)
         assert isinstance(client_creds, grpc.ChannelCredentials)
 
     def test_server_credentials_idempotent_access(self, test_certificates):
-        """Test server credentials property idempotency.
+        """Test server credentials method idempotency.
 
         Given:
             WorkerCredentials with valid certificates.
         When:
-            server_credentials property is accessed multiple times.
+            server_credentials() method is called multiple times.
         Then:
             Returns consistent grpc.ServerCredentials on each access.
         """
@@ -478,8 +473,8 @@ class TestWorkerCredentials:
         )
 
         # Act
-        server_creds_1 = creds.server_credentials
-        server_creds_2 = creds.server_credentials
+        server_creds_1 = creds.server_credentials()
+        server_creds_2 = creds.server_credentials()
 
         # Assert
         # Should return credentials each time (may not be same object)
@@ -487,12 +482,12 @@ class TestWorkerCredentials:
         assert isinstance(server_creds_2, grpc.ServerCredentials)
 
     def test_client_credentials_idempotent_access(self, test_certificates):
-        """Test client credentials property idempotency.
+        """Test client credentials method idempotency.
 
         Given:
             WorkerCredentials with valid certificates.
         When:
-            client_credentials property is accessed multiple times.
+            client_credentials() method is called multiple times.
         Then:
             Returns consistent grpc.ChannelCredentials on each access.
         """
@@ -503,31 +498,29 @@ class TestWorkerCredentials:
         )
 
         # Act
-        client_creds_1 = creds.client_credentials
-        client_creds_2 = creds.client_credentials
+        client_creds_1 = creds.client_credentials()
+        client_creds_2 = creds.client_credentials()
 
         # Assert
         # Should return credentials each time (may not be same object)
         assert isinstance(client_creds_1, grpc.ChannelCredentials)
         assert isinstance(client_creds_2, grpc.ChannelCredentials)
 
-    # === WTC-018: Property-based test for credential property idempotency ===
-
     @given(mutual=st.booleans())
     @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
     def test_server_credentials_and_client_credentials_type_consistency(
         self, mutual, test_certificates
     ):
-        """Test property-based credential property idempotency.
+        """Test credential method idempotency across mutual flag values.
 
         Given:
             WorkerCredentials with valid certificates and any mutual
             flag value.
         When:
-            server_credentials and client_credentials are accessed
+            server_credentials() and client_credentials() are called
             multiple times.
         Then:
-            Both properties consistently return the same credential
+            Both methods consistently return the same credential
             types.
         """
         # Arrange
@@ -537,10 +530,10 @@ class TestWorkerCredentials:
         )
 
         # Act
-        server1 = creds.server_credentials
-        server2 = creds.server_credentials
-        client1 = creds.client_credentials
-        client2 = creds.client_credentials
+        server1 = creds.server_credentials()
+        server2 = creds.server_credentials()
+        client1 = creds.client_credentials()
+        client2 = creds.client_credentials()
 
         # Assert
         assert isinstance(server1, grpc.ServerCredentials)
@@ -549,3 +542,31 @@ class TestWorkerCredentials:
         assert isinstance(client2, grpc.ChannelCredentials)
         assert type(server1) == type(server2)
         assert type(client1) == type(client2)
+
+    @given(mutual=st.booleans())
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_pickle_roundtrip(self, mutual, test_certificates):
+        """Test WorkerCredentials survives pickle roundtrip.
+
+        Given:
+            WorkerCredentials with valid certificates and any mutual
+            flag value.
+        When:
+            The instance is pickled and unpickled.
+        Then:
+            It should produce an equal instance that still builds
+            valid gRPC credentials.
+        """
+        # Arrange
+        key_pem, cert_pem, ca_pem = test_certificates
+        creds = WorkerCredentials(
+            ca_cert=ca_pem, worker_key=key_pem, worker_cert=cert_pem, mutual=mutual
+        )
+
+        # Act
+        restored = pickle.loads(pickle.dumps(creds))
+
+        # Assert
+        assert restored == creds
+        assert isinstance(restored.server_credentials(), grpc.ServerCredentials)
+        assert isinstance(restored.client_credentials(), grpc.ChannelCredentials)

--- a/wool/tests/runtime/worker/test_base.py
+++ b/wool/tests/runtime/worker/test_base.py
@@ -15,7 +15,6 @@ from wool.runtime.worker.base import WorkerFactory
 from wool.runtime.worker.base import WorkerLike
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.base import resolve_channel_credentials
-from wool.runtime.worker.base import resolve_server_credentials
 
 
 class TestWorkerOptions:
@@ -566,20 +565,6 @@ class TestWorkerFactory:
 
 # Fixtures for credential resolver tests
 @pytest.fixture
-def server_credentials():
-    """Create grpc.ServerCredentials for testing.
-
-    Returns:
-        grpc.ServerCredentials configured for testing
-    """
-    # Create dummy server credentials with a dummy key-cert pair
-    # In tests, we don't need valid certificates, just valid credential objects
-    dummy_key = b"-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA0Z\n-----END RSA PRIVATE KEY-----"
-    dummy_cert = b"-----BEGIN CERTIFICATE-----\nMIIC0jCC\n-----END CERTIFICATE-----"
-    return grpc.ssl_server_credentials([(dummy_key, dummy_cert)])
-
-
-@pytest.fixture
 def channel_credentials():
     """Create grpc.ChannelCredentials for testing.
 
@@ -588,146 +573,6 @@ def channel_credentials():
     """
     # Create minimal SSL channel credentials
     return grpc.ssl_channel_credentials()
-
-
-@pytest.mark.parametrize(
-    "input_value,expected_result",
-    [
-        (None, None),
-        pytest.param(
-            "server_credentials",
-            "server_credentials",
-            id="direct_credentials",
-        ),
-    ],
-)
-def test_resolve_server_credentials_direct_values(
-    input_value, expected_result, server_credentials
-):
-    """Test resolve_server_credentials with direct values.
-
-    Given:
-        None or ServerCredentials instance
-    When:
-        resolve_server_credentials is called
-    Then:
-        Returns the input unchanged
-    """
-    # Arrange
-    if input_value == "server_credentials":
-        input_value = server_credentials
-        expected_result = server_credentials
-
-    # Act
-    result = resolve_server_credentials(input_value)
-
-    # Assert
-    assert result is expected_result
-
-
-@pytest.mark.parametrize(
-    "return_value,expected_result",
-    [
-        (None, None),
-        pytest.param(
-            "server_credentials",
-            "server_credentials",
-            id="valid_credentials",
-        ),
-    ],
-)
-def test_resolve_server_credentials_callable_valid_returns(
-    return_value, expected_result, server_credentials
-):
-    """Test resolve_server_credentials with callable returning valid values.
-
-    Given:
-        Callable returning None or ServerCredentials
-    When:
-        resolve_server_credentials is called
-    Then:
-        Returns result from calling the callable
-    """
-    # Arrange
-    if return_value == "server_credentials":
-        return_value = server_credentials
-        expected_result = server_credentials
-    callable_creds = lambda: return_value
-
-    # Act
-    result = resolve_server_credentials(callable_creds)
-
-    # Assert
-    assert result is expected_result
-
-
-@pytest.mark.parametrize(
-    "invalid_value,error_pattern",
-    [
-        ("invalid", "Server credentials callable"),
-        (42, r"grpc\.ServerCredentials.*got <class 'int'>"),
-    ],
-)
-def test_resolve_server_credentials_callable_invalid_returns(
-    invalid_value,
-    error_pattern,
-):
-    """Test resolve_server_credentials with callable returning invalid types.
-
-    Given:
-        Callable returning non-ServerCredentials type
-    When:
-        resolve_server_credentials is called
-    Then:
-        Raises TypeError with appropriate message
-    """
-    # Arrange
-    callable_creds = lambda: invalid_value
-
-    # Act & assert
-    with pytest.raises(TypeError, match=error_pattern):
-        resolve_server_credentials(callable_creds)
-
-
-@given(
-    input_type=st.sampled_from(["none", "direct", "callable_none", "callable_creds"]),
-    call_count=st.integers(min_value=1, max_value=5),
-)
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-def test_resolve_server_credentials_idempotency_and_type_safety(
-    input_type,
-    call_count,
-    server_credentials,
-):
-    """Test resolve_server_credentials idempotency and type safety.
-
-    Given:
-        Any valid input (None, credentials, or callable)
-    When:
-        resolve_server_credentials is called multiple times
-    Then:
-        All results are identical (idempotent) and are
-        ServerCredentials or None (type safe).
-    """
-    # Arrange
-    if input_type == "none":
-        input_val = None
-    elif input_type == "direct":
-        input_val = server_credentials
-    elif input_type == "callable_none":
-        input_val = lambda: None
-    else:  # callable_creds
-        input_val = lambda: server_credentials
-
-    # Act
-    results = [resolve_server_credentials(input_val) for _ in range(call_count)]
-
-    # Assert
-    assert all(r == results[0] for r in results), "Results must be identical"
-    for result in results:
-        assert result is None or isinstance(result, grpc.ServerCredentials), (
-            "Result must be ServerCredentials or None"
-        )
 
 
 @pytest.mark.parametrize(

--- a/wool/tests/runtime/worker/test_local.py
+++ b/wool/tests/runtime/worker/test_local.py
@@ -110,7 +110,7 @@ class TestLocalWorker:
         When:
             LocalWorker is instantiated.
         Then:
-            WorkerProcess is called with options=None.
+            WorkerProcess is called with options=None and credentials=None.
         """
         # Arrange
         MockWorkerProcess = mocker.patch.object(local_module, "WorkerProcess")
@@ -121,6 +121,7 @@ class TestLocalWorker:
         # Assert
         MockWorkerProcess.assert_called_once()
         assert MockWorkerProcess.call_args.kwargs["options"] is None
+        assert MockWorkerProcess.call_args.kwargs["credentials"] is None
 
     def test___init___with_custom_options(self, mocker):
         """Test custom WorkerOptions are forwarded to WorkerProcess.
@@ -653,46 +654,6 @@ class TestLocalWorker:
         # Assert
         mock_secure_channel.assert_called_once()
         mock_stub.stop.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_stop_resolves_callable_channel_credentials(
-        self, mocker, worker_credentials_callable
-    ):
-        """Test callable ChannelCredentials resolution on stop.
-
-        Given:
-            LocalWorker with callable ChannelCredentials in WorkerCredentials
-        When:
-            Worker is stopped
-        Then:
-            Callable is resolved before creating secure channel
-        """
-        # Arrange
-        mock_process = mocker.MagicMock(spec=WorkerProcess)
-        mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
-        mock_process.start.return_value = None
-        mock_process.is_alive.return_value = True
-
-        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
-
-        worker = LocalWorker(credentials=worker_credentials_callable)
-        await worker.start()
-
-        mock_channel = mocker.MagicMock()
-        mock_stub = mocker.MagicMock()
-        mock_stub.stop = mocker.AsyncMock()
-
-        mock_secure_channel = mocker.patch.object(
-            grpc.aio, "secure_channel", return_value=mock_channel
-        )
-        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
-
-        # Act
-        await worker.stop()
-
-        # Assert
-        mock_secure_channel.assert_called_once()
 
     @pytest.mark.parametrize("mutual", [True, False], ids=["mtls", "one_way_tls"])
     @pytest.mark.asyncio

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -8,6 +8,7 @@ from hypothesis import settings
 from hypothesis import strategies as st
 
 from wool.runtime.worker import process as process_module
+from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.process import WorkerProcess
 from wool.runtime.worker.process import _proxy_factory
@@ -977,7 +978,7 @@ class TestWorkerProcess:
         """Test single insecure port for insecure workers.
 
         Given:
-            WorkerProcess with server_credentials=None
+            WorkerProcess with credentials=None
         When:
             Process is started and server is configured
         Then:
@@ -1000,7 +1001,7 @@ class TestWorkerProcess:
 
         mocker.patch("wool.runtime.worker.process._signal_handlers")
 
-        process = WorkerProcess(host="127.0.0.1", port=0, server_credentials=None)
+        process = WorkerProcess(host="127.0.0.1", port=0, credentials=None)
 
         mocker.patch.object(process._set_port, "send")
         mocker.patch.object(process._set_port, "close")
@@ -1016,7 +1017,7 @@ class TestWorkerProcess:
         """Test single secure port for secure workers.
 
         Given:
-            WorkerProcess with valid ServerCredentials
+            WorkerProcess with valid WorkerCredentials
         When:
             Process is started and server is configured
         Then:
@@ -1027,7 +1028,9 @@ class TestWorkerProcess:
             b"-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
         )
         dummy_cert = b"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
-        server_creds = grpc.ssl_server_credentials([(dummy_key, dummy_cert)])
+        creds = WorkerCredentials(
+            ca_cert=dummy_cert, worker_key=dummy_key, worker_cert=dummy_cert
+        )
 
         mock_server = mocker.MagicMock()
         mock_server.add_secure_port = mocker.MagicMock(return_value=50051)
@@ -1045,9 +1048,7 @@ class TestWorkerProcess:
 
         mocker.patch("wool.runtime.worker.process._signal_handlers")
 
-        process = WorkerProcess(
-            host="127.0.0.1", port=0, server_credentials=server_creds
-        )
+        process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
 
         mocker.patch.object(process._set_port, "send")
         mocker.patch.object(process._set_port, "close")
@@ -1059,58 +1060,11 @@ class TestWorkerProcess:
         mock_server.add_secure_port.assert_called_once()
         mock_server.add_insecure_port.assert_not_called()
 
-    def test_serve_callable_credentials_resolved(self, mocker):
-        """Test callable credential resolution.
-
-        Given:
-            WorkerProcess with callable ServerCredentials
-        When:
-            Process is started and server is configured
-        Then:
-            Credentials are resolved and add_secure_port is called with resolved credentials
-        """
-        # Arrange
-        dummy_key = (
-            b"-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
-        )
-        dummy_cert = b"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
-
-        def server_creds_factory():
-            return grpc.ssl_server_credentials([(dummy_key, dummy_cert)])
-
-        mock_server = mocker.MagicMock()
-        mock_server.add_secure_port = mocker.MagicMock(return_value=50051)
-        mock_server.start = mocker.AsyncMock()
-        mock_server.stop = mocker.AsyncMock()
-        mocker.patch("grpc.aio.server", return_value=mock_server)
-
-        mock_service = mocker.MagicMock()
-        mock_service.configure_server = mocker.AsyncMock(return_value=50051)
-        mock_service.stopped.wait = mocker.AsyncMock()
-        mocker.patch(
-            "wool.runtime.worker.process.WorkerService", return_value=mock_service
-        )
-
-        mocker.patch("wool.runtime.worker.process._signal_handlers")
-
-        process = WorkerProcess(
-            host="127.0.0.1", port=0, server_credentials=server_creds_factory
-        )
-
-        mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
-
-        # Act
-        process.run()
-
-        # Assert
-        mock_server.add_secure_port.assert_called_once()
-
     def test_serve_secure_worker_random_port_assignment(self, mocker):
         """Test random port assignment for secure worker.
 
         Given:
-            WorkerProcess with ServerCredentials and port=0
+            WorkerProcess with WorkerCredentials and port=0
         When:
             Process is started
         Then:
@@ -1121,7 +1075,9 @@ class TestWorkerProcess:
             b"-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
         )
         dummy_cert = b"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
-        server_creds = grpc.ssl_server_credentials([(dummy_key, dummy_cert)])
+        creds = WorkerCredentials(
+            ca_cert=dummy_cert, worker_key=dummy_key, worker_cert=dummy_cert
+        )
 
         mock_server = mocker.MagicMock()
         mock_server.add_secure_port = mocker.MagicMock(return_value=54321)
@@ -1138,9 +1094,7 @@ class TestWorkerProcess:
 
         mocker.patch("wool.runtime.worker.process._signal_handlers")
 
-        process = WorkerProcess(
-            host="127.0.0.1", port=0, server_credentials=server_creds
-        )
+        process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
 
         sent_ports = []
         mocker.patch.object(
@@ -1181,7 +1135,7 @@ class TestWorkerProcess:
 
         mocker.patch("wool.runtime.worker.process._signal_handlers")
 
-        process = WorkerProcess(host="127.0.0.1", port=0, server_credentials=None)
+        process = WorkerProcess(host="127.0.0.1", port=0, credentials=None)
 
         sent_ports = []
         mocker.patch.object(
@@ -1200,7 +1154,7 @@ class TestWorkerProcess:
         """Test no dual-port architecture.
 
         Given:
-            WorkerProcess with ServerCredentials
+            WorkerProcess with WorkerCredentials
         When:
             Process is started and port is retrieved
         Then:
@@ -1211,7 +1165,9 @@ class TestWorkerProcess:
             b"-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
         )
         dummy_cert = b"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
-        server_creds = grpc.ssl_server_credentials([(dummy_key, dummy_cert)])
+        creds = WorkerCredentials(
+            ca_cert=dummy_cert, worker_key=dummy_key, worker_cert=dummy_cert
+        )
 
         mock_server = mocker.MagicMock()
         mock_server.add_secure_port = mocker.MagicMock(return_value=50051)
@@ -1229,9 +1185,7 @@ class TestWorkerProcess:
 
         mocker.patch("wool.runtime.worker.process._signal_handlers")
 
-        process = WorkerProcess(
-            host="127.0.0.1", port=0, server_credentials=server_creds
-        )
+        process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
 
         mocker.patch.object(process._set_port, "send")
         mocker.patch.object(process._set_port, "close")
@@ -1247,7 +1201,7 @@ class TestWorkerProcess:
         """Test no insecure localhost backdoor.
 
         Given:
-            Running WorkerProcess with ServerCredentials
+            Running WorkerProcess with WorkerCredentials
         When:
             Attempt to connect via insecure channel to the port
         Then:
@@ -1258,7 +1212,9 @@ class TestWorkerProcess:
             b"-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
         )
         dummy_cert = b"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
-        server_creds = grpc.ssl_server_credentials([(dummy_key, dummy_cert)])
+        creds = WorkerCredentials(
+            ca_cert=dummy_cert, worker_key=dummy_key, worker_cert=dummy_cert
+        )
 
         mock_server = mocker.MagicMock()
         mock_server.add_secure_port = mocker.MagicMock(return_value=50051)
@@ -1276,9 +1232,7 @@ class TestWorkerProcess:
 
         mocker.patch("wool.runtime.worker.process._signal_handlers")
 
-        process = WorkerProcess(
-            host="127.0.0.1", port=0, server_credentials=server_creds
-        )
+        process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
 
         mocker.patch.object(process._set_port, "send")
         mocker.patch.object(process._set_port, "close")
@@ -1307,9 +1261,11 @@ class TestWorkerProcess:
                 b"-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
             )
             dummy_cert = b"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
-            server_creds = grpc.ssl_server_credentials([(dummy_key, dummy_cert)])
+            creds = WorkerCredentials(
+                ca_cert=dummy_cert, worker_key=dummy_key, worker_cert=dummy_cert
+            )
         else:
-            server_creds = None
+            creds = None
 
         mock_server = mocker.MagicMock()
         mock_server.add_secure_port = mocker.MagicMock(return_value=50051)
@@ -1327,9 +1283,7 @@ class TestWorkerProcess:
 
         mocker.patch("wool.runtime.worker.process._signal_handlers")
 
-        process = WorkerProcess(
-            host="127.0.0.1", port=0, server_credentials=server_creds
-        )
+        process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
 
         mocker.patch.object(process._set_port, "send")
         mocker.patch.object(process._set_port, "close")


### PR DESCRIPTION
## Summary

`LocalWorker.__init__` eagerly resolves `WorkerCredentials` properties into `grpc.ServerCredentials` and `grpc.ChannelCredentials` — C extension types that cannot be pickled. On `spawn`-based platforms (macOS), `multiprocessing.Process.start()` pickles the `WorkerProcess` instance, causing `TypeError`.

Drop `@property` from `WorkerCredentials` credential methods, store the picklable dataclass through the subprocess boundary, and resolve gRPC credential objects only at the point of use. Remove `resolve_server_credentials` and `ServerCredentialsType` from `base.py` (no remaining callers); `resolve_channel_credentials` and `ChannelCredentialsType` remain for use by `connection.py` and `proxy.py`.

Closes #60

## Proposed changes

### Convert `WorkerCredentials` credential properties to methods

Remove `@property` from `server_credentials` and `client_credentials` on `WorkerCredentials`. Callers now invoke `creds.server_credentials()` and `creds.client_credentials()` explicitly, making it clear that each call constructs a fresh gRPC object. The `WorkerCredentials` dataclass itself (frozen, bytes-only fields) remains fully picklable.

### Defer credential resolution in `WorkerProcess`

Change `WorkerProcess` to accept `credentials: WorkerCredentials | None` instead of `server_credentials: ServerCredentialsType`. The picklable dataclass is stored directly and only resolved to `grpc.ServerCredentials` inside `_serve()`, which runs in the child process after the pickle boundary.

### Defer credential resolution in `LocalWorker`

Replace the eager `credentials.server_credentials` / `credentials.client_credentials` calls in `LocalWorker.__init__` with a single `self._credentials = credentials` assignment. Server credentials are passed as `WorkerCredentials` to `WorkerProcess`. Client credentials are resolved on demand in `_stop()` via `self._credentials.client_credentials()`. Remove unused imports (`ChannelCredentialsType`, `ServerCredentialsType`, `resolve_channel_credentials`).

### Defer credential resolution in `WorkerPool`

Remove the eager `credentials.client_credentials()` call and `_client_credentials` field from `WorkerPool.__init__`. Resolve `self._credentials.client_credentials()` at each `WorkerProxy` construction site.

### Remove dead server credential indirection

Remove `resolve_server_credentials`, `ServerCredentialsType`, and their tests from `base.py` and `test_base.py`. These have no remaining callers after `WorkerProcess` switched to `WorkerCredentials`.

## Test cases

| Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|
| `TestWorkerCredentials` | WorkerCredentials with mutual=True | `server_credentials()` is called | Returns grpc.ServerCredentials for mTLS | Method transition |
| `TestWorkerCredentials` | WorkerCredentials with mutual=False | `server_credentials()` is called | Returns grpc.ServerCredentials for one-way TLS | Method transition |
| `TestWorkerCredentials` | WorkerCredentials with mutual=True | `client_credentials()` is called | Returns grpc.ChannelCredentials with worker cert | Method transition |
| `TestWorkerCredentials` | WorkerCredentials with mutual=False | `client_credentials()` is called | Returns grpc.ChannelCredentials without worker cert | Method transition |
| `TestWorkerCredentials` | Same certificate files for server and client | Both credential methods are called | Both return valid credentials from the same certs | Bidirectional generation |
| `TestWorkerCredentials` | WorkerCredentials with valid certificates | `server_credentials()` called multiple times | Returns consistent grpc.ServerCredentials each time | Method idempotency |
| `TestWorkerCredentials` | WorkerCredentials with valid certificates | `client_credentials()` called multiple times | Returns consistent grpc.ChannelCredentials each time | Method idempotency |
| `TestWorkerCredentials` | Any mutual flag value (PBT) | Both credential methods called multiple times | Both consistently return the same credential types | PBT idempotency |
| `TestWorkerCredentials` | Any mutual flag value (PBT) | Instance is pickled and unpickled | Produces an equal instance that still builds valid gRPC credentials | **Pickle roundtrip regression** |
| `TestWorkerProcess` | WorkerProcess with credentials=None | Process is started | Only add_insecure_port is called | Single-port (insecure) |
| `TestWorkerProcess` | WorkerProcess with valid WorkerCredentials | Process is started | Only add_secure_port is called | Single-port (secure) |
| `TestWorkerProcess` | WorkerProcess with WorkerCredentials, port=0 | Process is started | A single random port is assigned and returned | Random port (secure) |
| `TestWorkerProcess` | WorkerProcess with no credentials, port=0 | Process is started | A single random port is assigned and returned | Random port (insecure) |
| `TestWorkerProcess` | WorkerProcess with WorkerCredentials | Port is retrieved after start | No additional localhost port exists | No dual-port |
| `TestWorkerProcess` | WorkerProcess with WorkerCredentials | Insecure connection attempted | No insecure fallback port exists | No insecure backdoor |
| `TestWorkerProcess` | Any credentials or None (PBT) | Process is started | Exactly one port bound (secure xor insecure) | PBT single-port invariant |
| `TestLocalWorker` | No options parameter | LocalWorker is instantiated | WorkerProcess called with options=None and credentials=None | Default forwarding |
| `TestLocalWorker` | WorkerCredentials instance | LocalWorker is instantiated | Constructs successfully | Construction with credentials |
| `TestLocalWorker` | None as credentials | LocalWorker is instantiated | Constructs successfully | Construction without credentials |
| `TestLocalWorker` | LocalWorker with WorkerCredentials | Metadata accessed after start | metadata.secure is True | Secure flag (mTLS) |
| `TestLocalWorker` | LocalWorker with no credentials | Metadata accessed after start | metadata.secure is False | Secure flag (insecure) |
| `TestLocalWorker` | Running LocalWorker with WorkerCredentials | `stop()` is called | Uses secure channel with client credentials | Secure self-connection |
| `TestLocalWorker` | Running LocalWorker with no credentials | `stop()` is called | Uses insecure channel | Insecure self-connection |
| `TestLocalWorker` | LocalWorker with mutual=False credentials | Worker is started and stopped | Uses secure channel with one-way TLS credentials | One-way TLS lifecycle |

## Implementation plan

1. - [x] Drop `@property` from `WorkerCredentials.server_credentials` and `WorkerCredentials.client_credentials` in `auth.py`
2. - [x] Update `WorkerProcess` to accept `WorkerCredentials | None` and resolve credentials in `_serve()` in `process.py`
3. - [x] Update `LocalWorker` to store `WorkerCredentials` and defer resolution to `_start`/`_stop` in `local.py`
4. - [x] Defer credential resolution in `WorkerPool` — resolve at each `WorkerProxy` construction site in `pool.py`
5. - [x] Remove `resolve_server_credentials`, `ServerCredentialsType`, and associated tests from `base.py` and `test_base.py`
6. - [x] Update `test_auth.py` — property accesses to method calls, update docstrings, add pickle roundtrip regression test
7. - [x] Update `test_process.py` — use `WorkerCredentials` instead of `grpc.ssl_server_credentials`, remove callable credential test
8. - [x] Update `test_local.py` — remove callable credential test, update init assertions
9. - [x] Remove unused `worker_credentials_callable` fixture from `conftest.py`