### PR TITLE
Support joining existing LocalDiscovery namespaces without ownership — Closes #110

### DIFF
--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -235,15 +235,14 @@ class LocalDiscovery(Discovery):
 
         assert self._address_space.buf
         if self._owner:
-            self._cleanup = atexit.register(
-                lambda: self._address_space.unlink()
-            )
+            self._cleanup = atexit.register(lambda: self._address_space.unlink())
             for i in range(size):
                 self._address_space.buf[i] = 0
         return self
 
     def __exit__(self, *_):
         if self._owner:
+            self._address_space.close()
             self._address_space.unlink()
             atexit.unregister(self._cleanup)
         else:

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -219,20 +219,35 @@ class LocalDiscovery(Discovery):
 
     def __enter__(self) -> Self:
         size = self._capacity * 4
-        self._address_space = SharedMemory(
-            name=_short_hash(self._namespace),
-            create=True,
-            size=size,
-        )
+        try:
+            self._address_space = SharedMemory(
+                name=_short_hash(self._namespace),
+                create=True,
+                size=size,
+            )
+            self._owner = True
+        except FileExistsError:
+            self._address_space = SharedMemory(
+                name=_short_hash(self._namespace),
+                create=False,
+            )
+            self._owner = False
+
         assert self._address_space.buf
-        self._cleanup = atexit.register(lambda: self._address_space.unlink())
-        for i in range(size):
-            self._address_space.buf[i] = 0
+        if self._owner:
+            self._cleanup = atexit.register(
+                lambda: self._address_space.unlink()
+            )
+            for i in range(size):
+                self._address_space.buf[i] = 0
         return self
 
     def __exit__(self, *_):
-        self._address_space.unlink()
-        atexit.unregister(self._cleanup)
+        if self._owner:
+            self._address_space.unlink()
+            atexit.unregister(self._cleanup)
+        else:
+            self._address_space.close()
 
     @property
     def namespace(self):

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -391,6 +391,8 @@ def _resolve_joiner(namespace, factory):
                     yield d
 
             return _acm(), None
+        case _:
+            raise ValueError(f"Unsupported factory for joiner: {factory}")
 
 
 @asynccontextmanager
@@ -406,32 +408,31 @@ async def _durable_joined_pool_context(discovery_factory, lb, creds, options):
 
     worker = LocalWorker(credentials=creds, options=options)
     await worker.start()
-
-    owner = LocalDiscovery(namespace)
-    owner.__enter__()
     try:
-        publisher = owner.publisher
-        async with publisher:
-            await publisher.publish("worker-added", worker.metadata)
-            joiner, _joiner_cm = _resolve_joiner(
-                namespace, discovery_factory
-            )
-            try:
-                pool = WorkerPool(
-                    discovery=joiner,
-                    loadbalancer=lb,
-                    credentials=creds,
-                    options=options,
-                )
-                async with pool:
-                    yield pool
-            finally:
-                if _joiner_cm is not None:
-                    _joiner_cm.__exit__(None, None, None)
-                await publisher.publish("worker-dropped", worker.metadata)
+        owner = LocalDiscovery(namespace)
+        owner.__enter__()
+        try:
+            publisher = owner.publisher
+            async with publisher:
+                await publisher.publish("worker-added", worker.metadata)
+                joiner, _joiner_cm = _resolve_joiner(namespace, discovery_factory)
+                try:
+                    pool = WorkerPool(
+                        discovery=joiner,
+                        loadbalancer=lb,
+                        credentials=creds,
+                        options=options,
+                    )
+                    async with pool:
+                        yield pool
+                finally:
+                    if _joiner_cm is not None:
+                        _joiner_cm.__exit__(None, None, None)
+                    await publisher.publish("worker-dropped", worker.metadata)
+        finally:
+            owner.__exit__(None, None, None)
     finally:
         await worker.stop()
-        owner.__exit__(None, None, None)
 
 
 async def invoke_routine(scenario):
@@ -644,10 +645,7 @@ def _pairwise_filter(row):
             return False
         if forbids_discovery and discovery is not DiscoveryFactory.NONE:
             return False
