### PR TITLE
Document picklability constraint for pre-called context manager Factory forms — Closes #61

### DIFF
--- a/wool/src/wool/runtime/typing.py
+++ b/wool/src/wool/runtime/typing.py
@@ -35,3 +35,29 @@ Factory: TypeAlias = (
         [], T_CO | Awaitable[T_CO] | AsyncContextManager[T_CO] | ContextManager[T_CO]
     ]
 )
+"""Union of forms accepted wherever wool needs a lazily-resolved service.
+
+Accepted forms:
+
+- ``T`` — a direct instance.
+- ``Callable[[], T]`` — a callable returning an instance.
+- ``Callable[[], ContextManager[T]]`` — a callable returning a sync CM.
+- ``Callable[[], AsyncContextManager[T]]`` — a callable returning an async CM.
+- ``ContextManager[T]`` — a pre-called sync context manager.
+- ``AsyncContextManager[T]`` — a pre-called async context manager.
+- ``Awaitable[T]`` — an awaitable resolving to an instance.
+
+.. caution::
+
+   The two pre-called context manager forms (``ContextManager[T]`` and
+   ``AsyncContextManager[T]``) are **not picklable**.  If the resulting
+   object is serialized — as happens during nested routine dispatch —
+   ``cloudpickle`` will raise a ``TypeError``.  Wrap the context manager
+   in a zero-argument callable instead::
+
+       # Bad — pre-called CM, not picklable
+       WorkerProxy(discovery=my_discovery_cm())
+
+       # Good — callable returning a CM, picklable
+       WorkerProxy(discovery=my_discovery_cm)
+"""

--- a/wool/src/wool/runtime/typing.py
+++ b/wool/src/wool/runtime/typing.py
@@ -35,29 +35,3 @@ Factory: TypeAlias = (
         [], T_CO | Awaitable[T_CO] | AsyncContextManager[T_CO] | ContextManager[T_CO]
     ]
 )
-"""Union of forms accepted wherever wool needs a lazily-resolved service.
-
-Accepted forms:
-
-- ``T`` — a direct instance.
-- ``Callable[[], T]`` — a callable returning an instance.
-- ``Callable[[], ContextManager[T]]`` — a callable returning a sync CM.
-- ``Callable[[], AsyncContextManager[T]]`` — a callable returning an async CM.
-- ``ContextManager[T]`` — a pre-called sync context manager.
-- ``AsyncContextManager[T]`` — a pre-called async context manager.
-- ``Awaitable[T]`` — an awaitable resolving to an instance.
-
-.. caution::
-
-   The two pre-called context manager forms (``ContextManager[T]`` and
-   ``AsyncContextManager[T]``) are **not picklable**.  If the resulting
-   object is serialized — as happens during nested routine dispatch —
-   ``cloudpickle`` will raise a ``TypeError``.  Wrap the context manager
-   in a zero-argument callable instead::
-
-       # Bad — pre-called CM, not picklable
-       WorkerProxy(discovery=my_discovery_cm())
-
-       # Good — callable returning a CM, picklable
-       WorkerProxy(discovery=my_discovery_cm)
-"""

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -142,8 +142,21 @@ class WorkerPool:
         Worker factory callable. Defaults to :class:`LocalWorker`.
     :param loadbalancer:
         Load balancer instance, factory, or context manager.
+
+        .. caution::
+
+           Pre-called context manager instances are not picklable and
+           will cause nested routine dispatch to fail.  Pass a callable
+           returning the context manager instead.  See :data:`Factory`.
+
     :param discovery:
         Discovery service instance, factory, or context manager.
+
+        .. caution::
+
+           Pre-called context manager instances are not picklable and
+           will cause nested routine dispatch to fail.  Pass a callable
+           returning the context manager instead.  See :data:`Factory`.
     :param credentials:
         Optional channel credentials for TLS/mTLS connections to workers.
     :raises ValueError:

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -142,25 +142,19 @@ class WorkerPool:
         Worker factory callable. Defaults to :class:`LocalWorker`.
     :param loadbalancer:
         Load balancer instance, factory, or context manager.
-
-        .. caution::
-
-           Pre-called context manager instances are not picklable and
-           will cause nested routine dispatch to fail.  Pass a callable
-           returning the context manager instead.  See :data:`Factory`.
-
     :param discovery:
         Discovery service instance, factory, or context manager.
