### PR TITLE
Separate credential context manager from WorkerCredentials and keep it internal — Closes #78

### DIFF
--- a/wool/src/wool/runtime/worker/auth.py
+++ b/wool/src/wool/runtime/worker/auth.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from contextvars import ContextVar
 from contextvars import Token
 from dataclasses import dataclass
-from dataclasses import field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -62,30 +61,6 @@ class WorkerCredentials:
     worker_key: bytes
     worker_cert: bytes
     mutual: bool = True
-    _token: Token | None = field(
-        default=None, init=False, repr=False, compare=False
-    )
-
-    def __enter__(self) -> WorkerCredentials:
-        object.__setattr__(self, "_token", _current.set(self))
-        return self
-
-    def __exit__(self, *_) -> None:
-        if self._token is None:
-            raise RuntimeError(
-                "__exit__ called without matching __enter__"
-            )
-        _current.reset(self._token)
-        object.__setattr__(self, "_token", None)
-
-    @classmethod
-    def current(cls) -> WorkerCredentials | None:
-        """Get the current worker credentials from the context.
-
-        :returns:
-            The active WorkerCredentials, or None if no context is set.
-        """
-        return _current.get()
 
     @classmethod
     def from_files(
@@ -191,3 +166,37 @@ class WorkerCredentials:
             private_key=self.worker_key if self.mutual else None,
             certificate_chain=self.worker_cert if self.mutual else None,
         )
+
+
+class CredentialContext:
+    """Internal context manager for propagating WorkerCredentials via ContextVar.
+
+    Used by WorkerProcess._serve() to set credentials in worker subprocesses
+    and by WorkerProxy.__init__() to resolve credentials from context.
+    Not part of the public API.
+    """
+
+    def __init__(self, credentials: WorkerCredentials) -> None:
+        self._credentials = credentials
+        self._token: Token | None = None
+
+    def __enter__(self) -> CredentialContext:
+        self._token = _current.set(self._credentials)
+        return self
+
+    def __exit__(self, *_) -> None:
+        if self._token is None:
+            raise RuntimeError(
+                "__exit__ called without matching __enter__"
+            )
+        _current.reset(self._token)
+        self._token = None
+
+    @classmethod
+    def current(cls) -> WorkerCredentials | None:
+        """Get the current worker credentials from the context.
+
+        :returns:
+            The active WorkerCredentials, or None if no context is set.
+        """
+        return _current.get()

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -17,6 +17,7 @@ import wool
 from wool import protocol
 from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.auth import CredentialContext
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.interceptor import VersionInterceptor
 from wool.runtime.worker.service import WorkerService
@@ -184,7 +185,7 @@ class WorkerProcess(Process):
         starts listening for incoming connections.
         """
         creds_ctx = (
-            self._credentials
+            CredentialContext(self._credentials)
             if self._credentials is not None
             else contextlib.nullcontext()
         )

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -30,6 +30,7 @@ from wool.runtime.typing import Factory
 from wool.runtime.typing import Undefined
 from wool.runtime.typing import UndefinedType
 from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.auth import CredentialContext
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.connection import WorkerConnection
 
@@ -247,7 +248,7 @@ class WorkerProxy:
         self._started = False
         self._loadbalancer = loadbalancer
         if credentials is Undefined:
-            self._credentials = WorkerCredentials.current()
+            self._credentials = CredentialContext.current()
         else:
             self._credentials = credentials
         self._options = options
@@ -307,7 +308,7 @@ class WorkerProxy:
         Creates a new WorkerProxy instance with the same discovery stream,
         load balancer type, and options, then sets the preserved proxy ID
         on the new object.  Credentials are NOT serialized — the restored
-        proxy resolves them from :meth:`WorkerCredentials.current`.
+        proxy resolves them from the active credential context.
 
         :returns:
             Tuple of (callable, args) for unpickling.

--- a/wool/tests/runtime/worker/test_auth.py
+++ b/wool/tests/runtime/worker/test_auth.py
@@ -571,31 +571,15 @@ class TestWorkerCredentials:
         assert isinstance(restored.server_credentials(), grpc.ServerCredentials)
         assert isinstance(restored.client_credentials(), grpc.ChannelCredentials)
 
-    def test_current_without_active_context(self):
-        """Test current() returns None outside context manager.
-
-        Given:
-            No WorkerCredentials context manager is active.
-        When:
-            WorkerCredentials.current() is called.
-        Then:
-            It should return None.
-        """
-        # Act
-        result = WorkerCredentials.current()
-
-        # Assert
-        assert result is None
-
-    def test___enter___sets_current(self, test_certificates):
-        """Test __enter__ sets current() to the instance.
+    def test___enter___not_supported(self, test_certificates):
+        """Test WorkerCredentials does not support context manager protocol.
 
         Given:
             A WorkerCredentials instance.
         When:
-            Used as a context manager.
+            Used in a with statement.
         Then:
-            It should set current() to the instance inside the block.
+            It should raise TypeError.
         """
         # Arrange
         key_pem, cert_pem, ca_pem = test_certificates
