### PR TITLE
Add namespace parameter to LanDiscovery for network-level pool isolation — Closes #113

### DIFF
--- a/wool/src/wool/runtime/discovery/lan.py
+++ b/wool/src/wool/runtime/discovery/lan.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import socket
 from asyncio import Queue
@@ -8,9 +9,9 @@ from types import MappingProxyType
 from typing import AsyncIterator
 from typing import Dict
 from typing import Final
-from typing import Literal
 from typing import Tuple
 from uuid import UUID
+from uuid import uuid4
 
 from zeroconf import IPVersion
 from zeroconf import ServiceInfo
@@ -32,11 +33,22 @@ from wool.runtime.discovery.base import WorkerMetadata
 class LanDiscovery(Discovery):
     """Zeroconf DNS-SD discovery for network-wide worker pools.
 
-    Workers are advertised as DNS-SD service records
-    (``_wool._tcp.local.``) on the local network. Subscribers
-    browse for these services and receive events as workers come
-    and go. No central coordinator required.
+    Workers are advertised as DNS-SD service records on the local
+    network. Subscribers browse for these services and receive events
+    as workers come and go. No central coordinator required.
 
+    Each instance is scoped to a namespace that determines the DNS-SD
+    service type used for registration and browsing. Only publishers
+    and subscribers sharing the same namespace see each other's
+    announcements. When no namespace is provided, a UUID-based
+    namespace is auto-generated so that each instance is isolated by
+    default.
+
+    :param namespace:
+        Namespace identifier for discovery isolation. Publishers
+        and subscribers using the same namespace will see each
+        other's worker announcements. Defaults to a UUID-based
+        auto-generated namespace.
     :param filter:
         Optional default predicate function to filter workers.
         Used by :py:attr:`subscriber` and as the default for
@@ -46,7 +58,7 @@ class LanDiscovery(Discovery):
 
     .. code-block:: python
 
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery("my-pool").publisher
         async with publisher:
             await publisher.publish("worker-added", metadata)
 
@@ -54,20 +66,33 @@ class LanDiscovery(Discovery):
 
     .. code-block:: python
 
-        discovery = LanDiscovery()
+        discovery = LanDiscovery("my-pool")
         async for event in discovery.subscriber:
             print(f"Discovered worker: {event.metadata}")
     """
 
+    _namespace: Final[str]
     _filter: Final[PredicateFunction | None]
-    service_type: Literal["_wool._tcp.local."] = "_wool._tcp.local."
+    _service_type: Final[str]
 
     def __init__(
         self,
+        namespace: str | None = None,
         *,
         filter: PredicateFunction | None = None,
     ):
+        self._namespace = namespace or f"pool-{uuid4().hex}"
         self._filter = filter
+        self._service_type = _namespaced_service_type(self._namespace)
+
+    @property
+    def namespace(self) -> str:
+        """The namespace identifier for this discovery service.
+
+        :returns:
+            The namespace string.
+        """
+        return self._namespace
 
     @property
     def publisher(self) -> DiscoveryPublisherLike:
@@ -76,7 +101,7 @@ class LanDiscovery(Discovery):
         :returns:
             A publisher instance for broadcasting worker events.
         """
-        return self.Publisher()
+        return self.Publisher(self._service_type)
 
     @property
     def subscriber(self) -> DiscoverySubscriberLike:
@@ -102,7 +127,10 @@ class LanDiscovery(Discovery):
             A subscriber instance that receives filtered worker
             discovery events.
         """
-        return self.Subscriber(filter if filter is not None else self._filter)
+        return self.Subscriber(
+            self._service_type,
+            filter if filter is not None else self._filter,
+        )
 
     class Publisher:
         """Publisher for broadcasting worker discovery events.
@@ -115,13 +143,16 @@ class LanDiscovery(Discovery):
         Uses AsyncZeroconf for non-blocking service registration and
         management. Services are advertised on localhost (127.0.0.1) to
         avoid network warnings during development.
+
+        :param service_type:
+            The DNS-SD service type string for this namespace.
         """
 
         aiozc: AsyncZeroconf | None
         services: Dict[str, ServiceInfo]