-
-        .. caution::
-
-           Pre-called context manager instances are not picklable and
-           will cause nested routine dispatch to fail.  Pass a callable
-           returning the context manager instead.  See :data:`Factory`.
     :param credentials:
         Optional channel credentials for TLS/mTLS connections to workers.
     :raises ValueError:
         If configuration is invalid or CPU count unavailable.
+
+    .. caution::
+
+       Pre-called context manager instances passed as ``loadbalancer``
+       or ``discovery`` are not picklable and will cause nested routine
+       dispatch to fail.  Pass a callable returning the context manager
+       instead.  See :data:`Factory`.
     """
 
     _workers: Final[dict[WorkerLike, Coroutine]]

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -169,26 +169,19 @@ class WorkerProxy:
         Additional tags for filtering discovered workers.
     :param discovery:
         Discovery service or event stream.
-
-        .. caution::
-
-           Pre-called context manager instances are not picklable and
-           will cause nested routine dispatch to fail.  Pass a callable
-           returning the context manager instead.  See :data:`Factory`.
-
     :param workers:
         Static worker list for direct connection.
     :param loadbalancer:
         Load balancer instance, factory, or context manager.
-
-        .. caution::
-
-           Pre-called context manager instances are not picklable and
-           will cause nested routine dispatch to fail.  Pass a callable
-           returning the context manager instead.  See :data:`Factory`.
-
     :param credentials:
         Optional channel credentials for TLS/mTLS connections to workers.
+
+    .. caution::
+
+       Pre-called context manager instances passed as ``loadbalancer``
+       or ``discovery`` are not picklable and will cause nested routine
+       dispatch to fail.  Pass a callable returning the context manager
+       instead.  See :data:`Factory`.
     """
 
     _discovery: DiscoverySubscriberLike | Factory[DiscoverySubscriberLike]

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
+import warnings
 from typing import TYPE_CHECKING
 from typing import AsyncContextManager
 from typing import AsyncGenerator
@@ -261,6 +262,27 @@ class WorkerProxy:
         self._id: uuid.UUID = uuid.uuid4()
         self._started = False
         self._loadbalancer = loadbalancer
+
+        if isinstance(loadbalancer, (ContextManager, AsyncContextManager)):
+            warnings.warn(
+                "Passing a context manager instance as 'loadbalancer' is "
+                "not picklable and will fail during nested routine "
+                "dispatch. Wrap it in a callable instead "
+                "(e.g., loadbalancer=my_cm instead of "
+                "loadbalancer=my_cm()).",
+                UserWarning,
+                stacklevel=2,
+            )
+        if isinstance(discovery, (ContextManager, AsyncContextManager)):
+            warnings.warn(
+                "Passing a context manager instance as 'discovery' is "
+                "not picklable and will fail during nested routine "
+                "dispatch. Wrap it in a callable instead "
+                "(e.g., discovery=my_cm instead of discovery=my_cm()).",
+                UserWarning,
+                stacklevel=2,
+            )
+
         if credentials is Undefined:
             self._credentials = CredentialContext.current()
         else:
@@ -326,7 +348,22 @@ class WorkerProxy:
 
         :returns:
             Tuple of (callable, args) for unpickling.
+        :raises TypeError:
+            If ``loadbalancer`` or ``discovery`` is a context manager
+            instance, which cannot be pickled.
         """
+        for name, value in (
+            ("loadbalancer", self._loadbalancer),
+            ("discovery", self._discovery),
+        ):
+            if isinstance(value, (ContextManager, AsyncContextManager)):
+                raise TypeError(
+                    f"Cannot pickle WorkerProxy: the '{name}' parameter "
+                    f"is a context manager instance ({type(value).__name__}), "
+                    f"which is not picklable. Wrap it in a callable "
+                    f"instead (e.g., {name}=my_cm instead of "
+                    f"{name}=my_cm())."
+                )
 
         def _restore_proxy(discovery, loadbalancer, options, proxy_id):
             proxy = WorkerProxy(

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -168,10 +168,24 @@ class WorkerProxy:
         Additional tags for filtering discovered workers.
     :param discovery:
         Discovery service or event stream.
+
+        .. caution::
+
+           Pre-called context manager instances are not picklable and
+           will cause nested routine dispatch to fail.  Pass a callable
+           returning the context manager instead.  See :data:`Factory`.
+
     :param workers:
         Static worker list for direct connection.
     :param loadbalancer:
         Load balancer instance, factory, or context manager.
+
+        .. caution::
+
+           Pre-called context manager instances are not picklable and
+           will cause nested routine dispatch to fail.  Pass a callable
+           returning the context manager instead.  See :data:`Factory`.
+
     :param credentials:
         Optional channel credentials for TLS/mTLS connections to workers.
     """

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -7,6 +7,7 @@ to avoid network overhead and ensure deterministic behavior.
 
 import asyncio
 import uuid
