### PR TITLE
Restructure skill pipeline to move PR after implementation — Closes #89

### DIFF
--- a/llms/skills/audit.md
+++ b/llms/skills/audit.md
@@ -16,7 +16,7 @@ Spawn a fresh subagent to evaluate whether a skill's requirements were met durin
 
 ## Pipeline Context
 
-This skill is a **cross-cutting quality gate** invoked at the end of every SDLC pipeline stage: `/issue` → audit → `/pr` → audit → `/implement` → audit → `/commit` → audit → `/pr` (update) → audit → `/review` → audit.
+This skill is a **cross-cutting quality gate** invoked at the end of every SDLC pipeline stage: `/issue` → audit → `/implement` → audit → `/test` → audit → `/commit` → audit → `/pr` → audit → `/review` → audit.
 
 ## Arguments
 

--- a/llms/skills/commit.md
+++ b/llms/skills/commit.md
@@ -19,7 +19,7 @@ This skill transforms a messy working tree into a clean sequence of atomic, well
 
 ## Pipeline Context
 
-This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update). This skill is the **fourth** stage.
+This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr`. This skill is the **fourth** stage. The implement, test, and commit steps are iterative — they can be invoked multiple times for a given issue.
 
 ## Workflow
 
@@ -31,7 +31,7 @@ This skill is part of the development workflow pipeline: `/issue` → `/pr` → 
 4. Plan the commits
 5. Stage and commit sequentially
 6. Review and present
-7. Prompt the user to move onto the PR update step
+7. Prompt the user to move onto the PR step
 
 ### 1. Verify git state
 
@@ -157,25 +157,13 @@ git merge --ff-only {original-branch}-staging
 git branch -d {original-branch}-staging
 ```
 
-If the original branch contains a placeholder empty commit (e.g., `chore: Open draft PR for #<number>` created by the `/pr` skill), it MUST be dropped during the merge so the final history is clean. Use rebase instead of fast-forward merge:
-
-```bash
-git checkout {original-branch}
-git rebase --onto {original-branch}~1 {original-branch} {original-branch}-staging
-git checkout -B {original-branch} {original-branch}-staging
-git branch -d {original-branch}-staging
-```
-
 Or if they prefer to review as a PR first, they can push the staging branch and open a pull request against the original branch.
-
-If the current branch is associated with a PR, the user SHOULD be prompted with the next pipeline step: "Ready to update the PR? Run `/pr <number>` to sync the PR description with the committed changes."
 
 ---
 
-### 7. Prompt the user to move onto the PR update step
+### 7. Prompt the user to move onto the PR step
 
-1. Prompt the user to invoke the `/pr` skill to update the PR description: check off completed implementation steps, refresh the test cases table, and update the summary to reflect what was actually implemented. Ask the user: "Ready to update the PR description? Run `/pr <number>` to update the PR description to reflect the implementation." DO NOT proceed on your own.
-2. Inform the user that the branch is ready for review and the PR can be marked ready via `gh pr ready <number>`.
+The user MUST be prompted with the next pipeline step: "Ready to create the PR? Run `/pr <number>` to review the changes and open a draft pull request." DO NOT proceed on your own.
 
 ## Commit Message Style Guide
 

--- a/llms/skills/implement.md
+++ b/llms/skills/implement.md
@@ -1,40 +1,41 @@
 ---
 name: implement
 description: >
-  Implement a planned PR or issue. Use this skill whenever the user says
+  Implement a GitHub issue. Use this skill whenever the user says
   "/implement <number>", "implement #N", "start implementing #N", or similar.
-  Accepts a PR or issue number, resolves it to a draft PR (creating one via
-  the /pr skill if needed), checks out the branch, and enters plan mode to
-  design a concrete execution plan before writing code.
+  Accepts an issue number, fetches the issue, creates a branch, gathers
+  context, and enters plan mode to design a concrete execution plan before
+  writing code. On re-invocation after a PR exists, addresses unresolved
+  review feedback.
 ---
 
 The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
 
 # Implement Skill
 
-Resolve a PR or issue number, check out the branch, read the PR description, and enter plan mode to design a concrete execution plan before writing any code.
+Fetch a GitHub issue, create a branch, gather codebase context, and enter plan mode to design a concrete execution plan before writing any code. On re-invocation when a PR already exists, address unresolved review feedback or verify implementation completeness.
 
 ## Pipeline Context
 
