### PR TITLE
Bypass serialization on self-dispatch while retaining traceability and context propagation — Closes #80

### DIFF
--- a/wool/proto/wire.proto
+++ b/wool/proto/wire.proto
@@ -18,6 +18,7 @@ message Task {
     bytes kwargs = 9;
     int32 timeout = 10;
     optional RuntimeContext context = 11;
+    optional bytes serializer = 12;
 }
 
 // Minimal envelope for pre-deserialization metadata extraction.

--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -21,6 +21,7 @@ from wool.runtime.loadbalancer.base import LoadBalancerLike
 from wool.runtime.loadbalancer.base import NoWorkersAvailable
 from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
 from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.routine.task import Serializer
 from wool.runtime.routine.task import Task
 from wool.runtime.routine.task import TaskException
 from wool.runtime.routine.task import current_task
@@ -52,6 +53,14 @@ __proxy_pool__: Final[ContextVar[ResourcePool[WorkerProxy] | None]] = ContextVar
     "__proxy_pool__", default=None
 )
 
+__worker_metadata__: Final[ContextVar[WorkerMetadata | None]] = ContextVar(
+    "__worker_metadata__", default=None
+)
+
+__worker_service__: Final[ContextVar[WorkerService | None]] = ContextVar(
+    "__worker_service__", default=None
+)
+
 __all__ = [
     # Connection
     "RpcError",
@@ -66,6 +75,7 @@ __all__ = [
     "NoWorkersAvailable",
     "RoundRobinLoadBalancer",
     # Routines
+    "Serializer",
     "Task",
     "TaskException",
     "current_task",

--- a/wool/src/wool/runtime/routine/task.py
+++ b/wool/src/wool/runtime/routine/task.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
+import weakref
 import traceback
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -10,6 +12,7 @@ from dataclasses import dataclass
 from inspect import isasyncgenfunction
 from inspect import iscoroutinefunction
 from types import TracebackType
+from typing import Any
 from typing import AsyncGenerator
 from typing import ContextManager
 from typing import Coroutine
@@ -24,6 +27,7 @@ from typing import cast
 from typing import overload
 from typing import runtime_checkable
 from uuid import UUID
+from uuid import uuid4
 
 import cloudpickle
 
@@ -36,6 +40,87 @@ Kwargs = Dict
 Timeout = SupportsInt
 Routine: TypeAlias = Coroutine | AsyncGenerator
 W = TypeVar("W", bound=Routine)
+
+
+# public
+@runtime_checkable
+class Serializer(Protocol):
+    """Protocol for pluggable serialization of Task payload fields."""
+
+    def dumps(self, obj: Any) -> bytes: ...
+
+    def loads(self, data: bytes) -> Any: ...
+
+
+class _PassthroughKey:
+    """Weak-referenceable key for the passthrough store."""
+
+    __slots__ = ("__weakref__", "token")
+
+    def __init__(self, token: UUID | None = None):
+        self.token = token if token is not None else uuid4()
+
+    def __hash__(self):
+        return hash(self.token)
+
+    def __eq__(self, other):
+        return isinstance(other, _PassthroughKey) and self.token == other.token
+
+
+class PassthroughSerializer:
+    """In-process serializer that avoids pickling entirely.
+
+    Each instance acts as a scope guard for one dispatch.
+    ``dumps`` creates a weakly-referenceable key, stores the object
+    in a module-level :class:`~weakref.WeakKeyDictionary`, and
+    retains a strong reference to the key on ``self``.  When the
+    serializer goes out of scope the keys are garbage-collected and
+    the weak-dict entries are removed automatically.
+
+    ``loads`` is static — it reconstructs the key from the bytes
+    token in the protobuf message and pops the entry from the store.
+
+    All instances hash and compare equal so that
+    ``_pickle_serializer``'s LRU cache hits on every call.
+    """
+
+    def __init__(self):
+        self._keys: list[_PassthroughKey] = []
+
+    def __hash__(self):
+        return hash(PassthroughSerializer)
+
+    def __eq__(self, other):
+        return isinstance(other, PassthroughSerializer)
+
+    def __reduce__(self):
+        return (PassthroughSerializer, ())
+
+    def dumps(self, obj: Any) -> bytes:
+        key = _PassthroughKey()
+        self._keys.append(key)
+        _passthrough_store[key] = obj
+        return key.token.bytes
+
+    @staticmethod
+    def loads(data: bytes) -> Any:
+        key = _PassthroughKey(UUID(bytes=data))
+        return _passthrough_store.pop(key)
+
+
+_passthrough_store: weakref.WeakKeyDictionary[_PassthroughKey, Any] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+@functools.lru_cache(maxsize=8)
+def _pickle_serializer(s: Serializer) -> bytes:
+    return cloudpickle.dumps(s)
+
+
+@functools.lru_cache(maxsize=8)
+def _unpickle_serializer(data: bytes) -> Serializer:
+    return cloudpickle.loads(data)
 
 
 _do_dispatch: ContextVar[bool] = ContextVar("_do_dispatch", default=True)
@@ -209,6 +294,9 @@ class Task(Generic[W]):
     def from_protobuf(cls, task: protocol.Task) -> Task:
         """Deserialize a Task from a protobuf message.
 
+        .. note::
+            The payload's serializer is unpickled and cached for subsequent calls.
+
         :param task:
             A protobuf ``Task`` message.
         :returns:
@@ -219,32 +307,62 @@ class Task(Generic[W]):
             if task.HasField("context")
             else None
         )
+        if task.HasField("serializer"):
+            s = _unpickle_serializer(task.serializer)
+            loads = s.loads
+            if isinstance(s, PassthroughSerializer):
+                proxy_loads = s.loads
+            else:
+                proxy_loads = cloudpickle.loads
+        else:
+            loads = cloudpickle.loads
+            proxy_loads = cloudpickle.loads
         return cls(
             id=UUID(task.id),
-            callable=cloudpickle.loads(task.callable),
-            args=cloudpickle.loads(task.args),
-            kwargs=cloudpickle.loads(task.kwargs),
+            callable=loads(task.callable),
+            args=loads(task.args),
+            kwargs=loads(task.kwargs),
             caller=UUID(task.caller) if task.caller else None,
-            proxy=cloudpickle.loads(task.proxy),
+            proxy=proxy_loads(task.proxy),
             timeout=task.timeout if task.timeout else 0,
             tag=task.tag if task.tag else None,
             context=context,
         )
 
-    def to_protobuf(self) -> protocol.Task:
-        return protocol.Task(
+    def to_protobuf(self, serializer: Serializer | None = None) -> protocol.Task:
+        """Serialize this Task to a protobuf message.
+
+        :param serializer:
+            Optional serializer for the callable and its arguments. When ``None`` (the
+            default), ``cloudpickle`` is used and the protobuf ``serializer`` field is
+            left unset. When provided, the serializer is pickled into the ``serializer``
+            field so that :meth:`from_protobuf` can use it on the receiving side.
+
+            .. note::
+                If specified, the serializer is pickled and cached for subsequent calls.
+        :returns:
+            A protobuf ``Task`` message.
+        """
+        dumps = serializer.dumps if serializer is not None else cloudpickle.dumps
+        proxy_dumps = (
+            dumps if isinstance(serializer, PassthroughSerializer) else cloudpickle.dumps
+        )
+        task_msg = protocol.Task(
             version=protocol.__version__,
             id=str(self.id),
-            callable=cloudpickle.dumps(self.callable),
-            args=cloudpickle.dumps(self.args),
-            kwargs=cloudpickle.dumps(self.kwargs),
+            callable=dumps(self.callable),
+            args=dumps(self.args),
+            kwargs=dumps(self.kwargs),
             caller=str(self.caller) if self.caller else "",
-            proxy=cloudpickle.dumps(self.proxy),
+            proxy=proxy_dumps(self.proxy),
             proxy_id=str(self.proxy.id),
             timeout=int(self.timeout) if self.timeout else 0,
             tag=self.tag if self.tag else "",
             context=self.context.to_protobuf() if self.context else None,
         )
+        if serializer is not None:
+            task_msg.serializer = _pickle_serializer(serializer)
+        return task_msg
 
     def dispatch(self) -> W:
         if isasyncgenfunction(self.callable):

--- a/wool/src/wool/runtime/routine/task.py
+++ b/wool/src/wool/runtime/routine/task.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
-import weakref
 import traceback
+import weakref
 from collections.abc import Callable
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -64,7 +64,9 @@ class _PassthroughKey:
         return hash(self.token)
 
     def __eq__(self, other):
-        return isinstance(other, _PassthroughKey) and self.token == other.token
+        if not isinstance(other, _PassthroughKey):
+            return super().__eq__(other)
+        return self.token == other.token
 
 
 class PassthroughSerializer:
@@ -91,6 +93,10 @@ class PassthroughSerializer:
         return hash(PassthroughSerializer)
 
     def __eq__(self, other):
+        # Required by _pickle_serializer's lru_cache: all instances
+        # share the same hash, so __eq__ must confirm the match for
+        # the cache to hit instead of treating each instance as a
+        # separate key.
         return isinstance(other, PassthroughSerializer)
 
     def __reduce__(self):
@@ -331,6 +337,12 @@ class Task(Generic[W]):
 
     def to_protobuf(self, serializer: Serializer | None = None) -> protocol.Task:
         """Serialize this Task to a protobuf message.
+
+        The serializer itself is pickled via :func:`_pickle_serializer`
+        which uses an LRU cache keyed on the serializer instance.
+        :class:`PassthroughSerializer` instances all hash and compare
+        equal, so repeated calls hit the cache and avoid redundant
+        pickling.
 
         :param serializer:
             Optional serializer for the callable and its arguments. When ``None`` (the

--- a/wool/src/wool/runtime/worker/auth.py
+++ b/wool/src/wool/runtime/worker/auth.py
@@ -186,9 +186,7 @@ class CredentialContext:
 
     def __exit__(self, *_) -> None:
         if self._token is None:
-            raise RuntimeError(
-                "__exit__ called without matching __enter__"
-            )
+            raise RuntimeError("__exit__ called without matching __enter__")
         _current.reset(self._token)
         self._token = None
 

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -367,6 +367,14 @@ class WorkerConnection:
         concurrency limits and applies timeout to the dispatch phase only
         (semaphore acquisition and acknowledgment).
 
+        .. note::
+
+           When dispatching to the current worker process (self-dispatch),
+           a :class:`PassthroughSerializer` is used so the four payload
+           fields (callable, args, kwargs, proxy) are stored in-process
+           instead of being cloudpickled.  The request still travels
+           through gRPC so the full streaming protocol is preserved.
+
         :param task:
             The :class:`Task` instance to dispatch to the worker.
         :param timeout:
@@ -390,24 +398,19 @@ class WorkerConnection:
         if timeout is not None and timeout <= 0:
             raise ValueError("Dispatch timeout must be positive")
 
-        # Self-dispatch optimisation: when dispatching to the current
-        # worker process, use a PassthroughSerializer so the four
-        # payload fields (callable, args, kwargs, proxy) are stored
-        # in-process instead of being cloudpickled.  The request
-        # still travels through gRPC so the full streaming protocol
-        # is preserved.
-        metadata = wool.__worker_metadata__.get()
-        if metadata is not None and metadata.address == self._target:
+        if (
+            metadata := wool.__worker_metadata__.get()
+        ) is not None and metadata.address == self._target:
             serializer = PassthroughSerializer()
-            pb_task = task.to_protobuf(serializer=serializer)
         else:
             serializer = None
-            pb_task = task.to_protobuf()
 
         ch = await _channel_pool.acquire(self._key)
         try:
             try:
-                call = await self._dispatch(ch, pb_task, timeout)
+                call = await self._dispatch(
+                    ch, task.to_protobuf(serializer=serializer), timeout
+                )
             except grpc.RpcError as error:
                 code = error.code()
                 details = error.details() or str(error)
@@ -437,13 +440,18 @@ class WorkerConnection:
         except KeyError:
             pass
 
-    async def _dispatch(self, ch, pb_task, timeout):
+    async def _dispatch(
+        self,
+        channel: _Channel,
+        task_msg: protocol.Task,
+        timeout: float | None,
+    ) -> _DispatchCall:
         async with asyncio.timeout(timeout):
-            await ch.semaphore.acquire()
+            await channel.semaphore.acquire()
             try:
-                call: _DispatchCall = ch.stub.dispatch()
+                call: _DispatchCall = channel.stub.dispatch()
                 try:
-                    request = protocol.Request(task=pb_task)
+                    request = protocol.Request(task=task_msg)
                     await call.write(request)
                     response = await anext(aiter(call))
                     if response.HasField("nack"):
@@ -462,7 +470,7 @@ class WorkerConnection:
                         pass
                     raise
             except (Exception, asyncio.CancelledError):
-                ch.semaphore.release()
+                channel.semaphore.release()
                 raise
         return call
 
@@ -498,4 +506,3 @@ class WorkerConnection:
                 ch.semaphore.release()
         finally:
             await _channel_pool.release(self._key)
-

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -12,8 +12,10 @@ from typing import cast
 import cloudpickle
 import grpc.aio
 
+import wool
 from wool import protocol
 from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.routine.task import PassthroughSerializer
 from wool.runtime.routine.task import Task
 from wool.runtime.worker.base import WorkerOptions
 
@@ -388,10 +390,24 @@ class WorkerConnection:
         if timeout is not None and timeout <= 0:
             raise ValueError("Dispatch timeout must be positive")
 
+        # Self-dispatch optimisation: when dispatching to the current
+        # worker process, use a PassthroughSerializer so the four
+        # payload fields (callable, args, kwargs, proxy) are stored
+        # in-process instead of being cloudpickled.  The request
+        # still travels through gRPC so the full streaming protocol
+        # is preserved.
+        metadata = wool.__worker_metadata__.get()
+        if metadata is not None and metadata.address == self._target:
+            serializer = PassthroughSerializer()
+            pb_task = task.to_protobuf(serializer=serializer)
+        else:
+            serializer = None
+            pb_task = task.to_protobuf()
+
         ch = await _channel_pool.acquire(self._key)
         try:
             try:
-                call = await self._dispatch(ch, task, timeout)
+                call = await self._dispatch(ch, pb_task, timeout)
             except grpc.RpcError as error:
                 code = error.code()
                 details = error.details() or str(error)
@@ -421,13 +437,13 @@ class WorkerConnection:
         except KeyError:
             pass
 
-    async def _dispatch(self, ch, task, timeout):
+    async def _dispatch(self, ch, pb_task, timeout):
         async with asyncio.timeout(timeout):
             await ch.semaphore.acquire()
             try:
                 call: _DispatchCall = ch.stub.dispatch()
                 try:
-                    request = protocol.Request(task=task.to_protobuf())
+                    request = protocol.Request(task=pb_task)
                     await call.write(request)
                     response = await anext(aiter(call))
                     if response.HasField("nack"):
@@ -482,3 +498,4 @@ class WorkerConnection:
                 ch.semaphore.release()
         finally:
             await _channel_pool.release(self._key)
+

--- a/wool/src/wool/runtime/worker/local.py
+++ b/wool/src/wool/runtime/worker/local.py
@@ -7,7 +7,6 @@ from typing import Any
 import grpc.aio
 
 from wool import protocol
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import Worker
 from wool.runtime.worker.base import WorkerOptions
@@ -83,12 +82,15 @@ class LocalWorker(Worker):
         super().__init__(*tags, **extra)
         self._credentials = credentials
         self._worker_process = WorkerProcess(
+            uid=self._uid,
             host=host,
             port=port,
             shutdown_grace_period=shutdown_grace_period,
             proxy_pool_ttl=proxy_pool_ttl,
             credentials=credentials,
             options=options,
+            tags=frozenset(self._tags),
+            extra=MappingProxyType(self._extra),
         )
 
     @property
@@ -114,20 +116,9 @@ class LocalWorker(Worker):
         await loop.run_in_executor(
             None, lambda t: self._worker_process.start(timeout=t), timeout
         )
-        if not self._worker_process.address:
-            raise RuntimeError("Worker process failed to start - no address")
-        if not self._worker_process.pid:
-            raise RuntimeError("Worker process failed to start - no PID")
-
-        self._info = WorkerMetadata(
-            uid=self._uid,
-            address=self._worker_process.address,
-            pid=self._worker_process.pid,
-            version=protocol.__version__,
-            tags=frozenset(self._tags),
-            extra=MappingProxyType(self._extra),
-            secure=self._credentials is not None,
-        )
+        self._info = self._worker_process.metadata
+        if self._info is None:
+            raise RuntimeError("Worker process failed to start - no metadata")
 
     async def _stop(self, timeout: float | None):
         """Stop the worker process and unregister it from the pool.

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -11,7 +11,9 @@ import uuid
 from contextlib import contextmanager
 from functools import partial
 from multiprocessing.connection import Connection
+from types import MappingProxyType
 from typing import TYPE_CHECKING
+from typing import Any
 
 import grpc.aio
 
@@ -64,8 +66,9 @@ class WorkerProcess(Process):
     """
 
     _port: int | None
-    _get_port: Connection
-    _set_port: Connection
+    _get_metadata: Connection
+    _set_metadata: Connection
+    _metadata: WorkerMetadata | None
     _shutdown_grace_period: float
     _proxy_pool_ttl: float
     _credentials: WorkerCredentials | None
@@ -74,12 +77,15 @@ class WorkerProcess(Process):
     def __init__(
         self,
         *args,
+        uid: uuid.UUID | None = None,
         host: str = "127.0.0.1",
         port: int = 0,
         shutdown_grace_period: float = 60.0,
         proxy_pool_ttl: float = 60.0,
         credentials: WorkerCredentials | None = None,
         options: WorkerOptions | None = None,
+        tags: frozenset[str] = frozenset(),
+        extra: MappingProxyType[str, Any] | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -97,16 +103,28 @@ class WorkerProcess(Process):
         self._proxy_pool_ttl = proxy_pool_ttl
         self._credentials = credentials
         self._options = options or WorkerOptions()
-        self._get_port, self._set_port = Pipe(duplex=False)
+        self._uid = uid if uid is not None else uuid.uuid4()
+        self._tags = tags
+        self._extra = extra if extra is not None else MappingProxyType({})
+        self._metadata = None
+        self._get_metadata, self._set_metadata = Pipe(duplex=False)
 
     @property
     def address(self) -> str | None:
         """The network address where the gRPC server is listening.
 
+        After :meth:`start`, the address comes from the
+        :class:`WorkerMetadata` returned by the child process.
+        Before start, returns ``host:port`` when a fixed port was
+        given, or ``None`` when port is 0 (random).
+
         :returns:
-            The address in "host:port" format, or None if not started.
+            The address in "host:port" format, or None if not started
+            and port is 0.
         """
-        return self._address(self._host, self._port) if self._port else None
+        if self._metadata is not None:
+            return self._metadata.address
+        return None
 
     @property
     def host(self) -> str | None:
@@ -126,12 +144,22 @@ class WorkerProcess(Process):
         """
         return self._port or None
 
+    @property
+    def metadata(self) -> WorkerMetadata | None:
+        """The worker metadata received from the child process.
+
+        :returns:
+            :class:`WorkerMetadata` once started, or ``None``.
+        """
+        return self._metadata
+
     def start(self, *, timeout: float | None = None):
         """Start the worker process.
 
-        Launches the worker process and waits until it has started
-        listening on a port. After starting, the :attr:`address`
-        property will contain the actual network address.
+        Launches the worker process and waits until it has reported
+        its :class:`WorkerMetadata` back via pipe. After starting,
+        the :attr:`metadata` and :attr:`address` properties are
+        populated.
 
         :param timeout:
             Maximum time in seconds to wait for worker process startup.
@@ -153,7 +181,7 @@ class WorkerProcess(Process):
             raise RuntimeError(
                 f"Worker process failed to start within {timeout} seconds"
             )
-        self._get_port.close()
+        self._get_metadata.close()
 
     def run(self) -> None:
         """Run the worker process.
@@ -225,22 +253,22 @@ class WorkerProcess(Process):
                     await server.start()
                     logger.info(f"Worker gRPC server started on port {port}")
 
-                    # Publish worker identity for self-dispatch detection
-                    wool.__worker_metadata__.set(
-                        WorkerMetadata(
-                            uid=uuid.uuid4(),
-                            address=self._address(self._host, port),
-                            pid=os.getpid(),
-                            version=protocol.__version__,
-                            secure=self._credentials is not None,
-                        )
+                    metadata = WorkerMetadata(
+                        uid=self._uid,
+                        address=self._address(self._host, port),
+                        pid=os.getpid(),
+                        version=protocol.__version__,
+                        tags=self._tags,
+                        extra=self._extra,
+                        secure=self._credentials is not None,
                     )
+                    wool.__worker_metadata__.set(metadata)
                     wool.__worker_service__.set(service)
 
                     try:
-                        self._set_port.send(port)
+                        self._set_metadata.send(metadata)
                     finally:
-                        self._set_port.close()
+                        self._set_metadata.close()
                     await service.stopped.wait()
                     logger.info("Worker service stopped, shutting down server")
                 except Exception as e:

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -4,8 +4,10 @@ import asyncio
 import contextlib
 import logging
 import multiprocessing as _mp
+import os
 import signal
 import sys
+import uuid
 from contextlib import contextmanager
 from functools import partial
 from multiprocessing.connection import Connection
@@ -15,9 +17,10 @@ import grpc.aio
 
 import wool
 from wool import protocol
+from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.resourcepool import ResourcePool
-from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.auth import CredentialContext
+from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.interceptor import VersionInterceptor
 from wool.runtime.worker.service import WorkerService
@@ -140,8 +143,10 @@ class WorkerProcess(Process):
         if timeout is not None and timeout <= 0:
             raise ValueError("Timeout must be positive")
         super().start()
-        if self._get_port.poll(timeout=timeout):
-            self._port = self._get_port.recv()
+        if self._get_metadata.poll(timeout=timeout):
+            self._metadata = self._get_metadata.recv()
+            assert self._metadata is not None
+            self._port = int(self._metadata.address.rsplit(":", 1)[1])
         else:
             self.terminate()
             self.join()
@@ -219,6 +224,19 @@ class WorkerProcess(Process):
                 try:
                     await server.start()
                     logger.info(f"Worker gRPC server started on port {port}")
+
+                    # Publish worker identity for self-dispatch detection
+                    wool.__worker_metadata__.set(
+                        WorkerMetadata(
+                            uid=uuid.uuid4(),
+                            address=self._address(self._host, port),
+                            pid=os.getpid(),
+                            version=protocol.__version__,
+                            secure=self._credentials is not None,
+                        )
+                    )
+                    wool.__worker_service__.set(service)
+
                     try:
                         self._set_port.send(port)
                     finally:

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -29,8 +29,8 @@ from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
 from wool.runtime.typing import Factory
 from wool.runtime.typing import Undefined
 from wool.runtime.typing import UndefinedType
-from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.auth import CredentialContext
+from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.connection import WorkerConnection
 

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -1196,8 +1196,12 @@ class TestLocalDiscoverySubscriber:
             subscriber_b = discovery_b.subscribe(poll_interval=0.05)
 
             async with publisher_a, publisher_b:
-                task_a = asyncio.create_task(collect(subscriber_a, events_a, received_a, started_a))
-                task_b = asyncio.create_task(collect(subscriber_b, events_b, received_b, started_b))
+                task_a = asyncio.create_task(
+                    collect(subscriber_a, events_a, received_a, started_a)
+                )
+                task_b = asyncio.create_task(
+                    collect(subscriber_b, events_b, received_b, started_b)
+                )
                 await asyncio.gather(started_a.wait(), started_b.wait())
 
                 # Act
@@ -1260,8 +1264,12 @@ class TestLocalDiscoverySubscriber:
             subscriber_2 = discovery.subscribe(poll_interval=0.05)
 
             async with publisher:
-                task_1 = asyncio.create_task(collect(subscriber_1, events_1, received_1, started_1))
-                task_2 = asyncio.create_task(collect(subscriber_2, events_2, received_2, started_2))
+                task_1 = asyncio.create_task(
+                    collect(subscriber_1, events_1, received_1, started_1)
+                )
+                task_2 = asyncio.create_task(
+                    collect(subscriber_2, events_2, received_2, started_2)
+                )
                 await asyncio.gather(started_1.wait(), started_2.wait())
 
                 # Act

--- a/wool/tests/runtime/routine/test_task.py
+++ b/wool/tests/runtime/routine/test_task.py
@@ -13,6 +13,8 @@ from hypothesis import strategies as st
 from wool import protocol
 from wool.runtime.context import RuntimeContext
 from wool.runtime.context import dispatch_timeout
+from wool.runtime.routine.task import PassthroughSerializer
+from wool.runtime.routine.task import Serializer
 from wool.runtime.routine.task import Task
 from wool.runtime.routine.task import TaskException
 from wool.runtime.routine.task import WorkerProxyLike
@@ -31,9 +33,6 @@ class _PicklableProxy:
             yield "result"
 
         return _stream()
-
-
-# --- Protocol conformance test classes ---
 
 
 class TestWorkerProxyLike:
@@ -106,9 +105,6 @@ class TestWorkerProxyLike:
             )
 
 
-# --- Module-level do_dispatch tests ---
-
-
 def test_do_dispatch_with_default_context():
     """Test do_dispatch returns True with no active context.
 
@@ -159,9 +155,6 @@ def test_do_dispatch_with_nested_contexts():
             assert do_dispatch() is False
         assert do_dispatch() is True
     assert do_dispatch() is True
-
-
-# --- Module-level current_task tests ---
 
 
 @pytest.mark.asyncio
@@ -271,9 +264,6 @@ async def test_current_task_with_variable_nesting_depth(depth, sample_task):
 
     # After exiting all contexts, current_task should be None
     assert current_task() is None
-
-
-# --- TestTask ---
 
 
 class TestTask:
@@ -564,8 +554,8 @@ class TestTask:
         )
 
         # Act
-        pb_task = original_task.to_protobuf()
-        deserialized_task = Task.from_protobuf(pb_task)
+        task_msg = original_task.to_protobuf()
+        deserialized_task = Task.from_protobuf(task_msg)
 
         # Assert
         assert deserialized_task.id == original_task.id
@@ -644,7 +634,7 @@ class TestTask:
         args = (1, 2, 3)
         kwargs = {"key": "value"}
 
-        pb_task = protocol.Task(
+        task_msg = protocol.Task(
             version="0.1.0",
             id=str(task_id),
             callable=cloudpickle.dumps(sample_async_callable),
@@ -658,7 +648,7 @@ class TestTask:
         )
 
         # Act
-        task = Task.from_protobuf(pb_task)
+        task = Task.from_protobuf(task_msg)
 
         # Assert
         assert task.id == task_id
@@ -690,7 +680,7 @@ class TestTask:
         args = ()
         kwargs = {}
 
-        pb_task = protocol.Task(
+        task_msg = protocol.Task(
             id=str(task_id),
             callable=cloudpickle.dumps(sample_async_callable),
             args=cloudpickle.dumps(args),
@@ -703,7 +693,7 @@ class TestTask:
         )
 
         # Act
-        task = Task.from_protobuf(pb_task)
+        task = Task.from_protobuf(task_msg)
 
         # Assert
         assert task.id == task_id
@@ -737,22 +727,22 @@ class TestTask:
         )
 
         # Act
-        pb_task = task.to_protobuf()
+        task_msg = task.to_protobuf()
 
         # Assert
-        assert pb_task.version != ""
-        assert pb_task.id == str(task.id)
-        deserialized_callable = cloudpickle.loads(pb_task.callable)
+        assert task_msg.version != ""
+        assert task_msg.id == str(task.id)
+        deserialized_callable = cloudpickle.loads(task_msg.callable)
         assert callable(deserialized_callable)
         assert deserialized_callable.__name__ == task.callable.__name__
-        assert cloudpickle.loads(pb_task.args) == task.args
-        assert cloudpickle.loads(pb_task.kwargs) == task.kwargs
-        assert pb_task.caller == str(caller_id)
-        deserialized_proxy = cloudpickle.loads(pb_task.proxy)
+        assert cloudpickle.loads(task_msg.args) == task.args
+        assert cloudpickle.loads(task_msg.kwargs) == task.kwargs
+        assert task_msg.caller == str(caller_id)
+        deserialized_proxy = cloudpickle.loads(task_msg.proxy)
         assert deserialized_proxy.id == task.proxy.id
-        assert pb_task.proxy_id == str(task.proxy.id)
-        assert pb_task.timeout == 30
-        assert pb_task.tag == "test_tag"
+        assert task_msg.proxy_id == str(task.proxy.id)
+        assert task_msg.timeout == 30
+        assert task_msg.tag == "test_tag"
 
     def test_to_protobuf_none_optionals(self, sample_async_callable, picklable_proxy):
         """Test to_protobuf serializes None optionals as defaults.
@@ -779,12 +769,12 @@ class TestTask:
         )
 
         # Act
-        pb_task = task.to_protobuf()
+        task_msg = task.to_protobuf()
 
         # Assert
-        assert pb_task.caller == ""
-        assert pb_task.timeout == 0
-        assert pb_task.tag == ""
+        assert task_msg.caller == ""
+        assert task_msg.timeout == 0
+        assert task_msg.tag == ""
 
     def test_to_protobuf_with_version_field(
         self, sample_async_callable, picklable_proxy
@@ -809,10 +799,10 @@ class TestTask:
         )
 
         # Act
-        pb_task = task.to_protobuf()
+        task_msg = task.to_protobuf()
 
         # Assert
-        assert pb_task.version == protocol.__version__
+        assert task_msg.version == protocol.__version__
 
     def test_to_protobuf_includes_runtime_context(
         self, sample_async_callable, picklable_proxy
@@ -838,11 +828,11 @@ class TestTask:
             )
 
         # Act
-        pb_task = task.to_protobuf()
+        task_msg = task.to_protobuf()
 
         # Assert
-        assert pb_task.HasField("context")
-        assert pb_task.context.dispatch_timeout == 7.5
+        assert task_msg.HasField("context")
+        assert task_msg.context.dispatch_timeout == 7.5
 
     def test_from_protobuf_restores_runtime_context(
         self, sample_async_callable, picklable_proxy
@@ -859,7 +849,7 @@ class TestTask:
             carrying dispatch_timeout=12.0
         """
         # Arrange
-        pb_task = protocol.Task(
+        task_msg = protocol.Task(
             version="0.1.0",
             id=str(uuid4()),
             callable=cloudpickle.dumps(sample_async_callable),
@@ -874,7 +864,7 @@ class TestTask:
         )
 
         # Act
-        task = Task.from_protobuf(pb_task)
+        task = Task.from_protobuf(task_msg)
 
         # Assert
         assert task.context is not None
@@ -896,7 +886,7 @@ class TestTask:
             (dispatch_timeout=None)
         """
         # Arrange
-        pb_task = protocol.Task(
+        task_msg = protocol.Task(
             version="0.1.0",
             id=str(uuid4()),
             callable=cloudpickle.dumps(sample_async_callable),
@@ -910,7 +900,7 @@ class TestTask:
         )
 
         # Act
-        task = Task.from_protobuf(pb_task)
+        task = Task.from_protobuf(task_msg)
 
         # Assert
         assert task.context is not None
@@ -971,7 +961,7 @@ class TestTask:
         async def test_callable():
             return "result"
 
-        pb_task = protocol.Task(
+        task_msg = protocol.Task(
             version=version,
             id=str(uuid4()),
             callable=cloudpickle.dumps(test_callable),
@@ -985,7 +975,7 @@ class TestTask:
         )
 
         # Act
-        wire_bytes = pb_task.SerializeToString()
+        wire_bytes = task_msg.SerializeToString()
         parsed = protocol.Task()
         parsed.ParseFromString(wire_bytes)
 
@@ -1472,8 +1462,292 @@ class TestTask:
         assert observed_timeout is not sentinel
         assert observed_timeout is None
 
+    def test_to_protobuf_without_serializer(
+        self, sample_async_callable, picklable_proxy
+    ):
+        """Test to_protobuf without serializer omits the serializer field.
 
-# --- TestTaskException ---
+        Given:
+            A Task instance
+        When:
+            ``to_protobuf()`` is called with no serializer argument
+        Then:
+            It should not set the ``serializer`` field on the
+            protobuf message
+        """
+        # Arrange
+        task = Task(
+            id=uuid4(),
+            callable=sample_async_callable,
+            args=(),
+            kwargs={},
+            proxy=picklable_proxy,
+        )
+
+        # Act
+        task_msg = task.to_protobuf()
+
+        # Assert
+        assert not task_msg.HasField("serializer")
+
+    def test_to_protobuf_with_serializer(self, sample_async_callable, picklable_proxy):
+        """Test to_protobuf with serializer sets the serializer field.
+
+        Given:
+            A Task instance and a PassthroughSerializer
+        When:
+            ``to_protobuf(serializer=...)`` is called
+        Then:
+            It should set the ``serializer`` field on the protobuf
+            message
+        """
+        # Arrange
+        task = Task(
+            id=uuid4(),
+            callable=sample_async_callable,
+            args=(),
+            kwargs={},
+            proxy=picklable_proxy,
+        )
+        serializer = PassthroughSerializer()
+
+        # Act
+        task_msg = task.to_protobuf(serializer=serializer)
+
+        # Assert
+        assert task_msg.HasField("serializer")
+
+    def test_from_protobuf_without_serializer_field(
+        self, sample_async_callable, picklable_proxy
+    ):
+        """Test from_protobuf without serializer field uses cloudpickle.
+
+        Given:
+            A protobuf Task with no serializer field (standard
+            cloudpickle encoding)
+        When:
+            ``from_protobuf()`` is called
+        Then:
+            It should deserialize all fields correctly using
+            cloudpickle
+        """
+        # Arrange
+        task_id = uuid4()
+        args = (1, 2, 3)
+        kwargs = {"key": "value"}
+
+        task_msg = protocol.Task(
+            version="0.1.0",
+            id=str(task_id),
+            callable=cloudpickle.dumps(sample_async_callable),
+            args=cloudpickle.dumps(args),
+            kwargs=cloudpickle.dumps(kwargs),
+            caller="",
+            proxy=cloudpickle.dumps(picklable_proxy),
+            proxy_id=str(picklable_proxy.id),
+            timeout=0,
+            tag="",
+        )
+
+        # Act
+        task = Task.from_protobuf(task_msg)
+
+        # Assert
+        assert task.id == task_id
+        assert task.args == args
+        assert task.kwargs == kwargs
+
+    @settings(max_examples=50, deadline=None)
+    @given(
+        task_id=st.uuids(),
+        timeout=st.integers(min_value=0, max_value=3600),
+        caller_id=st.one_of(st.none(), st.uuids()),
+        tag=st.one_of(st.none(), st.text(min_size=1, max_size=100)),
+    )
+    @pytest.mark.asyncio
+    async def test_from_protobuf_with_passthrough_serializer(
+        self,
+        task_id,
+        timeout,
+        caller_id,
+        tag,
+    ):
+        """Test from_protobuf restores identity with PassthroughSerializer.
+
+        Given:
+            A Task serialized via ``to_protobuf(serializer=...)``
+            with a PassthroughSerializer
+        When:
+            ``from_protobuf()`` is called on the resulting message
+        Then:
+            It should produce a deserialized task equal to the
+            original in all public attributes, and the protobuf
+            ``serializer`` field should be present
+        """
+
+        # Arrange
+        async def test_callable():
+            return "result"
+
+        proxy = _PicklableProxy()
+        args = (1, "test", [1, 2, 3])
+        kwargs = {"key": "value", "number": 42}
+
+        original_task = Task(
+            id=task_id,
+            callable=test_callable,
+            args=args,
+            kwargs=kwargs,
+            proxy=proxy,
+            timeout=timeout,
+            caller=caller_id,
+            tag=tag,
+        )
+        serializer = PassthroughSerializer()
+        task_msg = original_task.to_protobuf(serializer=serializer)
+
+        # Act
+        deserialized_task = Task.from_protobuf(task_msg)
+
+        # Assert
+        assert task_msg.HasField("serializer")
+        assert deserialized_task.id == original_task.id
+        assert deserialized_task.callable is original_task.callable
+        assert deserialized_task.args is original_task.args
+        assert deserialized_task.kwargs is original_task.kwargs
+        assert deserialized_task.caller == original_task.caller
+        assert deserialized_task.proxy is original_task.proxy
+        assert deserialized_task.timeout == original_task.timeout
+        assert deserialized_task.tag == original_task.tag
+
+
+class TestPassthroughSerializer:
+    """Tests for :py:class:`PassthroughSerializer`."""
+
+    def test_dumps_with_object(self):
+        """Test dumps returns a 16-byte token.
+
+        Given:
+            An arbitrary Python object
+        When:
+            ``dumps`` is called
+        Then:
+            It should return a 16-byte bytes token
+        """
+        # Arrange
+        serializer = PassthroughSerializer()
+        obj = {"key": [1, 2, 3]}
+
+        # Act
+        data = serializer.dumps(obj)
+
+        # Assert
+        assert isinstance(data, bytes)
+        assert len(data) == 16
+
+    def test_dumps_with_distinct_objects(self):
+        """Test dumps returns unique tokens for distinct objects.
+
+        Given:
+            Two distinct Python objects
+        When:
+            ``dumps`` is called on each
+        Then:
+            It should return different tokens for each object
+        """
+        # Arrange
+        serializer = PassthroughSerializer()
+        obj_a = "alpha"
+        obj_b = "beta"
+
+        # Act
+        token_a = serializer.dumps(obj_a)
+        token_b = serializer.dumps(obj_b)
+
+        # Assert
+        assert token_a != token_b
+
+    def test_loads_with_stored_object(self):
+        """Test loads retrieves the original object by identity.
+
+        Given:
+            An arbitrary Python object stored via ``dumps``
+        When:
+            ``loads`` is called with the returned token
+        Then:
+            It should return the exact same object (identity, not
+            equality)
+        """
+        # Arrange
+        serializer = PassthroughSerializer()
+        obj = {"key": [1, 2, 3]}
+        data = serializer.dumps(obj)
+
+        # Act
+        result = serializer.loads(data)
+
+        # Assert
+        assert result is obj
+
+    def test_loads_after_prior_consumption(self):
+        """Test loads consumes the stored entry.
+
+        Given:
+            An object serialized via ``dumps``
+        When:
+            ``loads`` is called twice with the same data
+        Then:
+            It should raise ``KeyError`` on the second call because
+            the entry was consumed
+        """
+        # Arrange
+        serializer = PassthroughSerializer()
+        data = serializer.dumps("ephemeral")
+
+        # Act
+        serializer.loads(data)
+
+        # Act & assert
+        with pytest.raises(KeyError):
+            serializer.loads(data)
+
+    def test_isinstance_with_serializer_protocol(self):
+        """Test PassthroughSerializer satisfies the Serializer protocol.
+
+        Given:
+            A PassthroughSerializer instance
+        When:
+            Checked against the Serializer protocol via isinstance
+        Then:
+            It should be recognized as a Serializer
+        """
+        # Arrange & act
+        serializer = PassthroughSerializer()
+
+        # Assert
+        assert isinstance(serializer, Serializer)
+
+    def test_cloudpickle_roundtrip(self):
+        """Test PassthroughSerializer survives cloudpickle serialization.
+
+        Given:
+            A PassthroughSerializer instance
+        When:
+            Serialized and deserialized via cloudpickle
+        Then:
+            It should produce a functional PassthroughSerializer
+        """
+        # Arrange
+        original = PassthroughSerializer()
+
+        # Act
+        restored = cloudpickle.loads(cloudpickle.dumps(original))
+        obj = {"test": True}
+        data = restored.dumps(obj)
+        result = restored.loads(data)
+
+        # Assert
+        assert result is obj
 
 
 class TestTaskException:

--- a/wool/tests/runtime/routine/test_wrapper.py
+++ b/wool/tests/runtime/routine/test_wrapper.py
@@ -357,7 +357,6 @@ async def test_routine_with_various_arguments(
         mock_proxy_context.dispatch.assert_called_once()
 
 
-
 @pytest.mark.asyncio
 async def test_routine_with_empty_stream(
     mocker: MockerFixture,

--- a/wool/tests/runtime/worker/conftest.py
+++ b/wool/tests/runtime/worker/conftest.py
@@ -66,6 +66,23 @@ def _clear_proxy_context():
     wool.__proxy_pool__.reset(pool_token)
 
 
+@pytest.fixture(autouse=True)
+def _clear_worker_context():
+    """Reset worker identity context vars between tests.
+
+    Prevents ContextVar leakage from tests that set
+    ``wool.__worker_metadata__`` or ``wool.__worker_service__``
+    for self-dispatch testing.
+    """
+    import wool
+
+    meta_token = wool.__worker_metadata__.set(None)
+    svc_token = wool.__worker_service__.set(None)
+    yield
+    wool.__worker_metadata__.reset(meta_token)
+    wool.__worker_service__.reset(svc_token)
+
+
 @pytest.fixture
 def metadata():
     """Provides sample WorkerMetadata for testing.

--- a/wool/tests/runtime/worker/test_auth.py
+++ b/wool/tests/runtime/worker/test_auth.py
@@ -605,4 +605,3 @@ class TestWorkerCredentials:
         # Act & assert
         with pytest.raises(AttributeError):
             WorkerCredentials.current()
-

--- a/wool/tests/runtime/worker/test_connection.py
+++ b/wool/tests/runtime/worker/test_connection.py
@@ -12,6 +12,7 @@ from hypothesis import settings
 from hypothesis import strategies as st
 from pytest_mock import MockerFixture
 
+import wool
 from wool import protocol
 from wool.runtime.routine.task import Task
 from wool.runtime.routine.task import WorkerProxyLike
@@ -1168,3 +1169,150 @@ class TestWorkerConnection:
             "grpc.max_send_message_length",
             50 * 1024 * 1024,
         ) in call_options
+
+    @pytest.mark.asyncio
+    async def test_dispatch_with_self_dispatch(
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+    ):
+        """Test self-dispatch sends protobuf with serializer field set.
+
+        Given:
+            A WorkerConnection whose target matches the current
+            worker's address
+        When:
+            dispatch() is called
+        Then:
+            It should set the serializer field on the protobuf
+            Task and not call cloudpickle.dumps for payload fields
+        """
+        # Arrange
+        target = "localhost:50051"
+        wool.__worker_metadata__.set(
+            wool.WorkerMetadata(
+                uid=uuid4(),
+                address=target,
+                pid=1,
+                version="1.0.0",
+            )
+        )
+
+        responses = (
+            protocol.Response(ack=protocol.Ack()),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("result"))),
+        )
+        mock_call = mock_grpc_call(async_stream(responses))
+
+        mock_stub = mocker.MagicMock()
+        mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+
+        spy = mocker.patch.object(cloudpickle, "dumps", wraps=cloudpickle.dumps)
+
+        connection = WorkerConnection(target)
+
+        # Act
+        results = []
+        async for result in await connection.dispatch(sample_task):
+            results.append(result)
+
+        # Assert
+        assert results == ["result"]
+        first_write = mock_call.write.call_args_list[0][0][0]
+        assert first_write.task.HasField("serializer")
+        pickled_objects = [c.args[0] for c in spy.call_args_list]
+        assert sample_task.callable not in pickled_objects
+        assert sample_task.args not in pickled_objects
+        assert sample_task.proxy not in pickled_objects
+
+    @pytest.mark.asyncio
+    async def test_dispatch_with_address_mismatch(
+        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+    ):
+        """Test dispatch uses cloudpickle when addresses do not match.
+
+        Given:
+            A WorkerConnection whose target differs from the current
+            worker's address
+        When:
+            dispatch() is called
+        Then:
+            It should use cloudpickle and not set the serializer
+            field
+        """
+        # Arrange
+        wool.__worker_metadata__.set(
+            wool.WorkerMetadata(
+                uid=uuid4(),
+                address="10.0.0.1:50051",
+                pid=1,
+                version="1.0.0",
+            )
+        )
+
+        responses = (
+            protocol.Response(ack=protocol.Ack()),
+            protocol.Response(
+                result=protocol.Message(dump=cloudpickle.dumps("grpc_result"))
+            ),
+        )
+        mock_call = mock_grpc_call(async_stream(responses))
+
+        mock_stub = mocker.MagicMock()
+        mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+
+        connection = WorkerConnection("localhost:50051")
+
+        # Act
+        results = []
+        async for result in await connection.dispatch(sample_task):
+            results.append(result)
+
+        # Assert
+        assert results == ["grpc_result"]
+        first_write = mock_call.write.call_args_list[0][0][0]
+        assert not first_write.task.HasField("serializer")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_without_worker_metadata(
+        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+    ):
+        """Test dispatch uses cloudpickle when not in a worker process.
+
+        Given:
+            A WorkerConnection and no worker metadata set
+            (non-worker process)
+        When:
+            dispatch() is called
+        Then:
+            It should use cloudpickle and not set the serializer
+            field
+        """
+        # Arrange
+        responses = (
+            protocol.Response(ack=protocol.Ack()),
+            protocol.Response(
+                result=protocol.Message(dump=cloudpickle.dumps("grpc_result"))
+            ),
+        )
+        mock_call = mock_grpc_call(async_stream(responses))
+
+        mock_stub = mocker.MagicMock()
+        mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+
+        connection = WorkerConnection("localhost:50051")
+
+        # Act
+        results = []
+        async for result in await connection.dispatch(sample_task):
+            results.append(result)
+
+        # Assert
+        assert results == ["grpc_result"]
+        first_write = mock_call.write.call_args_list[0][0][0]
+        assert not first_write.task.HasField("serializer")

--- a/wool/tests/runtime/worker/test_local.py
+++ b/wool/tests/runtime/worker/test_local.py
@@ -1,15 +1,29 @@
+from uuid import uuid4
+
 import grpc.aio
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
 from wool import protocol
+from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.worker import local as local_module
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerLike
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.local import LocalWorker
 from wool.runtime.worker.process import WorkerProcess
+
+
+def _make_metadata(address="127.0.0.1:50051", pid=12345, secure=False) -> WorkerMetadata:
+    """Build a minimal WorkerMetadata for mock processes."""
+    return WorkerMetadata(
+        uid=uuid4(),
+        address=address,
+        pid=pid,
+        version="1.0.0",
+        secure=secure,
+    )
 
 
 class TestLocalWorker:
@@ -193,7 +207,7 @@ class TestLocalWorker:
         # Arrange
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = _make_metadata()
         mock_process.start.return_value = None
 
         mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
@@ -220,7 +234,7 @@ class TestLocalWorker:
         # Arrange
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = _make_metadata()
         mock_process.start.return_value = None
 
         mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
@@ -234,20 +248,31 @@ class TestLocalWorker:
         mock_process.start.assert_called_once_with(timeout=60.0)
 
     @pytest.mark.asyncio
-    async def test_start_creates_metadata(self, mocker):
-        """Test _start method creates WorkerMetadata.
+    async def test_start_uses_metadata_from_process(self, mocker):
+        """Test _start method uses WorkerMetadata from the process.
 
         Given:
             A LocalWorker with tags and extra metadata
         When:
             start() is called
         Then:
-            It should create WorkerMetadata with correct data
+            It should use the WorkerMetadata returned by the process
         """
         # Arrange
+        from types import MappingProxyType
+
+        from wool.runtime.discovery.base import WorkerMetadata
+
+        expected_metadata = WorkerMetadata(
+            uid=uuid4(),
+            address="192.168.1.100:50051",
+            pid=12345,
+            version="1.0.0",
+            tags=frozenset({"gpu", "ml"}),
+            extra=MappingProxyType({"region": "us-west"}),
+        )
         mock_process = mocker.MagicMock(spec=WorkerProcess)
-        mock_process.address = "192.168.1.100:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = expected_metadata
         mock_process.start.return_value = None
 
         mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
@@ -258,20 +283,15 @@ class TestLocalWorker:
         await worker.start()
 
         # Assert
-        assert worker.metadata is not None
-        assert worker.metadata.uid == worker.uid
-        assert worker.metadata.address == "192.168.1.100:50051"
-        assert worker.metadata.pid == 12345
-        assert "gpu" in worker.metadata.tags
-        assert "ml" in worker.metadata.tags
-        assert worker.metadata.extra["region"] == "us-west"
+        assert worker.metadata is expected_metadata
 
     @pytest.mark.asyncio
-    async def test_start_raises_error_if_no_address(self, mocker):
-        """Test _start raises error if WorkerProcess has no address.
+    async def test_start_raises_error_if_no_metadata(self, mocker):
+        """Test _start raises error if WorkerProcess has no metadata.
 
         Given:
-            A LocalWorker where WorkerProcess.start doesn't set address
+            A LocalWorker where WorkerProcess.start does not
+            populate metadata
         When:
             start() is called
         Then:
@@ -279,8 +299,7 @@ class TestLocalWorker:
         """
         # Arrange
         mock_process = mocker.MagicMock(spec=WorkerProcess)
-        mock_process.address = None
-        mock_process.pid = 12345
+        mock_process.metadata = None
         mock_process.start.return_value = None
 
         mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
@@ -288,32 +307,7 @@ class TestLocalWorker:
         worker = LocalWorker()
 
         # Act & assert
-        with pytest.raises(RuntimeError, match="no address"):
-            await worker.start()
-
-    @pytest.mark.asyncio
-    async def test_start_raises_error_if_no_pid(self, mocker):
-        """Test _start raises error if WorkerProcess has no PID.
-
-        Given:
-            A LocalWorker where WorkerProcess.start doesn't set PID
-        When:
-            start() is called
-        Then:
-            It should raise RuntimeError
-        """
-        # Arrange
-        mock_process = mocker.MagicMock(spec=WorkerProcess)
-        mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = None
-        mock_process.start.return_value = None
-
-        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
-
-        worker = LocalWorker()
-
-        # Act & assert
-        with pytest.raises(RuntimeError, match="no PID"):
+        with pytest.raises(RuntimeError, match="no metadata"):
             await worker.start()
 
     @pytest.mark.asyncio
@@ -328,9 +322,13 @@ class TestLocalWorker:
             It should correctly parse host and port
         """
         # Arrange
+        from types import MappingProxyType
+
+        from wool.runtime.discovery.base import WorkerMetadata
+
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "0.0.0.0:8080"
-        mock_process.pid = 99999
+        mock_process.metadata = _make_metadata(address="0.0.0.0:8080", pid=99999)
         mock_process.start.return_value = None
 
         mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
@@ -357,7 +355,7 @@ class TestLocalWorker:
         # Arrange
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = _make_metadata()
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = True
 
@@ -393,7 +391,7 @@ class TestLocalWorker:
         # Arrange
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = _make_metadata()
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = False
 
@@ -424,7 +422,7 @@ class TestLocalWorker:
         # Arrange
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = _make_metadata()
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = True
 
@@ -492,7 +490,7 @@ class TestLocalWorker:
         # Arrange
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = _make_metadata(secure=True)
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = False
 
@@ -520,7 +518,7 @@ class TestLocalWorker:
         # Arrange
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = _make_metadata()
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = False
 
@@ -550,7 +548,7 @@ class TestLocalWorker:
         # Arrange
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = _make_metadata()
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = True
 
@@ -590,7 +588,7 @@ class TestLocalWorker:
         # Arrange
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = _make_metadata()
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = True
 
@@ -628,7 +626,7 @@ class TestLocalWorker:
         # Arrange
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = _make_metadata()
         mock_process.start.return_value = None
         mock_process.is_alive.return_value = True
 
@@ -677,7 +675,7 @@ class TestLocalWorker:
 
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "127.0.0.1:50051"
-        mock_process.pid = 12345
+        mock_process.metadata = _make_metadata()
         mock_process.start.return_value = None
         mock_process.is_alive.side_effect = [True, False]
 

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -1,4 +1,5 @@
 import signal
+import uuid
 
 import grpc
 import grpc.aio
@@ -8,9 +9,10 @@ from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
 
+from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.worker import process as process_module
-from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.auth import CredentialContext
+from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.process import WorkerProcess
 from wool.runtime.worker.process import _proxy_factory
@@ -247,7 +249,7 @@ class TestWorkerProcess:
         # Assert
         assert process.host == "0.0.0.0"
         assert process.port == 8080
-        assert process.address == "0.0.0.0:8080"
+        assert process.address is None
 
     @given(
         grace_period=st.floats(min_value=0.1, max_value=300.0),
@@ -360,21 +362,21 @@ class TestWorkerProcess:
         # Act & assert
         assert process.address is None
 
-    def test_address_returns_formatted_string_when_port_is_set(self):
-        """Test address property returns formatted string when port is set.
+    def test_address_before_start(self):
+        """Test address property returns None before start.
 
         Given:
-            A WorkerProcess with a non-zero port
+            A WorkerProcess that has not been started
         When:
             The address property is accessed
         Then:
-            It should return formatted "host:port" string
+            It should return None regardless of configured port
         """
         # Arrange
         process = WorkerProcess(host="192.168.1.100", port=50051)
 
         # Act & assert
-        assert process.address == "192.168.1.100:50051"
+        assert process.address is None
 
     def test_host_returns_configured_host(self):
         """Test host property returns the configured host.
@@ -440,40 +442,7 @@ class TestWorkerProcess:
 
         # Assert
         assert process.port == port
-        assert process.address and f":{port}" in process.address
-
-    @given(
-        host=st.one_of(
-            st.ip_addresses(v=4).map(str),
-            st.from_regex(
-                r"^[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]{0,61}[a-z0-9])?)*$",
-                fullmatch=True,
-            ),
-        ),
-        port=st.integers(min_value=1, max_value=65535),
-    )
-    def test_address_parsing_roundtrip(self, host, port):
-        """Test address formatting and parsing is reversible.
-
-        Given:
-            Random valid host and port combinations
-        When:
-            Address is formatted via WorkerProcess
-        Then:
-            Parsing the address should recover original host and port
-        """
-        # Act
-        process = WorkerProcess(host=host, port=port)
-        address = process.address
-
-        # Assert
-        assert address
-
-        parsed_host, parsed_port_str = address.split(":")
-        parsed_port = int(parsed_port_str)
-
-        assert parsed_host == host
-        assert parsed_port == port
+        assert process.address is None
 
     @given(
         host=st.one_of(
@@ -500,7 +469,7 @@ class TestWorkerProcess:
 
         # Assert
         assert process.host == host
-        assert host in process.address
+        assert process.address is None
 
     @given(port=st.one_of(st.integers(max_value=-1), st.integers(min_value=65536)))
     def test___init___rejects_invalid_ports(self, port):
@@ -584,13 +553,18 @@ class TestWorkerProcess:
             It should call Process.start
         """
         # Arrange
-        mock_get_port = mocker.MagicMock()
-        mock_get_port.poll.return_value = True
-        mock_get_port.recv.return_value = 50051
-        mock_set_port = mocker.MagicMock()
+        mock_get_meta = mocker.MagicMock()
+        mock_get_meta.poll.return_value = True
+        mock_get_meta.recv.return_value = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50051",
+            pid=12345,
+            version="1.0.0",
+        )
+        mock_set_meta = mocker.MagicMock()
         mocker.patch(
             "wool.runtime.worker.process.Pipe",
-            return_value=(mock_get_port, mock_set_port),
+            return_value=(mock_get_meta, mock_set_meta),
         )
 
         mock_parent_start = mocker.patch.object(process_module.Process, "start")
@@ -602,9 +576,9 @@ class TestWorkerProcess:
 
         # Assert
         mock_parent_start.assert_called_once()
-        mock_get_port.poll.assert_called_once_with(timeout=60.0)
-        mock_get_port.recv.assert_called_once()
-        mock_get_port.close.assert_called_once()
+        mock_get_meta.poll.assert_called_once_with(timeout=60.0)
+        mock_get_meta.recv.assert_called_once()
+        mock_get_meta.close.assert_called_once()
 
     def test_start_receives_port_from_pipe(self, mocker):
         """Test start receives port from pipe and updates address.
@@ -617,13 +591,18 @@ class TestWorkerProcess:
             It should receive the port and provide correct address
         """
         # Arrange
-        mock_get_port = mocker.MagicMock()
-        mock_get_port.poll.return_value = True
-        mock_get_port.recv.return_value = 50051
-        mock_set_port = mocker.MagicMock()
+        mock_get_meta = mocker.MagicMock()
+        mock_get_meta.poll.return_value = True
+        mock_get_meta.recv.return_value = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50051",
+            pid=12345,
+            version="1.0.0",
+        )
+        mock_set_meta = mocker.MagicMock()
         mocker.patch(
             "wool.runtime.worker.process.Pipe",
-            return_value=(mock_get_port, mock_set_port),
+            return_value=(mock_get_meta, mock_set_meta),
         )
 
         mocker.patch.object(process_module.Process, "start")