+import warnings
 from types import MappingProxyType
 
 import cloudpickle
@@ -1766,6 +1767,245 @@ class TestWorkerProxy:
         assert insecure_worker in proxy.workers
         assert secure_worker not in proxy.workers
         await proxy.stop()
+
+    # =========================================================================
+    # Picklability Constraint Tests
+    # =========================================================================
+
+    def test___init___with_sync_cm_loadbalancer_warns(
+        self, mock_discovery_service
+    ):
+        """Test UserWarning for sync CM loadbalancer.
+
+        Given:
+            A sync context manager instance as loadbalancer.
+        When:
+            WorkerProxy is instantiated.
+        Then:
+            It should emit a UserWarning mentioning 'loadbalancer'.
+        """
+        # Arrange
+        class SyncCM:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        # Act & assert
+        with pytest.warns(UserWarning, match="loadbalancer"):
+            WorkerProxy(
+                discovery=mock_discovery_service, loadbalancer=SyncCM()
+            )
+
+    def test___init___with_async_cm_loadbalancer_warns(
+        self, mock_discovery_service
+    ):
+        """Test UserWarning for async CM loadbalancer.
+
+        Given:
+            An async context manager instance as loadbalancer.
+        When:
+            WorkerProxy is instantiated.
+        Then:
+            It should emit a UserWarning mentioning 'loadbalancer'.
+        """
+        # Arrange
+        class AsyncCM:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        # Act & assert
+        with pytest.warns(UserWarning, match="loadbalancer"):
+            WorkerProxy(
+                discovery=mock_discovery_service, loadbalancer=AsyncCM()
+            )
+
+    def test___init___with_sync_cm_discovery_warns(self):
+        """Test UserWarning for sync CM discovery.
+
+        Given:
+            A sync context manager instance as discovery.
+        When:
+            WorkerProxy is instantiated.
+        Then:
+            It should emit a UserWarning mentioning 'discovery'.
+        """
+        # Arrange
+        class SyncCM:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        # Act & assert
+        with pytest.warns(UserWarning, match="discovery"):
+            WorkerProxy(discovery=SyncCM())
+
+    def test___init___with_async_cm_discovery_warns(self):
+        """Test UserWarning for async CM discovery.
+
+        Given:
+            An async context manager instance as discovery.
+        When:
+            WorkerProxy is instantiated.
+        Then:
+            It should emit a UserWarning mentioning 'discovery'.
+        """
+        # Arrange
+        class AsyncCM:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        # Act & assert
+        with pytest.warns(UserWarning, match="discovery"):
+            WorkerProxy(discovery=AsyncCM())
+
+    def test___init___with_callable_loadbalancer_no_warning(
+        self, mock_discovery_service
+    ):
+        """Test no UserWarning for callable loadbalancer.
+
+        Given:
+            A callable (non-CM) as loadbalancer.
+        When:
+            WorkerProxy is instantiated.
+        Then:
+            It should not emit a UserWarning.
+        """
+        # Arrange, act, & assert
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            WorkerProxy(
+                discovery=mock_discovery_service,
+                loadbalancer=wp.RoundRobinLoadBalancer,
+            )
+
+        user_warnings = [
+            w for w in caught if issubclass(w.category, UserWarning)
+        ]
+        assert user_warnings == []
+
+    def test_cloudpickle_serialization_with_sync_cm_loadbalancer_raises(
+        self, mock_discovery_service
+    ):
+        """Test TypeError when pickling proxy with sync CM loadbalancer.
+
+        Given:
+            A WorkerProxy with a sync context manager instance as
+            loadbalancer.
+        When:
+            cloudpickle serialization is attempted.
+        Then:
+            It should raise TypeError mentioning 'loadbalancer'.
+        """
+        # Arrange
+        class SyncCM:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        with pytest.warns(UserWarning):
+            proxy = WorkerProxy(
+                discovery=mock_discovery_service,
+                loadbalancer=SyncCM(),
+            )
+
+        # Act & assert
+        with pytest.raises(TypeError, match="loadbalancer"):
+            cloudpickle.dumps(proxy)
+
+    def test_cloudpickle_serialization_with_async_cm_loadbalancer_raises(
+        self, mock_discovery_service
+    ):
+        """Test TypeError when pickling proxy with async CM loadbalancer.
+
+        Given:
+            A WorkerProxy with an async context manager instance as
+            loadbalancer.
+        When:
+            cloudpickle serialization is attempted.
+        Then:
+            It should raise TypeError mentioning 'loadbalancer'.
+        """
+        # Arrange
+        class AsyncCM:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        with pytest.warns(UserWarning):
+            proxy = WorkerProxy(
+                discovery=mock_discovery_service,
+                loadbalancer=AsyncCM(),
+            )
+
+        # Act & assert
+        with pytest.raises(TypeError, match="loadbalancer"):
+            cloudpickle.dumps(proxy)
+
+    def test_cloudpickle_serialization_with_sync_cm_discovery_raises(self):
+        """Test TypeError when pickling proxy with sync CM discovery.
+
+        Given:
+            A WorkerProxy with a sync context manager instance as
+            discovery.
+        When:
+            cloudpickle serialization is attempted.
+        Then:
+            It should raise TypeError mentioning 'discovery'.
+        """
+        # Arrange
+        class SyncCM:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        with pytest.warns(UserWarning):
+            proxy = WorkerProxy(discovery=SyncCM())
+
+        # Act & assert
+        with pytest.raises(TypeError, match="discovery"):
+            cloudpickle.dumps(proxy)
+
+    def test_cloudpickle_serialization_with_async_cm_discovery_raises(self):
+        """Test TypeError when pickling proxy with async CM discovery.
+
+        Given:
+            A WorkerProxy with an async context manager instance as
+            discovery.
+        When:
+            cloudpickle serialization is attempted.
+        Then:
+            It should raise TypeError mentioning 'discovery'.
+        """
+        # Arrange
+        class AsyncCM:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        with pytest.warns(UserWarning):
+            proxy = WorkerProxy(discovery=AsyncCM())
+
+        # Act & assert
+        with pytest.raises(TypeError, match="discovery"):
+            cloudpickle.dumps(proxy)
 
     # =========================================================================
     # Validation Tests

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -344,9 +344,6 @@ def test_is_version_compatible_different_major():
 class TestWorkerProxy:
     """Comprehensive test suite for WorkerProxy."""
 
