### PR TITLE
Fix broken total ordering in PreReleaseVersionSegment that causes non-deterministic version resolution — Closes #100

### DIFF
--- a/build-hooks/_version.py
+++ b/build-hooks/_version.py
@@ -247,6 +247,8 @@ class PreReleaseVersionSegment:
             return False
         elif not isinstance(other, PreReleaseVersionSegment):
             return super().__lt__(other)
+        elif not other.__PreReleaseVersionSegment_value__:
+            return True
         elif len(self.__PreReleaseVersionSegment_value__) < len(
             other.__PreReleaseVersionSegment_value__
         ):


### PR DESCRIPTION
## Summary

Add a missing guard clause to `PreReleaseVersionSegment.__lt__` that restores a consistent total ordering between pre-release and normal versions, fixing non-deterministic version resolution during release builds.

`PreReleaseVersionSegment.__lt__` correctly returned `False` when `self` was empty (normal version is not less than a pre-release), but never handled the reverse: when `self` has pre-release values and `other` is empty. Both directions reported greater-than, violating total ordering and making `max(repo.tags)` iteration-order dependent. On CI this caused the git version parser to select `v0.2.0-rc0` over `v0.2.0`, append a commit hash as a local version identifier, and produce a version string that PyPI rejects.

Closes #100

## Proposed changes

### Add empty-other guard to PreReleaseVersionSegment.__lt__

Insert `elif not other.__PreReleaseVersionSegment_value__: return True` after the existing `isinstance` guard in `build-hooks/_version.py`. This makes any pre-release segment compare as less-than an empty segment (representing a normal/production version), matching the SemVer 2.0 spec: "a pre-release version has lower precedence than a normal version."

Before the fix, the method's control flow was:

1. If `self` is empty → return `False` (correct)
2. If `other` is not a `PreReleaseVersionSegment` → delegate to `super()`
3. Compare lengths, then zip and compare element-wise

Step 3 silently returned `False` when `other` was empty because `len([]) < len([...])` is `False` and `zip(values, [])` yields nothing. The new guard catches this case before step 3 is reached.