### PR TITLE
Replace deprecated athrow() signature in async generator wrapper — Closes #94

### DIFF
--- a/wool/src/wool/runtime/routine/wrapper.py
+++ b/wool/src/wool/runtime/routine/wrapper.py
@@ -197,7 +197,7 @@ def routine(fn: C) -> C:
                         await stream.aclose()
                         return
                     except BaseException as exc:
-                        result = await stream.athrow(type(exc), exc)
+                        result = await stream.athrow(exc)
                     else:
                         if sent is None:
                             result = await stream.__anext__()
@@ -281,7 +281,7 @@ async def _stream(fn, parent, *args, **kwargs):
                 return
             except BaseException as exc:
                 with do_dispatch(True):
-                    result = await gen.athrow(type(exc), exc)
+                    result = await gen.athrow(exc)
             else:
                 with do_dispatch(True):
                     if sent is None:

--- a/wool/tests/runtime/routine/test_wrapper.py
+++ b/wool/tests/runtime/routine/test_wrapper.py
@@ -1,4 +1,5 @@
 import asyncio
+import warnings
 from inspect import getsourcelines
 from inspect import isasyncgen
 
@@ -781,6 +782,38 @@ async def test_routine_with_athrow_causing_return():
         # Act & assert
         with pytest.raises(StopAsyncIteration):
             await gen.athrow(Resettable)
+
+
+@pytest.mark.asyncio
+async def test_routine_with_athrow_no_deprecation_warning():
+    """Test athrow does not emit a DeprecationWarning.
+
+    Given:
+        A @routine-decorated async generator that catches a thrown
+        exception and yields a recovery value.
+    When:
+        athrow() is called with the exception.
+    Then:
+        It should not emit a DeprecationWarning.
+    """
+    with do_dispatch(False):
+        # Arrange
+        gen = resilient_counter(5)
+        await gen.__anext__()
+
+        # Act
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            await gen.athrow(Resettable)
+
+        # Assert
+        deprecations = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        assert deprecations == [], (
+            f"Unexpected DeprecationWarning(s): {deprecations}"
+        )
+        await gen.aclose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Replace the legacy two-arg `athrow(type(exc), exc)` calls with the single-arg `athrow(exc)` form in the async generator wrapper. Python 3.12 deprecated the `(type, value, traceback)` signature, and the single-arg form has been supported since Python 3.8 — well within the project's `>=3.11` requirement. This eliminates ~10 `DeprecationWarning` emissions per integration test run.

Closes #94

## Proposed changes

### Use single-arg athrow signature

Two call sites in `src/wool/runtime/routine/wrapper.py` forwarded exceptions to the underlying async generator using `athrow(type(exc), exc)`. Both are replaced with `athrow(exc)`, which is the modern form and avoids the deprecation warning introduced in Python 3.12.

The first site is in `async_generator_wrapper` (the dispatch path), the second in `_stream` (the local execution path). Both paths are exercised by existing tests.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | (module) | A `@routine`-decorated async generator that catches a thrown exception | `athrow()` is called with the exception | It should not emit a `DeprecationWarning` | Regression guard for #94 |

Existing `athrow` behavioral tests (handled, unhandled, causing return, interleaved with send) remain unchanged and continue to pass.