### PR TITLE
Force spawn start method for WorkerProcess to avoid gRPC fork unsafety — Closes #66

### DIFF
--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import multiprocessing as _mp
 import signal
 import sys
 from contextlib import contextmanager
 from functools import partial
-from multiprocessing import Pipe
-from multiprocessing import Process
 from multiprocessing.connection import Connection
 from typing import TYPE_CHECKING
 
@@ -24,6 +23,10 @@ from wool.runtime.worker.service import WorkerService
 
 if TYPE_CHECKING:
     from wool.runtime.worker.proxy import WorkerProxy
+
+_ctx = _mp.get_context("spawn")
+Pipe = _ctx.Pipe
+Process = _ctx.Process
 
 logger = logging.getLogger(__name__)
 

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -7,6 +7,7 @@ from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
 
+from wool.runtime.worker import process as process_module
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.process import WorkerProcess
 from wool.runtime.worker.process import _proxy_factory
@@ -265,6 +266,24 @@ class TestWorkerProcess:
         # Assert
         assert process.host == "127.0.0.1"
         assert process.address is None
+
+    def test___init___uses_spawn_context(self):
+        """Test WorkerProcess uses spawn multiprocessing context.
+
+        Given:
+            Default parameters
+        When:
+            WorkerProcess is instantiated
+        Then:
+            It should be an instance of SpawnProcess from the spawn context
+        """
+        import multiprocessing.context
+
+        # Act
+        process = WorkerProcess()
+
+        # Assert
+        assert isinstance(process, multiprocessing.context.SpawnProcess)
 
     def test___init___raises_error_for_blank_host(self):
         """Test WorkerProcess initialization raises error for blank host.
@@ -559,7 +578,7 @@ class TestWorkerProcess:
         When:
             start() is called
         Then:
-            It should call multiprocessing.Process.start
+            It should call Process.start
         """
         # Arrange
         mock_get_port = mocker.MagicMock()
@@ -571,7 +590,7 @@ class TestWorkerProcess:
             return_value=(mock_get_port, mock_set_port),
         )
 
-        mock_parent_start = mocker.patch("multiprocessing.Process.start")
+        mock_parent_start = mocker.patch.object(process_module.Process, "start")
 
         process = WorkerProcess()
 
@@ -604,7 +623,7 @@ class TestWorkerProcess:
             return_value=(mock_get_port, mock_set_port),
         )
 
-        mocker.patch("multiprocessing.Process.start")
+        mocker.patch.object(process_module.Process, "start")
 
         process = WorkerProcess()
 
@@ -634,7 +653,7 @@ class TestWorkerProcess:
             return_value=(mock_get_port, mock_set_port),
         )
 
-        mocker.patch("multiprocessing.Process.start")
+        mocker.patch.object(process_module.Process, "start")
 
         process = WorkerProcess()
         mock_terminate = mocker.patch.object(process, "terminate")
@@ -669,7 +688,7 @@ class TestWorkerProcess:
             return_value=(mock_get_port, mock_set_port),
         )
 
-        mocker.patch("multiprocessing.Process.start")
+        mocker.patch.object(process_module.Process, "start")
 
         process = WorkerProcess()
 


### PR DESCRIPTION
## Summary

`WorkerProcess` imports `Process` and `Pipe` directly from `multiprocessing`, which uses the platform default start method. On Linux this defaults to `fork`, copying the parent's memory including active gRPC threads and watchdog observers — causing worker subprocesses to fail silently or hang. Replace bare `multiprocessing` imports with an explicit `spawn` context via `multiprocessing.get_context("spawn")` so behavior is consistent across all platforms without changing the global default.

Closes #66

## Proposed changes

### Use explicit spawn context in `process.py`

Replace the two bare imports:

```python
from multiprocessing import Pipe
from multiprocessing import Process
```

with a module-level spawn context and aliases:

```python
import multiprocessing as _mp

_ctx = _mp.get_context("spawn")
Pipe = _ctx.Pipe
Process = _ctx.Process
```

Module-level `Pipe` and `Process` aliases keep the class definition (`class WorkerProcess(Process):`) and `Pipe(duplex=False)` call unchanged. This is scoped to the module — it does not call `multiprocessing.set_start_method()`, so other libraries sharing the process are unaffected.

### Update test mock targets

The `Pipe` mock target (`wool.runtime.worker.process.Pipe`) still resolves correctly since `Pipe` remains a module-level name — no change needed.

The `Process.start` mock target changes from `mocker.patch("multiprocessing.Process.start")` to `mocker.patch.object(process_module.Process, "start")` since `WorkerProcess` now inherits from `SpawnProcess`, not `multiprocessing.Process`. Four test methods are updated to use object-style patching per the test guide.

## Test cases

| Test Suite | Test ID | Given | When | Then | Coverage Target |
|------------|---------|-------|------|------|-----------------|
| `TestWorkerProcess` | SP-001 | Default parameters | `WorkerProcess` is instantiated | It should be an instance of `SpawnProcess` from the spawn multiprocessing context | Spawn context base class |
| `TestWorkerProcess` | SP-002 | Default parameters with mocked spawn-context pipe | `start()` is called and pipe returns a port | It should call parent `start`, receive port, and close pipe | `start` with spawn context |
| `TestWorkerProcess` | SP-003 | Default parameters with mocked pipe that times out | `start()` is called with a timeout | It should raise `RuntimeError` and terminate the process | Timeout handling under spawn context |
| `TestWorkerProcess` | SP-004 | A `WorkerProcess` with mocked gRPC server | `run()` is called | It should configure proxy pool, start server, send port, and stop gracefully | `run` end-to-end with spawn context |

## Implementation plan

1. - [x] Add spawn-context test to `tests/runtime/worker/test_process.py` verifying `WorkerProcess` is an instance of `SpawnProcess`
2. - [x] Replace bare `multiprocessing` imports in `src/wool/runtime/worker/process.py` with `_ctx = multiprocessing.get_context("spawn")`; alias `Pipe` and `Process` at module level
3. - [x] Update existing test mock targets from `multiprocessing.Process.start` to `process_module.Process` object-style patching