-This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update). This skill is the **third** stage.
+This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr`. This skill is the **second** stage. The implement, test, and commit steps are iterative — they can be invoked multiple times for a given issue to address PR feedback or refine the implementation.
 
 ## Arguments
 
-A PR or issue number MUST be provided as the sole argument (e.g., `/implement 103`).
+An issue number MUST be provided as the sole argument (e.g., `/implement 103`).
 
 ## Workflow
 
 ### TL;DR
 
 1. Resolve target repository
-2. Resolve the input to a PR
-3. Assign the PR and issue
-4. Check out the PR branch
-5. Read the PR description
+2. Fetch the issue
+3. Check for existing PR (re-invocation path)
+4. Generate branch name and create branch
+5. Assign the issue
 6. Gather context
 7. Enter plan mode
 8. Execute after approval
-9. Prompt the user to move onto the commit step
+9. Prompt the user to move onto the test or commit step
 
 ### 1. Resolve target repository
 
@@ -48,73 +49,80 @@ If `isFork` is `true`, extract `parent.owner.login` and `parent.name` to form th
 
 All `gh` commands in subsequent steps that reference issues or PRs MUST include `--repo <target>` when the target repo differs from the current repo.
 
-### 2. Resolve the input to a PR
-
-Run `gh pr view <number> --repo <target>` to check if the number is a PR.
-
-- **If it is a PR** — use it directly.
-- **If it is not a PR** (the command fails) — run `gh issue view <number> --repo <target>` to confirm it is an issue.
-  - **If it is an issue** — query for linked PRs via the Development sidebar field:
-    ```bash
-    gh issue view <number> --repo <target> --json closedByPullRequestsReferences \
-      --jq '.closedByPullRequestsReferences[].number'
-    ```
-    - If a linked PR exists, use it.
-    - If no linked PR exists, invoke the `/pr` skill to create one. Stop after the PR is created — the user MUST re-run `/implement` once the PR draft is approved.
-- **If the number is neither a PR nor an issue** — inform the user and stop.
-
-The `--repo <target>` flag ensures commands operate against the upstream repo when working from a fork (as resolved in step 1). If the target repo is the current repo, the flag MAY be omitted.
-
-### 3. Assign the PR and issue
-
-Assign both the PR and its linked issue to the current user so that ownership is visible on the board:
+### 2. Fetch the issue
 
 ```bash
-gh pr edit <number> --repo <target> --add-assignee @me
+gh issue view <number> --repo <target>
 ```
 
-The linked issue number is already known from the PR's summary (the `Closes #<issue>` reference parsed in step 2). Assign it as well:
+Read the issue title, body, and labels. If the issue does not exist or is closed, inform the user and stop. The `--repo <target>` flag ensures the issue is fetched from the upstream repo when working from a fork (as resolved in step 1). If the target repo is the current repo, the flag MAY be omitted.
+
+### 3. Check for existing PR (re-invocation path)
+
+Query for a linked PR:
 
 ```bash
-gh issue edit <issue-number> --repo <target> --add-assignee @me
+gh pr list --repo <target> --search "Closes #<number>" --json number,headRefName,url --jq '.[0]'
+```
+
+- **If a PR exists** — check out the branch (`git fetch origin <branch> && git checkout <branch>`). Then check for unresolved review comments:
+
+  ```bash
+  gh api graphql -f query='
+    query($owner: String!, $repo: String!, $pr: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pr) {
+          reviewThreads(first: 100) {
+            nodes { isResolved comments(first: 1) { nodes { body path line } } }
+          }
+        }
+      }
+    }
+  ' -f owner='<owner>' -f repo='<repo>' -F pr=<number>
+  ```
+
+  **Definition of "unresolved review comment":** A review comment is unresolved when its thread is literally marked as unresolved in GitHub's review UI (i.e., the thread has not been clicked "Resolve conversation"). This is a binary GitHub state, not a judgment call. Use the `isResolved` field on review comment threads to determine this. An unresolved thread means the reviewer intentionally left it open — the skill MUST read each unresolved comment, understand what the reviewer is asking for, and plan changes to address it. Do not dismiss unresolved comments as already handled without verifying the reviewer's intent.
+
+  - **If unresolved comments exist** — read each comment, understand the feedback, and proceed to step 6 (gather context) then step 7 (plan changes to address the feedback).
+  - **If no unresolved comments** — verify that the issue is fully implemented: review the issue body against the current branch state and tie off any loose ends. If everything is complete, inform the user and stop. Otherwise, plan remaining work.
+
+- **If no PR exists** — this is a fresh implementation. Continue to step 4.
+
+### 4. Generate branch name and create branch
+
+Derive a short, descriptive branch name from the issue number and title:
+
+```
+<number>-<kebab-case-summary>
+```
+
+Examples:
+- `96-fix-worker-factory-credentials`
+- `102-add-retry-logic-to-discovery`
+
+The branch name MUST be under 50 characters. Filler words SHOULD be stripped.
+
+```bash
+git checkout -b <branch-name> main
+```
+
+If the branch already exists, the user MUST be asked whether to switch to it or recreate it.
+
+### 5. Assign the issue
+
+Assign the issue to the current user so that ownership is visible on the board:
+
+```bash
+gh issue edit <number> --repo <target> --add-assignee @me
 ```
 
 The `--repo <target>` flag MUST be included when the target repo differs from the current repo.
-
-### 4. Check out the PR branch
-
-Extract the branch name from the PR:
-
-```bash
-gh pr view <number> --repo <target> --json headRefName --jq .headRefName
-```
-
-Fetch and check out the branch:
-
-```bash
-git fetch origin <branch>
-git checkout <branch>
-```
-
-If the local branch is behind the remote, pull to bring it up to date.
-
-### 5. Read the PR description
-
-Fetch the full PR body:
-
-```bash
-gh pr view <number> --repo <target> --json body,title
-```
-
-Parse the four sections: **Summary**, **Proposed changes**, **Test cases**, and **Implementation plan**.
-
-The implementation plan's checkbox list is the primary input for planning. If all items are already checked off, inform the user that the implementation plan appears complete and stop. If the plan is partially checked off, only plan the remaining unchecked items.
 
 ### 6. Gather context
 
 Before entering plan mode, read enough of the codebase to plan confidently:
 
