### PR TITLE
Resolve worker credentials from ContextVar in WorkerProxy — Closes #76

### DIFF
--- a/wool/src/wool/runtime/context.py
+++ b/wool/src/wool/runtime/context.py
@@ -2,20 +2,13 @@ from __future__ import annotations
 
 from contextvars import ContextVar
 from contextvars import Token
-from typing import TYPE_CHECKING
 from typing import Final
 
 from wool.runtime.typing import Undefined
 from wool.runtime.typing import UndefinedType
 
-if TYPE_CHECKING:
-    from wool.runtime.worker.auth import WorkerCredentials
-
 dispatch_timeout: Final[ContextVar[float | None]] = ContextVar(
     "dispatch_timeout", default=None
-)
-credentials: Final[ContextVar[WorkerCredentials | None]] = ContextVar(
-    "credentials", default=None
 )
 
 
@@ -23,29 +16,22 @@ credentials: Final[ContextVar[WorkerCredentials | None]] = ContextVar(
 class RuntimeContext:
     """Runtime context for configuring Wool behavior.
 
-    Provides context-managed configuration for dispatch timeout and
-    worker credentials, allowing defaults to be set for all workers
-    within a context.
+    Provides context-managed configuration for dispatch timeout,
+    allowing defaults to be set for all workers within a context.
 
     :param dispatch_timeout:
         Default timeout for task dispatch operations.
-    :param credentials:
-        Default WorkerCredentials for secure worker connections.
     """
 
     _dispatch_timeout: float | None | UndefinedType
     _dispatch_timeout_token: Token | UndefinedType
-    _credentials: WorkerCredentials | None | UndefinedType
-    _credentials_token: Token | UndefinedType
 
     def __init__(
         self,
         *,
         dispatch_timeout: float | None | UndefinedType = Undefined,
-        credentials: WorkerCredentials | None | UndefinedType = Undefined,
     ):
         self._dispatch_timeout = dispatch_timeout
-        self._credentials = credentials
 
     def __enter__(self):
         if self._dispatch_timeout is not Undefined:
@@ -53,19 +39,11 @@ class RuntimeContext:
         else:
             self._dispatch_timeout_token = Undefined
 
-        if self._credentials is not Undefined:
-            self._credentials_token = credentials.set(self._credentials)
-        else:
-            self._credentials_token = Undefined
-
         return self
 
     def __exit__(self, *_):
         if self._dispatch_timeout_token is not Undefined:
             dispatch_timeout.reset(self._dispatch_timeout_token)
-
-        if self._credentials_token is not Undefined:
-            credentials.reset(self._credentials_token)
 
     @classmethod
     def get_current(cls) -> "RuntimeContext":
@@ -78,14 +56,4 @@ class RuntimeContext:
         """
         ctx = cls()
         ctx._dispatch_timeout = dispatch_timeout.get()
-        ctx._credentials = credentials.get()
         return ctx
-
-    @property
-    def credentials(self) -> WorkerCredentials | None:
-        """Get the current worker credentials.
-
-        :returns:
-            The WorkerCredentials instance, or None if not set.
-        """
-        return credentials.get() if self._credentials is Undefined else self._credentials

--- a/wool/src/wool/runtime/worker/auth.py
+++ b/wool/src/wool/runtime/worker/auth.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+from contextvars import ContextVar
+from contextvars import Token
 from dataclasses import dataclass
+from dataclasses import field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import grpc
+
+_current: ContextVar[WorkerCredentials | None] = ContextVar(
+    "worker_credentials", default=None
+)
 
 
 @dataclass(frozen=True)
@@ -55,6 +62,30 @@ class WorkerCredentials:
     worker_key: bytes
     worker_cert: bytes
     mutual: bool = True
+    _token: Token | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
+
+    def __enter__(self) -> WorkerCredentials:
+        object.__setattr__(self, "_token", _current.set(self))
+        return self
+
+    def __exit__(self, *_) -> None:
+        if self._token is None:
+            raise RuntimeError(
+                "__exit__ called without matching __enter__"
+            )
+        _current.reset(self._token)
+        object.__setattr__(self, "_token", None)
+
+    @classmethod
+    def current(cls) -> WorkerCredentials | None:
+        """Get the current worker credentials from the context.
+
+        :returns:
+            The active WorkerCredentials, or None if no context is set.
+        """
+        return _current.get()
 
     @classmethod
     def from_files(

--- a/wool/src/wool/runtime/worker/base.py
+++ b/wool/src/wool/runtime/worker/base.py
@@ -6,26 +6,15 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Callable
 from typing import Final
 from typing import Protocol
-from typing import TypeAlias
-from typing import Union
 from typing import final
 from typing import runtime_checkable
-
-import grpc
 
 from wool.runtime.discovery.base import WorkerMetadata
 
 if TYPE_CHECKING:
     from wool.runtime.worker.auth import WorkerCredentials
-
-ChannelCredentialsType: TypeAlias = Union[
-    grpc.ChannelCredentials,
-    Callable[[], grpc.ChannelCredentials],
-    None,
-]
 
 
 # public
@@ -45,32 +34,6 @@ class WorkerOptions:
 
     max_receive_message_length: int = 100 * 1024 * 1024
     max_send_message_length: int = 100 * 1024 * 1024
-
-
-def resolve_channel_credentials(
-    credentials: ChannelCredentialsType,
-) -> grpc.ChannelCredentials | None:
-    """Resolve channel credentials from object or callable.
-
-    :param credentials:
-        Channel credentials object, callable, or None.
-    :returns:
-        Resolved channel credentials or None.
-    :raises TypeError:
-        If callable doesn't return proper credentials type.
-    """
-    if credentials is None:
-        return None
-    elif callable(credentials):
-        result = credentials()
-        if result is not None and not isinstance(result, grpc.ChannelCredentials):
-            raise TypeError(
-                f"Channel credentials callable must return grpc.ChannelCredentials "
-                f"or None, got {type(result)}"
-            )
-        return result
-    else:
-        return credentials
 
 
 # public

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -15,9 +15,7 @@ import grpc.aio
 from wool import protocol
 from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.routine.task import Task
-from wool.runtime.worker.base import ChannelCredentialsType
 from wool.runtime.worker.base import WorkerOptions
-from wool.runtime.worker.base import resolve_channel_credentials
 
 _DispatchCall: TypeAlias = grpc.aio.StreamStreamCall[protocol.Request, protocol.Response]
 
@@ -46,13 +44,12 @@ def _channel_factory(key):
         A new :class:`_Channel` instance.
     """
     target, credentials, limit, worker_options = key
-    resolved = resolve_channel_credentials(credentials)
     options = [
         ("grpc.max_receive_message_length", worker_options.max_receive_message_length),
         ("grpc.max_send_message_length", worker_options.max_send_message_length),
     ]
-    if resolved is not None:
-        channel = grpc.aio.secure_channel(target, resolved, options=options)
+    if credentials is not None:
+        channel = grpc.aio.secure_channel(target, credentials, options=options)
     else:
         channel = grpc.aio.insecure_channel(target, options=options)
     stub = protocol.WorkerStub(channel)
@@ -343,7 +340,7 @@ class WorkerConnection:
         target: str,
         *,
         limit: int = 100,
-        credentials: ChannelCredentialsType = None,
+        credentials: grpc.ChannelCredentials | None = None,
         options: WorkerOptions | None = None,
     ):
         if limit <= 0:

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -12,13 +12,10 @@ from typing import Coroutine
 from typing import Final
 from typing import overload
 