@@ -648,12 +627,12 @@ class TestWorkerProcess:
             It should raise RuntimeError and terminate the process
         """
         # Arrange
-        mock_get_port = mocker.MagicMock()
-        mock_get_port.poll.return_value = False
-        mock_set_port = mocker.MagicMock()
+        mock_get_meta = mocker.MagicMock()
+        mock_get_meta.poll.return_value = False
+        mock_set_meta = mocker.MagicMock()
         mocker.patch(
             "wool.runtime.worker.process.Pipe",
-            return_value=(mock_get_port, mock_set_port),
+            return_value=(mock_get_meta, mock_set_meta),
         )
 
         mocker.patch.object(process_module.Process, "start")
@@ -682,13 +661,18 @@ class TestWorkerProcess:
             It should close the pipe connection
         """
         # Arrange
-        mock_get_port = mocker.MagicMock()
-        mock_get_port.poll.return_value = True
-        mock_get_port.recv.return_value = 50051
-        mock_set_port = mocker.MagicMock()
+        mock_get_meta = mocker.MagicMock()
+        mock_get_meta.poll.return_value = True
+        mock_get_meta.recv.return_value = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50051",
+            pid=12345,
+            version="1.0.0",
+        )
+        mock_set_meta = mocker.MagicMock()
         mocker.patch(
             "wool.runtime.worker.process.Pipe",
-            return_value=(mock_get_port, mock_set_port),
+            return_value=(mock_get_meta, mock_set_meta),
         )
 
         mocker.patch.object(process_module.Process, "start")