-- Read every source file referenced in the PR's "Proposed changes" section.
+- Read source files referenced in the issue's description.
 - Read existing tests for the affected modules.
 - Read the project test guide (`@llm/guides/testguide-python.md`) to internalize testing conventions.
 - Read project-level instructions (`CLAUDE.md`) for build tooling, documentation style, and architecture context.
@@ -123,8 +131,8 @@ Before entering plan mode, read enough of the codebase to plan confidently:
 
 Call `EnterPlanMode` to begin the planning phase. The execution plan:
 
-- MUST map each unchecked item from the PR's implementation plan to concrete code changes: exact files, functions, classes, and the nature of each modification.
-- SHOULD prefer test-first ordering when the PR's plan supports it.
+- MUST map the issue's requirements (or unresolved review comments, on re-invocation) to concrete code changes: exact files, functions, classes, and the nature of each modification.
+- SHOULD prefer test-first ordering when applicable.
 - MUST follow the testing conventions in the project test guide (`@llm/guides/testguide-python.md`). Test case IDs (e.g., WC-001, VP-001) MUST NOT be assigned — the docstring provides sufficient traceability without the maintenance burden of cross-PR ID schemes.
 - MUST include a verification section with the exact command(s) to run the test suite (see the project test guide for the runner command).
 
@@ -132,13 +140,13 @@ Call `EnterPlanMode` to begin the planning phase. The execution plan:
 
 Once the user approves the plan, implement each step sequentially.
 
-### 9. Prompt the user to move onto the commit step
+### 9. Prompt the user to move onto the test or commit step
 
-The user MUST be prompted with the next pipeline step: "Ready to commit? Run `/commit` to stage and commit the changes." DO NOT proceed on your own.
+The user MUST be prompted with the next pipeline step: "Ready to generate tests? Run `/test <number>` to analyze coverage and write tests. Or ready to commit? Run `/commit` to stage and commit the changes." DO NOT proceed on your own.
 
 ## Edge cases
 
-- **All items already checked off:** Inform the user that the implementation plan appears complete and stop.
-- **Partially checked off:** Only plan the remaining unchecked items.
-- **PR is not a draft:** Proceed normally — the PR may have been marked ready for review before implementation was complete.
+- **Branch already exists:** Ask the user whether to switch to it or recreate it.
+- **Issue is closed:** Inform the user and stop.
 - **Merge conflicts:** Stop and explain the situation rather than trying to resolve automatically.
+- **Re-invocation with PR but no unresolved comments:** Verify the issue is fully implemented. If complete, inform the user and stop.

--- a/llms/skills/issue.md
+++ b/llms/skills/issue.md
@@ -15,7 +15,7 @@ Create a well-structured GitHub issue, either from a prepared `.issue.md` file o
 
 ## Pipeline Context
 
-This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update). This skill is the **first** stage.
+This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr`. This skill is the **first** stage. The implement, test, and commit steps are iterative — they can be invoked multiple times for a given issue.
 
 ## Workflow
 
@@ -29,7 +29,7 @@ This skill is part of the development workflow pipeline: `/issue` → `/pr` → 
 6. Push the issue
 7. Clean up `.issue.md` (if applicable)
 8. Return the issue URL
-9. Prompt the user to move onto the PR step
+9. Prompt the user to move onto the implement step
 
 ### 1. Determine the source
 
@@ -220,8 +220,8 @@ rm .issue.md
 
 The issue URL returned by `gh issue create` MUST be printed so the user can access it directly.
 
-The user SHOULD be prompted with the next pipeline step: "Ready to plan this? Run `/pr <number>` to create a branch and draft PR."
+The user SHOULD be prompted with the next pipeline step: "Ready to implement? Run `/implement <number>` to create a branch and start planning."
 
-### 9. Prompt the user to move onto the PR step
+### 9. Prompt the user to move onto the implement step
 
-The user MUST be prompted with the next pipeline step: "Ready to plan this? Run `/pr <number>` to create a branch and draft PR." When working from a fork, note that `<number>` refers to the issue on the upstream repo. DO NOT proceed on your own.
+The user MUST be prompted with the next pipeline step: "Ready to implement? Run `/implement <number>` to create a branch and start planning." When working from a fork, note that `<number>` refers to the issue on the upstream repo. DO NOT proceed on your own.

--- a/llms/skills/pr.md
+++ b/llms/skills/pr.md
@@ -1,41 +1,37 @@
 ---
 name: pr
 description: >
-  Create a branch and draft PR from a GitHub issue. Use this skill whenever the
-  user says "/pr <number>", "create a PR for issue #N", "start working on #N",
-  or similar. Takes an issue number as argument, fetches the issue, creates a
-  branch, and opens a draft PR with an implementation plan. Also use this skill
-  to update an existing draft PR when the implementation plan changes or code
-  is committed.
+  Review committed changes on a branch and create a draft pull request. Use
+  this skill whenever the user says "/pr <number>", "create a PR for #N",
+  "open a PR", or similar. Accepts an issue number, reviews the branch diff,
+  and drafts a PR description based on what was actually implemented.
 ---
 
 The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
 
 # PR Skill
 
-Create a branch and draft pull request from an existing GitHub issue. The PR serves as the implementation plan — no code is written yet.
+Review committed source and test changes on a branch and create a draft pull request with a description based on what was actually implemented.
 
 ## Pipeline Context
 
-This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update). This skill is the **second** stage, and is also invoked at the end to update the PR after implementation.
+This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr`. This skill is the **fifth** (final) stage. After review feedback is received, the user re-enters the loop at the implement skill to address comments, then optionally re-runs the test and commit skills before re-running the PR skill to update the description.
 
 ## Arguments
 