-    # =========================================================================
-    # Constructor Tests
-    # =========================================================================
 
     def test___init___discovery_and_loadbalancer(
         self, mock_discovery_service, mock_load_balancer_factory
@@ -522,9 +519,128 @@ class TestWorkerProxy:
         with pytest.raises(ValueError, match="Must specify either a workerpool URI"):
             WorkerProxy()
 
-    # =========================================================================
-    # Lifecycle Tests
-    # =========================================================================
+
+
+    def test___init___with_sync_cm_loadbalancer_warns(
+        self, mock_discovery_service
+    ):
+        """Test UserWarning for sync CM loadbalancer.
+
+        Given:
+            A sync context manager instance as loadbalancer.
+        When:
+            WorkerProxy is instantiated.
+        Then:
+            It should emit a UserWarning mentioning 'loadbalancer'.
+        """
+        # Arrange
+        class SyncCM:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        # Act & assert
+        with pytest.warns(UserWarning, match="loadbalancer"):
+            WorkerProxy(
+                discovery=mock_discovery_service, loadbalancer=SyncCM()
+            )
+
+    def test___init___with_async_cm_loadbalancer_warns(
+        self, mock_discovery_service
+    ):
+        """Test UserWarning for async CM loadbalancer.
+
+        Given:
+            An async context manager instance as loadbalancer.
+        When:
+            WorkerProxy is instantiated.
+        Then:
+            It should emit a UserWarning mentioning 'loadbalancer'.
+        """
+        # Arrange
+        class AsyncCM:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        # Act & assert
+        with pytest.warns(UserWarning, match="loadbalancer"):
+            WorkerProxy(
+                discovery=mock_discovery_service, loadbalancer=AsyncCM()
+            )
+
+    def test___init___with_sync_cm_discovery_warns(self):
+        """Test UserWarning for sync CM discovery.
+
+        Given:
+            A sync context manager instance as discovery.
+        When:
+            WorkerProxy is instantiated.
+        Then:
+            It should emit a UserWarning mentioning 'discovery'.
+        """
+        # Arrange
+        class SyncCM:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        # Act & assert
+        with pytest.warns(UserWarning, match="discovery"):
+            WorkerProxy(discovery=SyncCM())
+
+    def test___init___with_async_cm_discovery_warns(self):
+        """Test UserWarning for async CM discovery.
+
+        Given:
+            An async context manager instance as discovery.
+        When:
+            WorkerProxy is instantiated.
+        Then:
+            It should emit a UserWarning mentioning 'discovery'.
+        """
+        # Arrange
+        class AsyncCM:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        # Act & assert
+        with pytest.warns(UserWarning, match="discovery"):
+            WorkerProxy(discovery=AsyncCM())
+
+    def test___init___with_callable_loadbalancer_no_warning(
+        self, mock_discovery_service
+    ):
+        """Test no UserWarning for callable loadbalancer.
+
+        Given:
+            A callable (non-CM) as loadbalancer.
+        When:
+            WorkerProxy is instantiated.
+        Then:
+            It should not emit a UserWarning.
+        """
+        # Arrange, act, & assert
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            WorkerProxy(
+                discovery=mock_discovery_service,
+                loadbalancer=wp.RoundRobinLoadBalancer,
+            )
+
+        user_warnings = [
+            w for w in caught if issubclass(w.category, UserWarning)
+        ]
+        assert user_warnings == []
 
     @pytest.mark.asyncio
     async def test___aenter___lifecycle(self, mock_discovery_service):
@@ -829,9 +945,6 @@ class TestWorkerProxy:
         # Cleanup
         await proxy.stop()
 
-    # =========================================================================
-    # Discovery Integration Tests
-    # =========================================================================
 
     @pytest.mark.asyncio
     async def test_discovers_workers_from_service(self, mock_discovery_service):
@@ -969,9 +1082,6 @@ class TestWorkerProxy:
         # Cleanup
         await proxy.stop()
 
-    # =========================================================================
-    # Task Dispatch Tests
-    # =========================================================================
 
     @pytest.mark.asyncio
     async def test_dispatch_delegates_to_loadbalancer(
@@ -1228,9 +1338,6 @@ class TestWorkerProxy:
         # Cleanup
         await proxy.stop()
 
-    # =========================================================================
-    # Static Worker Configuration Tests
-    # =========================================================================
 
     @pytest.mark.asyncio
     async def test_proxy_with_static_workers_list(self):
@@ -1295,9 +1402,6 @@ class TestWorkerProxy:
         # After exit, proxy should be stopped
         assert not proxy.started
 
-    # =========================================================================
-    # Properties Tests
-    # =========================================================================
 
     @pytest.mark.asyncio
     async def test_workers_property_returns_workers_list(
@@ -1400,9 +1504,6 @@ class TestWorkerProxy:
         # Proxy should not equal non-WorkerProxy objects
         assert proxy1 != non_proxy
 
-    # =========================================================================
-    # Serialization Tests
-    # =========================================================================
 
     @pytest.mark.asyncio
     async def test_cloudpickle_serialization_with_services(self):
@@ -1630,6 +1731,119 @@ class TestWorkerProxy:
         assert insecure_worker not in restored_proxy.workers
         await restored_proxy.stop()
 
+    def test_cloudpickle_serialization_with_sync_cm_loadbalancer_raises(
+        self, mock_discovery_service
+    ):
+        """Test TypeError when pickling proxy with sync CM loadbalancer.
+
+        Given:
+            A WorkerProxy with a sync context manager instance as
+            loadbalancer.
+        When:
+            cloudpickle serialization is attempted.
+        Then:
+            It should raise TypeError mentioning 'loadbalancer'.
+        """
+        # Arrange
+        class SyncCM:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        with pytest.warns(UserWarning):
+            proxy = WorkerProxy(
+                discovery=mock_discovery_service,
+                loadbalancer=SyncCM(),
+            )
+
+        # Act & assert
+        with pytest.raises(TypeError, match="loadbalancer"):
+            cloudpickle.dumps(proxy)
+
+    def test_cloudpickle_serialization_with_async_cm_loadbalancer_raises(
+        self, mock_discovery_service
+    ):
+        """Test TypeError when pickling proxy with async CM loadbalancer.
+
+        Given:
+            A WorkerProxy with an async context manager instance as
+            loadbalancer.
+        When:
+            cloudpickle serialization is attempted.
+        Then:
+            It should raise TypeError mentioning 'loadbalancer'.
+        """
+        # Arrange
+        class AsyncCM:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        with pytest.warns(UserWarning):
+            proxy = WorkerProxy(
+                discovery=mock_discovery_service,
+                loadbalancer=AsyncCM(),
+            )
+
+        # Act & assert
+        with pytest.raises(TypeError, match="loadbalancer"):
+            cloudpickle.dumps(proxy)
+
+    def test_cloudpickle_serialization_with_sync_cm_discovery_raises(self):
+        """Test TypeError when pickling proxy with sync CM discovery.
+
+        Given:
+            A WorkerProxy with a sync context manager instance as
+            discovery.
+        When:
+            cloudpickle serialization is attempted.
+        Then:
+            It should raise TypeError mentioning 'discovery'.
+        """
+        # Arrange
+        class SyncCM:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                pass
+
+        with pytest.warns(UserWarning):
+            proxy = WorkerProxy(discovery=SyncCM())
+
+        # Act & assert
+        with pytest.raises(TypeError, match="discovery"):
+            cloudpickle.dumps(proxy)
+
+    def test_cloudpickle_serialization_with_async_cm_discovery_raises(self):
+        """Test TypeError when pickling proxy with async CM discovery.
+
+        Given:
+            A WorkerProxy with an async context manager instance as
+            discovery.
+        When:
+            cloudpickle serialization is attempted.
+        Then:
+            It should raise TypeError mentioning 'discovery'.
+        """
+        # Arrange
+        class AsyncCM:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        with pytest.warns(UserWarning):
+            proxy = WorkerProxy(discovery=AsyncCM())
+
+        # Act & assert
+        with pytest.raises(TypeError, match="discovery"):
+            cloudpickle.dumps(proxy)
     @pytest.mark.asyncio
     async def test_explicit_credentials_parameter_overrides_contextvar(
         self, mock_proxy_session, worker_credentials, mocker: MockerFixture
@@ -1768,248 +1982,7 @@ class TestWorkerProxy:
         assert secure_worker not in proxy.workers
         await proxy.stop()
 
-    # =========================================================================
-    # Picklability Constraint Tests
-    # =========================================================================
 
-    def test___init___with_sync_cm_loadbalancer_warns(
-        self, mock_discovery_service
-    ):
-        """Test UserWarning for sync CM loadbalancer.
-
-        Given:
-            A sync context manager instance as loadbalancer.
-        When:
-            WorkerProxy is instantiated.
-        Then:
-            It should emit a UserWarning mentioning 'loadbalancer'.
-        """
-        # Arrange
-        class SyncCM:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                pass
-
-        # Act & assert
-        with pytest.warns(UserWarning, match="loadbalancer"):
-            WorkerProxy(
-                discovery=mock_discovery_service, loadbalancer=SyncCM()
-            )
-
-    def test___init___with_async_cm_loadbalancer_warns(
-        self, mock_discovery_service
-    ):
-        """Test UserWarning for async CM loadbalancer.
-
-        Given:
-            An async context manager instance as loadbalancer.
-        When:
-            WorkerProxy is instantiated.
-        Then:
-            It should emit a UserWarning mentioning 'loadbalancer'.
-        """
-        # Arrange
-        class AsyncCM:
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *args):
-                pass
-
-        # Act & assert
-        with pytest.warns(UserWarning, match="loadbalancer"):
-            WorkerProxy(
-                discovery=mock_discovery_service, loadbalancer=AsyncCM()
-            )
-
-    def test___init___with_sync_cm_discovery_warns(self):
-        """Test UserWarning for sync CM discovery.
-
-        Given:
-            A sync context manager instance as discovery.
-        When:
-            WorkerProxy is instantiated.
-        Then:
-            It should emit a UserWarning mentioning 'discovery'.
-        """
-        # Arrange
-        class SyncCM:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                pass
-
-        # Act & assert
-        with pytest.warns(UserWarning, match="discovery"):
-            WorkerProxy(discovery=SyncCM())
-
-    def test___init___with_async_cm_discovery_warns(self):
-        """Test UserWarning for async CM discovery.
-
-        Given:
-            An async context manager instance as discovery.
-        When:
-            WorkerProxy is instantiated.
-        Then:
-            It should emit a UserWarning mentioning 'discovery'.
-        """
-        # Arrange
-        class AsyncCM:
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *args):
-                pass
-
-        # Act & assert
-        with pytest.warns(UserWarning, match="discovery"):
-            WorkerProxy(discovery=AsyncCM())
-
-    def test___init___with_callable_loadbalancer_no_warning(
-        self, mock_discovery_service
-    ):
-        """Test no UserWarning for callable loadbalancer.
-
-        Given:
-            A callable (non-CM) as loadbalancer.
-        When:
-            WorkerProxy is instantiated.
-        Then:
-            It should not emit a UserWarning.
-        """
-        # Arrange, act, & assert
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            WorkerProxy(
-                discovery=mock_discovery_service,
-                loadbalancer=wp.RoundRobinLoadBalancer,
-            )
-
-        user_warnings = [
-            w for w in caught if issubclass(w.category, UserWarning)
-        ]
-        assert user_warnings == []
-
-    def test_cloudpickle_serialization_with_sync_cm_loadbalancer_raises(
-        self, mock_discovery_service
-    ):
-        """Test TypeError when pickling proxy with sync CM loadbalancer.
-
-        Given:
-            A WorkerProxy with a sync context manager instance as
-            loadbalancer.
-        When:
-            cloudpickle serialization is attempted.
-        Then:
-            It should raise TypeError mentioning 'loadbalancer'.
-        """
-        # Arrange
-        class SyncCM:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                pass
-
-        with pytest.warns(UserWarning):
-            proxy = WorkerProxy(
-                discovery=mock_discovery_service,
-                loadbalancer=SyncCM(),
-            )
-
-        # Act & assert
-        with pytest.raises(TypeError, match="loadbalancer"):
-            cloudpickle.dumps(proxy)
-
-    def test_cloudpickle_serialization_with_async_cm_loadbalancer_raises(
-        self, mock_discovery_service
-    ):
-        """Test TypeError when pickling proxy with async CM loadbalancer.
-
-        Given:
-            A WorkerProxy with an async context manager instance as
-            loadbalancer.
-        When:
-            cloudpickle serialization is attempted.
-        Then:
-            It should raise TypeError mentioning 'loadbalancer'.
-        """
-        # Arrange
-        class AsyncCM:
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *args):
-                pass
-
-        with pytest.warns(UserWarning):
-            proxy = WorkerProxy(
-                discovery=mock_discovery_service,
-                loadbalancer=AsyncCM(),
-            )
-
-        # Act & assert
-        with pytest.raises(TypeError, match="loadbalancer"):
-            cloudpickle.dumps(proxy)
-
-    def test_cloudpickle_serialization_with_sync_cm_discovery_raises(self):
-        """Test TypeError when pickling proxy with sync CM discovery.
-
-        Given:
-            A WorkerProxy with a sync context manager instance as
-            discovery.
-        When:
-            cloudpickle serialization is attempted.
-        Then:
-            It should raise TypeError mentioning 'discovery'.
-        """
-        # Arrange
-        class SyncCM:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *args):
-                pass
-
-        with pytest.warns(UserWarning):
-            proxy = WorkerProxy(discovery=SyncCM())
-
-        # Act & assert
-        with pytest.raises(TypeError, match="discovery"):
-            cloudpickle.dumps(proxy)
-
-    def test_cloudpickle_serialization_with_async_cm_discovery_raises(self):
-        """Test TypeError when pickling proxy with async CM discovery.
-
-        Given:
-            A WorkerProxy with an async context manager instance as
-            discovery.
-        When:
-            cloudpickle serialization is attempted.
-        Then:
-            It should raise TypeError mentioning 'discovery'.
-        """
-        # Arrange
-        class AsyncCM:
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *args):
-                pass
-
-        with pytest.warns(UserWarning):
-            proxy = WorkerProxy(discovery=AsyncCM())
-
-        # Act & assert
-        with pytest.raises(TypeError, match="discovery"):
-            cloudpickle.dumps(proxy)
-
-    # =========================================================================
-    # Validation Tests
-    # =========================================================================
 
     @pytest.mark.asyncio
     async def test_start_invalid_loadbalancer_type_raises_error(
@@ -2061,9 +2034,6 @@ class TestWorkerProxy:
         with pytest.raises(ValueError):
             await proxy.start()
 
-    # =========================================================================
-    # Security Filtering Tests
-    # =========================================================================
 
     @pytest.mark.asyncio
     async def test_security_filter_with_credentials(
@@ -2171,9 +2141,6 @@ class TestWorkerProxy:
         )
         assert filter_fn(secure_matching) is False
 
-    # =========================================================================
-    # Property-Based Tests
-    # =========================================================================
 
     @given(worker_count=st.integers(min_value=0, max_value=10))
     @settings(


### PR DESCRIPTION
## Summary

Add runtime diagnostics and documentation for the two `Factory` forms that are not picklable: pre-called `ContextManager[T]` and `AsyncContextManager[T]` instances. Previously, passing one of these as `loadbalancer` or `discovery` to `WorkerProxy` produced an opaque `TypeError` from cloudpickle at nested routine dispatch time with no indication of the root cause. Now users get a `UserWarning` at construction time and a clear `TypeError` with an actionable fix suggestion at pickle time.

Closes #61

## Proposed changes

### Documentation: caution admonition on WorkerPool and WorkerProxy

Add a single `.. caution::` admonition at the end of each class docstring in `WorkerPool` (`pool.py`) and `WorkerProxy` (`proxy.py`), warning that pre-called context manager instances passed as `loadbalancer` or `discovery` are not picklable and will cause nested routine dispatch to fail.

### Runtime: UserWarning on construction

Emit a `UserWarning` in `WorkerProxy.__init__` when `loadbalancer` or `discovery` is detected as a `ContextManager` or `AsyncContextManager` instance via `isinstance`. The warning fires immediately at construction time — before any async work — so users see it in logs even if they never trigger nested dispatch. The message identifies which parameter is affected and suggests wrapping the CM in a callable.

### Runtime: TypeError on pickle

Raise a `TypeError` with a clear message in `WorkerProxy.__reduce__` when `self._loadbalancer` or `self._discovery` is a CM instance. This replaces the opaque cloudpickle failure with an actionable error that names the offending parameter, its type, and the callable-wrapper fix.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestWorkerProxy` | A sync CM instance as `loadbalancer` | `WorkerProxy` is instantiated | It should emit a `UserWarning` mentioning "loadbalancer" | `__init__` sync CM loadbalancer warning |
| 2 | `TestWorkerProxy` | An async CM instance as `loadbalancer` | `WorkerProxy` is instantiated | It should emit a `UserWarning` mentioning "loadbalancer" | `__init__` async CM loadbalancer warning |
| 3 | `TestWorkerProxy` | A sync CM instance as `discovery` | `WorkerProxy` is instantiated | It should emit a `UserWarning` mentioning "discovery" | `__init__` sync CM discovery warning |
| 4 | `TestWorkerProxy` | An async CM instance as `discovery` | `WorkerProxy` is instantiated | It should emit a `UserWarning` mentioning "discovery" | `__init__` async CM discovery warning |
| 5 | `TestWorkerProxy` | A callable (non-CM) as `loadbalancer` | `WorkerProxy` is instantiated | It should not emit a `UserWarning` | `__init__` no false positive for callables |
| 6 | `TestWorkerProxy` | A sync CM instance as `loadbalancer` | `cloudpickle` serialization is attempted | It should raise `TypeError` mentioning "loadbalancer" | `__reduce__` sync CM loadbalancer error |
| 7 | `TestWorkerProxy` | An async CM instance as `loadbalancer` | `cloudpickle` serialization is attempted | It should raise `TypeError` mentioning "loadbalancer" | `__reduce__` async CM loadbalancer error |
| 8 | `TestWorkerProxy` | A sync CM instance as `discovery` | `cloudpickle` serialization is attempted | It should raise `TypeError` mentioning "discovery" | `__reduce__` sync CM discovery error |
| 9 | `TestWorkerProxy` | An async CM instance as `discovery` | `cloudpickle` serialization is attempted | It should raise `TypeError` mentioning "discovery" | `__reduce__` async CM discovery error |