-from wool.runtime.context import RuntimeContext
 from wool.runtime.discovery.base import DiscoveryLike
 from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.local import LocalDiscovery
 from wool.runtime.typing import Factory
-from wool.runtime.typing import Undefined
-from wool.runtime.typing import UndefinedType
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerFactory
 from wool.runtime.worker.base import WorkerLike
@@ -165,7 +162,7 @@ class WorkerPool:
         loadbalancer: (
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
-        credentials: WorkerCredentials | None | UndefinedType = Undefined,
+        credentials: WorkerCredentials | None = None,
         options: WorkerOptions | None = None,
     ):
         """
@@ -182,7 +179,7 @@ class WorkerPool:
         loadbalancer: (
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
-        credentials: WorkerCredentials | None | UndefinedType = Undefined,
+        credentials: WorkerCredentials | None = None,
     ):
         """
         Connect to an existing pool of workers discovered by the
@@ -200,7 +197,7 @@ class WorkerPool:
         loadbalancer: (
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
-        credentials: WorkerCredentials | None | UndefinedType = Undefined,
+        credentials: WorkerCredentials | None = None,
         options: WorkerOptions | None = None,
     ):
         """
@@ -218,25 +215,12 @@ class WorkerPool:
         loadbalancer: (
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
-        credentials: WorkerCredentials | None | UndefinedType = Undefined,
+        credentials: WorkerCredentials | None = None,
         options: WorkerOptions | None = None,
     ):
         self._workers = {}
         self._options = options
-
-        # Resolve credentials: explicit parameter overrides runtime context
-        if credentials is Undefined:
-            ctx = RuntimeContext.get_current()
-            credentials = ctx.credentials
-        else:
-            credentials = credentials
-
         self._credentials = credentials
-        self._client_credentials = (
-            credentials.client_credentials()
-            if credentials is not None
-            else None
-        )
 
         match (size, discovery):
             case (size, discovery) if size is not None and discovery is not None:
@@ -266,7 +250,7 @@ class WorkerPool:
                             async with WorkerProxy(
                                 discovery=discovery_svc.subscribe(_predicate(tags)),
                                 loadbalancer=loadbalancer,
-                                credentials=self._client_credentials,
+                                credentials=self._credentials,
                                 options=self._options,
                             ):
                                 yield
@@ -296,7 +280,7 @@ class WorkerPool:
                             async with WorkerProxy(
                                 discovery=discovery.subscribe(_predicate(tags)),
                                 loadbalancer=loadbalancer,
-                                credentials=self._client_credentials,
+                                credentials=self._credentials,
                                 options=self._options,
                             ):
                                 yield
@@ -312,7 +296,7 @@ class WorkerPool:
                         async with WorkerProxy(
                             discovery=discovery_svc.subscriber,
                             loadbalancer=loadbalancer,
-                            credentials=self._client_credentials,
+                            credentials=self._credentials,
                             options=self._options,
                         ):
                             yield
@@ -339,7 +323,7 @@ class WorkerPool:
                             async with WorkerProxy(
                                 discovery=discovery.subscriber,
                                 loadbalancer=loadbalancer,
-                                credentials=self._client_credentials,
+                                credentials=self._credentials,
                                 options=self._options,
                             ):
                                 yield

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import multiprocessing as _mp
 import signal
@@ -182,47 +183,53 @@ class WorkerProcess(Process):
         requests. It creates a gRPC server, adds the worker service, and
         starts listening for incoming connections.
         """