@@ -604,55 +588,21 @@ class TestWorkerCredentials:
         )
 
         # Act & assert
-        with creds:
-            assert WorkerCredentials.current() is creds
+        with pytest.raises(TypeError):
+            with creds:
+                pass
 
-    def test___exit___resets_current(self, test_certificates):
-        """Test __exit__ resets current() to previous value.
-
-        Given:
-            A WorkerCredentials instance used as a context manager.
-        When:
-            The context manager exits.
-        Then:
-            It should reset current() to None.
-        """
-        # Arrange
-        key_pem, cert_pem, ca_pem = test_certificates
-        creds = WorkerCredentials(
-            ca_cert=ca_pem, worker_key=key_pem, worker_cert=cert_pem
-        )
-
-        # Act
-        with creds:
-            pass
-
-        # Assert
-        assert WorkerCredentials.current() is None
-
-    def test___enter___with_nested_contexts(self, test_certificates):
-        """Test nested context managers restore outer credentials on inner exit.
+    def test_current_not_supported(self):
+        """Test WorkerCredentials does not expose current() classmethod.
 
         Given:
-            Two WorkerCredentials instances used as nested context managers.
+            The WorkerCredentials class.
         When:
-            The inner context manager exits.
+            WorkerCredentials.current() is called.
         Then:
-            It should restore current() to the outer credentials.
+            It should raise AttributeError.
         """
-        # Arrange
-        key_pem, cert_pem, ca_pem = test_certificates
-        outer = WorkerCredentials(
-            ca_cert=ca_pem, worker_key=key_pem, worker_cert=cert_pem, mutual=True
-        )
-        inner = WorkerCredentials(
-            ca_cert=ca_pem, worker_key=key_pem, worker_cert=cert_pem, mutual=False
-        )
-
         # Act & assert
-        with outer:
-            assert WorkerCredentials.current() is outer
-            with inner:
-                assert WorkerCredentials.current() is inner
-            assert WorkerCredentials.current() is outer
-        assert WorkerCredentials.current() is None
+        with pytest.raises(AttributeError):
+            WorkerCredentials.current()
+

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -10,6 +10,7 @@ from hypothesis import strategies as st
 
 from wool.runtime.worker import process as process_module
 from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.auth import CredentialContext
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.process import WorkerProcess
 from wool.runtime.worker.process import _proxy_factory
@@ -1468,7 +1469,7 @@ class TestWorkerProcess:
         mock_service = mocker.MagicMock()
 
         async def capture_current():
-            captured_current.append(WorkerCredentials.current())
+            captured_current.append(CredentialContext.current())
 
         mock_service.stopped.wait = mocker.AsyncMock(side_effect=capture_current)
         mocker.patch.object(
@@ -1515,7 +1516,7 @@ class TestWorkerProcess:
         mock_service = mocker.MagicMock()
 
         async def capture_current():
-            captured_current.append(WorkerCredentials.current())
+            captured_current.append(CredentialContext.current())
 
         mock_service.stopped.wait = mocker.AsyncMock(side_effect=capture_current)
         mocker.patch.object(

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -25,6 +25,7 @@ from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.local import LocalDiscovery
 from wool.runtime.loadbalancer.base import NoWorkersAvailable
 from wool.runtime.routine.task import Task
+from wool.runtime.worker.auth import CredentialContext
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.connection import WorkerConnection
 from wool.runtime.worker.proxy import WorkerProxy
@@ -1613,7 +1614,7 @@ class TestWorkerProxy:
             version="1.0.0",
             secure=False,
         )
-        with worker_credentials:
+        with CredentialContext(worker_credentials):
             # Unpickle restores proxy with credentials from ContextVar.
             # Verify by constructing a new proxy (same mechanism) with
             # static workers — default credentials resolve from ContextVar.
@@ -1661,7 +1662,7 @@ class TestWorkerProxy:
         )
 
         # Act — ContextVar has mTLS creds, but we pass None explicitly
-        with worker_credentials:
+        with CredentialContext(worker_credentials):
             proxy = WorkerProxy(
                 workers=[secure_worker, insecure_worker],
                 credentials=None,
@@ -1708,7 +1709,7 @@ class TestWorkerProxy:
         )
 
         # Act
-        with worker_credentials:
+        with CredentialContext(worker_credentials):
             proxy = WorkerProxy(
                 workers=[secure_worker, insecure_worker],
             )


### PR DESCRIPTION
## Summary

Extract the `__enter__`/`__exit__` context manager protocol and `current()` classmethod from `WorkerCredentials` into a separate `CredentialContext` helper in `auth.py`. Remove the `_token` field from the frozen dataclass. Update `WorkerProcess._serve()` and `WorkerProxy.__init__` to use `CredentialContext` for credential context propagation. `WorkerCredentials` remains exported in `wool.__init__`; `CredentialContext` is not exported in `__all__` but is accessible for cross-module use within the runtime package.

Closes #78

## Proposed changes

### Extract `CredentialContext` helper in `auth.py`

Introduce `CredentialContext` — a lightweight context manager that wraps a `WorkerCredentials` instance and manages the `_current` ContextVar. The helper owns `__enter__`/`__exit__` and exposes a `current()` classmethod to retrieve the active credentials. The `_current` ContextVar stays at module level but is only accessed through `CredentialContext`.

Before:

```python
@dataclass(frozen=True)
class WorkerCredentials:
    ca_cert: bytes
    worker_key: bytes
    worker_cert: bytes
    mutual: bool = True
    _token: Token | None = field(default=None, init=False, repr=False, compare=False)

    def __enter__(self) -> WorkerCredentials: ...
    def __exit__(self, *_) -> None: ...

    @classmethod
    def current(cls) -> WorkerCredentials | None: ...
```

After:

```python
@dataclass(frozen=True)
class WorkerCredentials:
    ca_cert: bytes
    worker_key: bytes
    worker_cert: bytes
    mutual: bool = True


class CredentialContext:
    def __init__(self, credentials: WorkerCredentials) -> None: ...
    def __enter__(self) -> CredentialContext: ...
    def __exit__(self, *_) -> None: ...

    @classmethod
    def current(cls) -> WorkerCredentials | None: ...
```

### Update `WorkerProcess._serve()` in `process.py`

Replace `self._credentials` (entering `WorkerCredentials` as a CM) with `CredentialContext(self._credentials)` so the ContextVar is set through the new helper.

### Update `WorkerProxy.__init__` in `proxy.py`

Replace `WorkerCredentials.current()` with `CredentialContext.current()` for resolving credentials from the active context when `credentials=Undefined`. Update the `__reduce__` docstring to remove the stale reference to the removed `WorkerCredentials.current` method.

### Verify `__init__.py` exports

`WorkerCredentials` stays in `__all__`. `CredentialContext` is not exported — it is an implementation detail used across the runtime worker subpackage.

## Test cases

| Test Suite | Test ID | Given | When | Then | Coverage Target |
|------------|---------|-------|------|------|-----------------|
| `TestWorkerCredentials` | CC-001 | A `WorkerCredentials` instance | Used in a `with` statement | It should raise `TypeError` | CM protocol removal |
| `TestWorkerCredentials` | CC-002 | The `WorkerCredentials` class | `WorkerCredentials.current()` is called | It should raise `AttributeError` | `current()` removal |
| `TestWorkerCredentials` | CC-003 | `WorkerCredentials` with valid certs and any mutual flag | Pickled and unpickled | It should produce an equal instance that builds valid gRPC credentials | Pickle roundtrip without `_token` |
| `TestWorkerProxy` | CC-004 | No credential context active | `WorkerProxy` created with `credentials=Undefined` | It should resolve credentials to `None` | Default resolution via `CredentialContext` |
| `TestWorkerProxy` | CC-005 | Explicit `WorkerCredentials` passed | `WorkerProxy` created with explicit credentials | It should use the passed credentials directly | Explicit credential pass-through |
| `TestWorkerProxy` | CC-006 | Explicit `None` passed as credentials | `WorkerProxy` created with `credentials=None` | It should use `None` | Explicit null credentials |

Existing tests `test_current_without_active_context`, `test___enter___sets_current`, `test___exit___resets_current`, and `test___enter___with_nested_contexts` are removed — they test the CM protocol that moves to `CredentialContext`.

## Implementation plan

1. - [x] Write tests CC-001 and CC-002 in `test_auth.py` verifying CM protocol and `current()` removal from `WorkerCredentials`
2. - [x] Extract `CredentialContext` in `auth.py`; remove `__enter__`/`__exit__`/`current()`/`_token` from `WorkerCredentials`
3. - [x] Remove CM-related tests from `test_auth.py` (`test_current_without_active_context`, `test___enter___sets_current`, `test___exit___resets_current`, `test___enter___with_nested_contexts`)
4. - [x] Update `process.py`: wrap credentials in `CredentialContext` in `_serve()`
5. - [x] Update `proxy.py`: replace `WorkerCredentials.current()` with `CredentialContext.current()`; fix stale `__reduce__` docstring
6. - [x] Update credential context setup in `test_proxy.py` and `test_process.py` to use `CredentialContext`
7. - [x] Verify `__init__.py` exports unchanged — `WorkerCredentials` in `__all__`, `CredentialContext` not exported