-        if (
-            pool_mode is PoolMode.DURABLE_JOINED
-            and discovery not in _LOCAL_FACTORIES
-        ):
+        if pool_mode is PoolMode.DURABLE_JOINED and discovery not in _LOCAL_FACTORIES:
             return False
     if len(row) > 3:
         lb = row[3]

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -55,6 +55,7 @@ class PoolMode(Enum):
     DEFAULT = auto()
     EPHEMERAL = auto()
     DURABLE = auto()
+    DURABLE_JOINED = auto()
     HYBRID = auto()
     NESTED_DEFAULT_IN_EPHEMERAL = auto()
     NESTED_EPHEMERAL_IN_EPHEMERAL = auto()
@@ -212,7 +213,10 @@ async def build_pool_from_scenario(scenario, credentials_map):
     discovery_obj = None
     _local_cm = None
 
-    if scenario.discovery is not DiscoveryFactory.NONE:
+    if (
+        scenario.discovery is not DiscoveryFactory.NONE
+        and scenario.pool_mode is not PoolMode.DURABLE_JOINED
+    ):
         namespace = f"integration-{uuid.uuid4().hex[:12]}"
 
         match scenario.discovery:
@@ -262,6 +266,11 @@ async def build_pool_from_scenario(scenario, credentials_map):
         try:
             if scenario.pool_mode is PoolMode.DURABLE:
                 async with _durable_pool_context(lb, creds, options) as pool:
+                    yield pool
+            elif scenario.pool_mode is PoolMode.DURABLE_JOINED:
+                async with _durable_joined_pool_context(
+                    scenario.discovery, lb, creds, options
+                ) as pool:
                     yield pool
             else:
                 pool_kwargs = {
@@ -346,6 +355,110 @@ async def _durable_pool_context(lb, creds, options):
                     await publisher.publish("worker-dropped", worker.metadata)
         finally:
             await worker.stop()
+
+
+_LOCAL_FACTORIES = (
+    DiscoveryFactory.LOCAL_DIRECT,
+    DiscoveryFactory.LOCAL_CALLABLE,
+    DiscoveryFactory.LOCAL_SYNC_CM,
+    DiscoveryFactory.LOCAL_ASYNC_CM,
+)
+
+
+def _resolve_joiner(namespace, factory):
+    """Resolve a DiscoveryFactory into a joiner discovery object.
+
+    For LOCAL variants, uses the given namespace (same as the owner),
+    triggering the non-owner fallback path in ``LocalDiscovery.__enter__``.
+    For LAN variants, creates a separate LanDiscovery instance.
+
+    Returns ``(discovery_obj, entered_cm_or_None)``. The caller must
+    exit the CM (if non-None) when done.
+    """
+    match factory:
+        case DiscoveryFactory.LOCAL_DIRECT:
+            cm = LocalDiscovery(namespace)
+            cm.__enter__()
+            return _DirectDiscovery(cm), cm
+        case DiscoveryFactory.LOCAL_CALLABLE:
+            return (lambda: LocalDiscovery(namespace)), None  # noqa: E731
+        case DiscoveryFactory.LOCAL_SYNC_CM:
+            return LocalDiscovery(namespace), None
+        case DiscoveryFactory.LOCAL_ASYNC_CM:
+
+            @asynccontextmanager
+            async def _acm():
+                with LocalDiscovery(namespace) as d:
+                    yield d
+
+            return _acm(), None
+        case DiscoveryFactory.LAN_DIRECT:
+            from wool.runtime.discovery.lan import LanDiscovery
+
+            return LanDiscovery(), None
+        case DiscoveryFactory.LAN_CALLABLE:
+            from wool.runtime.discovery.lan import LanDiscovery
+
+            return (lambda: LanDiscovery()), None  # noqa: E731
+        case DiscoveryFactory.LAN_ASYNC_CM:
+            from wool.runtime.discovery.lan import LanDiscovery
+
+            @asynccontextmanager
+            async def _acm():
+                yield LanDiscovery()
+
+            return _acm(), None
+
+
+@asynccontextmanager
+async def _durable_joined_pool_context(discovery_factory, lb, creds, options):
+    """Create a DURABLE pool that joins an externally owned namespace.
+
+    Sets up an owner that creates workers and publishes them, then resolves
+    a joiner discovery from the D3 factory form. For LOCAL variants, the
+    joiner reuses the owner's namespace, exercising the non-owner fallback
+    path in ``LocalDiscovery.__enter__``. For LAN variants, a separate
+    publisher advertises the worker; the joiner discovers it via zeroconf.
+    """
+    is_local = discovery_factory in _LOCAL_FACTORIES
+    namespace = f"joined-{uuid.uuid4().hex[:12]}"
+
+    worker = LocalWorker(credentials=creds, options=options)
+    await worker.start()
+
+    _owner_cm = None
+    try:
+        if is_local:
+            _owner_cm = LocalDiscovery(namespace)
+            _owner_cm.__enter__()
+            publisher = _owner_cm.publisher
+        else:
+            from wool.runtime.discovery.lan import LanDiscovery as _Lan
+
+            publisher = _Lan.Publisher()
+
+        async with publisher:
+            await publisher.publish("worker-added", worker.metadata)
+            joiner, _joiner_cm = _resolve_joiner(
+                namespace, discovery_factory
+            )
+            try:
+                pool = WorkerPool(
+                    discovery=joiner,
+                    loadbalancer=lb,
+                    credentials=creds,
+                    options=options,
+                )
+                async with pool:
+                    yield pool
+            finally:
+                if _joiner_cm is not None:
+                    _joiner_cm.__exit__(None, None, None)
+                await publisher.publish("worker-dropped", worker.metadata)
+    finally:
+        await worker.stop()
+        if _owner_cm is not None:
+            _owner_cm.__exit__(None, None, None)
 
 
 async def invoke_routine(scenario):
@@ -528,7 +641,7 @@ def _pairwise_filter(row):
 
     - D3 must be NONE when D2 is DEFAULT, EPHEMERAL, DURABLE, or NESTED_*
       (DURABLE manages its own LocalDiscovery internally)
-    - D3 must NOT be NONE when D2 is HYBRID
+    - D3 must NOT be NONE when D2 is HYBRID or DURABLE_JOINED
     - D4 must not be ASYNC_CM (pre-called async CM instances are not
       picklable inside WorkerProxy.__reduce__; documented limitation,
       see #61)
@@ -541,7 +654,10 @@ def _pairwise_filter(row):
     if len(row) > 2:
         pool_mode = row[1]
         discovery = row[2]
-        needs_discovery = pool_mode in (PoolMode.HYBRID,)
+        needs_discovery = pool_mode in (
+            PoolMode.HYBRID,
+            PoolMode.DURABLE_JOINED,
+        )
         forbids_discovery = pool_mode in (
             PoolMode.DEFAULT,
             PoolMode.EPHEMERAL,
@@ -603,7 +719,10 @@ def scenarios_strategy(draw):
     shape = draw(st.sampled_from(RoutineShape))
     pool_mode = draw(st.sampled_from(PoolMode))
 
-    needs_discovery = pool_mode in (PoolMode.HYBRID,)
+    needs_discovery = pool_mode in (
+        PoolMode.HYBRID,
+        PoolMode.DURABLE_JOINED,
+    )
     forbids_discovery = pool_mode in (
         PoolMode.DEFAULT,
         PoolMode.EPHEMERAL,

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -368,9 +368,8 @@ _LOCAL_FACTORIES = (
 def _resolve_joiner(namespace, factory):
     """Resolve a DiscoveryFactory into a joiner discovery object.
 
-    For LOCAL variants, uses the given namespace (same as the owner),
-    triggering the non-owner fallback path in ``LocalDiscovery.__enter__``.
-    For LAN variants, creates a separate LanDiscovery instance.
+    Uses the given namespace (same as the owner), triggering the non-owner
+    fallback path in ``LocalDiscovery.__enter__``.
 
     Returns ``(discovery_obj, entered_cm_or_None)``. The caller must
     exit the CM (if non-None) when done.
@@ -392,51 +391,26 @@ def _resolve_joiner(namespace, factory):
                     yield d
 
             return _acm(), None
-        case DiscoveryFactory.LAN_DIRECT:
-            from wool.runtime.discovery.lan import LanDiscovery
-
-            return LanDiscovery(), None
-        case DiscoveryFactory.LAN_CALLABLE:
-            from wool.runtime.discovery.lan import LanDiscovery
-
-            return (lambda: LanDiscovery()), None  # noqa: E731
-        case DiscoveryFactory.LAN_ASYNC_CM:
-            from wool.runtime.discovery.lan import LanDiscovery
-
-            @asynccontextmanager
-            async def _acm():
-                yield LanDiscovery()
-
-            return _acm(), None
 
 
 @asynccontextmanager
 async def _durable_joined_pool_context(discovery_factory, lb, creds, options):
     """Create a DURABLE pool that joins an externally owned namespace.
 
-    Sets up an owner that creates workers and publishes them, then resolves
-    a joiner discovery from the D3 factory form. For LOCAL variants, the
+    Sets up an owner ``LocalDiscovery`` that creates workers and publishes
+    them, then resolves a joiner discovery from the D3 factory form. The
     joiner reuses the owner's namespace, exercising the non-owner fallback
-    path in ``LocalDiscovery.__enter__``. For LAN variants, a separate
-    publisher advertises the worker; the joiner discovers it via zeroconf.
+    path in ``LocalDiscovery.__enter__``.
     """
-    is_local = discovery_factory in _LOCAL_FACTORIES
     namespace = f"joined-{uuid.uuid4().hex[:12]}"
 
     worker = LocalWorker(credentials=creds, options=options)
     await worker.start()
 
-    _owner_cm = None
+    owner = LocalDiscovery(namespace)
+    owner.__enter__()
     try:
-        if is_local:
-            _owner_cm = LocalDiscovery(namespace)
-            _owner_cm.__enter__()
-            publisher = _owner_cm.publisher
-        else:
-            from wool.runtime.discovery.lan import LanDiscovery as _Lan
-
-            publisher = _Lan.Publisher()
-
+        publisher = owner.publisher
         async with publisher:
             await publisher.publish("worker-added", worker.metadata)
             joiner, _joiner_cm = _resolve_joiner(
@@ -457,8 +431,7 @@ async def _durable_joined_pool_context(discovery_factory, lb, creds, options):
                 await publisher.publish("worker-dropped", worker.metadata)
     finally:
         await worker.stop()
-        if _owner_cm is not None:
-            _owner_cm.__exit__(None, None, None)
+        owner.__exit__(None, None, None)
 
 
 async def invoke_routine(scenario):
@@ -642,6 +615,8 @@ def _pairwise_filter(row):
     - D3 must be NONE when D2 is DEFAULT, EPHEMERAL, DURABLE, or NESTED_*
       (DURABLE manages its own LocalDiscovery internally)
     - D3 must NOT be NONE when D2 is HYBRID or DURABLE_JOINED
+    - D3 must be a LOCAL_* variant when D2 is DURABLE_JOINED
+      (LanDiscovery does not support namespacing)
     - D4 must not be ASYNC_CM (pre-called async CM instances are not
       picklable inside WorkerProxy.__reduce__; documented limitation,
       see #61)
@@ -668,6 +643,11 @@ def _pairwise_filter(row):
         if needs_discovery and discovery is DiscoveryFactory.NONE:
             return False
         if forbids_discovery and discovery is not DiscoveryFactory.NONE:
+            return False
+        if (
+            pool_mode is PoolMode.DURABLE_JOINED
+            and discovery not in _LOCAL_FACTORIES
+        ):
             return False
     if len(row) > 3:
         lb = row[3]
@@ -731,7 +711,9 @@ def scenarios_strategy(draw):
         PoolMode.NESTED_EPHEMERAL_IN_EPHEMERAL,
     )
 
-    if needs_discovery:
+    if pool_mode is PoolMode.DURABLE_JOINED:
+        discovery = draw(st.sampled_from(list(_LOCAL_FACTORIES)))
+    elif needs_discovery:
         discovery = draw(
             st.sampled_from(
                 [d for d in DiscoveryFactory if d is not DiscoveryFactory.NONE]

--- a/wool/tests/integration/test_pool_composition.py
+++ b/wool/tests/integration/test_pool_composition.py
@@ -176,41 +176,6 @@ class TestPoolComposition:
         assert result == 3
 
     @pytest.mark.asyncio
-    async def test_build_pool_from_scenario_with_durable_joined_lan(
-        self, credentials_map
-    ):
-        """Test building a pool with DURABLE_JOINED mode and LAN_CALLABLE.
-
-        Given:
-            A complete scenario using DURABLE_JOINED pool mode with
-            LAN_CALLABLE discovery, where a separate LanDiscovery
-            instance discovers externally published workers.
-        When:
-            A pool is built and a coroutine routine is dispatched.
-        Then:
-            It should return the correct result via the separate
-            LanDiscovery.
-        """
-        # Arrange
-        scenario = Scenario(
-            shape=RoutineShape.COROUTINE,
-            pool_mode=PoolMode.DURABLE_JOINED,
-            discovery=DiscoveryFactory.LAN_CALLABLE,
-            lb=LbFactory.CLASS_REF,
-            credential=CredentialType.INSECURE,
-            options=WorkerOptionsKind.DEFAULT,
-            timeout=TimeoutKind.NONE,
-            binding=RoutineBinding.MODULE_FUNCTION,
-        )
-
-        # Act
-        async with build_pool_from_scenario(scenario, credentials_map):
-            result = await invoke_routine(scenario)
-
-        # Assert
-        assert result == 3
-
-    @pytest.mark.asyncio
     async def test_build_pool_from_scenario_with_restrictive_opts(self, credentials_map):
         """Test building a pool with restrictive message size options.
 

--- a/wool/tests/integration/test_pool_composition.py
+++ b/wool/tests/integration/test_pool_composition.py
@@ -141,6 +141,76 @@ class TestPoolComposition:
         assert result == 3
 
     @pytest.mark.asyncio
+    async def test_build_pool_from_scenario_with_durable_joined_local(
+        self, credentials_map
+    ):
+        """Test building a pool with DURABLE_JOINED mode and LOCAL_CALLABLE.
+
+        Given:
+            A complete scenario using DURABLE_JOINED pool mode with
+            LOCAL_CALLABLE discovery, where a non-owner joiner
+            discovers workers through an existing namespace.
+        When:
+            A pool is built and a coroutine routine is dispatched.
+        Then:
+            It should return the correct result via the non-owner
+            LocalDiscovery.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DURABLE_JOINED,
+            discovery=DiscoveryFactory.LOCAL_CALLABLE,
+            lb=LbFactory.CLASS_REF,
+            credential=CredentialType.INSECURE,
+            options=WorkerOptionsKind.DEFAULT,
+            timeout=TimeoutKind.NONE,
+            binding=RoutineBinding.MODULE_FUNCTION,
+        )
+
+        # Act
+        async with build_pool_from_scenario(scenario, credentials_map):
+            result = await invoke_routine(scenario)
+
+        # Assert
+        assert result == 3
+
+    @pytest.mark.asyncio
+    async def test_build_pool_from_scenario_with_durable_joined_lan(
+        self, credentials_map
+    ):
+        """Test building a pool with DURABLE_JOINED mode and LAN_CALLABLE.
+
+        Given:
+            A complete scenario using DURABLE_JOINED pool mode with
+            LAN_CALLABLE discovery, where a separate LanDiscovery
+            instance discovers externally published workers.
+        When:
+            A pool is built and a coroutine routine is dispatched.
+        Then:
+            It should return the correct result via the separate
+            LanDiscovery.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DURABLE_JOINED,
+            discovery=DiscoveryFactory.LAN_CALLABLE,
+            lb=LbFactory.CLASS_REF,
+            credential=CredentialType.INSECURE,
+            options=WorkerOptionsKind.DEFAULT,
+            timeout=TimeoutKind.NONE,
+            binding=RoutineBinding.MODULE_FUNCTION,
+        )
+
+        # Act
+        async with build_pool_from_scenario(scenario, credentials_map):
+            result = await invoke_routine(scenario)
+
+        # Assert
+        assert result == 3
+
+    @pytest.mark.asyncio
     async def test_build_pool_from_scenario_with_restrictive_opts(self, credentials_map):
         """Test building a pool with restrictive message size options.
 

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -330,7 +330,8 @@ class TestLocalDiscovery:
             with LocalDiscovery(namespace) as joiner:
                 assert joiner is not None
 
-    def test___exit___as_non_owner(self, namespace):
+    @pytest.mark.asyncio
+    async def test___exit___as_non_owner(self, namespace):
         """Test non-owner exit leaves shared memory accessible to owner.
 
         Given:
@@ -342,31 +343,22 @@ class TestLocalDiscovery:
             memory accessible to the owner.
         """
         # Arrange
-        with LocalDiscovery(namespace) as owner:
+        worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="localhost:50051",
+            pid=123,
+            version="1.0",
+        )
+
+        with LocalDiscovery(namespace):
             with LocalDiscovery(namespace):
                 pass  # non-owner enters and exits
 
-            # Act — verify the owner can still use the address space
+            # Act & assert — publishing succeeds, proving shared
+            # memory was not unlinked by the non-owner
             publisher = LocalDiscovery.Publisher(namespace)
-
-            # Assert — publishing succeeds, proving shared memory
-            # was not unlinked by the non-owner
-            worker = WorkerMetadata(
-                uid=uuid.uuid4(),
-                address="localhost:50051",
-                pid=123,
-                version="1.0",
-            )
-            loop = asyncio.new_event_loop()
-            try:
-
-                async def publish():
-                    async with publisher:
-                        await publisher.publish("worker-added", worker)
-
-                loop.run_until_complete(publish())
-            finally:
-                loop.close()
+            async with publisher:
+                await publisher.publish("worker-added", worker)
 
     @pytest.mark.asyncio
     async def test___enter___non_owner_discovers_workers(self, namespace):

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -314,6 +314,119 @@ class TestLocalDiscovery:
         with discovery as ctx:
             assert ctx is discovery
 
+    def test___enter___with_existing_namespace(self, namespace):
+        """Test LocalDiscovery joins an existing namespace without error.
+
+        Given:
+            A LocalDiscovery that owns a namespace
+        When:
+            A second LocalDiscovery enters the same namespace via with
+        Then:
+            It should succeed without raising FileExistsError.
+        """
+        # Arrange
+        with LocalDiscovery(namespace):
+            # Act & assert
+            with LocalDiscovery(namespace) as joiner:
+                assert joiner is not None
+
+    def test___exit___as_non_owner(self, namespace):
+        """Test non-owner exit leaves shared memory accessible to owner.
+
+        Given:
+            An owner and a non-owner sharing a namespace
+        When:
+            The non-owner exits via with
+        Then:
+            It should close without unlinking, leaving the shared
+            memory accessible to the owner.
+        """
+        # Arrange
+        with LocalDiscovery(namespace) as owner:
+            with LocalDiscovery(namespace):
+                pass  # non-owner enters and exits
+
+            # Act — verify the owner can still use the address space
+            publisher = LocalDiscovery.Publisher(namespace)
+
+            # Assert — publishing succeeds, proving shared memory
+            # was not unlinked by the non-owner
+            worker = WorkerMetadata(
+                uid=uuid.uuid4(),
+                address="localhost:50051",
+                pid=123,
+                version="1.0",
+            )
+            loop = asyncio.new_event_loop()
+            try:
+
+                async def publish():
+                    async with publisher:
+                        await publisher.publish("worker-added", worker)
+
+                loop.run_until_complete(publish())
+            finally:
+                loop.close()
+
+    @pytest.mark.asyncio
+    async def test___enter___non_owner_discovers_workers(self, namespace):
+        """Test non-owner can discover workers published by the owner.
+
+        Given:
+            An owner and a non-owner sharing a namespace
+        When:
+            A worker is published by the owner and discovered through
+            the non-owner's subscriber
+        Then:
+            It should yield the worker-added event with matching
+            metadata.
+        """
+        # Arrange
+        worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="localhost:50051",
+            pid=123,
+            version="1.0",
+        )
+        events = []
+        event_received = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                events.append(event)
+                event_received.set()
+                break
+
+        with LocalDiscovery(namespace):
+            with LocalDiscovery(namespace) as joiner:
+                publisher = LocalDiscovery.Publisher(namespace)
+                subscriber = joiner.subscribe(poll_interval=0.05)
+
+                # Act
+                async with publisher:
+                    await publisher.publish("worker-added", worker)
+
+                    task = asyncio.create_task(collect(subscriber))
+                    try:
+                        await asyncio.wait_for(
+                            event_received.wait(), timeout=2.0
+                        )
+                    except asyncio.TimeoutError:
+                        pytest.fail(
+                            "Worker not discovered via non-owner within timeout"
+                        )
+                    finally:
+                        task.cancel()
+                        try:
+                            await task
+                        except asyncio.CancelledError:
+                            pass
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].type == "worker-added"
+        assert events[0].metadata.uid == worker.uid
+
 
 class TestLocalDiscoveryPublisher:
     """Tests for LocalDiscovery.Publisher class.

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -361,7 +361,7 @@ class TestLocalDiscovery:
                 await publisher.publish("worker-added", worker)
 
     @pytest.mark.asyncio
-    async def test___enter___non_owner_discovers_workers(self, namespace):
+    async def test_subscribe_with_non_owner_discovery(self, namespace):
         """Test non-owner can discover workers published by the owner.
 
         Given:
@@ -400,13 +400,9 @@ class TestLocalDiscovery:
 
                     task = asyncio.create_task(collect(subscriber))
                     try:
-                        await asyncio.wait_for(
-                            event_received.wait(), timeout=2.0
-                        )
+                        await asyncio.wait_for(event_received.wait(), timeout=2.0)
                     except asyncio.TimeoutError:
-                        pytest.fail(
-                            "Worker not discovered via non-owner within timeout"
-                        )
+                        pytest.fail("Worker not discovered via non-owner within timeout")
                     finally:
                         task.cancel()
                         try:


### PR DESCRIPTION
## Summary

Add non-owner support to `LocalDiscovery` so that multiple processes can share a namespace without the second entrant crashing with `FileExistsError`. When `__enter__` detects the shared memory region already exists, it opens it with `create=False` and marks the instance as a non-owner. Non-owners close their handle on `__exit__` without unlinking, preserving the region for the owning process. This enables lightweight worker-to-worker dispatch on a single machine via named `LocalDiscovery` namespaces, avoiding the overhead of `LanDiscovery` (zeroconf).

Closes #110

## Proposed changes

### Non-owner fallback in LocalDiscovery context manager

`__enter__` wraps the `SharedMemory(create=True)` call in a `try`/`except FileExistsError`. On fallback, the region is opened with `create=False` and an `_owner` flag is set to `False`. Only owners zero-initialize the buffer and register the `atexit` unlink handler. `__exit__` branches on `_owner`: owners unlink and deregister as before; non-owners call `close()` only.

**File:** `src/wool/runtime/discovery/local.py`

### DURABLE_JOINED integration test dimension

Extend `PoolMode` with a new `DURABLE_JOINED` member that exercises the non-owner path end-to-end. An "owner" `LocalDiscovery` creates the namespace and publishes an externally started worker; a "joiner" discovery (resolved from the D3 factory dimension) opens the same namespace as a non-owner. The pairwise filter constrains `DURABLE_JOINED` to LOCAL discovery variants only, since `LanDiscovery` does not support namespacing. The covering array and Hypothesis strategy pick up the new member automatically.

**Files:** `tests/integration/conftest.py`, `tests/integration/test_pool_composition.py`

## Test cases

### Unit tests

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestLocalDiscovery` | A LocalDiscovery that owns a namespace | A second LocalDiscovery enters the same namespace via `with` | It should succeed without raising FileExistsError | Non-owner `__enter__` fallback path |
| 2 | `TestLocalDiscovery` | An owner and a non-owner sharing a namespace | The non-owner exits via `with` | It should close without unlinking, leaving the shared memory accessible to the owner | Non-owner `__exit__` close-only path |
| 3 | `TestLocalDiscovery` | An owner and a non-owner sharing a namespace | A worker is published by the owner and discovered through the non-owner's subscriber | It should yield the worker-added event with matching metadata | End-to-end non-owner discovery |

### Integration tests

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestPoolComposition` | DURABLE_JOINED scenario with LOCAL_CALLABLE discovery | Pool built and coroutine dispatched | It should return the correct result via non-owner LocalDiscovery | D2=DURABLE_JOINED, D3=LOCAL_CALLABLE |