-        service_type: Literal["_wool._tcp.local."] = "_wool._tcp.local."
 
-        def __init__(self):
+        def __init__(self, service_type: str):
+            self.service_type = service_type
             self.aiozc = None
             self.services = {}
 
@@ -296,6 +327,8 @@ class LanDiscovery(Discovery):
         changes and converts Zeroconf events into Wool discovery
         events.
 
+        :param service_type:
+            The DNS-SD service type string for this namespace.
         :param filter:
             Optional predicate function to filter workers. Only workers
             for which the predicate returns True will be included in
@@ -303,12 +336,13 @@ class LanDiscovery(Discovery):
         """
 
         _filter: Final[PredicateFunction[WorkerMetadata] | None]
-        service_type: Literal["_wool._tcp.local."] = "_wool._tcp.local."
 
         def __init__(
             self,
+            service_type: str,
             filter: PredicateFunction[WorkerMetadata] | None = None,
         ) -> None:
+            self.service_type = service_type
             self._filter = filter
 
         def __aiter__(self) -> AsyncIterator[DiscoveryEvent]:
@@ -337,6 +371,7 @@ class LanDiscovery(Discovery):
                     aiozc.zeroconf,
                     self.service_type,
                     listener=self._Listener(
+                        service_type=self.service_type,
                         aiozc=aiozc,
                         event_queue=event_queue,
                         service_cache=service_cache,
@@ -356,6 +391,8 @@ class LanDiscovery(Discovery):
         class _Listener(ServiceListener):
             """Zeroconf listener that delivers worker service events.
 
+            :param service_type:
+                The DNS-SD service type string for this namespace.
             :param aiozc:
                 The AsyncZeroconf instance to use for async service
                 info retrieval.
@@ -375,11 +412,13 @@ class LanDiscovery(Discovery):
 
             def __init__(
                 self,
+                service_type: str,
                 aiozc: AsyncZeroconf,
                 event_queue: Queue[DiscoveryEvent],
                 predicate: PredicateFunction[WorkerMetadata],
                 service_cache: Dict[str, WorkerMetadata],
             ) -> None:
+                self._service_type = service_type
                 self.aiozc = aiozc
                 self._event_queue = event_queue
                 self._predicate = predicate
@@ -388,12 +427,12 @@ class LanDiscovery(Discovery):
 
             def add_service(self, zc: Zeroconf, type_: str, name: str):  # noqa: ARG002
                 """Called by Zeroconf when a service is added."""
-                if type_ == LanDiscovery.service_type:
+                if type_ == self._service_type:
                     asyncio.create_task(self._handle_add_service(type_, name))
 
             def remove_service(self, zc: Zeroconf, type_: str, name: str):  # noqa: ARG002
                 """Called by Zeroconf when a service is removed."""