@@ -699,7 +683,7 @@ class TestWorkerProcess:
         process.start()
 
         # Assert
-        mock_get_port.close.assert_called_once()
+        mock_get_meta.close.assert_called_once()
 
     @pytest.mark.asyncio
     async def test__proxy_factory_starts_proxy_when_not_started(self, mocker):
@@ -827,8 +811,8 @@ class TestWorkerProcess:
 
         mocker.patch("wool.runtime.worker.process._signal_handlers")
 
-        mock_send = mocker.patch.object(process._set_port, "send")
-        mock_close = mocker.patch.object(process._set_port, "close")
+        mock_send = mocker.patch.object(process._set_metadata, "send")
+        mock_close = mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
@@ -843,7 +827,10 @@ class TestWorkerProcess:
         mock_proxy_pool.set.assert_called_once_with(mock_resource_pool)
 
         mock_server.start.assert_called_once()
-        mock_send.assert_called_once_with(50051)
+        mock_send.assert_called_once()
+        sent = mock_send.call_args[0][0]
+        assert isinstance(sent, WorkerMetadata)
+        assert sent.address == "127.0.0.1:50051"
         mock_close.assert_called_once()
         mock_service.stopped.wait.assert_called_once()
         mock_server.stop.assert_called_once_with(grace=30.0)