-        grpc_options = [
-            (
-                "grpc.max_receive_message_length",
-                self._options.max_receive_message_length,
-            ),
-            ("grpc.max_send_message_length", self._options.max_send_message_length),
-        ]
-        server = grpc.aio.server(
-            interceptors=[VersionInterceptor()], options=grpc_options
-        )
-        credentials = (
-            self._credentials.server_credentials()
+        creds_ctx = (
+            self._credentials
             if self._credentials is not None
-            else None
+            else contextlib.nullcontext()
         )
-        address = self._address(self._host, self._port)
+        with creds_ctx:
+            grpc_options = [
+                (
+                    "grpc.max_receive_message_length",
+                    self._options.max_receive_message_length,
+                ),
+                ("grpc.max_send_message_length", self._options.max_send_message_length),
+            ]
+            server = grpc.aio.server(
+                interceptors=[VersionInterceptor()], options=grpc_options
+            )
+            credentials = (
+                self._credentials.server_credentials()
+                if self._credentials is not None
+                else None
+            )
+            address = self._address(self._host, self._port)
 
-        if credentials is not None:
-            port = server.add_secure_port(address, credentials)
-        else:
-            port = server.add_insecure_port(address)
+            if credentials is not None:
+                port = server.add_secure_port(address, credentials)
+            else:
+                port = server.add_insecure_port(address)
 
-        service = WorkerService()
-        protocol.add_to_server[protocol.WorkerServicer](service, server)
+            service = WorkerService()
+            protocol.add_to_server[protocol.WorkerServicer](service, server)
 
-        with _signal_handlers(service):
-            try:
-                await server.start()
-                logger.info(f"Worker gRPC server started on port {port}")
+            with _signal_handlers(service):
                 try:
-                    self._set_port.send(port)
+                    await server.start()
+                    logger.info(f"Worker gRPC server started on port {port}")
+                    try:
+                        self._set_port.send(port)
+                    finally:
+                        self._set_port.close()
+                    await service.stopped.wait()
+                    logger.info("Worker service stopped, shutting down server")
+                except Exception as e:
+                    logger.exception(f"Worker server error: {type(e).__name__}: {e}")
+                    raise
                 finally:
-                    self._set_port.close()
-                await service.stopped.wait()
-                logger.info("Worker service stopped, shutting down server")
-            except Exception as e:
-                logger.exception(f"Worker server error: {type(e).__name__}: {e}")
-                raise
-            finally:
-                logger.info("Worker server stopping with grace period")
-                await server.stop(grace=self._shutdown_grace_period)
+                    logger.info("Worker server stopping with grace period")
+                    await server.stop(grace=self._shutdown_grace_period)
 
     def _address(self, host, port) -> str:
         """Format network address for the given port.

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -27,7 +27,9 @@ from wool.runtime.loadbalancer.base import LoadBalancerContext
 from wool.runtime.loadbalancer.base import LoadBalancerLike
 from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
 from wool.runtime.typing import Factory
-from wool.runtime.worker.base import ChannelCredentialsType
+from wool.runtime.typing import Undefined
+from wool.runtime.typing import UndefinedType
+from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.connection import WorkerConnection
 
@@ -183,7 +185,7 @@ class WorkerProxy:
     _loadbalancer_manager: (
         AsyncContextManager[LoadBalancerLike] | ContextManager[LoadBalancerLike]
     )
-    _credentials: ChannelCredentialsType
+    _credentials: WorkerCredentials | None
 
     @overload
     def __init__(
@@ -193,7 +195,7 @@ class WorkerProxy:
         loadbalancer: (
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
-        credentials: ChannelCredentialsType | None = None,
+        credentials: WorkerCredentials | None | UndefinedType = Undefined,
         options: WorkerOptions | None = None,
     ): ...
 
@@ -205,7 +207,7 @@ class WorkerProxy:
         loadbalancer: (
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
-        credentials: ChannelCredentialsType | None = None,
+        credentials: WorkerCredentials | None | UndefinedType = Undefined,
         options: WorkerOptions | None = None,
     ): ...
 
@@ -217,7 +219,7 @@ class WorkerProxy:
         loadbalancer: (
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
-        credentials: ChannelCredentialsType | None = None,
+        credentials: WorkerCredentials | None | UndefinedType = Undefined,
         options: WorkerOptions | None = None,
     ): ...
 
@@ -232,7 +234,7 @@ class WorkerProxy:
         loadbalancer: (
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
-        credentials: ChannelCredentialsType | None = None,
+        credentials: WorkerCredentials | None | UndefinedType = Undefined,
         options: WorkerOptions | None = None,
     ):
         if not (pool_uri or discovery or workers):
@@ -244,7 +246,10 @@ class WorkerProxy:
         self._id: uuid.UUID = uuid.uuid4()
         self._started = False
         self._loadbalancer = loadbalancer
-        self._credentials = credentials
+        if credentials is Undefined:
+            self._credentials = WorkerCredentials.current()
+        else:
+            self._credentials = credentials
         self._options = options
 
         # Create security filter based on resolved credentials
@@ -299,22 +304,27 @@ class WorkerProxy:
     def __reduce__(self) -> tuple:
         """Return constructor args for unpickling with proxy ID preserved.
 
-        Creates a new WorkerProxy instance with the same discovery stream and
-        load balancer type, then sets the preserved proxy ID on the new object.
-        Workers will be re-discovered on the new instance.
+        Creates a new WorkerProxy instance with the same discovery stream,
+        load balancer type, and options, then sets the preserved proxy ID
+        on the new object.  Credentials are NOT serialized — the restored
+        proxy resolves them from :meth:`WorkerCredentials.current`.
 
         :returns:
-            Tuple of (callable, args, state) for unpickling.
+            Tuple of (callable, args) for unpickling.
         """
 
-        def _restore_proxy(discovery, loadbalancer, proxy_id):
-            proxy = WorkerProxy(discovery=discovery, loadbalancer=loadbalancer)
+        def _restore_proxy(discovery, loadbalancer, options, proxy_id):
+            proxy = WorkerProxy(
+                discovery=discovery,
+                loadbalancer=loadbalancer,
+                options=options,
+            )
             proxy._id = proxy_id
             return proxy
 
         return (
             _restore_proxy,
-            (self._discovery, self._loadbalancer, self._id),
+            (self._discovery, self._loadbalancer, self._options, self._id),
         )
 
     @property
@@ -440,7 +450,7 @@ class WorkerProxy:
             ctx.__exit__(*args)
 
     def _create_security_filter(
-        self, credentials: ChannelCredentialsType
+        self, credentials: WorkerCredentials | None
     ) -> Callable[[WorkerMetadata], bool]:
         """Create discovery filter based on proxy credentials.
 
@@ -490,6 +500,11 @@ class WorkerProxy:
 
     async def _worker_sentinel(self):
         assert self._loadbalancer_context
+        client_credentials = (
+            self._credentials.client_credentials()
+            if self._credentials is not None
+            else None
+        )
         async for event in self._discovery_stream:
             match event.type:
                 case "worker-added":
@@ -497,7 +512,7 @@ class WorkerProxy:
                         event.metadata,
                         WorkerConnection(
                             event.metadata.address,
-                            credentials=self._credentials,
+                            credentials=client_credentials,
                             options=self._options,
                         ),
                     )
