### PR TITLE
Use Unix domain sockets for self-dispatch gRPC connections — Closes #96

### DIFF
--- a/llms/test-guides/python.md
+++ b/llms/test-guides/python.md
@@ -393,17 +393,40 @@ Use `@st.composite` strategies that draw from per-dimension `st.sampled_from(Enu
 
 ### xfail for Known Bugs
 
-Scenarios that hit known bugs MUST use `pytest.xfail()` in the test body (not `skip`, not filtered out) with a reference to the issue number:
+Scenarios that hit known bugs MUST be registered in a `_KnownBug` data structure and handled by an `xfail_known_bugs` fixture (not `skip`, not filtered out). Each entry defines a `match` predicate, a `raises` tuple constraining the expected failure mode, a `reason` referencing the issue, and optional `retries` with a `retryable` predicate for transient errors:
 
 ```python
-def _xfail_known_bugs(scenario):
-    if scenario.credential is not CredentialType.INSECURE:
-        pytest.xfail("credential pickling across subprocess boundary (#60)")
-    if scenario.pool_mode in _NESTED_MODES:
-        pytest.xfail("resource collision with nested pools (#62)")
+@dataclass(frozen=True)
+class _KnownBug:
+    match: Callable[[Scenario], bool]
+    raises: tuple[type[BaseException], ...]
+    reason: str
+    retries: int = 0
+    backoff: float = 0.5
+    retryable: Callable[[BaseException], bool] = lambda _: False
+
+_KNOWN_BUGS: list[_KnownBug] = [
+    _KnownBug(
+        match=lambda s: s.shape in _NESTED_SHAPES,
+        raises=(grpc.RpcError, TimeoutError),
+        reason="grpcio race condition (#41483)",
+        retries=3,
+        retryable=lambda e: (
+            isinstance(e, grpc.RpcError)
+            and e.code() == grpc.StatusCode.INTERNAL
+        ),
+    ),
+]
 ```
 
-This keeps the scenarios visible in the test output (as `xfail`, not silently missing) and automatically surfaces when a bug fix causes them to pass unexpectedly (`xpass`).
+The fixture wraps the test body, catches matching exceptions, retries transient ones with exponential backoff, and calls `pytest.xfail()` when retries are exhausted or the error is non-retryable. Unmatched exceptions propagate as real failures. Tests use the fixture as an async callable:
+
+```python
+async def test_dispatch(scenario, xfail_known_bugs):
+    async def body():
+        ...
+    await xfail_known_bugs(scenario, body)
+```
 
 The distinction from permanent filter exclusions: filtered combinations are documented limitations that will not be fixed. `xfail` combinations are bugs with open issues that will eventually pass.
 

--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -53,9 +53,9 @@ __proxy_pool__: Final[ContextVar[ResourcePool[WorkerProxy] | None]] = ContextVar
     "__proxy_pool__", default=None
 )
 
-__worker_metadata__: Final[ContextVar[WorkerMetadata | None]] = ContextVar(
-    "__worker_metadata__", default=None
-)
+__worker_metadata__: WorkerMetadata | None = None
+
+__worker_uds_address__: str | None = None
 
 __worker_service__: Final[ContextVar[WorkerService | None]] = ContextVar(
     "__worker_service__", default=None

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -20,6 +20,7 @@ from wool.runtime.routine.task import Task
 from wool.runtime.worker.base import WorkerOptions
 
 _DispatchCall: TypeAlias = grpc.aio.StreamStreamCall[protocol.Request, protocol.Response]
+_PoolKey: TypeAlias = tuple[str, grpc.ChannelCredentials | None, int, WorkerOptions]
 
 _T = TypeVar("_T")
 
@@ -353,6 +354,7 @@ class WorkerConnection:
         self._limit = limit
         self._options = options if options is not None else WorkerOptions()
         self._key = (target, credentials, limit, self._options)
+        self._uds_key: _PoolKey | None = None
 
     async def dispatch(
         self,
@@ -399,17 +401,23 @@ class WorkerConnection:
             raise ValueError("Dispatch timeout must be positive")
 
         if (
-            metadata := wool.__worker_metadata__.get()
+            metadata := wool.__worker_metadata__
         ) is not None and metadata.address == self._target:
             serializer = PassthroughSerializer()
+            if (uds_address := wool.__worker_uds_address__) is not None:
+                key = (uds_address, None, self._limit, self._options)
+                self._uds_key = key
+            else:
+                key = self._key
         else:
             serializer = None
+            key = self._key
 
-        ch = await _channel_pool.acquire(self._key)
+        channel = await _channel_pool.acquire(key)
         try:
             try:
                 call = await self._dispatch(
-                    ch, task.to_protobuf(serializer=serializer), timeout
+                    channel, task.to_protobuf(serializer=serializer), timeout
                 )
             except grpc.RpcError as error:
                 code = error.code()
@@ -419,26 +427,31 @@ class WorkerConnection:
                 else:
                     raise RpcError(code, details) from error
 
-            gen = self._execute(call, task)
-            await gen.__anext__()  # Prime: _execute acquires its own ref
+            stream = self._execute(call, task, key)
+            await stream.__anext__()  # Prime: _execute acquires its own ref
         except BaseException:
-            await _channel_pool.release(self._key)
+            await _channel_pool.release(key)
             raise
 
-        await _channel_pool.release(self._key)
-        return cast(AsyncGenerator[protocol.Message, None], gen)
+        await _channel_pool.release(key)
+        return cast(AsyncGenerator[protocol.Message, None], stream)
 
     async def close(self):
         """Close the connection and release all pooled resources.
 
-        Clears the pooled channel entry for this connection's key.
-        Idempotent: safe to call multiple times or on connections
-        that were never used.
+        Clears the pooled channel entries for both the TCP key and,
+        if a UDS address is available, the UDS key. Idempotent: safe
+        to call multiple times or on connections that were never used.
         """
         try:
             await _channel_pool.clear(self._key)
         except KeyError:
             pass
+        if self._uds_key is not None:
+            try:
+                await _channel_pool.clear(self._uds_key)
+            except KeyError:
+                pass
 
     async def _dispatch(
         self,
@@ -475,9 +488,9 @@ class WorkerConnection:
         return call
 
     async def _execute(
-        self, call: _DispatchCall, task: Task
+        self, call: _DispatchCall, task: Task, key: _PoolKey
     ) -> AsyncGenerator[protocol.Message | None, None]:
-        ch = await _channel_pool.acquire(self._key)
+        channel = await _channel_pool.acquire(key)
         try:
             yield  # Priming yield — signals dispatch() that ref is held
             stream = _DispatchStream(call, task)
@@ -503,6 +516,6 @@ class WorkerConnection:
                     pass
                 raise
             finally:
-                ch.semaphore.release()
+                channel.semaphore.release()
         finally:
-            await _channel_pool.release(self._key)
+            await _channel_pool.release(key)

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -6,7 +6,9 @@ import logging
 import multiprocessing as _mp
 import os
 import signal
+import socket
 import sys
+import tempfile
 import uuid
 from contextlib import contextmanager
 from functools import partial
@@ -14,6 +16,7 @@ from multiprocessing.connection import Connection
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Final
 
 import grpc.aio
 
@@ -35,6 +38,8 @@ Pipe = _ctx.Pipe
 Process = _ctx.Process
 
 logger = logging.getLogger(__name__)
+
+_HAS_UDS: Final[bool] = hasattr(socket, "AF_UNIX")
 
 
 class WorkerProcess(Process):
@@ -173,9 +178,7 @@ class WorkerProcess(Process):
         super().start()
         if self._get_metadata.poll(timeout=timeout):
             self._metadata = WorkerMetadata.from_protobuf(
-                protocol.WorkerMetadata.FromString(
-                    self._get_metadata.recv()
-                )
+                protocol.WorkerMetadata.FromString(self._get_metadata.recv())
             )
             assert self._metadata is not None
             self._port = int(self._metadata.address.rsplit(":", 1)[1])
@@ -249,6 +252,15 @@ class WorkerProcess(Process):
             else:
                 port = server.add_insecure_port(address)
 
+            uds_address = None
+            if _HAS_UDS:
+                uds_path = os.path.join(tempfile.gettempdir(), f"wool-{self._uid}.sock")
+                uds_target = f"unix:{uds_path}"
+                with contextlib.suppress(OSError):
+                    os.unlink(uds_path)
+                server.add_insecure_port(uds_target)
+                uds_address = uds_target
+
             service = WorkerService()
             protocol.add_to_server[protocol.WorkerServicer](service, server)
 
@@ -266,7 +278,8 @@ class WorkerProcess(Process):
                         extra=MappingProxyType(self._extra),
                         secure=self._credentials is not None,
                     )
-                    wool.__worker_metadata__.set(metadata)
+                    wool.__worker_metadata__ = metadata
+                    wool.__worker_uds_address__ = uds_address
                     wool.__worker_service__.set(service)
 
                     try:
@@ -283,6 +296,10 @@ class WorkerProcess(Process):
                 finally:
                     logger.info("Worker server stopping with grace period")
                     await server.stop(grace=self._shutdown_grace_period)
+                    if uds_address is not None:
+                        uds_path = uds_address.removeprefix("unix:")
+                        with contextlib.suppress(OSError):
+                            os.unlink(uds_path)
 
     def _address(self, host, port) -> str:
         """Format network address for the given port.

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -10,12 +10,14 @@ import asyncio
 import datetime
 import ipaddress
 import uuid
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from dataclasses import fields
 from enum import Enum
 from enum import auto
 
+import grpc
 import pytest
 import pytest_asyncio
 from allpairspy import AllPairs
@@ -484,6 +486,43 @@ _NESTED_SHAPES = (
 )
 
 
+@dataclass(frozen=True)
+class _KnownBug:
+    """A known bug that should be treated as an expected failure.
+
+    When ``retryable`` returns True for a caught exception, the test
+    body is re-executed up to ``retries`` times with exponential
+    backoff before falling through to xfail. Exceptions that match
+    ``raises`` but not ``retryable`` xfail immediately.
+    """
+
+    match: Callable[[Scenario], bool]
+    raises: tuple[type[BaseException], ...]
+    reason: str
+    retries: int = 0
+    backoff: float = 0.5
+    retryable: Callable[[BaseException], bool] = lambda _: False
+
+
+def _is_grpc_internal(exc: BaseException) -> bool:
+    return isinstance(exc, grpc.RpcError) and exc.code() == grpc.StatusCode.INTERNAL
+
+
+_KNOWN_BUGS: list[_KnownBug] = [
+    _KnownBug(
+        match=lambda s: s.shape in _NESTED_SHAPES,
+        raises=(grpc.RpcError, TimeoutError),
+        reason=(
+            "grpcio 1.78 PollerCompletionQueue thundering herd race "
+            "(https://github.com/grpc/grpc/pull/41483)"
+        ),
+        retries=3,
+        backoff=0.5,
+        retryable=_is_grpc_internal,
+    ),
+]
+
+
 def _pairwise_filter(row):
     """Filter invalid dimension combinations.
 
@@ -714,3 +753,42 @@ def _clear_proxy_context():
     yield
     wool.__proxy__.reset(proxy_token)
     wool.__proxy_pool__.reset(pool_token)
+
+
+@pytest.fixture
+def xfail_known_bugs():
+    """Run a test body with retry and xfail for known bugs.
+
+    Returns an async callable. Usage::
+
+        await xfail_known_bugs(scenario, body)
+
+    where ``body`` is a no-argument async callable containing the
+    test logic. If the body raises an exception matching a known
+    bug's ``retryable`` predicate, it is retried with exponential
+    backoff. After retries are exhausted (or for non-retryable
+    matches against ``raises``), the test is marked as xfail.
+    Unmatched exceptions propagate normally.
+    """
+
+    async def run(scenario, body):
+        bugs = [b for b in _KNOWN_BUGS if b.match(scenario)]
+        if not bugs:
+            return await body()
+
+        max_retries = max(b.retries for b in bugs)
+        backoff = min(b.backoff for b in bugs)
+
+        for attempt in range(max_retries + 1):
+            try:
+                return await body()
+            except BaseException as exc:
+                matching = next((b for b in bugs if isinstance(exc, b.raises)), None)
+                if matching is None:
+                    raise
+                if attempt < max_retries and matching.retryable(exc):
+                    await asyncio.sleep(backoff * (2**attempt))
+                    continue
+                pytest.xfail(f"{matching.reason}: {exc}")
+
+    return run

--- a/wool/tests/integration/test_integration.py
+++ b/wool/tests/integration/test_integration.py
@@ -24,21 +24,11 @@ from .conftest import scenarios_strategy
 
 _INTEGRATION_TIMEOUT = 30
 
-_NESTED_SHAPES = {RoutineShape.NESTED_COROUTINE, RoutineShape.NESTED_ASYNC_GEN}
-
-
-def _xfail_known_bugs(scenario):
-    if scenario.shape in _NESTED_SHAPES:
-        pytest.xfail(
-            "grpcio 1.78 PollerCompletionQueue thundering herd race "
-            "(https://github.com/grpc/grpc/pull/41483)"
-        )
-
 
 @pytest.mark.integration
 @pytest.mark.asyncio
 @pytest.mark.parametrize("scenario", PAIRWISE_SCENARIOS, ids=str)
-async def test_dispatch_pairwise(scenario, credentials_map):
+async def test_dispatch_pairwise(scenario, credentials_map, xfail_known_bugs):
     """Test routine dispatch across pairwise scenario combinations.
 
     Given:
@@ -48,12 +38,14 @@ async def test_dispatch_pairwise(scenario, credentials_map):
     Then:
         It should return the expected result for the given routine shape.
     """
-    _xfail_known_bugs(scenario)
 
     # Arrange, act, & assert
-    async with asyncio.timeout(_INTEGRATION_TIMEOUT):
-        async with build_pool_from_scenario(scenario, credentials_map):
-            await invoke_routine(scenario)
+    async def body():
+        async with asyncio.timeout(_INTEGRATION_TIMEOUT):
+            async with build_pool_from_scenario(scenario, credentials_map):
+                await invoke_routine(scenario)
+
+    await xfail_known_bugs(scenario, body)
 
 
 @pytest.mark.integration
@@ -91,7 +83,7 @@ async def test_dispatch_pairwise(scenario, credentials_map):
     )
 )
 @given(scenario=scenarios_strategy())
-async def test_dispatch_hypothesis(scenario, credentials_map):
+async def test_dispatch_hypothesis(scenario, credentials_map, xfail_known_bugs):
     """Test routine dispatch with Hypothesis-generated scenarios.
 
     Given:
@@ -101,9 +93,11 @@ async def test_dispatch_hypothesis(scenario, credentials_map):
     Then:
         It should return the expected result for the given routine shape.
     """
-    _xfail_known_bugs(scenario)
 
     # Arrange, act, & assert
-    async with asyncio.timeout(_INTEGRATION_TIMEOUT):
-        async with build_pool_from_scenario(scenario, credentials_map):
-            await invoke_routine(scenario)
+    async def body():
+        async with asyncio.timeout(_INTEGRATION_TIMEOUT):
+            async with build_pool_from_scenario(scenario, credentials_map):
+                await invoke_routine(scenario)
+
+    await xfail_known_bugs(scenario, body)

--- a/wool/tests/runtime/worker/conftest.py
+++ b/wool/tests/runtime/worker/conftest.py
@@ -68,18 +68,20 @@ def _clear_proxy_context():
 
 @pytest.fixture(autouse=True)
 def _clear_worker_context():
-    """Reset worker identity context vars between tests.
+    """Reset worker identity state between tests.
 
-    Prevents ContextVar leakage from tests that set
+    Prevents leakage from tests that set
     ``wool.__worker_metadata__`` or ``wool.__worker_service__``
     for self-dispatch testing.
     """
     import wool
 
-    meta_token = wool.__worker_metadata__.set(None)
+    wool.__worker_metadata__ = None
+    wool.__worker_uds_address__ = None
     svc_token = wool.__worker_service__.set(None)
     yield
-    wool.__worker_metadata__.reset(meta_token)
+    wool.__worker_metadata__ = None
+    wool.__worker_uds_address__ = None
     wool.__worker_service__.reset(svc_token)
 
 

--- a/wool/tests/runtime/worker/test_connection.py
+++ b/wool/tests/runtime/worker/test_connection.py
@@ -626,6 +626,71 @@ class TestWorkerConnection:
         await connection.close()
 
     @pytest.mark.asyncio
+    async def test_close_clears_uds_pool_entry(
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+    ):
+        """Test close clears UDS channel pool entry after self-dispatch.
+
+        Given:
+            A WorkerConnection that has dispatched over UDS
+        When:
+            close() is called
+        Then:
+            It should clear both the TCP and UDS pool entries
+        """
+        # Arrange
+        target = "localhost:50051"
+        uds_target = "unix:/tmp/wool-test.sock"
+        wool.__worker_metadata__ = wool.WorkerMetadata(
+            uid=uuid4(),
+            address=target,
+            pid=1,
+            version="1.0.0",
+        )
+        wool.__worker_uds_address__ = uds_target
+
+        responses = (
+            protocol.Response(ack=protocol.Ack()),
+            protocol.Response(
+                result=protocol.Message(dump=cloudpickle.dumps("result"))
+            ),
+        )
+        mock_call = mock_grpc_call(async_stream(responses))
+
+        mock_stub = mocker.MagicMock()
+        mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+
+        mock_channel = mocker.AsyncMock()
+        mocker.patch.object(
+            grpc.aio, "insecure_channel", return_value=mock_channel
+        )
+
+        connection = WorkerConnection(target, limit=10)
+
+        async for _ in await connection.dispatch(sample_task):
+            pass
+
+        from wool.runtime.worker import connection as connection_module
+
+        clear_spy = mocker.patch.object(
+            connection_module._channel_pool, "clear", mocker.AsyncMock()
+        )
+
+        # Act
+        await connection.close()
+
+        # Assert
+        cleared_keys = [c.args[0] for c in clear_spy.call_args_list]
+        assert len(cleared_keys) == 2
+        assert (target, None, 10, connection._options) in cleared_keys
+        assert (uds_target, None, 10, connection._options) in cleared_keys
+
+    @pytest.mark.asyncio
     async def test_dispatch_task_that_yields_multiple_results(
         self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
     ):
@@ -1191,13 +1256,11 @@ class TestWorkerConnection:
         """
         # Arrange
         target = "localhost:50051"
-        wool.__worker_metadata__.set(
-            wool.WorkerMetadata(
-                uid=uuid4(),
-                address=target,
-                pid=1,
-                version="1.0.0",
-            )
+        wool.__worker_metadata__ = wool.WorkerMetadata(
+            uid=uuid4(),
+            address=target,
+            pid=1,
+            version="1.0.0",
         )
 
         responses = (
@@ -1229,6 +1292,74 @@ class TestWorkerConnection:
         assert sample_task.proxy not in pickled_objects
 
     @pytest.mark.asyncio
+    async def test_dispatch_with_self_dispatch_over_uds(
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+    ):
+        """Test self-dispatch uses UDS channel when UDS address is set.
+
+        Given:
+            A WorkerConnection whose target matches the current
+            worker's address and a UDS address is available
+        When:
+            dispatch() is called
+        Then:
+            It should create the gRPC channel with the UDS address
+            and None credentials
+        """
+        # Arrange
+        target = "localhost:50051"
+        uds_target = "unix:/tmp/wool-test.sock"
+        wool.__worker_metadata__ = wool.WorkerMetadata(
+            uid=uuid4(),
+            address=target,
+            pid=1,
+            version="1.0.0",
+        )
+        wool.__worker_uds_address__ = uds_target
+
+        responses = (
+            protocol.Response(ack=protocol.Ack()),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("result"))),
+        )
+        mock_call = mock_grpc_call(async_stream(responses))
+
+        mock_stub = mocker.MagicMock()
+        mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+
+        mock_channel = mocker.AsyncMock()
+        channel_spy = mocker.patch.object(
+            grpc.aio, "insecure_channel", return_value=mock_channel
+        )
+        secure_spy = mocker.patch.object(
+            grpc.aio, "secure_channel", return_value=mock_channel
+        )
+
+        spy = mocker.patch.object(cloudpickle, "dumps", wraps=cloudpickle.dumps)
+
+        connection = WorkerConnection(target)
+
+        # Act
+        results = []
+        async for result in await connection.dispatch(sample_task):
+            results.append(result)
+
+        # Assert
+        assert results == ["result"]
+        channel_spy.assert_called()
+        uds_calls = [c for c in channel_spy.call_args_list if c.args[0] == uds_target]
+        assert len(uds_calls) >= 1
+        secure_spy.assert_not_called()
+        first_write = mock_call.write.call_args_list[0][0][0]
+        assert first_write.task.HasField("serializer")
+        pickled_objects = [c.args[0] for c in spy.call_args_list]
+        assert sample_task.callable not in pickled_objects
+
+    @pytest.mark.asyncio
     async def test_dispatch_with_address_mismatch(
         self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
     ):
@@ -1244,13 +1375,11 @@ class TestWorkerConnection:
             field
         """
         # Arrange
-        wool.__worker_metadata__.set(
-            wool.WorkerMetadata(
-                uid=uuid4(),
-                address="10.0.0.1:50051",
-                pid=1,
-                version="1.0.0",
-            )
+        wool.__worker_metadata__ = wool.WorkerMetadata(
+            uid=uuid4(),
+            address="10.0.0.1:50051",
+            pid=1,
+            version="1.0.0",
         )
 
         responses = (

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -557,12 +557,16 @@ class TestWorkerProcess:
         # Arrange
         mock_get_meta = mocker.MagicMock()
         mock_get_meta.poll.return_value = True
-        mock_get_meta.recv.return_value = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="127.0.0.1:50051",
-            pid=12345,
-            version="1.0.0",
-        ).to_protobuf().SerializeToString()
+        mock_get_meta.recv.return_value = (
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address="127.0.0.1:50051",
+                pid=12345,
+                version="1.0.0",
+            )
+            .to_protobuf()
+            .SerializeToString()
+        )
         mock_set_meta = mocker.MagicMock()
         mocker.patch(
             "wool.runtime.worker.process.Pipe",
@@ -595,12 +599,16 @@ class TestWorkerProcess:
         # Arrange
         mock_get_meta = mocker.MagicMock()
         mock_get_meta.poll.return_value = True
-        mock_get_meta.recv.return_value = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="127.0.0.1:50051",
-            pid=12345,
-            version="1.0.0",
-        ).to_protobuf().SerializeToString()
+        mock_get_meta.recv.return_value = (
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address="127.0.0.1:50051",
+                pid=12345,
+                version="1.0.0",
+            )
+            .to_protobuf()
+            .SerializeToString()
+        )
         mock_set_meta = mocker.MagicMock()
         mocker.patch(
             "wool.runtime.worker.process.Pipe",
@@ -665,12 +673,16 @@ class TestWorkerProcess:
         # Arrange
         mock_get_meta = mocker.MagicMock()
         mock_get_meta.poll.return_value = True
-        mock_get_meta.recv.return_value = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="127.0.0.1:50051",
-            pid=12345,
-            version="1.0.0",
-        ).to_protobuf().SerializeToString()
+        mock_get_meta.recv.return_value = (
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address="127.0.0.1:50051",
+                pid=12345,
+                version="1.0.0",
+            )
+            .to_protobuf()
+            .SerializeToString()
+        )
         mock_set_meta = mocker.MagicMock()
         mocker.patch(
             "wool.runtime.worker.process.Pipe",
@@ -699,14 +711,18 @@ class TestWorkerProcess:
             and metadata.tags as frozenset
         """
         # Arrange
-        metadata_bytes = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="127.0.0.1:50051",
-            pid=12345,
-            version="1.0.0",
-            tags=frozenset({"gpu"}),
-            extra=MappingProxyType({"key": "value"}),
-        ).to_protobuf().SerializeToString()
+        metadata_bytes = (
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address="127.0.0.1:50051",
+                pid=12345,
+                version="1.0.0",
+                tags=frozenset({"gpu"}),
+                extra=MappingProxyType({"key": "value"}),
+            )
+            .to_protobuf()
+            .SerializeToString()
+        )
 
         mock_get_meta = mocker.MagicMock()
         mock_get_meta.poll.return_value = True
@@ -928,9 +944,7 @@ class TestWorkerProcess:
         )
         assert deserialized.address == "0.0.0.0:8080"
 
-    def test_run_with_extra_and_tags_serializes_complete_metadata(
-        self, mocker
-    ):
+    def test_run_with_extra_and_tags_serializes_complete_metadata(self, mocker):
         """Test run serializes metadata including extra and tags to pipe.
 
         Given:
@@ -1121,16 +1135,18 @@ class TestWorkerProcess:
     # === SINGLE-PORT ARCHITECTURE TESTS ===
 
     def test_serve_insecure_worker_single_port(self, mocker):
-        """Test single insecure port for insecure workers.
+        """Test single insecure TCP port for insecure workers.
 
         Given:
-            WorkerProcess with credentials=None
+            WorkerProcess with credentials=None and UDS disabled
         When:
             Process is started and server is configured
         Then:
             Only add_insecure_port is called, add_secure_port is not called
         """
         # Arrange
+        mocker.patch.object(process_module, "_HAS_UDS", False)
+
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
         mock_server.add_secure_port = mocker.MagicMock()
@@ -1160,16 +1176,18 @@ class TestWorkerProcess:
         mock_server.add_secure_port.assert_not_called()
 
     def test_serve_secure_worker_single_port(self, mocker):
-        """Test single secure port for secure workers.
+        """Test single secure TCP port for secure workers.
 
         Given:
-            WorkerProcess with valid WorkerCredentials
+            WorkerProcess with valid WorkerCredentials and UDS disabled
         When:
             Process is started and server is configured
         Then:
             Only add_secure_port is called with credentials, add_insecure_port is not called
         """
         # Arrange
+        mocker.patch.object(process_module, "_HAS_UDS", False)
+
         dummy_key = (
             b"-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
         )
@@ -1305,16 +1323,18 @@ class TestWorkerProcess:
         assert deserialized.address == "127.0.0.1:54322"
 
     def test_serve_no_dual_port_architecture(self, mocker):
-        """Test no dual-port architecture.
+        """Test no dual TCP port architecture.
 
         Given:
-            WorkerProcess with WorkerCredentials
+            WorkerProcess with WorkerCredentials and UDS disabled
         When:
             Process is started and port is retrieved
         Then:
-            Port number matches the secure port, no additional localhost port exists
+            Port number matches the secure port, no additional TCP port exists
         """
         # Arrange
+        mocker.patch.object(process_module, "_HAS_UDS", False)
+
         dummy_key = (
             b"-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
         )
@@ -1352,16 +1372,18 @@ class TestWorkerProcess:
         assert mock_server.add_secure_port.call_count == 1
 
     def test_serve_no_insecure_backdoor(self, mocker):
-        """Test no insecure localhost backdoor.
+        """Test no insecure TCP backdoor.
 
         Given:
-            Running WorkerProcess with WorkerCredentials
+            Running WorkerProcess with WorkerCredentials and UDS disabled
         When:
             Attempt to connect via insecure channel to the port
         Then:
-            Connection fails or is rejected (no insecure fallback port)
+            Connection fails or is rejected (no insecure TCP fallback port)
         """
         # Arrange
+        mocker.patch.object(process_module, "_HAS_UDS", False)
+
         dummy_key = (
             b"-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
         )
@@ -1400,16 +1422,18 @@ class TestWorkerProcess:
     @given(has_credentials=st.booleans())
     @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
     def test_single_port_invariant(self, has_credentials, mocker):
-        """Test single-port invariant property.
+        """Test single TCP port invariant property.
 
         Given:
-            Any WorkerProcess with valid or None credentials
+            Any WorkerProcess with valid or None credentials and UDS disabled
         When:
             Process is started and configured
         Then:
-            Exactly one port is bound (either secure or insecure, never both)
+            Exactly one TCP port is bound (either secure or insecure, never both)
         """
         # Arrange
+        mocker.patch.object(process_module, "_HAS_UDS", False)
+
         if has_credentials:
             dummy_key = (
                 b"-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
@@ -1448,7 +1472,7 @@ class TestWorkerProcess:
         # Assert
         secure_calls = mock_server.add_secure_port.call_count
         insecure_calls = mock_server.add_insecure_port.call_count
-        assert secure_calls + insecure_calls == 1, "Exactly one port must be bound"
+        assert secure_calls + insecure_calls == 1, "Exactly one TCP port must be bound"
 
         if has_credentials:
             assert secure_calls == 1, "Secure worker must use secure port"


### PR DESCRIPTION
## Summary

Bind a Unix domain socket alongside the TCP port during worker subprocess startup and route self-dispatch gRPC connections through it to bypass the TCP stack. On platforms without `AF_UNIX` support, fall back to the existing TCP loopback path. Remote dispatch is unaffected. Clean up the UDS socket file and channel pool entry when the worker process exits or the connection is closed.

The UDS address is stored as a plain module-level variable (`wool.__worker_uds_address__`) rather than on `WorkerMetadata`, since it is a local transport detail with no meaning for remote workers or discovery protocols. As part of this change, simplify `wool.__worker_metadata__` from a `ContextVar` to a plain module variable, since both are set once per worker process and never vary per task.

Additionally, extract the integration test xfail helper into a data-driven `_KnownBug` registry with an `xfail_known_bugs` fixture that retries `StatusCode.INTERNAL` errors with exponential backoff before falling through to xfail. Update the test guide to document the new convention.

Closes #96

## Proposed changes

### Bind UDS path in worker subprocess

Add a `_HAS_UDS` platform guard (`hasattr(socket, "AF_UNIX")`) and, when available, bind an additional insecure port at `unix:{tempdir}/wool-{uid}.sock` during `WorkerProcess._serve()`. Clean up any stale socket file before binding and unlink the path in the `finally` block on server shutdown.

### Route self-dispatch through UDS

In `WorkerConnection.dispatch()`, when self-dispatch is detected and `wool.__worker_uds_address__` is set, construct a channel pool key using the UDS target with `None` credentials (UDS is kernel-secured, no TLS needed). Thread the effective key through `_execute()` so both acquire and release use the same pool entry. Clear both TCP and UDS pool entries in `close()`.

### Simplify worker identity state to plain variables

Replace `wool.__worker_metadata__` (a `ContextVar`) with a plain module-level variable and add `wool.__worker_uds_address__` as another plain variable. Both are set once per worker process in `_serve()` and read during dispatch — per-task isolation is unnecessary.

### Extract xfail_known_bugs fixture with retry

Replace the inline `_xfail_known_bugs` helper with a data-driven `_KnownBug` registry and an `xfail_known_bugs` fixture. Each bug entry defines a `retryable` predicate and retry count — `StatusCode.INTERNAL` errors from the grpc race are retried with exponential backoff before falling through to xfail. Non-retryable matches xfail immediately. Unmatched exceptions propagate normally. Update the test guide to document the new xfail convention.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestWorkerConnection` | WorkerConnection target matches worker metadata and UDS address is set | `dispatch()` is called | Channel is created with the UDS address, None credentials, and PassthroughSerializer | UDS key construction in dispatch |
| 2 | `TestWorkerConnection` | WorkerConnection and UDS address is available | `close()` is called | Both TCP and UDS pool entries are cleared without error | UDS pool cleanup in close |
| 3 | `TestWorkerConnection` | WorkerConnection target matches worker metadata and no UDS address | `dispatch()` is called | PassthroughSerializer is used with TCP key | Self-dispatch TCP fallback |
| 4 | `TestWorkerConnection` | WorkerConnection target differs from worker metadata | `dispatch()` is called | Cloudpickle is used with TCP key | Non-self-dispatch path |
| 5 | `TestWorkerConnection` | No worker metadata set | `dispatch()` is called | Cloudpickle is used with TCP key | No-metadata path |
| 6 | `TestWorkerProcess` | WorkerProcess with UDS disabled | Server is configured | Only one TCP port is bound | Single TCP port invariant |
| 7 | `TestWorkerProcess` | Secure WorkerProcess with UDS disabled | Server is configured | No insecure TCP port is bound | No insecure TCP backdoor |