@@ -879,14 +866,17 @@ class TestWorkerProcess:
 
         mocker.patch("wool.runtime.worker.process._signal_handlers")
 
-        mock_send = mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
+        mock_send = mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
 
         # Assert
-        mock_send.assert_called_once_with(8080)
+        mock_send.assert_called_once()
+        sent = mock_send.call_args[0][0]
+        assert isinstance(sent, WorkerMetadata)
+        assert sent.address == "0.0.0.0:8080"
 
     def test_run_closes_pipe_even_on_error(self, mocker):
         """Test run closes pipe even if send fails.
@@ -920,9 +910,9 @@ class TestWorkerProcess:
         mocker.patch("wool.runtime.worker.process._signal_handlers")
 
         mocker.patch.object(
-            process._set_port, "send", side_effect=Exception("Pipe error")
+            process._set_metadata, "send", side_effect=Exception("Pipe error")
         )
-        mock_close = mocker.patch.object(process._set_port, "close")
+        mock_close = mocker.patch.object(process._set_metadata, "close")
 
         # Act & assert
         with pytest.raises(Exception, match="Pipe error"):
@@ -965,8 +955,8 @@ class TestWorkerProcess:
 
         mocker.patch("wool.runtime.worker.process._signal_handlers")
 
-        mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act & assert
         with pytest.raises(Exception, match="Service error"):
@@ -1005,8 +995,8 @@ class TestWorkerProcess:
 
         process = WorkerProcess(host="127.0.0.1", port=0, credentials=None)
 
-        mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
@@ -1052,8 +1042,8 @@ class TestWorkerProcess:
 
         process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
 
-        mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
@@ -1098,18 +1088,19 @@ class TestWorkerProcess:
 
         process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
 
-        sent_ports = []
+        sent_metadata = []
         mocker.patch.object(
-            process._set_port, "send", side_effect=lambda x: sent_ports.append(x)
+            process._set_metadata, "send", side_effect=lambda x: sent_metadata.append(x)
         )
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
 
         # Assert
-        assert len(sent_ports) == 1
-        assert sent_ports[0] == 54321
+        assert len(sent_metadata) == 1
+        assert isinstance(sent_metadata[0], WorkerMetadata)
+        assert sent_metadata[0].address == "127.0.0.1:54321"
 
     def test_serve_insecure_worker_random_port_assignment(self, mocker):
         """Test random port assignment for insecure worker.