-An issue number MUST be provided as the sole argument (e.g., `/pr 96`).
+An issue number MUST be provided as the sole argument (e.g., `/pr 103`). The issue number is used to identify the branch (`<number>-<kebab-case-summary>`) and to link the PR via `Closes #<number>`.
 
 ## Workflow
 
 ### TL;DR
 
 1. Resolve target repository
-2. Fetch the issue
-3. Generate a branch name
-4. Create and checkout the branch
-5. Draft the PR description
-6. Show draft for approval
-7. Push and create the draft PR
-8. Return the PR URL
-9. Prompt the user to move onto the implementation step
+2. Identify the issue and branch
+3. Review the branch diff
+4. Draft the PR description
+5. Show draft for approval
+6. Push and create the draft PR
+7. Return the PR URL
 
 ### 1. Resolve target repository
 
@@ -49,51 +45,61 @@ If `isFork` is `true`, extract `parent.owner.login` and `parent.name` to form th
 
 All `gh` commands in subsequent steps that reference issues or PRs MUST include `--repo <target>` when the target repo differs from the current repo.
 
-### 2. Fetch the issue
+### 2. Identify the issue and branch
+
+Fetch the issue:
 
 ```bash
 gh issue view <number> --repo <target>
 ```
 
-Read the issue title, body, and labels. If the issue does not exist or is closed, inform the user and stop. The `--repo <target>` flag ensures the issue is fetched from the upstream repo when working from a fork (as resolved in step 1). If the target repo is the current repo, the flag MAY be omitted.
+Read the issue title, body, and labels. If the issue does not exist or is closed, inform the user and stop.
 
-### 3. Generate a branch name
-
-Derive a short, descriptive branch name from the issue number and title:
-
-```
-<number>-<kebab-case-summary>
-```
-
-Examples:
-- `96-fix-worker-factory-credentials`
-- `102-add-retry-logic-to-discovery`
-
-The branch name MUST be under 50 characters. Filler words SHOULD be stripped.
-
-### 4. Create and checkout the branch
+Check out the branch. The branch name follows the convention `<number>-<kebab-case-summary>`:
 
 ```bash
-git checkout -b <branch-name> main
+git fetch origin
+git checkout <branch>
 ```
 
-If the branch already exists, the user MUST be asked whether to switch to it or recreate it.
+If the branch does not exist, inform the user that the implement skill must be run first and stop.
 
-### 5. Draft the PR
+Check for an existing PR:
 
-The PR title should match its associated issue exactly with `— Closes #<number>` appended to the end.
+```bash
+gh pr list --repo <target> --search "Closes #<number>" --json number --jq '.[0].number'
+```
 
-All PR description prose MUST be written in the imperative mood — "Add retry logic" not "Adds retry logic" or "Added retry logic". This applies to the title, summary, proposed changes, and implementation plan steps. The imperative mood MUST be maintained even when updating the description after work has been completed. Descriptions of the current state of the system are exempt and SHOULD use present tense — "The registry stores entries in memory" not "Store entries in memory".
+If a PR already exists, this is an update — the description will be edited rather than a new PR created.
+
+### 3. Review the branch diff
+
+Determine the base and diff against it:
+
+```bash
+git merge-base HEAD $(git rev-parse --abbrev-ref @{upstream} 2>/dev/null || echo main)
+git log <merge-base>..HEAD --oneline
+git diff <merge-base>..HEAD
+git diff <merge-base>..HEAD --stat
+```
+
+Analyze all committed source and test changes. Understand what was implemented, what was refactored, what tests were added or modified.
+
+### 4. Draft the PR description
+
+The PR title MUST match the associated issue title exactly with ` — Closes #<number>` appended to the end.
+
+All PR description prose MUST be written in the imperative mood — "Add retry logic" not "Adds retry logic" or "Added retry logic". This applies to the title, summary, and proposed changes. Descriptions of the current state of the system are exempt and SHOULD use present tense — "The registry stores entries in memory" not "Store entries in memory".
 
 Prose in PR descriptions MUST NOT be hard-wrapped at a fixed column width. Write each sentence or logical phrase as a single unwrapped line. Markdown renderers handle line wrapping automatically — manual line breaks inside paragraphs create unnecessary diffs and awkward rendering.
 