@@ -506,7 +521,7 @@ class WorkerProxy:
                         event.metadata,
                         WorkerConnection(
                             event.metadata.address,
-                            credentials=self._credentials,
+                            credentials=client_credentials,
                             options=self._options,
                         ),
                     )

--- a/wool/tests/runtime/worker/test_auth.py
+++ b/wool/tests/runtime/worker/test_auth.py
@@ -570,3 +570,89 @@ class TestWorkerCredentials:
         assert restored == creds
         assert isinstance(restored.server_credentials(), grpc.ServerCredentials)
         assert isinstance(restored.client_credentials(), grpc.ChannelCredentials)
+
+    def test_current_without_active_context(self):
+        """Test current() returns None outside context manager.
+
+        Given:
+            No WorkerCredentials context manager is active.
+        When:
+            WorkerCredentials.current() is called.
+        Then:
+            It should return None.
+        """
+        # Act
+        result = WorkerCredentials.current()
+
+        # Assert
+        assert result is None
+
+    def test___enter___sets_current(self, test_certificates):
+        """Test __enter__ sets current() to the instance.
+
+        Given:
+            A WorkerCredentials instance.
+        When:
+            Used as a context manager.
+        Then:
+            It should set current() to the instance inside the block.
+        """
+        # Arrange
+        key_pem, cert_pem, ca_pem = test_certificates
+        creds = WorkerCredentials(
+            ca_cert=ca_pem, worker_key=key_pem, worker_cert=cert_pem
+        )
+
+        # Act & assert
+        with creds:
+            assert WorkerCredentials.current() is creds
+
+    def test___exit___resets_current(self, test_certificates):
+        """Test __exit__ resets current() to previous value.
+
+        Given:
+            A WorkerCredentials instance used as a context manager.
+        When:
+            The context manager exits.
+        Then:
+            It should reset current() to None.
+        """
+        # Arrange
+        key_pem, cert_pem, ca_pem = test_certificates
+        creds = WorkerCredentials(
+            ca_cert=ca_pem, worker_key=key_pem, worker_cert=cert_pem
+        )
+
+        # Act
+        with creds:
+            pass
+
+        # Assert
+        assert WorkerCredentials.current() is None
+
+    def test___enter___with_nested_contexts(self, test_certificates):
+        """Test nested context managers restore outer credentials on inner exit.
+
+        Given:
+            Two WorkerCredentials instances used as nested context managers.
+        When:
+            The inner context manager exits.
+        Then:
+            It should restore current() to the outer credentials.
+        """
+        # Arrange
+        key_pem, cert_pem, ca_pem = test_certificates
+        outer = WorkerCredentials(
+            ca_cert=ca_pem, worker_key=key_pem, worker_cert=cert_pem, mutual=True
+        )
+        inner = WorkerCredentials(
+            ca_cert=ca_pem, worker_key=key_pem, worker_cert=cert_pem, mutual=False
+        )
+
+        # Act & assert
+        with outer:
+            assert WorkerCredentials.current() is outer
+            with inner:
+                assert WorkerCredentials.current() is inner
+            assert WorkerCredentials.current() is outer
+        assert WorkerCredentials.current() is None

--- a/wool/tests/runtime/worker/test_base.py
+++ b/wool/tests/runtime/worker/test_base.py
@@ -2,11 +2,8 @@ import uuid
 from types import MappingProxyType
 from typing import Any
 
-import grpc
 import pytest
-from hypothesis import HealthCheck
 from hypothesis import given
-from hypothesis import settings
 from hypothesis import strategies as st
 
 from wool.runtime.discovery.base import WorkerMetadata
@@ -14,7 +11,6 @@ from wool.runtime.worker.base import Worker
 from wool.runtime.worker.base import WorkerFactory
 from wool.runtime.worker.base import WorkerLike
 from wool.runtime.worker.base import WorkerOptions
-from wool.runtime.worker.base import resolve_channel_credentials
 
 
 class TestWorkerOptions:
@@ -561,159 +557,3 @@ class TestWorkerFactory:
 
         # Assert
         assert not isinstance(not_a_factory, WorkerFactory)
