### PR TITLE
Fix LocalDiscovery subscriber notifications broken on macOS due to unresolved symlink in temp path — Closes #115

### DIFF
--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -788,7 +788,7 @@ async def _lock(namespace: str):
         The namespace identifying the shared memory region to lock.
     """
     lock_name = _short_hash(namespace)
-    lock_path = Path(tempfile.gettempdir()) / f"wool-lock-{lock_name}"
+    lock_path = Path(tempfile.gettempdir()).resolve() / f"wool-lock-{lock_name}"
 
     with open(lock_path, "w") as lock_file:
         while True:
@@ -815,6 +815,6 @@ def _watchdog_path(namespace: str) -> Path:
     :returns:
         Path to the notification file for this namespace.
     """
-    directory = Path(tempfile.gettempdir()) / f"wool-{namespace}"
+    directory = Path(tempfile.gettempdir()).resolve() / f"wool-{namespace}"
     directory.mkdir(exist_ok=True)
     return directory / "notify"

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -1228,6 +1228,59 @@ class TestLocalDiscoverySubscriber:
         assert len(events) >= 1
         assert events[0].type == "worker-added"
 
+    @pytest.mark.asyncio
+    async def test___aiter___with_watchdog_notification(self, namespace, metadata):
+        """Test subscriber discovers workers via watchdog filesystem notification.
+
+        Given:
+            A subscriber with no poll_interval (watchdog-only, no polling fallback)
+        When:
+            A worker is published
+        Then:
+            It should yield the event promptly via filesystem notification,
+            proving the watchdog on_modified path comparison works with
+            resolved symlinks.
+        """
+        # Arrange
+        events = []
+        event_received = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                events.append(event)
+                event_received.set()
+                break
+
+        with LocalDiscovery(namespace):
+            publisher = LocalDiscovery.Publisher(namespace)
+            subscriber = LocalDiscovery.Subscriber(namespace)
+
+            async with publisher:
+                task = asyncio.create_task(collect(subscriber))
+                await asyncio.sleep(0.05)
+
+                # Act
+                await publisher.publish("worker-added", metadata)
+
+                try:
+                    await asyncio.wait_for(event_received.wait(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    pytest.fail(
+                        "Worker not discovered via watchdog notification "
+                        "within timeout — symlink path mismatch? (see #115)"
+                    )
+                finally:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].type == "worker-added"
+        assert events[0].metadata.uid == metadata.uid
+
     def test___reduce___pickle_roundtrip(self, namespace):
         """Test Subscriber pickle roundtrip via cloudpickle.
 


### PR DESCRIPTION
## Summary

Resolve the temp directory path in `_watchdog_path` and `_lock` so that stored notification file paths use the same canonical form as paths delivered by macOS FSEvents. On macOS, `tempfile.gettempdir()` returns an unresolved symlink (`/var/folders/…`) while FSEvents reports the resolved real path (`/private/var/folders/…`). The lexical `Path.__eq__` comparison in `_Watchdog.on_modified` never matched, so subscriber notifications silently failed — discovery fell back to polling or hung indefinitely when `poll_interval` was `None`.

Closes #115

## Proposed changes

### Resolve temp directory symlinks in path helpers

Add `.resolve()` to `Path(tempfile.gettempdir())` in both `_watchdog_path` and `_lock`. This ensures the notification file path stored by the subscriber and the event path reported by FSEvents use the same resolved form, so the `on_modified` handler matches correctly.

### Regression test for watchdog notification path

Add `test___aiter___with_watchdog_notification` to `TestLocalDiscoverySubscriber`. The test creates a subscriber with no `poll_interval` (no polling fallback) so discovery relies entirely on watchdog filesystem notifications. Without the fix, the test times out after 2 seconds; with the fix, it completes in under 0.5 seconds.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestLocalDiscoverySubscriber` | A subscriber with no poll_interval (watchdog-only) | A worker is published | It should yield the event promptly via filesystem notification | Regression for #115: on_modified path comparison with resolved symlinks |