-The PR description MUST contain exactly four sections:
+The PR description MUST contain a **Summary** and **Proposed changes** section. A **Test cases** section MUST be included when the PR contains code changes; it MAY be omitted for PRs that only modify documentation, configuration, or other non-code files.
 
-**Summary** — A quick recap of the issue, the high-level approach, and any trade-offs worth noting. The summary MUST end with `Closes #<number>` to link the issue.
+**Summary** — A recap of what was implemented, the high-level approach, and any trade-offs worth noting. The summary is based on the actual diff, not the issue body. The summary MUST end with `Closes #<number>` to link the issue.
 
-**Proposed changes** — Subsections for each logical change. Design rationale and before/after code snippets SHOULD be included where useful.
+**Proposed changes** — Subsections for each logical change, derived from the committed diff. Design rationale and before/after code snippets SHOULD be included where useful.
 
-**Test cases** — The `/test` skill MUST be used to generate a Given-When-Then test case table for the affected modules. The table MUST be included in the PR description so reviewers can see expected behavior at a glance. The table format:
+**Test cases** (code changes only) — A Given-When-Then table summarizing the test coverage from committed test files. Read the test files and generate a table in this format:
 
 | Test Suite | Test ID | Given | When | Then | Coverage Target |
 |------------|---------|-------|------|------|-----------------|
@@ -101,51 +107,34 @@ The PR description MUST contain exactly four sections:
 
 The first word of every plain-language table entry MUST be capitalized. Table entries MUST NOT end with punctuation (no trailing periods, commas, etc.). Code spans in entries (e.g., `` `foo.bar()` is called ``) are exempt from the capitalization rule.
 
-**Implementation plan** — Sequenced steps for the implementation, formatted as an ordered checkbox list. Test-first ordering SHOULD be preferred when applicable. Each step MUST describe a concrete output (writing code, tests, documentation, schema changes, etc.). Steps MUST NOT include running tests, linting, or other verification tasks — these are handled automatically by CI/CD. Example format:
-
-```markdown
-1. - [ ] Add `version` field to `Ack` in `worker.proto`; regenerate bindings
-2. - [ ] Write discovery-time version filter tests (VP-001 through VP-004)
-3. - [ ] Implement major-version filter in `proxy.py`
-```
-
-When code is committed and the PR description is updated to reflect the implemented state, completed steps MUST be checked off:
-
-```markdown
-1. - [x] Add `version` field to `Ack` in `worker.proto`; regenerate bindings
-2. - [x] Write discovery-time version filter tests (VP-001 through VP-004)
-3. - [ ] Implement major-version filter in `proxy.py`
-```
-
-### 6. Show draft for approval
+### 5. Show draft for approval
 
 The full PR (title, body, branch name) MUST be presented to the user. The PR MUST NOT be created until the user explicitly approves.
 
-### 7. Push and create the draft PR
+### 6. Push and create the draft PR
 
-GitHub requires at least one commit of difference between the base and head branches to create a PR. Since the branch has no code yet, an empty commit MUST be created as a placeholder (it can be rebased away when real work starts):
+Push the branch if not already pushed:
 
 ```bash
-git commit --allow-empty -m "chore: Open draft PR for #<number>"
 git push -u origin <branch-name>
+```
+
+**Creating a new PR:**
+
+A heredoc MUST be used for the body to avoid shell escaping issues:
+
+```bash
 gh pr create --draft --title "<title>" --body "$(cat <<'EOF'
 <body>
 EOF
 )"
 ```
 
-When the repo is a fork (detected in step 2), add `--repo <upstream-owner>/<upstream-name>` so the PR is opened against the upstream repo:
+When the repo is a fork (detected in step 1), add `--repo <upstream-owner>/<upstream-name>` so the PR is opened against the upstream repo.
 
-```bash
-gh pr create --draft --repo <upstream-owner>/<upstream-name> --title "<title>" --body "$(cat <<'EOF'
-<body>
-EOF
-)"
-```
+The PR MUST always be created as a **draft**. The user marks it ready for review when satisfied.
 
-The PR MUST be created as a **draft** since no code has been written yet.
-
-After the PR is created, explicitly link the issue to the PR so the Development sidebar is populated immediately. The `Closes #<number>` keyword in the body is only processed on merge and does not always create the sidebar link:
+After the PR is created, link the issue to the PR in the Development sidebar:
 
 ```bash
 gh issue develop <issue-number> --repo <target> --branch <branch-name>
@@ -153,30 +142,21 @@ gh issue develop <issue-number> --repo <target> --branch <branch-name>
 
 If the command is not available in the installed `gh` version, the `Closes #<number>` reference in the PR body serves as the fallback.
 
-### 8. Return the PR URL
+**Updating an existing PR:**
 
-The PR URL returned by `gh pr create` MUST be printed so the user can access it directly.
+If a PR already exists (detected in step 2), update the description instead of creating a new PR:
 
-The user SHOULD be prompted with the next pipeline step: "Ready to implement? Run `/implement <number>` to start coding against this plan."
+```bash
+gh pr edit <pr-number> --repo <target> --body "$(cat <<'EOF'
+<updated body>
+EOF
+)"
+```
 
-## Keeping the PR consistent
+The `--repo <target>` flag MUST be included when the target repo differs from the current repo.
 