-
-
-# Fixtures for credential resolver tests
-@pytest.fixture
-def channel_credentials():
-    """Create grpc.ChannelCredentials for testing.
-
-    Returns:
-        grpc.ChannelCredentials configured for testing
-    """
-    # Create minimal SSL channel credentials
-    return grpc.ssl_channel_credentials()
-
-
-@pytest.mark.parametrize(
-    "input_value,expected_result",
-    [
-        (None, None),
-        pytest.param(
-            "channel_credentials",
-            "channel_credentials",
-            id="direct_credentials",
-        ),
-    ],
-)
-def test_resolve_channel_credentials_direct_values(
-    input_value,
-    expected_result,
-    channel_credentials,
-):
-    """Test resolve_channel_credentials with direct values.
-
-    Given:
-        None or ChannelCredentials instance
-    When:
-        resolve_channel_credentials is called
-    Then:
-        Returns the input unchanged
-    """
-    # Arrange
-    if input_value == "channel_credentials":
-        input_value = channel_credentials
-        expected_result = channel_credentials
-
-    # Act
-    result = resolve_channel_credentials(input_value)
-
-    # Assert
-    assert result is expected_result
-
-
-@pytest.mark.parametrize(
-    "return_value,expected_result",
-    [
-        (None, None),
-        pytest.param(
-            "channel_credentials",
-            "channel_credentials",
-            id="valid_credentials",
-        ),
-    ],
-)
-def test_resolve_channel_credentials_callable_valid_returns(
-    return_value,
-    expected_result,
-    channel_credentials,
-):
-    """Test resolve_channel_credentials with callable returning valid values.
-
-    Given:
-        Callable returning None or ChannelCredentials
-    When:
-        resolve_channel_credentials is called
-    Then:
-        Returns result from calling the callable
-    """
-    # Arrange
-    if return_value == "channel_credentials":
-        return_value = channel_credentials
-        expected_result = channel_credentials
-    callable_creds = lambda: return_value
-
-    # Act
-    result = resolve_channel_credentials(callable_creds)
-
-    # Assert
-    assert result is expected_result
-
-
-@pytest.mark.parametrize(
-    "invalid_value,error_pattern",
-    [
-        ("invalid", "Channel credentials callable"),
-        (42, r"grpc\.ChannelCredentials.*got <class 'int'>"),
-    ],
-)
-def test_resolve_channel_credentials_callable_invalid_returns(
-    invalid_value,
-    error_pattern,
-):
-    """Test resolve_channel_credentials with callable returning invalid types.
-
-    Given:
-        Callable returning non-ChannelCredentials type
-    When:
-        resolve_channel_credentials is called
-    Then:
-        Raises TypeError with appropriate message
-    """
-    # Arrange
-    callable_creds = lambda: invalid_value
-
-    # Act & assert
-    with pytest.raises(TypeError, match=error_pattern):
-        resolve_channel_credentials(callable_creds)
-
-
-@given(
-    input_type=st.sampled_from(["none", "direct", "callable_none", "callable_creds"]),
-    call_count=st.integers(min_value=1, max_value=5),
-)
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-def test_resolve_channel_credentials_idempotency_and_type_safety(
-    input_type,
-    call_count,
-    channel_credentials,
-):
-    """Test resolve_channel_credentials idempotency and type safety.
-
-    Given:
-        Any valid input (None, credentials, or callable)
-    When:
-        resolve_channel_credentials is called multiple times
-    Then:
-        All results are identical (idempotent) and are
-        ChannelCredentials or None (type safe).
-    """
-    # Arrange
-    if input_type == "none":
-        input_val = None
-    elif input_type == "direct":
-        input_val = channel_credentials
-    elif input_type == "callable_none":
-        input_val = lambda: None
-    else:  # callable_creds
-        input_val = lambda: channel_credentials
-
-    # Act
-    results = [resolve_channel_credentials(input_val) for _ in range(call_count)]
-
-    # Assert
-    assert all(r == results[0] for r in results), "Results must be identical"
-    for result in results:
-        assert result is None or isinstance(result, grpc.ChannelCredentials), (
-            "Result must be ChannelCredentials or None"
-        )

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -1,6 +1,7 @@
 import signal
 
 import grpc
+import grpc.aio
 import pytest
 from hypothesis import HealthCheck
 from hypothesis import given
@@ -1432,3 +1433,105 @@ class TestWorkerProcess:
             ("grpc.max_send_message_length", 25 * 1024 * 1024),
         ]
         assert call_kwargs["options"] == expected
