### PR TITLE
Make RoundRobinLoadBalancer instances picklable — Closes #73

### DIFF
--- a/wool/src/wool/runtime/loadbalancer/roundrobin.py
+++ b/wool/src/wool/runtime/loadbalancer/roundrobin.py
@@ -37,6 +37,9 @@ class RoundRobinLoadBalancer(LoadBalancerLike):
         self._index = {}
         self._lock = Lock()
 
+    def __reduce__(self):
+        return (self.__class__, ())
+
     async def dispatch(
         self,
         task: Task,

--- a/wool/tests/runtime/loadbalancer/test_roundrobin.py
+++ b/wool/tests/runtime/loadbalancer/test_roundrobin.py
@@ -74,6 +74,32 @@ class TestRoundRobinLoadBalancer:
         # Act & assert
         assert isinstance(RoundRobinLoadBalancer(), LoadBalancerLike)
 
+    def test___reduce___with_populated_index(self):
+        """Test pickle roundtrip excludes runtime connection state.
+
+        Given:
+            A RoundRobinLoadBalancer with a populated _index
+        When:
+            Pickled and unpickled
+        Then:
+            It should restore with an empty _index and a fresh _lock
+        """
+        # Arrange
+        import pickle
+        from asyncio import Lock
+
+        lb = RoundRobinLoadBalancer()
+        context = LoadBalancerContext()
+        lb._index[context] = 3
+
+        # Act
+        restored = pickle.loads(pickle.dumps(lb))
+
+        # Assert
+        assert isinstance(restored, RoundRobinLoadBalancer)
+        assert restored._index == {}
+        assert isinstance(restored._lock, Lock)
+
     @pytest.mark.asyncio
     async def test_dispatch_with_empty_context(
         self,


### PR DESCRIPTION
## Summary

`WorkerProxy.__reduce__` pickles the live `RoundRobinLoadBalancer` instance, which accumulates an `_index` containing `LoadBalancerContext` → `WorkerConnection` → `grpc.ChannelCredentials` (unpicklable). The connection context is dead weight — the restored proxy creates a fresh `LoadBalancerContext` and re-discovers workers from scratch.

Add `__reduce__` to `RoundRobinLoadBalancer` that returns a clean instance without the `_index`. Users with custom lb implementations control their own pickle behavior.

Closes #73

## Proposed changes

### Add `__reduce__` to RoundRobinLoadBalancer

Add a `__reduce__` method that excludes the `_index` and `_lock` (both are runtime state that gets rebuilt):

```python
def __reduce__(self):
    return (self.__class__, ())
```

On restore, `__init__` creates a fresh empty `_index` and a new `_lock`. The proxy's `start()` creates a new `LoadBalancerContext` and the sentinel repopulates it via discovery.

## Test cases

| Test Suite | Test ID | Given | When | Then | Coverage Target |
|------------|---------|-------|------|------|-----------------|
| `TestRoundRobinLoadBalancer` | RR-PICKLE | A RoundRobinLoadBalancer with a populated `_index` | Pickled and unpickled | Restored instance has empty `_index` and functional `_lock` | `__reduce__` excludes runtime state |

## Implementation plan

1. - [x] Add `__reduce__` to `RoundRobinLoadBalancer` in `wool/src/wool/runtime/loadbalancer/roundrobin.py`
2. - [x] Add unit test for `__reduce__` roundtrip in `wool/tests/runtime/loadbalancer/test_roundrobin.py`