@@ -1139,18 +1130,19 @@ class TestWorkerProcess:
 
         process = WorkerProcess(host="127.0.0.1", port=0, credentials=None)
 
-        sent_ports = []
+        sent_metadata = []
         mocker.patch.object(
-            process._set_port, "send", side_effect=lambda x: sent_ports.append(x)
+            process._set_metadata, "send", side_effect=lambda x: sent_metadata.append(x)
         )
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
 
         # Assert
-        assert len(sent_ports) == 1
-        assert sent_ports[0] == 54322
+        assert len(sent_metadata) == 1
+        assert isinstance(sent_metadata[0], WorkerMetadata)
+        assert sent_metadata[0].address == "127.0.0.1:54322"
 
     def test_serve_no_dual_port_architecture(self, mocker):
         """Test no dual-port architecture.
@@ -1189,8 +1181,8 @@ class TestWorkerProcess:
 
         process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
 
-        mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
@@ -1236,8 +1228,8 @@ class TestWorkerProcess:
 
         process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
 
-        mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
@@ -1287,8 +1279,8 @@ class TestWorkerProcess:
 
         process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
 
-        mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
@@ -1372,8 +1364,8 @@ class TestWorkerProcess:
             return_value=mock_service,
         )
         mocker.patch("wool.runtime.worker.process._signal_handlers")
-        mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
@@ -1420,8 +1412,8 @@ class TestWorkerProcess:
             return_value=mock_service,
         )
         mocker.patch("wool.runtime.worker.process._signal_handlers")
-        mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
@@ -1472,16 +1464,14 @@ class TestWorkerProcess:
             captured_current.append(CredentialContext.current())
 
         mock_service.stopped.wait = mocker.AsyncMock(side_effect=capture_current)
-        mocker.patch.object(
-            process_module, "WorkerService", return_value=mock_service
-        )
+        mocker.patch.object(process_module, "WorkerService", return_value=mock_service)
 
         mocker.patch.object(process_module, "_signal_handlers")
 
         process = WorkerProcess(host="127.0.0.1", port=0, credentials=creds)
 
-        mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()
@@ -1519,16 +1509,14 @@ class TestWorkerProcess:
             captured_current.append(CredentialContext.current())
 
         mock_service.stopped.wait = mocker.AsyncMock(side_effect=capture_current)
-        mocker.patch.object(
-            process_module, "WorkerService", return_value=mock_service
-        )
+        mocker.patch.object(process_module, "WorkerService", return_value=mock_service)
 
         mocker.patch.object(process_module, "_signal_handlers")
 
         process = WorkerProcess(host="127.0.0.1", port=0, credentials=None)
 
-        mocker.patch.object(process._set_port, "send")
-        mocker.patch.object(process._set_port, "close")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
 
         # Act
         process.run()

--- a/wool/tests/test_public.py
+++ b/wool/tests/test_public.py
@@ -40,6 +40,7 @@ def test_public_api_completeness():
         "LoadBalancerLike",
         "NoWorkersAvailable",
         "RoundRobinLoadBalancer",
+        "Serializer",
         "Task",
         "TaskException",
         "current_task",


### PR DESCRIPTION
## Summary

When a worker dispatches a routine that routes back to itself, the current path cloudpickles every payload field even though both sides are in the same process. Introduce a `Serializer` protocol and a `PassthroughSerializer` implementation that stores objects in a process-local `WeakKeyDictionary` keyed by UUID sentinels, returning only the raw UUID bytes to the protobuf layer. The gRPC streaming path is unchanged — only the serialization cost is eliminated for self-dispatch.

The `PassthroughSerializer` instance doubles as a scope guard: it holds strong references to the store keys, and when it goes out of scope the `WeakKeyDictionary` entries are garbage-collected automatically.

Closes #80

## Proposed changes

### Proto schema extension

Add an optional `serializer` field to the Task message. When absent, the receiver falls back to cloudpickle with zero overhead for existing remote dispatch. When present, the receiver recovers the serializer and uses it for payload deserialization.

### Serializer abstraction

Define a `Serializer` runtime-checkable protocol (`dumps`/`loads`) that `cloudpickle` already satisfies. Implement `PassthroughSerializer` backed by a module-level `WeakKeyDictionary` — `dumps` stores the object and returns a 16-byte UUID token, `loads` pops the entry by reconstructing the key from the token. All instances hash and compare equal so LRU caching works across pickle boundaries.

Extend `Task.to_protobuf` and `Task.from_protobuf` to accept and detect the serializer. The proxy field is always cloudpickled unless the serializer is a `PassthroughSerializer` — custom serializers are not trusted for proxy serialization.

### Self-dispatch detection

`WorkerConnection.dispatch()` compares the target address against the current process's `WorkerMetadata`. On match, it creates a `PassthroughSerializer` and passes it to `to_protobuf`, bypassing cloudpickle for callable, args, kwargs, and proxy. The serializer is scoped to the dispatch lifetime for automatic cleanup.

### Worker identity context

Add `__worker_metadata__` and `__worker_service__` ContextVars to the package root, set by the worker subprocess during server startup. Refactor `WorkerProcess` to send full `WorkerMetadata` (including uid, tags, extra) back to the parent via pipe, replacing the previous port-only pipe.

### Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestTask` | A Task instance | `to_protobuf()` called with no serializer | Serializer field is not set | Default serialization |
| 2 | `TestTask` | A Task and a PassthroughSerializer | `to_protobuf(serializer=...)` called | Serializer field is set | Serializer field presence |
| 3 | `TestTask` | A protobuf Task with no serializer field | `from_protobuf()` called | All fields deserialized via cloudpickle | Backward compatibility |
| 4 | `TestTask` | A Task round-tripped via PassthroughSerializer | `from_protobuf()` called | All public attributes preserved by identity | Passthrough roundtrip |
| 5 | `TestPassthroughSerializer` | An arbitrary Python object | `dumps` called | Returns a 16-byte token | Token format |
| 6 | `TestPassthroughSerializer` | Two distinct objects | `dumps` called on each | Returns different tokens | Token uniqueness |
| 7 | `TestPassthroughSerializer` | An object stored via `dumps` | `loads` called with the token | Returns the exact same object by identity | Roundtrip identity |
| 8 | `TestPassthroughSerializer` | An object stored via `dumps` | `loads` called twice with the same token | Raises KeyError on second call | Entry consumption |
| 9 | `TestPassthroughSerializer` | A PassthroughSerializer instance | Checked via isinstance against Serializer | Recognized as a Serializer | Protocol conformance |
| 10 | `TestPassthroughSerializer` | A PassthroughSerializer instance | Cloudpickled and unpickled | Produces a functional instance | Pickle survivability |
| 11 | `TestWorkerConnection` | Worker metadata address matches target | `dispatch(task)` called | Serializer field set, payload not cloudpickled | Self-dispatch serializer |
| 12 | `TestWorkerConnection` | Worker metadata address differs from target | `dispatch(task)` called | Serializer field not set | Address mismatch fallback |
| 13 | `TestWorkerConnection` | No worker metadata set | `dispatch(task)` called | Serializer field not set | Non-worker fallback |