-The PR description is a living document. It MUST be re-evaluated and updated when:
+### 7. Return the PR URL
 
-- **The user requests changes to the proposed implementation plan.** The test cases table MUST be regenerated to reflect the revised plan before showing the updated draft for approval.
-- **Code is committed to the branch.** This skill MUST be re-run against the actual code being pushed: update the summary, proposed changes, and test cases to match what was implemented rather than what was planned. Use `gh pr edit` to update the existing PR body:
+The PR URL MUST be printed so the user can access it directly.
 
-  ```bash
-  gh pr edit <number> --repo <target> --body "$(cat <<'EOF'
-  <updated body>
-  EOF
-  )"
-  ```
-
-  The `--repo <target>` flag MUST be included when the target repo differs from the current repo (as resolved in step 1).
-
-The PR description MUST always accurately reflect the current state — planned or implemented — and MUST NOT drift from reality.
-
-### 9. Prompt the user to move onto the implementation step
-
-The user MUST be prompted with the next pipeline step: "Ready to implement? Run `/implement <number>` to start coding against this plan." DO NOT proceed on your own.
+The user MUST be informed that the draft PR is created and can be marked ready for review via `gh pr ready <number>`. Note that if review feedback is received, they can re-enter the implementation loop by running the implement skill again.

--- a/llms/skills/review.md
+++ b/llms/skills/review.md
@@ -17,7 +17,7 @@ Fetch a pull request, analyze its diff against project guides and source context
 
 ## Pipeline Context
 
-This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update) → `/review`. This skill is the **sixth** stage, invoked after the PR has been updated and is ready for review.
+This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr` → `/review`. This skill is the **sixth** stage, invoked after the PR has been created and is ready for review.
 
 ## Arguments
 

--- a/llms/skills/test.md
+++ b/llms/skills/test.md
@@ -1,28 +1,28 @@
 ---
 name: test
 description: >
-  Generate comprehensive test specifications for source modules with 100%
-  coverage of public APIs. Use this skill whenever the user says "/test",
-  "generate test specs", "create test plan", "write test specifications", or
-  similar. Analyzes module structure and produces Given-When-Then test case
-  tables organized by public class and function.
+  Analyze code changes for an issue, evaluate existing test coverage, plan
+  and implement tests. Use this skill whenever the user says "/test <number>",
+  "write tests for #N", "test #N", or similar. Accepts an issue number,
+  resolves the branch, diffs against the base, evaluates existing tests, and
+  writes new or updated tests to achieve comprehensive coverage.
 ---
 
 The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
 
 # Test Skill
 
-Generate comprehensive test specifications for source modules with 100% coverage of public APIs.
+Analyze code changes associated with an issue, evaluate existing test coverage, and plan and implement tests to achieve comprehensive coverage of public APIs.
 
 ## Pipeline Context
 
-This skill is part of the development workflow pipeline: `/issue` → `/pr` → `/implement` → `/commit` → `/pr` (update). This skill is a **supporting tool** invoked by `/pr` to generate test case tables.
+This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr`. This skill is the **third** stage. The implement, test, and commit steps are iterative — they can be invoked multiple times for a given issue.
 
 ## Arguments
 
-A list of target modules or file references MUST be provided as arguments (e.g., `/test src/wool/worker/service.py`). If no arguments are provided, the user MUST be asked which modules to analyze.
+An issue number MUST be provided as the sole argument (e.g., `/test 103`).
 
-> **Test guide:** Determine the language of the target modules from their file extensions, then read the corresponding test guide before generating test specifications:
+> **Test guide:** Determine the language of the changed source files from their file extensions, then read the corresponding test guide before generating test specifications:
 >
 > | Language | Guide |
 > |----------|-------|
