### PR TITLE
Rename issue template sections for clarity — Closes #85

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -3,10 +3,17 @@ description: Report something that isn't working correctly.
 labels: ["bug"]
 body:
   - type: textarea
-    id: summary
+    id: description
     attributes:
-      label: Summary
+      label: Description
       description: What is the bug? Include steps to reproduce if applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
     validations:
       required: true
   - type: textarea
@@ -14,12 +21,5 @@ body:
     attributes:
       label: Root cause
       description: What is causing the bug? Include relevant code snippets.
-    validations:
-      required: true
-  - type: textarea
-    id: affected-code
-    attributes:
-      label: Affected code
-      description: Which files, modules, or components are affected?
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -3,9 +3,9 @@ description: Propose a new feature or capability.
 labels: ["feature"]
 body:
   - type: textarea
-    id: summary
+    id: description
     attributes:
-      label: Summary
+      label: Description
       description: What is the feature? Describe the desired behavior.
     validations:
       required: true
@@ -17,9 +17,9 @@ body:
     validations:
       required: true
   - type: textarea
-    id: affected-code
+    id: expected-outcome
     attributes:
-      label: Affected code
-      description: Which files, modules, or components would be affected?
+      label: Expected outcome
+      description: What should be true when this is done?
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -22,4 +22,4 @@ body:
       label: Expected outcome
       description: What should be true when this is done?
     validations:
-      required: false
+      required: true

--- a/llms/skills/issue.md
+++ b/llms/skills/issue.md
@@ -170,7 +170,7 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 <What should be true when this is done?>
 ```
 
-The **Expected outcome** (or **Expected behavior** in bug templates) section MAY be omitted if it is not relevant.
+For issue types backed by a GitHub form template (Bug, Feature), the **Expected outcome** / **Expected behavior** section is required by the form and MUST be included. For fallback-only templates (Refactor, Test, CI/CD, Build), the section MAY be omitted if it is not relevant.
 
 When the project defines a GitHub issue form template in `.github/ISSUE_TEMPLATE/` that matches the issue type (e.g., `bug.yaml` for bugs, `feature.yaml` for features), the skill MUST mirror the form template's section structure instead of using the built-in Markdown template above. The built-in Markdown templates serve as a fallback for issue types that do not have a corresponding GitHub form template.
 

--- a/llms/skills/issue.md
+++ b/llms/skills/issue.md
@@ -67,17 +67,17 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 ```markdown
 # <title>
 
-## Summary
+## Description
 
 <What is the bug? Steps to reproduce if applicable.>
+
+## Expected behavior
+
+<What did you expect to happen?>
 
 ## Root cause
 
 <What is causing the bug? Include relevant code snippets.>
-
-## Affected code
-
-<Which files, modules, or components are affected?>
 ```
 
 **Feature** (label: `feature`):
@@ -85,7 +85,7 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 ```markdown
 # <title>
 
-## Summary
+## Description
 
 <What is the feature? Describe the desired behavior.>
 
@@ -93,9 +93,9 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 
 <Why is this feature needed? What problem does it solve?>
 
-## Affected code
+## Expected outcome
 
-<Which files, modules, or components would be affected?>
+<What should be true when this is done?>
 ```
 
 **Refactor** (label: `refactor`):
@@ -103,7 +103,7 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 ```markdown
 # <title>
 
-## Summary
+## Description
 
 <What should be restructured and what does the end state look like?>
 
@@ -111,9 +111,9 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 
 <Why is this restructuring needed?>
 
-## Affected code
+## Expected outcome
 
-<Which files, modules, or components are affected?>
+<What should be true when this is done?>
 ```
 
 **Test** (label: `test`):
@@ -121,7 +121,7 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 ```markdown
 # <title>
 
-## Summary
+## Description
 
 <What needs to be tested or what test infrastructure is needed?>
 
@@ -129,9 +129,9 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 
 <Why is this test work needed? What gap does it fill?>
 
-## Affected code
+## Expected outcome
 
-<Which files, modules, or components are affected?>
+<What should be true when this is done?>
 ```
 
 **CI/CD** (label: `cicd`):
@@ -139,7 +139,7 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 ```markdown
 # <title>
 
-## Summary
+## Description
 
 <What CI/CD change is needed?>
 
@@ -147,9 +147,9 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 
 <Why is this change needed? What does it improve?>
 
-## Affected code
+## Expected outcome
 
-<Which workflows, pipelines, or config files are affected?>
+<What should be true when this is done?>
 ```
 
 **Build** (label: `build`):
@@ -157,7 +157,7 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 ```markdown
 # <title>
 
-## Summary
+## Description
 
 <What build system or dependency change is needed?>
 
@@ -165,12 +165,14 @@ Prose in issue bodies MUST NOT be hard-wrapped at a fixed column width. Write ea
 
 <Why is this change needed?>
 
-## Affected code
+## Expected outcome
 
-<Which build files, configs, or dependencies are affected?>
+<What should be true when this is done?>
 ```
 
-The **Affected code** section MAY be omitted if it is not relevant.
+The **Expected outcome** (or **Expected behavior** in bug templates) section MAY be omitted if it is not relevant.
+
+When the project defines a GitHub issue form template in `.github/ISSUE_TEMPLATE/` that matches the issue type (e.g., `bug.yaml` for bugs, `feature.yaml` for features), the skill MUST mirror the form template's section structure instead of using the built-in Markdown template above. The built-in Markdown templates serve as a fallback for issue types that do not have a corresponding GitHub form template.
 
 The draft MUST be shown to the user and iterated until they approve.
 


### PR DESCRIPTION
## Summary

Rename and restructure sections across GitHub issue form templates and the skill-level Markdown templates to use clearer, more purposeful headings. Replace the vague "Summary" with "Description" and swap "Affected code" — which presupposes implementation knowledge — for outcome-oriented sections: "Expected outcome" (features) and "Expected behavior" (bugs). Reorder the bug template so reporters describe expected behavior before root cause, and adjust required/optional status so reporters are not blocked by fields they cannot fill.

Update the issue skill's built-in Markdown templates to mirror the YAML form structure for Bug and Feature types, and add a fallback-preference rule so agents use GitHub form templates when available.

Closes #85

## Proposed changes

### Rename "Summary" to "Description" across all templates

Replace the ambiguous "Summary" label and `id` with "Description" in both `feature.yaml` and `bug.yaml`, and in all six skill-level Markdown templates (Bug, Feature, Refactor, Test, CI/CD, Build). "Description" sets a clearer expectation for what the reporter should write.

### Replace "Affected code" with outcome-oriented sections

- **Feature template:** "Affected code" → "Expected outcome" — shift focus from which files are touched to what should be true when the work is done. Mark as required.
- **Bug template:** "Affected code" → "Expected behavior" — more natural for bug reports. Mark as required and position before "Root cause".
- **Skill-only templates** (Refactor, Test, CI/CD, Build): "Affected code" → "Expected outcome" with a MAY-omit allowance for cases where it is not relevant.

### Reorder bug template fields

Move "Expected behavior" before "Root cause" so reporters describe what *should* happen before diagnosing *why* it doesn't. Make "Root cause" optional — reporters always know the expected behavior but may not know the root cause.

### Add form-template preference rule to the issue skill

Add a directive instructing agents to prefer the project's GitHub issue form templates (`.github/ISSUE_TEMPLATE/`) when a matching template exists, falling back to the built-in Markdown templates for issue types without a corresponding form (Refactor, Test, CI/CD, Build). Update the MAY-omit rule to reflect that form-backed templates require their outcome/behavior section.