-                if type_ == LanDiscovery.service_type:
+                if type_ == self._service_type:
                     if worker := self._service_cache.pop(name, None):
                         asyncio.create_task(
                             self._event_queue.put(
@@ -403,7 +442,7 @@ class LanDiscovery(Discovery):
 
             def update_service(self, zc: Zeroconf, type_, name):  # noqa: ARG002
                 """Called by Zeroconf when a service is updated."""
-                if type_ == LanDiscovery.service_type:
+                if type_ == self._service_type:
                     asyncio.create_task(self._handle_update_service(type_, name))
 
             async def _handle_add_service(self, type_: str, name: str):
@@ -469,6 +508,24 @@ class LanDiscovery(Discovery):
                     pass
 
 
+def _namespaced_service_type(namespace: str) -> str:
+    """Derive a DNS-SD service type from a namespace string.
+
+    Produces a deterministic service type by appending a short hash of
+    the namespace to the base ``_wool`` label. The resulting label is
+    at most 13 characters, within the DNS-SD 15-character limit.
+
+    :param namespace:
+        The namespace identifier.
+    :returns:
+        A service type string like ``_wool-a1b2c3._tcp.local.``.
+    """
+    short = hashlib.md5(
+        namespace.encode(), usedforsecurity=False
+    ).hexdigest()[:6]
+    return f"_wool-{short}._tcp.local."
+
+
 def _serialize_metadata(
     info: WorkerMetadata,
 ) -> dict[str, str | None]:
@@ -525,7 +582,7 @@ def _deserialize_metadata(info: ServiceInfo) -> WorkerMetadata:
     if "secure" in properties and properties["secure"]:
         secure = properties["secure"].lower() == "true"
 
-    # Extract UID from service name (format: "<uuid>._wool._tcp.local.")
+    # Extract UID from service name (format: "<uuid>.<service_type>")
     service_name = info.name
     uid_str = service_name.split(".")[0]
 

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -235,17 +235,21 @@ async def build_pool_from_scenario(scenario, credentials_map):
             case DiscoveryFactory.LAN_DIRECT:
                 from wool.runtime.discovery.lan import LanDiscovery
 
-                discovery_obj = LanDiscovery()
+                lan_ns = f"integration-lan-{uuid.uuid4().hex[:12]}"
+                discovery_obj = LanDiscovery(lan_ns)
             case DiscoveryFactory.LAN_CALLABLE:
                 from wool.runtime.discovery.lan import LanDiscovery
 
-                discovery_obj = lambda: LanDiscovery()  # noqa: E731
+                lan_ns = f"integration-lan-{uuid.uuid4().hex[:12]}"
+                discovery_obj = lambda: LanDiscovery(lan_ns)  # noqa: E731
             case DiscoveryFactory.LAN_ASYNC_CM:
                 from wool.runtime.discovery.lan import LanDiscovery
 
+                lan_ns = f"integration-lan-{uuid.uuid4().hex[:12]}"
+
                 @asynccontextmanager
                 async def _lan_async_cm():
-                    discovery = LanDiscovery()
+                    discovery = LanDiscovery(lan_ns)
                     yield discovery
 
                 discovery_obj = _lan_async_cm()

--- a/wool/tests/runtime/discovery/test_lan.py
+++ b/wool/tests/runtime/discovery/test_lan.py
@@ -13,6 +13,9 @@ from zeroconf import ServiceInfo
 from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.lan import LanDiscovery
 
+_TEST_NAMESPACE = "test-namespace"
+_TEST_SERVICE_TYPE = "_wool-c6c84a._tcp.local."
+
 
 @pytest.fixture
 def metadata():
@@ -61,22 +64,54 @@ class TestLanDiscovery:
     Fully qualified name: wool.runtime.discovery.lan.LanDiscovery
     """
 
-    def test___init___with_default_service_type(self):
-        """Test LanDiscovery default service type.
+    def test___init___with_auto_generated_namespace(self):
+        """Test LanDiscovery auto-generates a namespace.
 
         Given:
-            No arguments
+            No namespace argument
         When:
             LanDiscovery is instantiated
         Then:
-            It should have service_type equal to
-            "_wool._tcp.local.".
+            It should have a namespace starting with "pool-".
         """
         # Act
         discovery = LanDiscovery()
 
         # Assert
-        assert discovery.service_type == "_wool._tcp.local."
+        assert discovery.namespace.startswith("pool-")
+
+    def test___init___with_explicit_namespace(self):
+        """Test LanDiscovery stores an explicit namespace.
+
+        Given:
+            An explicit namespace string
+        When:
+            LanDiscovery is instantiated with that namespace
+        Then:
+            It should return the provided namespace.
+        """
+        # Act
+        discovery = LanDiscovery("my-pool")
+
+        # Assert
+        assert discovery.namespace == "my-pool"
+
+    def test___init___with_unique_auto_namespaces(self):
+        """Test auto-generated namespaces are unique.
+
+        Given:
+            Two LanDiscovery instances with no namespace argument
+        When:
+            Both are instantiated
+        Then:
+            Their namespace values should differ.
+        """
+        # Act
+        d1 = LanDiscovery()
+        d2 = LanDiscovery()
+
+        # Assert
+        assert d1.namespace != d2.namespace
 
     def test_publisher_with_default_instance(self):
         """Test publisher property returns Publisher instance.
@@ -132,8 +167,8 @@ class TestLanDiscovery:
         def predicate(w):
             return w.address.endswith(":50051")
 
-        discovery = LanDiscovery(filter=predicate)
-        publisher = LanDiscovery.Publisher()
+        discovery = LanDiscovery(_TEST_NAMESPACE, filter=predicate)
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
         subscriber = discovery.subscribe()
 
         worker_match = worker_factory(
@@ -192,8 +227,8 @@ class TestLanDiscovery:
         def predicate(w):
             return w.address.endswith(":50051")
 
-        discovery = LanDiscovery()
-        publisher = LanDiscovery.Publisher()
+        discovery = LanDiscovery(_TEST_NAMESPACE)
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
         subscriber = discovery.subscribe(filter=predicate)
 
         worker_match = worker_factory(
@@ -236,6 +271,47 @@ class TestLanDiscovery:
         assert len(events) >= 1
         assert all(e.metadata.address.endswith(":50051") for e in events)
 
+    @pytest.mark.asyncio
+    async def test_subscribe_with_namespace_isolation(self, metadata):
+        """Test subscribers on different namespaces are isolated.
+
+        Given:
+            Two LanDiscovery instances with different namespaces, a
+            publisher on namespace A, and a subscriber on namespace B
+        When:
+            The publisher publishes a worker
+        Then:
+            The subscriber on namespace B should not receive the event.
+        """
+        # Arrange
+        discovery_a = LanDiscovery("ns-alpha")
+        discovery_b = LanDiscovery("ns-beta")
+        publisher = discovery_a.publisher
+        subscriber = discovery_b.subscriber
+
+        events = []
+
+        async def collect():
+            async for event in subscriber:
+                events.append(event)
+
+        # Act
+        async with publisher:
+            task = asyncio.create_task(collect())
+            await asyncio.sleep(0.1)
+
+            await publisher.publish("worker-added", metadata)
+            await asyncio.sleep(1.0)
+
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # Assert
+        assert events == []
+
 
 class TestLanDiscoveryPublisher:
     """Tests for LanDiscovery.Publisher class.
@@ -255,7 +331,7 @@ class TestLanDiscoveryPublisher:
             It should be None.
         """
         # Act
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
 
         # Assert
         assert publisher.aiozc is None
@@ -273,7 +349,7 @@ class TestLanDiscoveryPublisher:
             exit.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
 
         # Act & assert
         async with publisher:
@@ -293,17 +369,17 @@ class TestLanDiscoveryPublisher:
             It should register the worker as a DNS-SD service.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
 
         # Act
         async with publisher:
             await publisher.publish("worker-added", metadata)
 
             # Assert
-            service_name = f"{metadata.uid}._wool._tcp.local."
+            service_name = f"{metadata.uid}.{_TEST_SERVICE_TYPE}"
             assert publisher.aiozc is not None
             service_info = await publisher.aiozc.async_get_service_info(
-                "_wool._tcp.local.",
+                _TEST_SERVICE_TYPE,
                 service_name,
             )
             assert service_info is not None
@@ -321,7 +397,7 @@ class TestLanDiscoveryPublisher:
             It should unregister the worker service.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
 
         # Act
         async with publisher:
@@ -345,7 +421,7 @@ class TestLanDiscoveryPublisher:
             It should update the worker service properties.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
         updated_worker = WorkerMetadata(
             uid=metadata.uid,
             address=metadata.address,
@@ -377,7 +453,7 @@ class TestLanDiscoveryPublisher:
             It should raise RuntimeError.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
 
         # Act & assert
         with pytest.raises(RuntimeError, match="not properly initialized"):
@@ -395,7 +471,7 @@ class TestLanDiscoveryPublisher:
             It should raise RuntimeError.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
 
         # Act & assert
         async with publisher:
@@ -421,7 +497,7 @@ class TestLanDiscoveryPublisher:
             keyed by UID string.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
 
         # Act
         async with publisher:
@@ -441,21 +517,21 @@ class TestLanDiscoverySubscriber:
     wool.runtime.discovery.lan.LanDiscovery.Subscriber
     """
 
-    def test_service_type_with_default_value(self):
-        """Test Subscriber service_type constant.
+    def test_service_type_with_provided_value(self):
+        """Test Subscriber stores the provided service type.
 
         Given:
-            A Subscriber instance
+            A service type string
         When:
-            service_type is accessed
+            Subscriber is instantiated with that service type
         Then:
-            It should be "_wool._tcp.local.".
+            It should store the provided service type.
         """
         # Act
-        subscriber = LanDiscovery.Subscriber()
+        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE)
 
         # Assert
-        assert subscriber.service_type == "_wool._tcp.local."
+        assert subscriber.service_type == _TEST_SERVICE_TYPE
 
     @pytest.mark.asyncio
     async def test___aiter___discovers_added_worker(self, metadata):
@@ -470,8 +546,8 @@ class TestLanDiscoverySubscriber:
             metadata.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
-        subscriber = LanDiscovery.Subscriber()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
+        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE)
 
         events = []
         worker_discovered = asyncio.Event()
@@ -518,8 +594,8 @@ class TestLanDiscoverySubscriber:
             It should yield a worker-dropped event.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
-        subscriber = LanDiscovery.Subscriber()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
+        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE)
 
         events = []
         worker_dropped = asyncio.Event()
@@ -569,8 +645,8 @@ class TestLanDiscoverySubscriber:
             It should yield a worker-updated event with new metadata.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
-        subscriber = LanDiscovery.Subscriber()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
+        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE)
 
         updated_worker = WorkerMetadata(
             uid=metadata.uid,
@@ -628,12 +704,12 @@ class TestLanDiscoverySubscriber:
             It should yield only matching workers.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
 
         def filter_fn(w):
             return w.address.endswith(":50051")
 
-        subscriber = LanDiscovery.Subscriber(filter=filter_fn)
+        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE, filter=filter_fn)
 
         worker_match = worker_factory(
             address="127.0.0.1:50051", tags=frozenset(["match"])
@@ -689,9 +765,9 @@ class TestLanDiscoverySubscriber:
             Each iterator should receive events independently.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
-        subscriber1 = LanDiscovery.Subscriber()
-        subscriber2 = LanDiscovery.Subscriber()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
+        subscriber1 = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE)
+        subscriber2 = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE)
 
         events1 = []
         events2 = []
@@ -749,12 +825,12 @@ class TestLanDiscoverySubscriber:
             now-filtered worker.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
 
         def filter_fn(w):
             return "gpu" in w.tags
 
-        subscriber = LanDiscovery.Subscriber(filter=filter_fn)
+        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE, filter=filter_fn)
 
         worker = worker_factory(address="127.0.0.1:50051", tags=frozenset(["gpu"]))
 
@@ -815,12 +891,12 @@ class TestLanDiscoverySubscriber:
             worker.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
 
         def filter_fn(w):
             return "gpu" in w.tags
 
-        subscriber = LanDiscovery.Subscriber(filter=filter_fn)
+        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE, filter=filter_fn)
 
         worker = worker_factory(address="127.0.0.1:50051", tags=frozenset(["cpu"]))
 
@@ -883,8 +959,8 @@ class TestLanDiscoverySubscriber:
             with matching metadata.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
-        subscriber = LanDiscovery.Subscriber()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
+        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE)
 
         events = []
         worker_discovered = asyncio.Event()
@@ -972,8 +1048,8 @@ class TestLanDiscoverySubscriber:
             tags=tags,
             extra=MappingProxyType({}),
         )
-        publisher = LanDiscovery.Publisher()
-        subscriber = LanDiscovery.Subscriber()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
+        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE)
 
         events = []
         discovered = asyncio.Event()
@@ -1026,13 +1102,13 @@ class TestLanDiscoverySubscriber:
             It should only yield the valid worker's event.
         """
         # Arrange
-        publisher = LanDiscovery.Publisher()
-        subscriber = LanDiscovery.Subscriber()
+        publisher = LanDiscovery.Publisher(_TEST_SERVICE_TYPE)
+        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE)
 
         malformed_uid = uuid.uuid4()
-        malformed_name = f"{malformed_uid}._wool._tcp.local."
+        malformed_name = f"{malformed_uid}.{_TEST_SERVICE_TYPE}"
         malformed_service = ServiceInfo(
-            "_wool._tcp.local.",
+            _TEST_SERVICE_TYPE,
             malformed_name,
             addresses=[socket.inet_aton("127.0.0.1")],
             port=9999,


### PR DESCRIPTION
## Summary

Add a `namespace` parameter to `LanDiscovery` that scopes Zeroconf service discovery to a named group, preventing unrelated pools on the same LAN from seeing each other's traffic. The namespace is encoded into the DNS-SD service type via a deterministic 6-character MD5 hash (e.g., `_wool-a1b2c3._tcp.local.`), so isolation happens at the Zeroconf layer rather than through client-side filtering. When no namespace is provided, a UUID-based namespace is auto-generated — matching `LocalDiscovery`'s behavior — so each instance is isolated by default.

Closes #113

## Proposed changes

### Namespace-derived service type

Add a `_namespaced_service_type()` helper that hashes the namespace string and produces a DNS-SD service type like `_wool-a1b2c3._tcp.local.`. The resulting label is at most 13 characters, within the DNS-SD 15-character limit for service type names.

### LanDiscovery constructor and property

Accept `namespace: str | None = None` as the first positional parameter, auto-generate `f"pool-{uuid4().hex}"` when `None`, and expose a read-only `namespace` property. The computed service type is passed down to `Publisher` and `Subscriber` instances, replacing the former class-level `service_type` constant.

### Publisher and Subscriber parameterization

Both `Publisher.__init__` and `Subscriber.__init__` now accept a `service_type` parameter instead of using a hardcoded class attribute. The `Subscriber._Listener` also receives the service type and uses it for event filtering, replacing the previous `LanDiscovery.service_type` class-level reference.

### Integration test fixture update

Update `LAN_DIRECT`, `LAN_CALLABLE`, and `LAN_ASYNC_CM` builder cases in `tests/integration/conftest.py` to pass an explicit shared namespace so the publisher and subscriber within each test share the same discovery scope.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestLanDiscovery` | No namespace argument | `LanDiscovery` is instantiated | `namespace` starts with "pool-" | Auto-generated namespace |
| 2 | `TestLanDiscovery` | An explicit namespace string | `LanDiscovery` is instantiated with that namespace | `namespace` returns the provided string | Explicit namespace |
| 3 | `TestLanDiscovery` | Two `LanDiscovery` instances with no namespace | Both are instantiated | Their `namespace` values differ | Auto-generation uniqueness |
| 4 | `TestLanDiscovery` | Two `LanDiscovery` instances with different namespaces | Publisher on namespace A publishes a worker | Subscriber on namespace B receives no events | Namespace isolation |
| 5 | `TestLanDiscoverySubscriber` | A service type string | `Subscriber` is instantiated | `service_type` matches the provided value | Subscriber service type storage |