@@ -32,55 +32,92 @@ A list of target modules or file references MUST be provided as arguments (e.g.,
 
 ## Workflow
 
-### 1. Identify target modules
+### TL;DR
 
-Analyze referenced files or use the provided arguments to determine which source modules need test specifications.
+1. Resolve issue, PR, and branch
+2. Analyze code changes
+3. Evaluate existing tests
+4. Generate test plan
+5. Enter plan mode
+6. Implement tests after approval
+7. Prompt the user to move onto the commit step
 
-### 2. Analyze module structure
+### 1. Resolve issue, PR, and branch
 
-For each module:
+Perform the same resolution logic as the implement skill:
 
-- **CRITICAL**: MUST NOT consider any existing tests when creating the test plan. Analyze only the source module itself.
-- Identify all public classes (no underscore prefix).
-- Identify all public functions (no underscore prefix).
-- Identify all public methods in each class.
-- Note language-specific idioms that need idiomatic testing (per the project test guide).
+```bash
+gh repo view --json isFork,parent
+gh issue view <number> --repo <target>
+```
 
-### 3. Generate test specifications
+Read the issue title, body, and labels. If the issue does not exist or is closed, inform the user and stop.
 
-For each source module, create a test specification file using the naming convention from the project test guide:
+Check for an existing PR:
 
-- Module header: `## Module: <module_name>`
-- For each public class:
-  - Section header: `### Public Class: <ClassName>`
-  - Test table (see Table Format below)
-  - Include: basic cases, variations, edge cases, property-based tests
-- For each public function:
-  - Section header: `### Public Function: <function_name>()`
-  - Test table (see Table Format below)
-- Test Implementation Notes section
-- Test Organization section (showing test file structure)
-- Summary Statistics section
+```bash
+gh pr list --repo <target> --search "Closes #<number>" --json number,headRefName --jq '.[0]'
+```
 
-Create `specs/QUICK_REFERENCE.md` with an at-a-glance summary:
+If a PR exists, note its number for context. Check out the branch:
 
-- Test spec file locations (links to each spec file)
-- Test suite class names per module
-- Coverage statistics per module
-- Quick navigation to each module/class/function
+```bash
+git fetch origin <branch>
+git checkout <branch>
+```
 
-### 4. Validate test specifications
+If the branch does not exist, inform the user that the implement skill must be run first and stop. The test skill MUST NOT create branches.
 
-- All tests focus on public APIs only (no underscore-prefixed symbols).
-- All tests use Given-When-Then format.
-- Language idioms tested idiomatically (not by calling special methods directly).
-- Edge cases grouped with normal cases.
-- Property-based tests grouped with their target object.
-- 100% coverage of public APIs achieved.
+### 2. Analyze code changes
 
-### 5. Report completion
+Determine the base branch and diff against it:
 
-Provide paths to generated files and summary statistics.
+```bash
+git merge-base HEAD $(git rev-parse --abbrev-ref @{upstream} 2>/dev/null || echo main)
+git diff <merge-base>..HEAD --name-only
+git diff <merge-base>..HEAD
+```
+
+Read every changed source file to understand what was implemented. Note which modules have new or modified public APIs.
+
+### 3. Evaluate existing tests
+
+Read the current test files for all affected modules. For each existing test:
+
+- Determine which behaviors are already covered and whether the coverage is satisfactory.
+- Identify tests that can be **modified** to cover new behavior rather than duplicating coverage.
+- Identify tests that **no longer apply** due to removed or significantly changed functionality — flag these for removal or rewriting.
+- Note gaps that require **new** test cases.
+
+### 4. Generate test plan
+
+Generate a Given-When-Then test plan internally. This plan is an agent planning artifact — do NOT write spec files to disk. The plan MUST:
+
+- Account for existing coverage: mark behaviors already tested, propose modifications to existing tests where appropriate, flag stale tests for removal or rewriting, and only add new test cases for genuinely uncovered behavior.
+- Achieve 100% coverage of new or changed public APIs.
+- Follow the structure in [Table Format](#table-format) below.
+- Follow the project test guide conventions.
+
+### 5. Enter plan mode
+
+Call `EnterPlanMode` to present the test plan to the user for approval. The plan MUST clearly distinguish between:
+
+- **Existing tests to keep** — already cover the behavior correctly
+- **Existing tests to modify** — need updates to cover changed behavior
+- **Existing tests to remove** — no longer apply due to removed or changed functionality
+- **New tests to add** — cover genuinely uncovered behavior
+
+### 6. Implement tests after approval
+
+Once the user approves the plan, implement the test files:
+
+- Modify existing test files where the plan calls for updates or removals.
+- Add new test cases where the plan identifies coverage gaps.
+- Follow the project test guide for file naming, class organization, and test conventions.
+
+### 7. Prompt the user to move onto the commit step
+
+The user MUST be prompted with the next pipeline step: "Ready to commit? Run `/commit` to stage and commit the changes." DO NOT proceed on your own.
 
 ## Table Format
 
@@ -102,7 +139,7 @@ Each test table MUST have these columns:
 
 ### Coverage and Scope
 
-- MUST achieve 100% test coverage of all public APIs.
+- MUST achieve 100% test coverage of all new or changed public APIs.
 - MUST test ONLY public functions, methods, and classes (no underscore prefix).
 - MUST NOT manipulate or validate any private/internal state.
 - MUST NOT reference private functions/methods/variables in test specifications.
@@ -130,6 +167,42 @@ MUST test language idioms using their natural syntax, not by calling special met
 - MUST group edge cases with their target function/class.
 - SHOULD follow progression: basic cases, variations, edge cases, property-based tests.
 
+## Integration Test Specifications
+
+When the user requests integration specs or targets an `integration/` directory, generate cross-boundary scenario specifications instead of per-module API coverage. Integration specs validate that assembled subsystems work together — they are orthogonal to unit specs, not a replacement.
+
+### Discover existing dimensions
+
+Before proposing any changes, MUST read the existing integration test infrastructure to discover:
+
+- The current dimension definitions (enumerations or equivalent) and their members
+- Cross-dimension constraints (which combinations are structurally invalid)
+- Permanent exclusions (documented limitations that will not be fixed) vs temporary expected failures (bugs with open issues)
+- The scenario model, builder, and invocation dispatcher
+- Any expected-failure conditions in the test files and the issues they reference
+
+### Extending vs adding dimensions
+
+New work SHOULD extend existing dimensions with new members rather than adding new dimensions. A new dimension MUST only be added when the feature or subsystem being tested is genuinely orthogonal to all existing dimensions — i.e., it cannot be expressed as a new member of any existing dimension. When in doubt, prefer a new member over a new dimension; the combinatorial explosion of pairwise coverage grows with each new dimension.
+
+When adding a new member to an existing dimension:
+
+1. Add the member to the dimension definition
+2. Update the filter function if the new member has cross-dimension constraints
+3. Update the builder to resolve the new member to its concrete runtime value
+4. Update the invocation dispatcher if the new member changes how results are produced or asserted
+5. The pairwise covering array and exploration strategy automatically pick up the new member
+
+### Spec generation
+
+- **Scope**: Integration specs focus on interactions between components, not exhaustive coverage of a single module's API surface
+- **Dimensions column**: Integration spec tables include a "Dimensions" column listing which scenario axes are exercised (e.g., "D1=COROUTINE, D2=DEFAULT, D3=NONE")
+- **Pairwise coverage**: Scenarios are generated combinatorially via pairwise covering arrays, not enumerated manually — the spec describes the dimensions and constraints, not individual test cases
+- **Stochastic exploration**: A random strategy draws from per-dimension value sets with conditional filtering, providing coverage beyond the deterministic pairwise array
+- **Table format**: Use the same table columns as unit specs, but replace "Coverage Target" with "Dimensions" to indicate which scenario axes each test exercises
+
+Consult the language-specific test guide for implementation details (libraries, data structures, parametrization mechanisms).
+
 ## Good and Bad Examples
 
 See the project test guide for language-specific good/bad examples.
@@ -153,7 +226,7 @@ See the project test guide for language-specific good/bad examples.
 
 ## Validation Checklist
 
-A test specification is valid if and only if:
+A test plan is valid if and only if:
 
 - Describes only publicly observable behavior.
 - Uses natural language idioms (context managers, instantiation, etc.).
@@ -162,13 +235,15 @@ A test specification is valid if and only if:
 - Has clear Given-When-Then structure.
 - Would remain valid even if all private code is rewritten.
 - Focuses on "what" not "how".
+- Accounts for existing test coverage (no unnecessary duplication).
+- Flags stale tests for removal.
 
 ## Key Rules
 
-- **Ignore existing tests**: MUST NOT consider any existing test files when creating test specifications.
+- **Evaluate existing tests**: MUST read existing test files and account for current coverage before planning new tests.
 - **Public APIs only**: No underscore-prefixed symbols in test specs.
 - **Behavior not implementation**: Tests validate what, not how.
 - **Idiomatic testing**: Use language idioms, not direct special method calls.
-- **Comprehensive coverage**: 100% of public APIs must be covered.
+- **Comprehensive coverage**: 100% of new or changed public APIs must be covered.
 - **Clear organization**: Group by module, class/function, test progression.
-- **Separate files**: One spec file per source module in `specs/` directory.
+- **No spec files**: The test plan is an internal planning artifact, not a physical document.


### PR DESCRIPTION
## Summary

Restructure the development workflow pipeline from issue → pr → implement → commit → pr (update) to issue → implement → test → commit → pr. The implement skill absorbs branch creation and issue loading from the PR skill, with a re-invocation path that checks for unresolved GitHub review comments. The test skill becomes an explicit pipeline step that analyzes code changes, evaluates existing test coverage, and implements tests rather than writing spec files. The PR skill moves to the final step and drafts a description by reviewing the actual branch diff. The implement, test, and commit steps are iterative. All seven skill definitions (issue, implement, test, commit, pr, audit, review) have consistent pipeline context references.

Closes #89

## Proposed changes

### 1. Update the issue skill pipeline references

Update `llms/skills/issue.md` to change the pipeline context to issue → implement → test → commit → pr and point the next-step prompt to the implement skill instead of the PR skill.

### 2. Rewrite the implement skill

Replace the PR-resolution workflow in `llms/skills/implement.md` with direct issue loading and branch creation. Add a re-invocation path: when a PR already exists, query GitHub for unresolved review comment threads via the `isResolved` GraphQL field. If unresolved threads exist, plan changes to address them. If none exist, verify implementation completeness. Include an explicit definition of "unresolved review comment" as a binary GitHub state.

### 3. Rewrite the test skill

Replace the spec-file-generation workflow in `llms/skills/test.md` with an issue-aware, diff-based approach. Accept an issue number, resolve the branch (but never create one), diff against the upstream tracking branch, evaluate existing tests for coverage gaps and stale tests, generate a Given-When-Then plan internally (not as physical spec files), and implement tests after user approval.

### 4. Update the commit skill pipeline references

Update `llms/skills/commit.md` to change the pipeline context to fourth stage and point the next-step prompt to the PR skill. Remove the placeholder empty commit handling that was tied to the old PR-first workflow.

### 5. Rewrite the PR skill

Replace the upfront planning workflow in `llms/skills/pr.md` with a diff-review workflow. Accept an issue number, check out the branch, diff against the base, and draft a description from the actual changes. Always create as draft. Run `gh issue develop` to link the issue in the Development sidebar. Support updating an existing PR via `gh pr edit`.

### 6. Update audit and review pipeline references

Update `llms/skills/audit.md` and `llms/skills/review.md` to reference the new pipeline ordering.

## Test cases

No test cases — these are Markdown skill definitions with no executable code.