### PR TITLE
Serialize WorkerMetadata in worker process before piping it back to the main process — Closes #90

### DIFF
--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -172,7 +172,11 @@ class WorkerProcess(Process):
             raise ValueError("Timeout must be positive")
         super().start()
         if self._get_metadata.poll(timeout=timeout):
-            self._metadata = self._get_metadata.recv()
+            self._metadata = WorkerMetadata.from_protobuf(
+                protocol.WorkerMetadata.FromString(
+                    self._get_metadata.recv()
+                )
+            )
             assert self._metadata is not None
             self._port = int(self._metadata.address.rsplit(":", 1)[1])
         else:
@@ -266,7 +270,9 @@ class WorkerProcess(Process):
                     wool.__worker_service__.set(service)
 
                     try:
-                        self._set_metadata.send(metadata)
+                        self._set_metadata.send(
+                            metadata.to_protobuf().SerializeToString()
+                        )
                     finally:
                         self._set_metadata.close()
                     await service.stopped.wait()

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -1,5 +1,6 @@
 import signal
 import uuid
+from types import MappingProxyType
 
 import grpc
 import grpc.aio
@@ -686,6 +687,48 @@ class TestWorkerProcess:
         # Assert
         mock_get_meta.close.assert_called_once()
 
+    def test_start_deserializes_metadata_with_extra_from_pipe(self, mocker):
+        """Test start deserializes metadata with extra and tags from pipe.
+
+        Given:
+            A pipe returning protobuf bytes encoding extra and tags
+        When:
+            start() is called
+        Then:
+            It should populate metadata.extra as MappingProxyType
+            and metadata.tags as frozenset
+        """
+        # Arrange
+        metadata_bytes = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50051",
+            pid=12345,
+            version="1.0.0",
+            tags=frozenset({"gpu"}),
+            extra=MappingProxyType({"key": "value"}),
+        ).to_protobuf().SerializeToString()
+
+        mock_get_meta = mocker.MagicMock()
+        mock_get_meta.poll.return_value = True
+        mock_get_meta.recv.return_value = metadata_bytes
+        mock_set_meta = mocker.MagicMock()
+        mocker.patch(
+            "wool.runtime.worker.process.Pipe",
+            return_value=(mock_get_meta, mock_set_meta),
+        )
+
+        mocker.patch.object(process_module.Process, "start")
+
+        process = WorkerProcess()
+
+        # Act
+        process.start()
+
+        # Assert
+        assert process.metadata.extra == MappingProxyType({"key": "value"})
+        assert isinstance(process.metadata.extra, MappingProxyType)
+        assert process.metadata.tags == frozenset({"gpu"})
+
     @pytest.mark.asyncio
     async def test__proxy_factory_starts_proxy_when_not_started(self, mocker):
         """Test _proxy_factory starts proxy when not already started.
@@ -884,6 +927,61 @@ class TestWorkerProcess:
             protocol.WorkerMetadata.FromString(sent)
         )
         assert deserialized.address == "0.0.0.0:8080"
+
+    def test_run_with_extra_and_tags_serializes_complete_metadata(
+        self, mocker
+    ):
+        """Test run serializes metadata including extra and tags to pipe.
+
+        Given:
+            A WorkerProcess with extra=MappingProxyType({"k": "v"})
+            and tags=frozenset({"gpu"})
+        When:
+            run() executes
+        Then:
+            It should send protobuf bytes that deserialize to
+            WorkerMetadata with matching extra and tags
+        """
+        # Arrange
+        process = WorkerProcess(
+            extra=MappingProxyType({"k": "v"}),
+            tags=frozenset({"gpu"}),
+        )
+
+        mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
+        mocker.patch("wool.runtime.worker.process.ResourcePool")
+
+        mock_server = mocker.MagicMock()
+        mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
+        mock_server.start = mocker.AsyncMock()
+        mock_server.stop = mocker.AsyncMock()
+        mocker.patch("grpc.aio.server", return_value=mock_server)
+
+        mock_service = mocker.MagicMock()
+        mock_service.stopped.wait = mocker.AsyncMock()
+        mocker.patch(
+            "wool.runtime.worker.process.WorkerService",
+            return_value=mock_service,
+        )
+
+        mocker.patch("wool.runtime.worker.process._signal_handlers")
+
+        mock_send = mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
+
+        # Act
+        process.run()
+
+        # Assert
+        mock_send.assert_called_once()
+        sent = mock_send.call_args[0][0]
+        assert isinstance(sent, bytes)
+        deserialized = WorkerMetadata.from_protobuf(
+            protocol.WorkerMetadata.FromString(sent)
+        )
+        assert deserialized.extra == MappingProxyType({"k": "v"})
+        assert isinstance(deserialized.extra, MappingProxyType)
+        assert deserialized.tags == frozenset({"gpu"})
 
     def test_run_closes_pipe_even_on_error(self, mocker):
         """Test run closes pipe even if send fails.

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -9,6 +9,7 @@ from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
 
