### PR TITLE
Propagate runtime context to worker subprocesses for nested dispatch — Closes #69

### DIFF
--- a/wool/proto/wire.proto
+++ b/wool/proto/wire.proto
@@ -2,6 +2,10 @@ syntax = "proto3";
 
 package wool.runtime.protobuf.wire;
 
+message RuntimeContext {
+    optional double dispatch_timeout = 1;
+}
+
 message Task {
     string version = 1;
     string id = 2;
@@ -13,6 +17,7 @@ message Task {
     bytes args = 8;
     bytes kwargs = 9;
     int32 timeout = 10;
+    optional RuntimeContext context = 11;
 }
 
 // Minimal envelope for pre-deserialization metadata extraction.

--- a/wool/src/wool/protocol/__init__.py
+++ b/wool/src/wool/protocol/__init__.py
@@ -17,6 +17,7 @@ try:
     from wool.protocol.wire_pb2 import Nack
     from wool.protocol.wire_pb2 import Request
     from wool.protocol.wire_pb2 import Response
+    from wool.protocol.wire_pb2 import RuntimeContext
     from wool.protocol.wire_pb2 import StopRequest
     from wool.protocol.wire_pb2 import Task
     from wool.protocol.wire_pb2 import TaskEnvelope
@@ -47,6 +48,7 @@ __all__ = [
     "Nack",
     "Request",
     "Response",
+    "RuntimeContext",
     "StopRequest",
     "Task",
     "TaskEnvelope",

--- a/wool/src/wool/runtime/context.py
+++ b/wool/src/wool/runtime/context.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from contextvars import ContextVar
 from contextvars import Token
+from typing import TYPE_CHECKING
 from typing import Final
 
 from wool.runtime.typing import Undefined
 from wool.runtime.typing import UndefinedType
+
+if TYPE_CHECKING:
+    from wool import protocol
 
 dispatch_timeout: Final[ContextVar[float | None]] = ContextVar(
     "dispatch_timeout", default=None
@@ -46,7 +50,7 @@ class RuntimeContext:
             dispatch_timeout.reset(self._dispatch_timeout_token)
 
     @classmethod
-    def get_current(cls) -> "RuntimeContext":
+    def get_current(cls) -> RuntimeContext:
         """Get the current runtime context.
 
         Returns a RuntimeContext instance with the current context values.
@@ -54,6 +58,40 @@ class RuntimeContext:
         :returns:
             RuntimeContext with current context variable values.
         """
-        ctx = cls()
-        ctx._dispatch_timeout = dispatch_timeout.get()
-        return ctx
+        return cls(dispatch_timeout=dispatch_timeout.get())
+
+    def to_protobuf(self) -> protocol.RuntimeContext:
+        """Serialize the wire-safe subset of this context to protobuf.
+
+        Only ``dispatch_timeout`` is propagated over the wire.
+
+        :returns:
+            A protobuf ``RuntimeContext`` message.
+        """
+        from wool import protocol
+
+        dt = self._dispatch_timeout
+        if dt is Undefined:
+            dt = dispatch_timeout.get()
+        pb = protocol.RuntimeContext()
+        if dt is not None:
+            pb.dispatch_timeout = dt
+        return pb
+
+    @classmethod
+    def from_protobuf(cls, context: protocol.RuntimeContext) -> RuntimeContext:
+        """Reconstruct a ``RuntimeContext`` from a protobuf message.
+
+        No runtime import of ``protocol`` is needed here — the message
+        is received as a parameter rather than constructed.
+
+        :param context:
+            A protobuf ``RuntimeContext`` message.
+        :returns:
+            A ``RuntimeContext`` instance.
+        """
+        return cls(
+            dispatch_timeout=context.dispatch_timeout
+            if context.HasField("dispatch_timeout")
+            else None,
+        )

--- a/wool/src/wool/runtime/routine/task.py
+++ b/wool/src/wool/runtime/routine/task.py
@@ -29,6 +29,7 @@ import cloudpickle
 
 import wool
 from wool import protocol
+from wool.runtime.context import RuntimeContext
 
 Args = Tuple
 Kwargs = Dict
@@ -116,6 +117,10 @@ class Task(Generic[W]):
         Line number where the task was defined.
     :param tag:
         Optional descriptive tag for the task.
+    :param context:
+        RuntimeContext snapshot captured at task creation time.
+        Propagated over the wire so workers can restore the caller's
+        runtime settings (e.g. dispatch_timeout) before execution.
     """
 
     id: UUID
@@ -130,6 +135,7 @@ class Task(Generic[W]):
     function: str | None = None
     line_no: int | None = None
     tag: str | None = None
+    context: RuntimeContext | None = None
 
     def __post_init__(self, **kwargs):
         """
@@ -144,6 +150,8 @@ class Task(Generic[W]):
             )
         if caller := _current_task.get():
             self.caller = caller.id
+        if self.context is None:
+            self.context = RuntimeContext.get_current()
 
     def __enter__(self) -> Callable[[], Coroutine | AsyncGenerator]:
         """
@@ -199,6 +207,18 @@ class Task(Generic[W]):
 
     @classmethod
     def from_protobuf(cls, task: protocol.Task) -> Task:
+        """Deserialize a Task from a protobuf message.
+
+        :param task:
+            A protobuf ``Task`` message.
+        :returns:
+            A :class:`Task` instance with all fields restored.
+        """
+        context = (
+            RuntimeContext.from_protobuf(task.context)
+            if task.HasField("context")
+            else None
+        )
         return cls(
             id=UUID(task.id),
             callable=cloudpickle.loads(task.callable),
@@ -208,6 +228,7 @@ class Task(Generic[W]):
             proxy=cloudpickle.loads(task.proxy),
             timeout=task.timeout if task.timeout else 0,
             tag=task.tag if task.tag else None,
+            context=context,
         )
 
     def to_protobuf(self) -> protocol.Task:
@@ -222,6 +243,7 @@ class Task(Generic[W]):
             proxy_id=str(self.proxy.id),
             timeout=int(self.timeout) if self.timeout else 0,
             tag=self.tag if self.tag else "",
+            context=self.context.to_protobuf() if self.context else None,
         )
 
     def dispatch(self) -> W:
@@ -249,10 +271,12 @@ class Task(Generic[W]):
             # Set the proxy in context variable for nested task dispatch
             token = wool.__proxy__.set(proxy)
             try:
-                with self:
-                    with do_dispatch(False):
-                        await asyncio.sleep(0)
-                        return await self.callable(*self.args, **self.kwargs)
+                assert self.context is not None
+                with self.context:
+                    with self:
+                        with do_dispatch(False):
+                            await asyncio.sleep(0)
+                            return await self.callable(*self.args, **self.kwargs)
             finally:
                 wool.__proxy__.reset(token)
 
@@ -277,12 +301,14 @@ class Task(Generic[W]):
                     # Set the proxy in context variable for nested task dispatch
                     token = wool.__proxy__.set(proxy)
                     try:
-                        with self:
-                            with do_dispatch(False):
-                                try:
-                                    result = await anext(gen)
-                                except StopAsyncIteration:
-                                    break
+                        assert self.context is not None
+                        with self.context:
+                            with self:
+                                with do_dispatch(False):
+                                    try:
+                                        result = await anext(gen)
+                                    except StopAsyncIteration:
+                                        break
                     finally:
                         wool.__proxy__.reset(token)
 

--- a/wool/tests/runtime/routine/test_task.py
+++ b/wool/tests/runtime/routine/test_task.py
@@ -11,6 +11,8 @@ from hypothesis import settings
 from hypothesis import strategies as st
 
 from wool import protocol
+from wool.runtime.context import RuntimeContext
+from wool.runtime.context import dispatch_timeout
 from wool.runtime.routine.task import Task
 from wool.runtime.routine.task import TaskException
 from wool.runtime.routine.task import WorkerProxyLike
@@ -314,6 +316,61 @@ class TestTask:
 
         # Assert
         assert task.caller is None
+
+    def test___post_init___captures_runtime_context(self, sample_task):
+        """Test post-init captures RuntimeContext with dispatch_timeout.
+
+        Given:
+            A RuntimeContext with dispatch_timeout=5.0 is active
+        When:
+            A Task is created
+        Then:
+            It should capture a RuntimeContext with dispatch_timeout=5.0
+            in its context field
+        """
+        # Arrange & act
+        with RuntimeContext(dispatch_timeout=5.0):
+            task = sample_task()
+
+        # Assert
+        assert task.context is not None
+        assert task.context.to_protobuf().dispatch_timeout == 5.0
+
+    def test___post_init___captures_default_runtime_context(self, sample_task):
+        """Test post-init captures default RuntimeContext when none is active.
+
+        Given:
+            No RuntimeContext is active (default None)
+        When:
+            A Task is created
+        Then:
+            It should capture a RuntimeContext with dispatch_timeout=None
+        """
+        # Act
+        task = sample_task()
+
+        # Assert
+        assert task.context is not None
+        assert not task.context.to_protobuf().HasField("dispatch_timeout")
+
+    def test___post_init___captures_innermost_runtime_context(self, sample_task):
+        """Test post-init captures the innermost nested RuntimeContext.
+
+        Given:
+            Nested RuntimeContexts with outer=10.0 and inner=5.0
+        When:
+            A Task is created inside the inner context
+        Then:
+            It should capture dispatch_timeout=5.0 from the innermost
+            context
+        """
+        # Arrange & act
+        with RuntimeContext(dispatch_timeout=10.0):
+            with RuntimeContext(dispatch_timeout=5.0):
+                task = sample_task()
+
+        # Assert
+        assert task.context.to_protobuf().dispatch_timeout == 5.0
 
     @pytest.mark.asyncio
     async def test___enter___with_coroutine_callable(self, sample_task):
@@ -757,6 +814,139 @@ class TestTask:
         # Assert
         assert pb_task.version == protocol.__version__
 
+    def test_to_protobuf_includes_runtime_context(
+        self, sample_async_callable, picklable_proxy
+    ):
+        """Test to_protobuf includes RuntimeContext submessage.
+
+        Given:
+            A Task with a RuntimeContext carrying dispatch_timeout=7.5
+        When:
+            to_protobuf() is called
+        Then:
+            It should include the RuntimeContext submessage with
+            dispatch_timeout
+        """
+        # Arrange
+        with RuntimeContext(dispatch_timeout=7.5):
+            task = Task(
+                id=uuid4(),
+                callable=sample_async_callable,
+                args=(),
+                kwargs={},
+                proxy=picklable_proxy,
+            )
+
+        # Act
+        pb_task = task.to_protobuf()
+
+        # Assert
+        assert pb_task.HasField("context")
+        assert pb_task.context.dispatch_timeout == 7.5
+
+    def test_from_protobuf_restores_runtime_context(
+        self, sample_async_callable, picklable_proxy
+    ):
+        """Test from_protobuf restores RuntimeContext from submessage.
+
+        Given:
+            A protobuf Task with a RuntimeContext submessage
+            (dispatch_timeout=12.0)
+        When:
+            Task.from_protobuf() is called
+        Then:
+            It should reconstruct the Task with a RuntimeContext
+            carrying dispatch_timeout=12.0
+        """
+        # Arrange
+        pb_task = protocol.Task(
+            version="0.1.0",
+            id=str(uuid4()),
+            callable=cloudpickle.dumps(sample_async_callable),
+            args=cloudpickle.dumps(()),
+            kwargs=cloudpickle.dumps({}),
+            caller="",
+            proxy=cloudpickle.dumps(picklable_proxy),
+            proxy_id=str(picklable_proxy.id),
+            timeout=0,
+            tag="",
+            context=protocol.RuntimeContext(dispatch_timeout=12.0),
+        )
+
+        # Act
+        task = Task.from_protobuf(pb_task)
+
+        # Assert
+        assert task.context is not None
+        with task.context:
+            assert dispatch_timeout.get() == 12.0
+
+    def test_from_protobuf_without_context_backward_compat(
+        self, sample_async_callable, picklable_proxy
+    ):
+        """Test from_protobuf falls back to default context.
+
+        Given:
+            A protobuf Task with no RuntimeContext submessage
+            (older client)
+        When:
+            Task.from_protobuf() is called
+        Then:
+            It should fall back to default context
+            (dispatch_timeout=None)
+        """
+        # Arrange
+        pb_task = protocol.Task(
+            version="0.1.0",
+            id=str(uuid4()),
+            callable=cloudpickle.dumps(sample_async_callable),
+            args=cloudpickle.dumps(()),
+            kwargs=cloudpickle.dumps({}),
+            caller="",
+            proxy=cloudpickle.dumps(picklable_proxy),
+            proxy_id=str(picklable_proxy.id),
+            timeout=0,
+            tag="",
+        )
+
+        # Act
+        task = Task.from_protobuf(pb_task)
+
+        # Assert
+        assert task.context is not None
+        with task.context:
+            assert dispatch_timeout.get() is None
+
+    def test_to_protobuf_from_protobuf_preserves_runtime_context(
+        self, sample_async_callable, picklable_proxy
+    ):
+        """Test protobuf roundtrip preserves RuntimeContext.
+
+        Given:
+            A Task created with dispatch_timeout=6.0 in context
+        When:
+            Serialized via to_protobuf() then deserialized via
+            from_protobuf()
+        Then:
+            It should preserve the RuntimeContext through the roundtrip
+        """
+        # Arrange
+        with RuntimeContext(dispatch_timeout=6.0):
+            original = Task(
+                id=uuid4(),
+                callable=sample_async_callable,
+                args=(),
+                kwargs={},
+                proxy=picklable_proxy,
+            )
+
+        # Act
+        restored = Task.from_protobuf(original.to_protobuf())
+
+        # Assert
+        with restored.context:
+            assert dispatch_timeout.get() == 6.0
+
     @settings(
         max_examples=50,
         deadline=None,
@@ -1139,6 +1329,148 @@ class TestTask:
 
         # Assert
         assert results == []
+
+    @pytest.mark.asyncio
+    async def test_dispatch_restores_runtime_context_for_coroutine(
+        self,
+        sample_task,
+        mock_worker_proxy_cache,
+    ):
+        """Test dispatch restores RuntimeContext for coroutine callable.
+
+        Given:
+            A Task with context carrying dispatch_timeout=9.0
+            dispatched as a coroutine
+        When:
+            The callable reads dispatch_timeout.get()
+        Then:
+            It should observe dispatch_timeout=9.0 in the ContextVar
+        """
+        # Arrange
+        observed_timeout = None
+
+        async def test_callable():
+            nonlocal observed_timeout
+            observed_timeout = dispatch_timeout.get()
+            return "done"
+
+        with RuntimeContext(dispatch_timeout=9.0):
+            task = sample_task(callable=test_callable)
+
+        # Act
+        result = await task.dispatch()
+
+        # Assert
+        assert result == "done"
+        assert observed_timeout == 9.0
+
+    @pytest.mark.asyncio
+    async def test_dispatch_restores_runtime_context_for_async_generator(
+        self,
+        sample_task,
+        mock_worker_proxy_cache,
+    ):
+        """Test dispatch restores RuntimeContext for async generator callable.
+
+        Given:
+            A Task with context carrying dispatch_timeout=4.5
+            dispatched as an async generator
+        When:
+            The async generator reads dispatch_timeout.get() on
+            each yield
+        Then:
+            It should observe dispatch_timeout=4.5 on every iteration
+        """
+        # Arrange
+        observed_timeouts = []
+
+        async def test_generator():
+            for i in range(3):
+                observed_timeouts.append(dispatch_timeout.get())
+                yield i
+
+        with RuntimeContext(dispatch_timeout=4.5):
+            task = sample_task(callable=test_generator)
+
+        # Act
+        results = []
+        async for value in task.dispatch():
+            results.append(value)
+
+        # Assert
+        assert results == [0, 1, 2]
+        assert all(t == 4.5 for t in observed_timeouts)
+
+    @pytest.mark.asyncio
+    async def test_dispatch_sequential_task_isolation(
+        self,
+        sample_task,
+        mock_worker_proxy_cache,
+    ):
+        """Test sequential tasks do not leak dispatch_timeout.
+
+        Given:
+            Two Tasks with dispatch_timeout=3.0 and 7.0 dispatched
+            sequentially
+        When:
+            Each callable reads dispatch_timeout.get()
+        Then:
+            Each should observe its own dispatch_timeout without
+            cross-contamination
+        """
+        # Arrange
+        observed = []
+
+        async def capture_timeout():
+            observed.append(dispatch_timeout.get())
+            return "done"
+
+        with RuntimeContext(dispatch_timeout=3.0):
+            task1 = sample_task(callable=capture_timeout)
+        with RuntimeContext(dispatch_timeout=7.0):
+            task2 = sample_task(callable=capture_timeout)
+
+        # Act
+        await task1.dispatch()
+        await task2.dispatch()
+
+        # Assert
+        assert observed[0] == 3.0
+        assert observed[1] == 7.0
+
+    @pytest.mark.asyncio
+    async def test_dispatch_restores_none_runtime_context(
+        self,
+        sample_task,
+        mock_worker_proxy_cache,
+    ):
+        """Test dispatch restores None dispatch_timeout.
+
+        Given:
+            A Task with context carrying dispatch_timeout=None
+            dispatched as a coroutine
+        When:
+            The callable reads dispatch_timeout.get()
+        Then:
+            It should observe dispatch_timeout=None
+        """
+        # Arrange
+        sentinel = object()
+        observed_timeout = sentinel
+
+        async def test_callable():
+            nonlocal observed_timeout
+            observed_timeout = dispatch_timeout.get()
+            return "done"
+
+        task = sample_task(callable=test_callable)
+
+        # Act
+        await task.dispatch()
+
+        # Assert
+        assert observed_timeout is not sentinel
+        assert observed_timeout is None
 
 
 # --- TestTaskException ---

--- a/wool/tests/runtime/test_context.py
+++ b/wool/tests/runtime/test_context.py
@@ -2,6 +2,7 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
+from wool import protocol
 from wool.runtime.context import RuntimeContext
 from wool.runtime.context import dispatch_timeout
 from wool.runtime.typing import Undefined
@@ -469,3 +470,171 @@ class TestRuntimeContext:
 
         # Cleanup
         dispatch_timeout.set(original_value)
+
+    def test_to_protobuf_with_dispatch_timeout(self):
+        """Test to_protobuf serializes dispatch_timeout.
+
+        Given:
+            A RuntimeContext with dispatch_timeout=5.0
+        When:
+            to_protobuf() is called
+        Then:
+            It should return a protobuf message with dispatch_timeout=5.0
+        """
+        # Arrange
+        context = RuntimeContext(dispatch_timeout=5.0)
+
+        # Act
+        pb = context.to_protobuf()
+
+        # Assert
+        assert pb.dispatch_timeout == 5.0
+
+    def test_to_protobuf_with_none_dispatch_timeout(self):
+        """Test to_protobuf leaves field unset for None.
+
+        Given:
+            A RuntimeContext with dispatch_timeout=None
+        When:
+            to_protobuf() is called
+        Then:
+            It should return a protobuf message with dispatch_timeout unset
+        """
+        # Arrange
+        context = RuntimeContext(dispatch_timeout=None)
+
+        # Act
+        pb = context.to_protobuf()
+
+        # Assert
+        assert not pb.HasField("dispatch_timeout")
+
+    def test_to_protobuf_with_undefined_dispatch_timeout_reads_contextvar(self):
+        """Test to_protobuf falls back to the ContextVar when Undefined.
+
+        Given:
+            A RuntimeContext with no explicit dispatch_timeout and the
+            dispatch_timeout ContextVar set to 3.5
+        When:
+            to_protobuf() is called
+        Then:
+            It should read the current value from the ContextVar
+        """
+        # Arrange
+        original_value = dispatch_timeout.get()
+        dispatch_timeout.set(3.5)
+        context = RuntimeContext()
+
+        # Act
+        pb = context.to_protobuf()
+
+        # Assert
+        assert pb.dispatch_timeout == 3.5
+
+        # Cleanup
+        dispatch_timeout.set(original_value)
+
+    def test_from_protobuf_with_dispatch_timeout(self):
+        """Test from_protobuf deserializes dispatch_timeout.
+
+        Given:
+            A protobuf RuntimeContext message with dispatch_timeout=12.0
+        When:
+            RuntimeContext.from_protobuf() is called
+        Then:
+            It should return a RuntimeContext with dispatch_timeout=12.0
+        """
+        # Arrange
+        pb = protocol.RuntimeContext(dispatch_timeout=12.0)
+
+        # Act
+        context = RuntimeContext.from_protobuf(pb)
+
+        # Assert
+        with context:
+            assert dispatch_timeout.get() == 12.0
+
+    def test_from_protobuf_with_zero_dispatch_timeout(self):
+        """Test from_protobuf preserves zero dispatch_timeout.
+
+        Given:
+            A protobuf RuntimeContext message with dispatch_timeout=0.0
+        When:
+            RuntimeContext.from_protobuf() is called
+        Then:
+            It should return a RuntimeContext with dispatch_timeout=0.0
+        """
+        # Arrange
+        pb = protocol.RuntimeContext(dispatch_timeout=0.0)
+
+        # Act
+        context = RuntimeContext.from_protobuf(pb)
+
+        # Assert
+        with context:
+            assert dispatch_timeout.get() == 0.0
+
+    def test_from_protobuf_with_unset_dispatch_timeout(self):
+        """Test from_protobuf maps unset field to None.
+
+        Given:
+            A protobuf RuntimeContext message with dispatch_timeout unset
+        When:
+            RuntimeContext.from_protobuf() is called
+        Then:
+            It should return a RuntimeContext with dispatch_timeout=None
+        """
+        # Arrange
+        pb = protocol.RuntimeContext()
+
+        # Act
+        context = RuntimeContext.from_protobuf(pb)
+
+        # Assert
+        with context:
+            assert dispatch_timeout.get() is None
+
+    def test_to_protobuf_from_protobuf_roundtrip(self):
+        """Test protobuf roundtrip preserves dispatch_timeout.
+
+        Given:
+            A RuntimeContext with dispatch_timeout=8.5
+        When:
+            Serialized via to_protobuf() then deserialized via from_protobuf()
+        Then:
+            It should preserve dispatch_timeout through the roundtrip
+        """
+        # Arrange
+        original = RuntimeContext(dispatch_timeout=8.5)
+
+        # Act
+        restored = RuntimeContext.from_protobuf(original.to_protobuf())
+
+        # Assert
+        with restored:
+            assert dispatch_timeout.get() == 8.5
+
+    @given(
+        timeout=st.floats(
+            min_value=0.0, max_value=1000.0, allow_nan=False, allow_infinity=False
+        )
+    )
+    def test_to_protobuf_from_protobuf_roundtrip_property(self, timeout):
+        """Test protobuf roundtrip with arbitrary non-negative floats.
+
+        Given:
+            Any non-negative float dispatch_timeout (including 0.0)
+        When:
+            Serialized via to_protobuf() then deserialized via from_protobuf()
+        Then:
+            It should equal the original value
+        """
+        # Arrange
+        original = RuntimeContext(dispatch_timeout=timeout)
+
+        # Act
+        restored = RuntimeContext.from_protobuf(original.to_protobuf())
+
+        # Assert
+        with restored:
+            assert dispatch_timeout.get() == timeout


### PR DESCRIPTION
## Summary

`RuntimeContext(dispatch_timeout=N)` sets a `ContextVar` in the parent process, but context variables do not propagate across the `spawn` subprocess boundary. The `Task` dataclass is pickled for dispatch but does not carry the runtime context, so workers start with the default `None` — silently ignoring the user-configured timeout.

The fix introduces a `RuntimeContext` protobuf submessage on the wire `Task`, giving `RuntimeContext` its own `to_protobuf()` / `from_protobuf()` serialization pair. The `Task` dataclass gains a `context: RuntimeContext` field that is captured at creation time. On the worker side, the context is restored into the `ContextVar` before executing the callable so nested dispatch respects the original timeout.

Only `dispatch_timeout` is propagated over the wire. `credentials` holds TLS material and is intentionally excluded — it is set per-worker, not inherited from the caller. The proto field uses `optional double` (64-bit) to faithfully preserve Python float precision and distinguish "unset" from "zero" via `HasField`.

Closes #69

## Proposed changes

### Add `RuntimeContext` protobuf message to `wire.proto`

Define a new `RuntimeContext` message with an `optional double dispatch_timeout` field. Add it as an `optional` submessage field on the existing `Task` message (`optional RuntimeContext context = 11`). The `optional` qualifier on both the submessage and the scalar enables `HasField` checks at each level: the worker can distinguish "no context sent" (older client) from "context sent with no timeout" from "context sent with timeout=0.0". Use `double` (64-bit IEEE 754) rather than `float` (32-bit) to preserve Python float fidelity.

### Add `to_protobuf()` / `from_protobuf()` to `RuntimeContext`

Give `RuntimeContext` serialization methods that convert between the Python class and the new protobuf message. `to_protobuf()` snapshots the wire-safe subset of the context (currently just `dispatch_timeout`), leaving the field unset when the value is `None`. `from_protobuf()` reconstructs a `RuntimeContext` from the message, using `HasField("dispatch_timeout")` to losslessly distinguish "unset" (`None`) from "zero" (`0.0`). The `protocol` import in `to_protobuf()` is lazy to avoid a circular import (`wool.__init__` imports `RuntimeContext` at module level).

### Carry `RuntimeContext` on the `Task` dataclass

Add a `context: RuntimeContext` field to `Task`. `__post_init__()` captures the current context via `RuntimeContext.get_current()` when no explicit context is provided. `to_protobuf()` and `from_protobuf()` delegate to the context's own serialization methods, with a `HasField("context")` guard in `from_protobuf()` for backward compatibility with older clients that omit the submessage.

### Restore context on the worker side

`Task._run()` and `Task._stream()` assert `self.context is not None` then enter it as a context manager before calling the user's function, restoring `dispatch_timeout` into the `ContextVar`. The existing `__enter__` / `__exit__` machinery on `RuntimeContext` handles token management and cleanup, so sequential tasks on the same worker loop do not leak state.

## Test cases

| Test Suite | Test ID | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| `TestRuntimeContext` | RC-001 | A RuntimeContext with dispatch_timeout=5.0 | `to_protobuf()` is called | It should return a protobuf message with dispatch_timeout=5.0 | `to_protobuf()` serializes dispatch_timeout |
| `TestRuntimeContext` | RC-002 | A RuntimeContext with dispatch_timeout=None | `to_protobuf()` is called | It should return a protobuf message with dispatch_timeout unset | `to_protobuf()` handles None |
| `TestRuntimeContext` | RC-003 | A RuntimeContext with no explicit dispatch_timeout and the ContextVar set to 3.5 | `to_protobuf()` is called | It should read the current value from the ContextVar | `to_protobuf()` Undefined fallback |
| `TestRuntimeContext` | RC-004 | A protobuf RuntimeContext message with dispatch_timeout=12.0 | `RuntimeContext.from_protobuf()` is called | It should return a RuntimeContext with dispatch_timeout=12.0 | `from_protobuf()` deserializes dispatch_timeout |
| `TestRuntimeContext` | RC-005 | A protobuf RuntimeContext message with dispatch_timeout=0.0 | `RuntimeContext.from_protobuf()` is called | It should return a RuntimeContext with dispatch_timeout=0.0 | `from_protobuf()` preserves zero |
| `TestRuntimeContext` | RC-006 | A protobuf RuntimeContext message with dispatch_timeout unset | `RuntimeContext.from_protobuf()` is called | It should return a RuntimeContext with dispatch_timeout=None | `from_protobuf()` maps unset to None |
| `TestRuntimeContext` | RC-007 | A RuntimeContext with dispatch_timeout=8.5 | Serialized via `to_protobuf()` then deserialized via `from_protobuf()` | It should preserve dispatch_timeout through the roundtrip | Protobuf roundtrip fidelity |
| `TestRuntimeContext` | RC-008 | Any non-negative float dispatch_timeout (including 0.0) | Serialized via `to_protobuf()` then deserialized via `from_protobuf()` | It should equal the original value | Property-based roundtrip |
| `TestTask` | TASK-DT-001 | A RuntimeContext with dispatch_timeout=5.0 is active | A Task is created | It should capture a RuntimeContext with dispatch_timeout=5.0 in its context field | `__post_init__()` captures context |
| `TestTask` | TASK-DT-002 | No RuntimeContext is active (default None) | A Task is created | It should capture a RuntimeContext with dispatch_timeout=None | `__post_init__()` uses default context |
| `TestTask` | TASK-DT-003 | Nested RuntimeContexts with outer=10.0 and inner=5.0 | A Task is created inside the inner context | It should capture dispatch_timeout=5.0 from the innermost context | `__post_init__()` respects innermost context |
| `TestTask` | TASK-DT-004 | A Task with a RuntimeContext carrying dispatch_timeout=7.5 | `to_protobuf()` is called | It should include the RuntimeContext submessage with dispatch_timeout | `to_protobuf()` delegates to context |
| `TestTask` | TASK-DT-005 | A protobuf Task with a RuntimeContext submessage (dispatch_timeout=12.0) | `Task.from_protobuf()` is called | It should reconstruct the Task with a RuntimeContext carrying dispatch_timeout=12.0 | `from_protobuf()` restores context |
| `TestTask` | TASK-DT-006 | A protobuf Task with no RuntimeContext submessage (older client) | `Task.from_protobuf()` is called | It should fall back to default context (dispatch_timeout=None) | `from_protobuf()` backward compat |
| `TestTask` | TASK-DT-007 | A Task created with dispatch_timeout=6.0 in context | Serialized via `to_protobuf()` then deserialized via `from_protobuf()` | It should preserve the RuntimeContext through the roundtrip | Task protobuf roundtrip with context |
| `TestTask` | TASK-DT-008 | A Task with context carrying dispatch_timeout=9.0 dispatched as a coroutine | The callable reads `dispatch_timeout.get()` | It should observe dispatch_timeout=9.0 in the ContextVar | `dispatch()` restores context for coroutines |
| `TestTask` | TASK-DT-009 | A Task with context carrying dispatch_timeout=4.5 dispatched as an async generator | The async generator reads `dispatch_timeout.get()` on each yield | It should observe dispatch_timeout=4.5 on every iteration | `dispatch()` restores context for generators |
| `TestTask` | TASK-DT-010 | Two Tasks with dispatch_timeout=3.0 and 7.0 dispatched sequentially | Each callable reads `dispatch_timeout.get()` | Each should observe its own dispatch_timeout without cross-contamination | Sequential task isolation |
| `TestTask` | TASK-DT-011 | A Task with context carrying dispatch_timeout=None dispatched as a coroutine | The callable reads `dispatch_timeout.get()` | It should observe dispatch_timeout=None | `dispatch()` handles None timeout |

## Implementation plan

1. - [x] Add `RuntimeContext` message to `wire.proto` with `optional double dispatch_timeout = 1`; add `optional RuntimeContext context = 11` field to the `Task` message; regenerate bindings
2. - [x] Add `to_protobuf()` and `from_protobuf()` class methods to `RuntimeContext` in `context.py`
3. - [x] Write tests for `RuntimeContext` serialization (RC-001 through RC-008)
4. - [x] Add `context: RuntimeContext` field to `Task` dataclass; capture via `RuntimeContext.get_current()` in `__post_init__()`; update `Task.to_protobuf()` and `Task.from_protobuf()` to delegate to the context's serialization, falling back to default context when the submessage is absent
5. - [x] Write tests for `Task` context capture, serialization roundtrip, context restoration, and backward compatibility (TASK-DT-001 through TASK-DT-011)
6. - [x] Restore context in `Task._run()` and `Task._stream()` by asserting `self.context is not None` then entering it as a context manager before calling the user's function