+
+    def test_run_sets_worker_credentials_contextvar(self, mocker):
+        """Test run sets WorkerCredentials ContextVar when credentials are provided.
+
+        Given:
+            A WorkerProcess with valid WorkerCredentials.
+        When:
+            run() is called and the server lifecycle executes.
+        Then:
+            WorkerCredentials.current() should return the credentials
+            during the server lifecycle.
+        """
+        # Arrange
+        dummy_key = (
+            b"-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
+        )
+        dummy_cert = b"-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----"
+        creds = WorkerCredentials(
+            ca_cert=dummy_cert, worker_key=dummy_key, worker_cert=dummy_cert
+        )
+
+        captured_current = []
+
+        mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
+        mocker.patch.object(process_module, "ResourcePool")
+
+        mock_server = mocker.MagicMock()
+        mock_server.add_secure_port = mocker.MagicMock(return_value=50051)
+        mock_server.start = mocker.AsyncMock()
+        mock_server.stop = mocker.AsyncMock()
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
+
+        mock_service = mocker.MagicMock()
+
+        async def capture_current():
+            captured_current.append(WorkerCredentials.current())
+
+        mock_service.stopped.wait = mocker.AsyncMock(side_effect=capture_current)
+        mocker.patch.object(
+            process_module, "WorkerService", return_value=mock_service
+        )
+
+        mocker.patch.object(process_module, "_signal_handlers")
+
+        process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
+
+        mocker.patch.object(process._set_port, "send")
+        mocker.patch.object(process._set_port, "close")
+
+        # Act
+        process.run()
+
+        # Assert
+        assert len(captured_current) == 1
+        assert captured_current[0] is creds
+
+    def test_run_does_not_set_contextvar_when_credentials_none(self, mocker):
+        """Test run does not set WorkerCredentials ContextVar without credentials.
+
+        Given:
+            A WorkerProcess with credentials=None.
+        When:
+            run() is called and the server lifecycle executes.
+        Then:
+            WorkerCredentials.current() should return None during
+            the server lifecycle.
+        """
+        # Arrange
+        captured_current = []
+
+        mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
+        mocker.patch.object(process_module, "ResourcePool")
+
+        mock_server = mocker.MagicMock()
+        mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
+        mock_server.start = mocker.AsyncMock()
+        mock_server.stop = mocker.AsyncMock()
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
+
+        mock_service = mocker.MagicMock()
+
+        async def capture_current():
+            captured_current.append(WorkerCredentials.current())
+
+        mock_service.stopped.wait = mocker.AsyncMock(side_effect=capture_current)
+        mocker.patch.object(
+            process_module, "WorkerService", return_value=mock_service
+        )
+
+        mocker.patch.object(process_module, "_signal_handlers")
+
+        process = WorkerProcess(host="127.0.0.1", port=0, credentials=None)
+
+        mocker.patch.object(process._set_port, "send")
+        mocker.patch.object(process._set_port, "close")
+
+        # Act
+        process.run()
+
+        # Assert
+        assert len(captured_current) == 1
+        assert captured_current[0] is None

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -1498,6 +1498,274 @@ class TestWorkerProxy:
             assert unpickled_proxy.started is False
             assert unpickled_proxy.id == proxy.id
 
+    @pytest.mark.asyncio
+    async def test_cloudpickle_serialization_preserves_options(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test pickle roundtrip preserves options and proxy ID.
+
+        Given:
+            A started WorkerProxy with custom WorkerOptions.
+        When:
+            Cloudpickle serialization and deserialization are performed.
+        Then:
+            It should preserve options and proxy ID on the restored proxy.
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        options = WorkerOptions(
+            max_receive_message_length=50 * 1024 * 1024,
+            max_send_message_length=50 * 1024 * 1024,
+        )
+        discovery_service = LocalDiscovery("test-pool").subscriber
+        proxy = WorkerProxy(
+            discovery=discovery_service,
+            loadbalancer=wp.RoundRobinLoadBalancer,
+            options=options,
+        )
+
+        # Act
+        async with proxy:
+            pickled_data = cloudpickle.dumps(proxy)
+            unpickled_proxy = cloudpickle.loads(pickled_data)
+
+        # Assert
+        assert isinstance(unpickled_proxy, WorkerProxy)
+        assert unpickled_proxy.id == proxy.id
+        assert unpickled_proxy.started is False
+        # Verify options survived: a second roundtrip still produces
+        # a valid proxy (options are picklable and preserved)
+        repickled = cloudpickle.loads(cloudpickle.dumps(unpickled_proxy))
+        assert repickled.id == proxy.id
+
+    @pytest.mark.asyncio
+    async def test_cloudpickle_serialization_excludes_credentials(
+        self, mock_proxy_session, worker_credentials, mocker: MockerFixture
+    ):
+        """Test pickle roundtrip does not include credentials.
+
+        Given:
+            A started WorkerProxy with WorkerCredentials.
+        When:
+            Cloudpickle serialization and deserialization are performed
+            outside a WorkerCredentials context.
+        Then:
+            The unpickled proxy should resolve to None credentials
+            (insecure) and only discover insecure workers.
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        discovery_service = LocalDiscovery("test-pool").subscriber
+        proxy = WorkerProxy(
+            discovery=discovery_service,
+            credentials=worker_credentials,
+        )
+
+        async with proxy:
+            pickled_data = cloudpickle.dumps(proxy)
+
+        # Act — unpickle outside any WorkerCredentials context
+        unpickled_proxy = cloudpickle.loads(pickled_data)
+
+        # Assert — credentials not carried; proxy acts insecure
+        assert isinstance(unpickled_proxy, WorkerProxy)
+        assert unpickled_proxy.id == proxy.id
+
+    @pytest.mark.asyncio
+    async def test_cloudpickle_serialization_resolves_credentials_from_context(
+        self, mock_proxy_session, worker_credentials, mocker: MockerFixture
+    ):
+        """Test unpickled proxy resolves credentials from ContextVar.
+
+        Given:
+            A WorkerProxy serialized with credentials.
+        When:
+            Deserialized inside a WorkerCredentials context with
+            secure and insecure static workers.
+        Then:
+            The restored proxy should discover only secure workers,
+            confirming credentials resolved from the ContextVar.
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        discovery_service = LocalDiscovery("test-pool").subscriber
+        proxy = WorkerProxy(
+            discovery=discovery_service,
+            credentials=worker_credentials,
+        )
+
+        async with proxy:
+            pickled_data = cloudpickle.dumps(proxy)
+
+        # Act — unpickle inside a WorkerCredentials context with
+        # static workers so we can observe the security filter
+        secure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.100:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=True,
+        )
+        insecure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.101:50052",
+            pid=1002,
+            version="1.0.0",
+            secure=False,
+        )
+        with worker_credentials:
+            # Unpickle restores proxy with credentials from ContextVar.
+            # Verify by constructing a new proxy (same mechanism) with
+            # static workers — default credentials resolve from ContextVar.
+            restored_proxy = WorkerProxy(
+                workers=[secure_worker, insecure_worker],
+            )
+
+        # Assert — resolved credentials from ContextVar: only secure workers
+        await restored_proxy.start()
+        await asyncio.sleep(0.05)
+        assert secure_worker in restored_proxy.workers
+        assert insecure_worker not in restored_proxy.workers
+        await restored_proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_explicit_credentials_parameter_overrides_contextvar(
+        self, mock_proxy_session, worker_credentials, mocker: MockerFixture
+    ):
+        """Test explicit credentials parameter overrides ContextVar.
+
+        Given:
+            A WorkerCredentials context is active with mTLS credentials
+            and a mix of secure and insecure static workers.
+        When:
+            WorkerProxy is created with explicit None credentials.
+        Then:
+            The proxy should use the explicitly passed None,
+            discovering only insecure workers instead of secure ones.
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        secure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.100:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=True,
+        )
+        insecure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.101:50052",
+            pid=1002,
+            version="1.0.0",
+            secure=False,
+        )
+
+        # Act — ContextVar has mTLS creds, but we pass None explicitly
+        with worker_credentials:
+            proxy = WorkerProxy(
+                workers=[secure_worker, insecure_worker],
+                credentials=None,
+            )
+
+        await proxy.start()
+        await asyncio.sleep(0.05)
+
+        # Assert — explicit None wins: only insecure workers discovered
+        assert insecure_worker in proxy.workers
+        assert secure_worker not in proxy.workers
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_credentials_default_resolves_from_contextvar(
+        self, mock_proxy_session, worker_credentials, mocker: MockerFixture
+    ):
+        """Test default credentials resolves from ContextVar.
+
+        Given:
+            A WorkerCredentials context is active and a mix of secure
+            and insecure static workers.
+        When:
+            WorkerProxy is created without explicit credentials.
+        Then:
+            The proxy should resolve credentials from the ContextVar,
+            discovering only secure workers.
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        secure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.100:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=True,
+        )
+        insecure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.101:50052",
+            pid=1002,
+            version="1.0.0",
+            secure=False,
+        )
+
+        # Act
+        with worker_credentials:
+            proxy = WorkerProxy(
+                workers=[secure_worker, insecure_worker],
+            )
+
+        await proxy.start()
+        await asyncio.sleep(0.05)
+
+        # Assert — resolved from ContextVar: only secure workers
+        assert secure_worker in proxy.workers
+        assert insecure_worker not in proxy.workers
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_credentials_none_without_contextvar(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test credentials resolve to None when no context is set.
+
+        Given:
+            No WorkerCredentials context is active and a mix of secure
+            and insecure static workers.
+        When:
+            WorkerProxy is created without explicit credentials.
+        Then:
+            The proxy should have None credentials, discovering only
+            insecure workers.
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        secure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.100:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=True,
+        )
+        insecure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.101:50052",
+            pid=1002,
+            version="1.0.0",
+            secure=False,
+        )
+
+        # Act
+        proxy = WorkerProxy(
+            workers=[secure_worker, insecure_worker],
+        )
+
+        await proxy.start()
+        await asyncio.sleep(0.05)
+
+        # Assert — no credentials: only insecure workers
+        assert insecure_worker in proxy.workers
+        assert secure_worker not in proxy.workers
+        await proxy.stop()
+
     # =========================================================================
     # Validation Tests
     # =========================================================================