+from wool import protocol
 from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.worker import process as process_module
 from wool.runtime.worker.auth import CredentialContext
@@ -560,7 +561,7 @@ class TestWorkerProcess:
             address="127.0.0.1:50051",
             pid=12345,
             version="1.0.0",
-        )
+        ).to_protobuf().SerializeToString()
         mock_set_meta = mocker.MagicMock()
         mocker.patch(
             "wool.runtime.worker.process.Pipe",
@@ -598,7 +599,7 @@ class TestWorkerProcess:
             address="127.0.0.1:50051",
             pid=12345,
             version="1.0.0",
-        )
+        ).to_protobuf().SerializeToString()
         mock_set_meta = mocker.MagicMock()
         mocker.patch(
             "wool.runtime.worker.process.Pipe",
@@ -668,7 +669,7 @@ class TestWorkerProcess:
             address="127.0.0.1:50051",
             pid=12345,
             version="1.0.0",
-        )
+        ).to_protobuf().SerializeToString()
         mock_set_meta = mocker.MagicMock()
         mocker.patch(
             "wool.runtime.worker.process.Pipe",
@@ -829,8 +830,11 @@ class TestWorkerProcess:
         mock_server.start.assert_called_once()
         mock_send.assert_called_once()
         sent = mock_send.call_args[0][0]
-        assert isinstance(sent, WorkerMetadata)
-        assert sent.address == "127.0.0.1:50051"
+        assert isinstance(sent, bytes)
+        deserialized = WorkerMetadata.from_protobuf(
+            protocol.WorkerMetadata.FromString(sent)
+        )
+        assert deserialized.address == "127.0.0.1:50051"
         mock_close.assert_called_once()
         mock_service.stopped.wait.assert_called_once()
         mock_server.stop.assert_called_once_with(grace=30.0)
@@ -875,8 +879,11 @@ class TestWorkerProcess:
         # Assert
         mock_send.assert_called_once()
         sent = mock_send.call_args[0][0]
-        assert isinstance(sent, WorkerMetadata)
-        assert sent.address == "0.0.0.0:8080"
+        assert isinstance(sent, bytes)
+        deserialized = WorkerMetadata.from_protobuf(
+            protocol.WorkerMetadata.FromString(sent)
+        )
+        assert deserialized.address == "0.0.0.0:8080"
 
     def test_run_closes_pipe_even_on_error(self, mocker):
         """Test run closes pipe even if send fails.
@@ -1099,8 +1106,11 @@ class TestWorkerProcess:
 
         # Assert
         assert len(sent_metadata) == 1
-        assert isinstance(sent_metadata[0], WorkerMetadata)
-        assert sent_metadata[0].address == "127.0.0.1:54321"
+        assert isinstance(sent_metadata[0], bytes)
+        deserialized = WorkerMetadata.from_protobuf(
+            protocol.WorkerMetadata.FromString(sent_metadata[0])
+        )
+        assert deserialized.address == "127.0.0.1:54321"
 
     def test_serve_insecure_worker_random_port_assignment(self, mocker):
         """Test random port assignment for insecure worker.
@@ -1141,8 +1151,11 @@ class TestWorkerProcess:
 
         # Assert
         assert len(sent_metadata) == 1
-        assert isinstance(sent_metadata[0], WorkerMetadata)
-        assert sent_metadata[0].address == "127.0.0.1:54322"
+        assert isinstance(sent_metadata[0], bytes)
+        deserialized = WorkerMetadata.from_protobuf(
+            protocol.WorkerMetadata.FromString(sent_metadata[0])
+        )
+        assert deserialized.address == "127.0.0.1:54322"
 
     def test_serve_no_dual_port_architecture(self, mocker):
         """Test no dual-port architecture.


### PR DESCRIPTION
## Summary

Replace pickle-based transfer of WorkerMetadata over the multiprocessing pipe with explicit protobuf serialization. Serialize to protobuf bytes before `send()` in the child process and deserialize after `recv()` in the parent, matching how LocalDiscovery already handles metadata in shared memory. Avoid the `TypeError: cannot pickle 'mappingproxy' object` crash caused by `MappingProxyType` in the `extra` field.

Closes #90

## Proposed changes

### Serialize metadata to protobuf bytes on the child send side

Replace `self._set_metadata.send(metadata)` in `WorkerProcess._serve()` with `self._set_metadata.send(metadata.to_protobuf().SerializeToString())`. Send raw bytes over the pipe instead of a Python object, eliminating pickle entirely.

### Deserialize protobuf bytes on the parent receive side

Replace `self._metadata = self._get_metadata.recv()` in `WorkerProcess.start()` with a `WorkerMetadata.from_protobuf(protocol.WorkerMetadata.FromString(...))` chain. No new imports are needed — `protocol` and `WorkerMetadata` are already available in the module.

### Update existing tests to expect protobuf bytes

Update seven existing tests that mock the pipe to return serialized protobuf bytes instead of raw `WorkerMetadata` objects, and assert via deserialization rather than `isinstance(sent, WorkerMetadata)`.

### Add regression tests for extra and tags

Add two new tests that verify `MappingProxyType` extra and `frozenset` tags survive the protobuf serialization roundtrip through the pipe — the exact fields that triggered the pickle crash.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestWorkerProcess` | A pipe returning protobuf bytes encoding extra and tags | `start()` is called | `metadata.extra` is MappingProxyType and `metadata.tags` is frozenset with expected values | `start()` deserializes all fields from pipe bytes |
| 2 | `TestWorkerProcess` | A WorkerProcess with extra=MappingProxyType({"k": "v"}) and tags=frozenset({"gpu"}) | `run()` executes | Sent bytes deserialize to WorkerMetadata with matching extra and tags | `run()` serializes all fields to pipe bytes |
| 3 | `TestWorkerProcess` | A WorkerProcess with mocked parent start and pipe returning protobuf bytes | `start()` is called | Process.start is called, pipe is polled, recv'd, and closed | `start()` calls parent and receives from pipe |
| 4 | `TestWorkerProcess` | A WorkerProcess with mocked pipe returning protobuf bytes | `start()` is called | Port and address are populated from deserialized metadata | `start()` populates port and address |
| 5 | `TestWorkerProcess` | A WorkerProcess with mocked pipe returning protobuf bytes | `start()` successfully receives metadata | Pipe connection is closed | `start()` closes pipe after receive |
| 6 | `TestWorkerProcess` | A WorkerProcess with mocked server setup | `run()` executes | Sent data is bytes that deserialize to correct address | `run()` sends protobuf bytes via pipe |
| 7 | `TestWorkerProcess` | A WorkerProcess with mocked server returning port 8080 | `run()` executes | Sent bytes deserialize to address 0.0.0.0:8080 | `run()` sends correct port in metadata |
| 8 | `TestWorkerProcess` | A WorkerProcess with credentials and port=0 | `run()` executes | Sent bytes deserialize to correct secure address | Secure worker port assignment via pipe |
| 9 | `TestWorkerProcess` | A WorkerProcess with no credentials and port=0 | `run()` executes | Sent bytes deserialize to correct insecure address | Insecure worker port assignment via pipe |