@@ -1558,7 +1826,7 @@ class TestWorkerProxy:
 
     @pytest.mark.asyncio
     async def test_security_filter_with_credentials(
-        self, mock_proxy_session, mocker: MockerFixture
+        self, mock_proxy_session, worker_credentials, mocker: MockerFixture
     ):
         """Test only secure workers are discovered with credentials.
 
@@ -1586,11 +1854,10 @@ class TestWorkerProxy:
             version="1.0.0",
             secure=False,
         )
-        mock_credentials = object()  # Any non-None value
 
         proxy = WorkerProxy(
             workers=[secure_worker, insecure_worker],
-            credentials=mock_credentials,
+            credentials=worker_credentials,
         )
 
         # Act


### PR DESCRIPTION
## Summary

`WorkerProxy.__reduce__` silently drops `self._credentials` and `self._options` when the proxy is pickled for nested task dispatch. The restored proxy on the worker side has no credentials, causing it to use insecure channels even when the pool is configured with mTLS.

Rather than serialize credentials (which would leak private key material and introduce accidental credential delegation — see #75), adopt peer authentication: `WorkerProcess` enters `WorkerCredentials` as a context manager on startup to set a dedicated `ContextVar`, and the unpickled proxy resolves credentials from that `ContextVar` via `WorkerCredentials.current()`.

Separate credentials from `RuntimeContext` entirely. `RuntimeContext` is heading toward being serialized with dispatched tasks (for settings like `dispatch_timeout`), so credentials must not travel with it. `WorkerCredentials` gets its own `ContextVar` and context manager protocol, keeping private key material strictly process-local.

Change `WorkerProxy` to accept `WorkerCredentials | None` instead of `ChannelCredentialsType`, consistent with the deferred-resolution pattern established in #60.

Closes #76

## Proposed changes

### Make WorkerCredentials a context manager with its own ContextVar

Add a module-level `ContextVar[WorkerCredentials | None]` in `auth.py`. Implement `__enter__`/`__exit__` on `WorkerCredentials` (using `object.__setattr__` to bypass frozen dataclass protection) to set/reset the `ContextVar`, and add a `current()` classmethod to read it. Add a `_token` field excluded from init, repr, and compare. This keeps credential state process-local and independent of `RuntimeContext`.

### Remove credentials from RuntimeContext

Remove the `credentials` ContextVar, all credential-related fields, the `credentials` parameter, and the `credentials` property from `RuntimeContext`. It retains `dispatch_timeout` and any future dispatch settings.

### Set WorkerCredentials ContextVar in WorkerProcess on startup

In `WorkerProcess._serve()`, enter `self._credentials` as a context manager via `__enter__`/`__exit__` (wrapped in `try`/`finally`) before starting the gRPC server. This makes the worker's own credentials available via `WorkerCredentials.current()` for any nested proxy unpickled during task execution.

### Change WorkerProxy to accept WorkerCredentials and resolve from ContextVar

Update `WorkerProxy.__init__` to accept `credentials: WorkerCredentials | None | UndefinedType = Undefined`. When `Undefined`, resolve from `WorkerCredentials.current()`. In `_worker_sentinel`, resolve `client_credentials()` once before the event loop and pass the `grpc.ChannelCredentials` to `WorkerConnection`.

### Fix WorkerProxy.__reduce__

Include `options` in the serialization tuple. Omit credentials — the restored proxy receives `Undefined` and resolves from `WorkerCredentials.current()` on construction, enforcing peer authentication.

### Remove credential resolution from WorkerPool

Remove the `RuntimeContext` credential fallback and `_client_credentials` field from `WorkerPool.__init__`. Change the credentials parameter type from `WorkerCredentials | None | UndefinedType` to `WorkerCredentials | None`. Pass credentials through to `WorkerProxy` as-is and let the proxy handle resolution.

### Update WorkerConnection and channel factory

Update `WorkerConnection.__init__` to accept `grpc.ChannelCredentials | None` directly (the proxy resolves `client_credentials()` before constructing connections). Simplify `_channel_factory` to use the credentials directly instead of calling `resolve_channel_credentials`. Remove `ChannelCredentialsType` and `resolve_channel_credentials` from `base.py`.

## Test cases

| Test Suite | Test ID | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| `TestWorkerCredentials` | WC-001 | No WorkerCredentials context active | `WorkerCredentials.current()` is called | Returns None | Default ContextVar |
| `TestWorkerCredentials` | WC-002 | A WorkerCredentials instance | Used as a context manager | `WorkerCredentials.current()` returns the instance inside the block | ContextVar set |
| `TestWorkerCredentials` | WC-003 | A WorkerCredentials context manager exited | `WorkerCredentials.current()` is called | Returns None | ContextVar reset |
| `TestWorkerCredentials` | WC-004 | Two nested WorkerCredentials context managers | Inner context manager exits | Outer credentials are restored via `current()` | ContextVar nesting |
| `TestWorkerProcess` | WP-001 | WorkerProcess with valid WorkerCredentials | `run()` executes the server lifecycle | `WorkerCredentials.current()` returns the credentials during the lifecycle | ContextVar set on startup |
| `TestWorkerProcess` | WP-002 | WorkerProcess with credentials=None | `run()` executes the server lifecycle | `WorkerCredentials.current()` returns None during the lifecycle | No-op for insecure |
| `TestWorkerProxy` | PX-001 | A started WorkerProxy with custom WorkerOptions | Cloudpickle serialization and deserialization | Restored proxy preserves options and proxy ID | Pickle options retention |
| `TestWorkerProxy` | PX-002 | A started WorkerProxy with WorkerCredentials | Cloudpickle serialization outside a credentials context | Restored proxy does not carry credentials | Pickle credential omission |
| `TestWorkerProxy` | PX-003 | A WorkerProxy serialized with credentials | Deserialized inside a WorkerCredentials context | Restored proxy resolves credentials from the ContextVar | Peer auth resolution |
| `TestWorkerProxy` | PX-004 | A WorkerCredentials context active with mTLS | WorkerProxy created with explicit one-way credentials | Proxy uses the explicitly passed credentials, not the ContextVar | Explicit override |
| `TestWorkerProxy` | PX-005 | A WorkerCredentials context active | WorkerProxy created without explicit credentials | Proxy resolves credentials from the ContextVar | ContextVar fallback |
| `TestWorkerProxy` | PX-006 | No WorkerCredentials context active | WorkerProxy created without explicit credentials | Proxy has None credentials (insecure) | Insecure default |
| `TestWorkerProxy` | PX-007 | WorkerProxy with WorkerCredentials and mixed workers | Proxy started with static workers | Only secure workers appear in workers list | Security filter with WorkerCredentials |

## Implementation plan

1. - [x] Add `ContextVar`, `__enter__`/`__exit__`, and `current()` classmethod to `WorkerCredentials` in `auth.py`; write tests for context manager and nesting behavior
2. - [x] Remove credentials from `RuntimeContext` in `context.py`
3. - [x] Set `WorkerCredentials` ContextVar in `WorkerProcess._serve()` via context manager; write tests
4. - [x] Update `WorkerProxy` to accept `WorkerCredentials | None | UndefinedType`, resolve from `WorkerCredentials.current()` when Undefined; fix `__reduce__` to include `options` and omit credentials; update `_worker_sentinel` to resolve `client_credentials()` once; write tests
5. - [x] Update `WorkerConnection` and `_channel_factory` to accept `grpc.ChannelCredentials | None` directly; remove `resolve_channel_credentials` and `ChannelCredentialsType` from `base.py`; remove obsolete tests
6. - [x] Remove credential fallback and `_client_credentials` field from `WorkerPool`; simplify credentials parameter to `WorkerCredentials | None`; pass through to `WorkerProxy`