### PR TITLE
Pool discovery protocols shared across proxies on the same worker — Closes #55

### DIFF
--- a/wool/src/wool/runtime/discovery/__init__.py
+++ b/wool/src/wool/runtime/discovery/__init__.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from contextvars import ContextVar
+from typing import Any
 from typing import Final
 
 from wool.runtime.resourcepool import ResourcePool
 
-__subscriber_pool__: Final[ContextVar[ResourcePool | None]] = ContextVar(
+__subscriber_pool__: Final[ContextVar[ResourcePool[Any] | None]] = ContextVar(
     "__subscriber_pool__", default=None
 )

--- a/wool/src/wool/runtime/discovery/__init__.py
+++ b/wool/src/wool/runtime/discovery/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Final
+
+from wool.runtime.resourcepool import ResourcePool
+
+__subscriber_pool__: Final[ContextVar[ResourcePool | None]] = ContextVar(
+    "__subscriber_pool__", default=None
+)

--- a/wool/src/wool/runtime/discovery/lan.py
+++ b/wool/src/wool/runtime/discovery/lan.py
@@ -6,6 +6,7 @@ import json
 import socket
 from asyncio import Queue
 from types import MappingProxyType
+from typing import AsyncGenerator
 from typing import AsyncIterator
 from typing import Dict
 from typing import Final
@@ -27,6 +28,8 @@ from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.base import PredicateFunction
 from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.discovery.pool import SubscriberMeta
+from wool.utilities.afilter import afilter
 
 
 # public
@@ -85,6 +88,14 @@ class LanDiscovery(Discovery):
         self._filter = filter
         self._service_type = _namespaced_service_type(self._namespace)
 
+    def __hash__(self) -> int:
+        return hash((type(self), self._namespace))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, LanDiscovery):
+            return self._namespace == other._namespace
+        return NotImplemented
+
     @property
     def namespace(self) -> str:
         """The namespace identifier for this discovery service.
@@ -127,10 +138,11 @@ class LanDiscovery(Discovery):
             A subscriber instance that receives filtered worker
             discovery events.
         """
-        return self.Subscriber(
-            self._service_type,
-            filter if filter is not None else self._filter,
-        )
+        effective = filter if filter is not None else self._filter
+        subscriber = self.Subscriber(self._service_type)
+        if effective is not None:
+            return afilter(effective, subscriber)
+        return subscriber
 
     class Publisher:
         """Publisher for broadcasting worker discovery events.
@@ -311,7 +323,7 @@ class LanDiscovery(Discovery):
 
             return socket.inet_aton(socket.gethostbyname(host)), port
 
-    class Subscriber:
+    class Subscriber(metaclass=SubscriberMeta):
         """Subscriber for receiving worker discovery events.
 
         Subscribes to worker :class:`discovery events
@@ -319,36 +331,33 @@ class LanDiscovery(Discovery):
         local network. As workers register and unregister their
         services, the subscriber yields corresponding events.
 
-        Each call to ``__aiter__`` creates an isolated iterator with its
-        own state. Multiple concurrent iterations from the same
-        subscriber instance are fully independent.
+        Each call to ``__aiter__`` creates an isolated consumer that
+        receives events from a shared underlying Zeroconf browser via
+        :class:`~wool.runtime.discovery.pool._SharedSubscription`.
+        Multiple concurrent iterations are fully independent.
 
-        Uses AsyncZeroconf's service browser to monitor for service
-        changes and converts Zeroconf events into Wool discovery
-        events.
+        Instances are cached as singletons by
+        :class:`~wool.runtime.discovery.pool.SubscriberMeta` — two
+        calls with the same ``service_type`` return the same object.
 
         :param service_type:
             The DNS-SD service type string for this namespace.
-        :param filter:
-            Optional predicate function to filter workers. Only workers
-            for which the predicate returns True will be included in
-            events.
         """
 
-        _filter: Final[PredicateFunction[WorkerMetadata] | None]
-
-        def __init__(
-            self,
-            service_type: str,
-            filter: PredicateFunction[WorkerMetadata] | None = None,
-        ) -> None:
+        def __init__(self, service_type: str) -> None:
             self.service_type = service_type
-            self._filter = filter
+
+        @classmethod
+        def _cache_key(cls, service_type: str) -> tuple:
+            return (cls, service_type)
+
+        async def _shutdown(self) -> None:
+            """Clean up shared subscription state for this subscriber."""
 
         def __aiter__(self) -> AsyncIterator[DiscoveryEvent]:
             return self._event_stream()
 
-        async def _event_stream(self) -> AsyncIterator[DiscoveryEvent]:
+        async def _event_stream(self) -> AsyncGenerator[DiscoveryEvent, None]:
             """Stream discovery events from the network.
 
             Creates isolated state for this iteration including its own
@@ -357,13 +366,13 @@ class LanDiscovery(Discovery):
             completes or is interrupted.
 
             :yields:
-                Discovery events as workers are added, updated, or removed.
+                Discovery events as workers are added, updated, or
+                removed.
             """
-            # Create isolated state for this iterator
             event_queue: Queue[DiscoveryEvent] = Queue()
             service_cache: Dict[str, WorkerMetadata] = {}
 
-            # Configure zeroconf to use localhost only to avoid network warnings
+            # Configure zeroconf to use localhost only
             aiozc = AsyncZeroconf(interfaces=["127.0.0.1"])
 
             try:
@@ -375,7 +384,6 @@ class LanDiscovery(Discovery):
                         aiozc=aiozc,
                         event_queue=event_queue,
                         service_cache=service_cache,
-                        predicate=self._filter or (lambda _: True),
                     ),
                 )
 
@@ -401,13 +409,10 @@ class LanDiscovery(Discovery):
             :param service_cache:
                 Cache to track service properties for pre/post event
                 states.
-            :param predicate:
-                Function to filter which workers to track.
             """
 
             aiozc: AsyncZeroconf
             _event_queue: Queue[DiscoveryEvent]
-            _service_addresses: Dict[str, str]
             _service_cache: Dict[str, WorkerMetadata]
 
             def __init__(
@@ -415,14 +420,11 @@ class LanDiscovery(Discovery):
                 service_type: str,
                 aiozc: AsyncZeroconf,
                 event_queue: Queue[DiscoveryEvent],
-                predicate: PredicateFunction[WorkerMetadata],
                 service_cache: Dict[str, WorkerMetadata],
             ) -> None:
                 self._service_type = service_type
                 self.aiozc = aiozc
                 self._event_queue = event_queue
-                self._predicate = predicate
-                self._service_addresses = {}
                 self._service_cache = service_cache
 
             def add_service(self, zc: Zeroconf, type_: str, name: str):  # noqa: ARG002
@@ -460,10 +462,10 @@ class LanDiscovery(Discovery):
                     except ValueError:
                         return
 
-                    if self._predicate(metadata):
-                        self._service_cache[name] = metadata
-                        event = DiscoveryEvent("worker-added", metadata=metadata)
-                        await self._event_queue.put(event)
+                    self._service_cache[name] = metadata
+                    await self._event_queue.put(
+                        DiscoveryEvent("worker-added", metadata=metadata)
+                    )
                 except Exception:  # pragma: no cover
                     pass
 
@@ -483,27 +485,15 @@ class LanDiscovery(Discovery):
                         return
 
                     if name not in self._service_cache:
-                        # New worker that wasn't tracked before
-                        if self._predicate(metadata):
-                            self._service_cache[name] = metadata
-                            event = DiscoveryEvent("worker-added", metadata=metadata)
-                            await self._event_queue.put(event)
+                        self._service_cache[name] = metadata
+                        await self._event_queue.put(
+                            DiscoveryEvent("worker-added", metadata=metadata)
+                        )
                     else:
-                        # Existing tracked worker
-                        old_worker = self._service_cache[name]
-                        if self._predicate(metadata):
-                            # Still satisfies filter, update cache and emit update
-                            self._service_cache[name] = metadata
-                            event = DiscoveryEvent("worker-updated", metadata=metadata)
-                            await self._event_queue.put(event)
-                        else:
-                            # No longer satisfies filter, remove and emit removal
-                            del self._service_cache[name]
-                            removal_event = DiscoveryEvent(
-                                "worker-dropped", metadata=old_worker
-                            )
-                            await self._event_queue.put(removal_event)
-
+                        self._service_cache[name] = metadata
+                        await self._event_queue.put(
+                            DiscoveryEvent("worker-updated", metadata=metadata)
+                        )
                 except Exception:  # pragma: no cover
                     pass
 
@@ -520,9 +510,7 @@ def _namespaced_service_type(namespace: str) -> str:
     :returns:
         A service type string like ``_wool-a1b2c3._tcp.local.``.
     """
-    short = hashlib.md5(
-        namespace.encode(), usedforsecurity=False
-    ).hexdigest()[:6]
+    short = hashlib.md5(namespace.encode(), usedforsecurity=False).hexdigest()[:6]
     return f"_wool-{short}._tcp.local."
 
 

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from contextlib import contextmanager
 from multiprocessing.shared_memory import SharedMemory
 from pathlib import Path
+from typing import AsyncGenerator
 from typing import AsyncIterator
 from typing import Callable
 from typing import Final
@@ -29,7 +30,9 @@ from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.base import PredicateFunction
 from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.discovery.pool import SubscriberMeta
 from wool.runtime.resourcepool import ResourcePool
+from wool.utilities.afilter import afilter
 
 REF_WIDTH: Final = 16
 NULL_REF: Final = b"\x00" * REF_WIDTH
@@ -248,6 +251,14 @@ class LocalDiscovery(Discovery):
         else:
             self._address_space.close()
 
+    def __hash__(self) -> int:
+        return hash((type(self), self._namespace))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, LocalDiscovery):
+            return self._namespace == other._namespace
+        return NotImplemented
+
     @property
     def namespace(self):
         """The namespace identifier for this discovery service.
@@ -297,11 +308,14 @@ class LocalDiscovery(Discovery):
             A subscriber instance that receives filtered worker
             discovery events.
         """
-        return self.Subscriber(
+        effective = filter if filter is not None else self._filter
+        subscriber = self.Subscriber(
             self._namespace,
-            filter if filter is not None else self._filter,
             poll_interval=poll_interval,
         )
+        if effective is not None:
+            return afilter(effective, subscriber)
+        return subscriber
 
     class Publisher:
         """Publisher for broadcasting worker discovery events.
@@ -546,7 +560,7 @@ class LocalDiscovery(Discovery):
                 pass  # pragma: no cover
             atexit.unregister(self._cleanups.pop(shared_memory.name))
 
-    class Subscriber:
+    class Subscriber(metaclass=SubscriberMeta):
         """Subscriber for receiving worker discovery events.
 
         Subscribes to worker :class:`discovery events <~wool.DiscoveryEvent>`
@@ -560,60 +574,64 @@ class LocalDiscovery(Discovery):
         of changes. Falls back to periodic polling if notifications are
         delayed or missed.
 
+        Instances are cached as singletons by
+        :class:`~wool.runtime.discovery.pool.SubscriberMeta` — two
+        calls with the same ``namespace`` and ``poll_interval`` return
+        the same object.
+
         :param namespace:
             The namespace identifier for the shared memory region.
-        :param filter:
-            Optional predicate function to filter workers. Only workers for
-            which the predicate returns True will be included in events.
         :param poll_interval:
             Maximum polling interval in seconds for when filesystem
             notifications are delayed or missed.
         """
 
-        _filter: Final[PredicateFunction | None]
         _namespace: Final[str]
         _poll_interval: Final[float | None]
 
         def __init__(
             self,
             namespace: str,
-            filter: PredicateFunction | None = None,
             *,
             poll_interval: float | None = None,
         ):
             self._namespace = namespace
-            self._filter = filter
             if poll_interval is not None and poll_interval < 0:
                 raise ValueError(f"Expected positive poll interval, got {poll_interval}")
             self._poll_interval = poll_interval
 
+        @classmethod
+        def _cache_key(cls, namespace: str, *, poll_interval: float | None = None):
+            return (cls, namespace, poll_interval)
+
+        async def _shutdown(self) -> None:
+            """Clean up shared subscription state for this subscriber."""
+
         def __reduce__(self):
-            return type(self), (self._namespace, self._filter)
+            return type(self), (self._namespace,)
 
         def __aiter__(self) -> AsyncIterator[DiscoveryEvent]:
-            return self._event_stream(self._filter)
+            return self._event_stream()
 
         @property
         def namespace(self):
             """The namespace identifier for this subscriber."""
             return self._namespace
 
-        async def _event_stream(
-            self, filter: PredicateFunction | None = None
-        ) -> AsyncIterator[DiscoveryEvent]:
-            """Monitor shared memory for worker changes via filesystem notifications.
+        async def _event_stream(self) -> AsyncGenerator[DiscoveryEvent, None]:
+            """Monitor shared memory for worker changes via filesystem
+            notifications.
 
-            Sets up a watchdog filesystem observer to monitor the notification
-            file for modifications. When publishers touch the file (after
-            updating shared memory), the observer triggers scanning of the
-            shared memory address space. Falls back to periodic polling in
-            case notifications are delayed or missed.
+            Sets up a watchdog filesystem observer to monitor the
+            notification file for modifications. When publishers touch
+            the file (after updating shared memory), the observer
+            triggers scanning of the shared memory address space. Falls
+            back to periodic polling in case notifications are delayed
+            or missed.
 
-            :param filter:
-                Optional predicate function to filter workers. Only workers for
-                which the predicate returns True will be included in events.
             :yields:
-                Discovery events as changes are detected in shared memory.
+                Discovery events as changes are detected in shared
+                memory.
             """
             cached_workers: dict[str, WorkerMetadata] = {}
             notification = asyncio.Event()
@@ -639,14 +657,14 @@ class LocalDiscovery(Discovery):
                                 if slot != NULL_REF:
                                     ref = _WorkerReference.from_bytes(slot)
                                     metadata = self._deserialize_metadata(str(ref))
-                                    if filter is None or filter(metadata):
-                                        discovered_workers[str(metadata.uid)] = metadata
+                                    discovered_workers[str(metadata.uid)] = metadata
 
                             for event in self._diff(cached_workers, discovered_workers):
                                 yield event
                         try:
                             await asyncio.wait_for(
-                                notification.wait(), timeout=self._poll_interval
+                                notification.wait(),
+                                timeout=self._poll_interval,
                             )
                         except asyncio.TimeoutError:
                             pass

--- a/wool/src/wool/runtime/discovery/pool.py
+++ b/wool/src/wool/runtime/discovery/pool.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import weakref
+from typing import Any
+from typing import AsyncIterator
+from typing import Callable
+from typing import ClassVar
+
+from wool.runtime.discovery import __subscriber_pool__
+from wool.runtime.discovery.base import DiscoveryEvent
+from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.resourcepool import ResourcePool
+from wool.utilities.fanout import Fanout
+
+_subscriber_factories: dict[Any, Callable[[Any], Any]] = {}
+"""Per-key factory registry populated by :class:`SubscriberMeta`."""
+
+
+def _pool_factory(key: Any) -> Any:
+    """Dispatch to the registered factory for *key*."""
+    return _subscriber_factories[key](key)
+
+
+def _reconstruct(cls: type, args: tuple, kwargs: dict) -> Any:
+    """Pickle helper — calls ``cls(*args, **kwargs)``."""
+    return cls(*args, **kwargs)
+
+
+class _SharedSubscription:
+    """Adapter bridging a discovery subscriber and a :class:`Fanout`.
+
+    Each ``__aiter__`` call returns an independent async generator
+    that enters a :class:`~wool.runtime.resourcepool.Resource` from
+    the pool, wraps the raw subscriber in a shared
+    :class:`~wool.utilities.fanout.Fanout`, and iterates a
+    :class:`~wool.utilities.fanout.FanoutConsumer`.  The ``async
+    with`` context naturally releases the pool reference on
+    exhaustion or ``aclose()``.
+
+    Late-joining consumers receive a replay of ``worker-added``
+    events for all workers the shared source has already discovered,
+    so they start with a consistent view of the current state.
+
+    :param key:
+        Cache key for the :class:`ResourcePool`.
+    :param reduce_info:
+        ``(cls, args, kwargs)`` tuple used by :meth:`__reduce__` for
+        pickle support.
+    """
+
+    _fanouts: ClassVar[weakref.WeakKeyDictionary[Any, Fanout[DiscoveryEvent]]] = (
+        weakref.WeakKeyDictionary()
+    )
+    _workers: ClassVar[weakref.WeakKeyDictionary[Any, dict[str, WorkerMetadata]]] = (
+        weakref.WeakKeyDictionary()
+    )
+
+    def __init__(
+        self,
+        key: Any,
+        reduce_info: tuple[type, tuple, dict[str, Any]],
+    ) -> None:
+        self._key = key
+        self._reduce_info = reduce_info
+
+    def __aiter__(self) -> AsyncIterator[DiscoveryEvent]:
+        return self._iter()
+
+    async def _iter(self) -> AsyncIterator[DiscoveryEvent]:
+        """Enter the pool resource, create a consumer, and iterate."""
+        pool = __subscriber_pool__.get()
+        if pool is None:
+            raise RuntimeError("subscriber pool not initialised")
+        async with pool.get(self._key) as subscriber:
+            fanout = self._fanouts.get(subscriber)
+            if fanout is None:
+                fanout = Fanout(subscriber)
+                self._fanouts[subscriber] = fanout
+            consumer = fanout.consumer()
+            # Replay current workers so late joiners see existing
+            # state.
+            workers = self._workers.get(subscriber)
+            if workers:
+                for metadata in workers.values():
+                    consumer.enqueue(DiscoveryEvent("worker-added", metadata=metadata))
+            async for event in consumer:
+                # Track latest worker state for late-joiner replay.
+                uid = str(event.metadata.uid)
+                ws = self._workers.setdefault(subscriber, {})
+                if event.type in ("worker-added", "worker-updated"):
+                    ws[uid] = event.metadata
+                elif event.type == "worker-dropped":
+                    ws.pop(uid, None)
+                yield event
+
+    def __reduce__(self) -> tuple:
+        cls, args, kwargs = self._reduce_info
+        return _reconstruct, (cls, args, kwargs)
+
+
+class SubscriberMeta(type):
+    """Metaclass that caches discovery subscriber singletons.
+
+    Intercepts class creation via ``__new__`` and injects a custom
+    ``__new__`` onto the subscriber class.  The injected method
+    registers a factory that creates raw subscribers, then returns a
+    :class:`_SharedSubscription` whose pool
+    :class:`~wool.runtime.resourcepool.Resource` is entered lazily
+    on first iteration.
+
+    Subscriber classes using this metaclass must define a
+    ``_cache_key`` classmethod that returns a hashable key from the
+    constructor arguments.
+    """
+
+    def __new__(
+        mcs,
+        name: str,
+        bases: tuple[type, ...],
+        namespace: dict[str, Any],
+    ) -> SubscriberMeta:
+        cls = super().__new__(mcs, name, bases, namespace)
+        original_init = cls.__init__  # type: ignore[misc]
+
+        def _subscriber_new(cls_arg: type, *args: Any, **kwargs: Any) -> Any:
+            key = cls_arg._cache_key(*args, **kwargs)  # type: ignore[attr-defined]
+            pool = __subscriber_pool__.get()
+            if pool is None:
+                pool = ResourcePool(
+                    factory=_pool_factory,
+                    finalizer=_pool_finalizer,
+                    ttl=0,
+                )
+                __subscriber_pool__.set(pool)
+
+            def factory(_: Any) -> Any:
+                instance = object.__new__(cls_arg)
+                original_init(instance, *args, **kwargs)
+                return instance
+
+            _subscriber_factories.setdefault(key, factory)
+            return _SharedSubscription(
+                key=key,
+                reduce_info=(cls_arg, args, kwargs),
+            )
+
+        cls.__new__ = _subscriber_new  # type: ignore[assignment]
+        return cls  # type: ignore[return-value]
+
+
+async def _pool_finalizer(subscriber: Any) -> None:
+    """Resource pool finalizer — clean up fanout and subscriber."""
+    fanout = _SharedSubscription._fanouts.pop(subscriber, None)
+    if fanout is not None:
+        await fanout.cleanup()
+    if hasattr(subscriber, "_shutdown"):
+        await subscriber._shutdown()

--- a/wool/src/wool/runtime/resourcepool.py
+++ b/wool/src/wool/runtime/resourcepool.py
@@ -222,6 +222,43 @@ class ResourcePool(Generic[T]):
         """
         return Resource(self, key)
 
+    def get_or_create_sync(
+        self, key: Any, factory: Callable[[Any], T] | None = None
+    ) -> T:
+        """Synchronously get or create a cached resource.
+
+        Returns the cached object for *key* if it exists, incrementing
+        its reference count.  On cache miss, calls *factory* (or the
+        pool's default factory) with *key* to create and cache a new
+        object.
+
+        .. note::
+            Safe to call from synchronous code only when the factory
+            requires no I/O.  Does not acquire the async lock —
+            callers must ensure no concurrent async operations on the
+            same key.
+
+        :param key:
+            The cache key.
+        :param factory:
+            Optional factory override.  Falls back to the pool's
+            default factory.
+        :returns:
+            The cached or newly created object.
+        """
+        if key in self._cache:
+            entry = self._cache[key]
+            entry.reference_count += 1
+            if entry.cleanup is not None and not entry.cleanup.done():
+                entry.cleanup.cancel()
+                entry.cleanup = None
+            return entry.obj
+
+        f = factory or self._factory
+        obj = cast(T, f(key))
+        self._cache[key] = self.CacheEntry(obj=obj, reference_count=1)
+        return obj
+
     async def acquire(self, key: Any) -> T:
         """
         Internal acquire method - acquires a reference to the cached object.

--- a/wool/src/wool/runtime/resourcepool.py
+++ b/wool/src/wool/runtime/resourcepool.py
@@ -222,43 +222,6 @@ class ResourcePool(Generic[T]):
         """
         return Resource(self, key)
 
-    def get_or_create_sync(
-        self, key: Any, factory: Callable[[Any], T] | None = None
-    ) -> T:
-        """Synchronously get or create a cached resource.
-
-        Returns the cached object for *key* if it exists, incrementing
-        its reference count.  On cache miss, calls *factory* (or the
-        pool's default factory) with *key* to create and cache a new
-        object.
-
-        .. note::
-            Safe to call from synchronous code only when the factory
-            requires no I/O.  Does not acquire the async lock —
-            callers must ensure no concurrent async operations on the
-            same key.
-
-        :param key:
-            The cache key.
-        :param factory:
-            Optional factory override.  Falls back to the pool's
-            default factory.
-        :returns:
-            The cached or newly created object.
-        """
-        if key in self._cache:
-            entry = self._cache[key]
-            entry.reference_count += 1
-            if entry.cleanup is not None and not entry.cleanup.done():
-                entry.cleanup.cancel()
-                entry.cleanup = None
-            return entry.obj
-
-        f = factory or self._factory
-        obj = cast(T, f(key))
-        self._cache[key] = self.CacheEntry(obj=obj, reference_count=1)
-        return obj
-
     async def acquire(self, key: Any) -> T:
         """
         Internal acquire method - acquires a reference to the cached object.

--- a/wool/src/wool/runtime/worker/service.py
+++ b/wool/src/wool/runtime/worker/service.py
@@ -432,6 +432,10 @@ class WorkerService(protocol.WorkerServicer):
         try:
             if proxy_pool := wool.__proxy_pool__.get():
                 await proxy_pool.clear()
+            from wool.runtime.discovery import __subscriber_pool__
+
+            if subscriber_pool := __subscriber_pool__.get():
+                await subscriber_pool.clear()
         finally:
             await self._loop_pool.clear()
             self._stopped.set()

--- a/wool/src/wool/utilities/afilter.py
+++ b/wool/src/wool/utilities/afilter.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from typing import AsyncIterator
+from typing import Final
+
+from wool.runtime.discovery.base import DiscoveryEvent
+from wool.runtime.discovery.base import DiscoverySubscriberLike
+from wool.runtime.discovery.base import PredicateFunction
+from wool.runtime.discovery.base import WorkerMetadata
+
+
+class afilter:
+    """Async filter for discovery event streams with transition
+    tracking.
+
+    Wraps a :class:`~wool.runtime.discovery.base.DiscoverySubscriberLike`
+    and yields only events whose worker metadata satisfies the
+    predicate.  Maintains per-iteration state so that filter
+    transitions produce correct synthetic events:
+
+    - Worker enters filter → ``worker-added``
+    - Worker exits filter → ``worker-dropped`` (with prior metadata)
+    - ``worker-dropped`` for tracked worker → pass through
+    - ``worker-dropped`` for untracked worker → suppressed
+
+    Each ``__aiter__`` call creates a new independent filtered
+    iterator, so the object supports multiple concurrent iterations.
+
+    :param predicate:
+        Function that accepts :class:`WorkerMetadata` and returns
+        ``True`` for workers that should pass the filter.
+    :param inner:
+        The upstream subscriber to filter.
+    """
+
+    _predicate: Final[PredicateFunction[WorkerMetadata]]
+    _inner: Final[DiscoverySubscriberLike]
+
+    def __init__(
+        self,
+        predicate: PredicateFunction[WorkerMetadata],
+        inner: DiscoverySubscriberLike,
+    ) -> None:
+        self._predicate = predicate
+        self._inner = inner
+
+    def __aiter__(self) -> AsyncIterator[DiscoveryEvent]:
+        return self._filter()
+
+    async def _filter(self) -> AsyncIterator[DiscoveryEvent]:
+        """Iterate the inner subscriber and apply the predicate."""
+        tracked: dict[str, WorkerMetadata] = {}
+        async for event in self._inner:
+            worker = event.metadata
+            uid = str(worker.uid)
+            passes = self._predicate(worker)
+            was_tracked = uid in tracked
+
+            if event.type == "worker-dropped":
+                if was_tracked:
+                    del tracked[uid]
+                    yield DiscoveryEvent(
+                        "worker-dropped", metadata=worker
+                    )
+            elif passes and not was_tracked:
+                tracked[uid] = worker
+                yield DiscoveryEvent("worker-added", metadata=worker)
+            elif passes and was_tracked:
+                tracked[uid] = worker
+                yield DiscoveryEvent(
+                    "worker-updated", metadata=worker
+                )
+            elif not passes and was_tracked:
+                old = tracked.pop(uid)
+                yield DiscoveryEvent("worker-dropped", metadata=old)

--- a/wool/src/wool/utilities/afilter.py
+++ b/wool/src/wool/utilities/afilter.py
@@ -44,6 +44,9 @@ class afilter:
         self._predicate = predicate
         self._inner = inner
 
+    def __reduce__(self) -> tuple:
+        return (afilter, (self._predicate, self._inner))
+
     def __aiter__(self) -> AsyncIterator[DiscoveryEvent]:
         return self._filter()
 
@@ -59,17 +62,13 @@ class afilter:
             if event.type == "worker-dropped":
                 if was_tracked:
                     del tracked[uid]
-                    yield DiscoveryEvent(
-                        "worker-dropped", metadata=worker
-                    )
+                    yield DiscoveryEvent("worker-dropped", metadata=worker)
             elif passes and not was_tracked:
                 tracked[uid] = worker
                 yield DiscoveryEvent("worker-added", metadata=worker)
             elif passes and was_tracked:
                 tracked[uid] = worker
-                yield DiscoveryEvent(
-                    "worker-updated", metadata=worker
-                )
+                yield DiscoveryEvent("worker-updated", metadata=worker)
             elif not passes and was_tracked:
                 old = tracked.pop(uid)
                 yield DiscoveryEvent("worker-dropped", metadata=old)

--- a/wool/src/wool/utilities/fanout.py
+++ b/wool/src/wool/utilities/fanout.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import weakref
-from typing import AsyncIterable
+from typing import AsyncGenerator
 from typing import AsyncIterator
 from typing import Final
 from typing import Generic
@@ -23,16 +23,14 @@ class Fanout(Generic[T]):
     it to every other consumer's queue.
 
     :param source:
-        The async iterable to multicast.
+        The async generator to multicast.
     """
 
-    def __init__(self, source: AsyncIterable[T]) -> None:
+    def __init__(self, source: AsyncGenerator[T]) -> None:
         self._source = source
         self._lock = asyncio.Lock()
         self._iterator: AsyncIterator[T] | None = None
-        self._consumers: weakref.WeakSet[FanoutConsumer[T]] = (
-            weakref.WeakSet()
-        )
+        self._consumers: weakref.WeakSet[FanoutConsumer[T]] = weakref.WeakSet()
 
     def consumer(self) -> FanoutConsumer[T]:
         """Create a new independent consumer.
@@ -51,12 +49,11 @@ class Fanout(Generic[T]):
         After cleanup, any active consumer will receive
         :exc:`StopAsyncIteration` on its next pull.
         """
-        it, self._iterator = self._iterator, None
-        if it is not None:
-            try:
-                await it.aclose()
-            except Exception:
-                pass
+        self._iterator = None
+        try:
+            await self._source.aclose()
+        except Exception:
+            pass
         for c in list(self._consumers):
             c._queue.put_nowait(_SENTINEL)
 

--- a/wool/src/wool/utilities/fanout.py
+++ b/wool/src/wool/utilities/fanout.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+import weakref
+from typing import AsyncIterable
+from typing import AsyncIterator
+from typing import Final
+from typing import Generic
+from typing import TypeVar
+
+T = TypeVar("T")
+
+_SENTINEL: Final = object()
+
+
+class Fanout(Generic[T]):
+    """Demand-driven async multicast container.
+
+    Wraps a single async iterable source and fans out items to
+    multiple independent consumers on demand.  No background task
+    runs — the first consumer whose queue is empty acquires a lock,
+    pulls one item from the shared source iterator, and distributes
+    it to every other consumer's queue.
+
+    :param source:
+        The async iterable to multicast.
+    """
+
+    def __init__(self, source: AsyncIterable[T]) -> None:
+        self._source = source
+        self._lock = asyncio.Lock()
+        self._iterator: AsyncIterator[T] | None = None
+        self._consumers: weakref.WeakSet[FanoutConsumer[T]] = (
+            weakref.WeakSet()
+        )
+
+    def consumer(self) -> FanoutConsumer[T]:
+        """Create a new independent consumer.
+
+        :returns:
+            A :class:`FanoutConsumer` backed by this container's
+            shared source iterator.
+        """
+        c: FanoutConsumer[T] = FanoutConsumer(self)
+        self._consumers.add(c)
+        return c
+
+    async def cleanup(self) -> None:
+        """Close the shared iterator and signal remaining consumers.
+
+        After cleanup, any active consumer will receive
+        :exc:`StopAsyncIteration` on its next pull.
+        """
+        it, self._iterator = self._iterator, None
+        if it is not None:
+            try:
+                await it.aclose()
+            except Exception:
+                pass
+        for c in list(self._consumers):
+            c._queue.put_nowait(_SENTINEL)
+
+
+class FanoutConsumer(Generic[T]):
+    """Independent consumer backed by a shared :class:`Fanout` source.
+
+    Instances are created via :meth:`Fanout.consumer` and implement
+    the async iterator protocol.  Each consumer maintains its own
+    queue so that items are delivered independently.
+
+    :param fanout:
+        The parent :class:`Fanout` container.
+    """
+
+    def __init__(self, fanout: Fanout[T]) -> None:
+        self._fanout = fanout
+        self._queue: asyncio.Queue[T | object] = asyncio.Queue()
+
+    def enqueue(self, item: T) -> None:
+        """Push an item directly into this consumer's queue.
+
+        Useful for injecting replay or synthetic items that bypass
+        the shared source iterator.
+
+        :param item:
+            The item to enqueue.
+        """
+        self._queue.put_nowait(item)
+
+    def __aiter__(self) -> FanoutConsumer[T]:
+        return self
+
+    async def __anext__(self) -> T:
+        # Fast path — dequeue if available.
+        if not self._queue.empty():
+            value = self._queue.get_nowait()
+            if value is _SENTINEL:
+                raise StopAsyncIteration
+            return value  # type: ignore[return-value]
+
+        fanout = self._fanout
+        async with fanout._lock:
+            # Double-check after acquiring lock — another consumer
+            # may have filled our queue while we waited.
+            if not self._queue.empty():
+                value = self._queue.get_nowait()
+                if value is _SENTINEL:
+                    raise StopAsyncIteration
+                return value  # type: ignore[return-value]
+
+            # Lazily initialise the shared source iterator.
+            if fanout._iterator is None:
+                fanout._iterator = aiter(fanout._source)
+
+            try:
+                item = await anext(fanout._iterator)
+            except StopAsyncIteration:
+                for c in list(fanout._consumers):
+                    if c is not self:
+                        c._queue.put_nowait(_SENTINEL)
+                raise
+
+            # Fan out to all other registered consumers.
+            for c in list(fanout._consumers):
+                if c is not self:
+                    c._queue.put_nowait(item)
+            return item

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -55,6 +55,7 @@ class PoolMode(Enum):
     EPHEMERAL = auto()
     DURABLE = auto()
     DURABLE_JOINED = auto()
+    DURABLE_SHARED = auto()
     HYBRID = auto()
     NESTED_DEFAULT_IN_EPHEMERAL = auto()
     NESTED_EPHEMERAL_IN_EPHEMERAL = auto()
@@ -270,6 +271,9 @@ async def build_pool_from_scenario(scenario, credentials_map):
             if scenario.pool_mode is PoolMode.DURABLE:
                 async with _durable_pool_context(lb, creds, options) as pool:
                     yield pool
+            elif scenario.pool_mode is PoolMode.DURABLE_SHARED:
+                async with _durable_shared_pool_context(lb, creds, options) as pool:
+                    yield pool
             elif scenario.pool_mode is PoolMode.DURABLE_JOINED:
                 async with _durable_joined_pool_context(
                     scenario.discovery, lb, creds, options
@@ -354,6 +358,47 @@ async def _durable_pool_context(lb, creds, options):
                     )
                     async with pool:
                         yield pool
+                finally:
+                    await publisher.publish("worker-dropped", worker.metadata)
+        finally:
+            await worker.stop()
+
+
+@asynccontextmanager
+async def _durable_shared_pool_context(lb, creds, options):
+    """Create two pools sharing the same LocalDiscovery subscriber.
+
+    Exercises ``SubscriberMeta`` singleton caching and
+    ``_SharedSubscription`` fan-out: both pools call
+    ``Subscriber(namespace)`` through the metaclass, the second
+    hits the cache and gets a separate ``_SharedSubscription``
+    backed by the same raw subscriber and source iterator.
+    """
+    namespace = f"shared-{uuid.uuid4().hex[:12]}"
+    with LocalDiscovery(namespace) as discovery:
+        worker = LocalWorker(credentials=creds, options=options)
+        await worker.start()
+        try:
+            publisher = discovery.publisher
+            async with publisher:
+                await publisher.publish("worker-added", worker.metadata)
+                try:
+                    shared = _DirectDiscovery(discovery)
+                    pool_a = WorkerPool(
+                        discovery=shared,
+                        loadbalancer=lb,
+                        credentials=creds,
+                        options=options,
+                    )
+                    pool_b = WorkerPool(
+                        discovery=shared,
+                        loadbalancer=lb,
+                        credentials=creds,
+                        options=options,
+                    )
+                    async with pool_a:
+                        async with pool_b:
+                            yield pool_a
                 finally:
                     await publisher.publish("worker-dropped", worker.metadata)
         finally:
@@ -612,6 +657,7 @@ def _pairwise_filter(row):
             PoolMode.DEFAULT,
             PoolMode.EPHEMERAL,
             PoolMode.DURABLE,
+            PoolMode.DURABLE_SHARED,
             PoolMode.NESTED_DEFAULT_IN_EPHEMERAL,
             PoolMode.NESTED_EPHEMERAL_IN_EPHEMERAL,
         )
@@ -679,6 +725,7 @@ def scenarios_strategy(draw):
         PoolMode.DEFAULT,
         PoolMode.EPHEMERAL,
         PoolMode.DURABLE,
+        PoolMode.DURABLE_SHARED,
         PoolMode.NESTED_DEFAULT_IN_EPHEMERAL,
         PoolMode.NESTED_EPHEMERAL_IN_EPHEMERAL,
     )
@@ -821,11 +868,15 @@ async def _clear_channel_pool():
 @pytest.fixture(autouse=True)
 def _clear_proxy_context():
     """Reset proxy context vars between tests."""
+    from wool.runtime.discovery import __subscriber_pool__
+
     proxy_token = wool.__proxy__.set(None)
     pool_token = wool.__proxy_pool__.set(None)
+    sub_token = __subscriber_pool__.set(None)
     yield
     wool.__proxy__.reset(proxy_token)
     wool.__proxy_pool__.reset(pool_token)
+    __subscriber_pool__.reset(sub_token)
 
 
 @pytest.fixture
@@ -852,9 +903,7 @@ def retry_grpc_internal():
                 if not _is_grpc_internal(exc):
                     raise
                 if attempt < _GRPC_INTERNAL_RETRIES:
-                    await asyncio.sleep(
-                        _GRPC_INTERNAL_BACKOFF * (2**attempt)
-                    )
+                    await asyncio.sleep(_GRPC_INTERNAL_BACKOFF * (2**attempt))
                     continue
                 raise
 

--- a/wool/tests/integration/test_pool_composition.py
+++ b/wool/tests/integration/test_pool_composition.py
@@ -236,3 +236,37 @@ class TestPoolComposition:
 
         # Assert
         assert result == 3
+
+    @pytest.mark.asyncio
+    async def test_build_pool_from_scenario_with_shared_discovery(self, credentials_map):
+        """Test two pools sharing the same discovery subscriber.
+
+        Given:
+            Two WorkerPool instances sharing the same LocalDiscovery
+            with one externally started worker, exercising
+            SubscriberMeta caching and _SharedSubscription fan-out.
+        When:
+            Both pools are entered and a coroutine is dispatched
+            through the primary pool.
+        Then:
+            It should discover the worker and return the correct
+            result.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DURABLE_SHARED,
+            discovery=DiscoveryFactory.NONE,
+            lb=LbFactory.CLASS_REF,
+            credential=CredentialType.INSECURE,
+            options=WorkerOptionsKind.DEFAULT,
+            timeout=TimeoutKind.NONE,
+            binding=RoutineBinding.MODULE_FUNCTION,
+        )
+
+        # Act
+        async with build_pool_from_scenario(scenario, credentials_map):
+            result = await invoke_routine(scenario)
+
+        # Assert
+        assert result == 3

--- a/wool/tests/runtime/discovery/conftest.py
+++ b/wool/tests/runtime/discovery/conftest.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest_asyncio
+
+from wool.runtime.discovery import __subscriber_pool__
+from wool.runtime.discovery.pool import _subscriber_factories
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_subscriber_pool():
+    """Clear the discovery subscriber pool and factory registry
+    between tests.
+    """
+    yield
+    if pool := __subscriber_pool__.get():
+        await pool.clear()
+    __subscriber_pool__.set(None)
+    _subscriber_factories.clear()

--- a/wool/tests/runtime/discovery/test_lan.py
+++ b/wool/tests/runtime/discovery/test_lan.py
@@ -10,8 +10,10 @@ from hypothesis import settings
 from hypothesis import strategies as st
 from zeroconf import ServiceInfo
 
+from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.lan import LanDiscovery
+from wool.utilities.afilter import afilter
 
 _TEST_NAMESPACE = "test-namespace"
 _TEST_SERVICE_TYPE = "_wool-c6c84a._tcp.local."
@@ -113,6 +115,87 @@ class TestLanDiscovery:
         # Assert
         assert d1.namespace != d2.namespace
 
+    def test___hash___with_same_namespace(self):
+        """Test hash equality for same namespace.
+
+        Given:
+            Two LanDiscovery instances with the same namespace.
+        When:
+            Their hashes are compared.
+        Then:
+            It should produce equal hashes.
+        """
+        # Arrange
+        a = LanDiscovery("shared-ns")
+        b = LanDiscovery("shared-ns")
+
+        # Act & assert
+        assert hash(a) == hash(b)
+
+    def test___hash___with_different_namespace(self):
+        """Test hash inequality for different namespaces.
+
+        Given:
+            Two LanDiscovery instances with different namespaces.
+        When:
+            Their hashes are compared.
+        Then:
+            It should produce different hashes.
+        """
+        # Arrange
+        a = LanDiscovery("ns-a")
+        b = LanDiscovery("ns-b")
+
+        # Act & assert
+        assert hash(a) != hash(b)
+
+    def test___eq___with_same_namespace(self):
+        """Test equality for same namespace.
+
+        Given:
+            Two LanDiscovery instances with the same namespace.
+        When:
+            They are compared with ==.
+        Then:
+            It should return True.
+        """
+        # Arrange
+        a = LanDiscovery("shared-ns")
+        b = LanDiscovery("shared-ns")
+
+        # Act & assert
+        assert a == b
+
+    def test___eq___with_different_namespace(self):
+        """Test inequality for different namespaces.
+
+        Given:
+            Two LanDiscovery instances with different namespaces.
+        When:
+            They are compared with ==.
+        Then:
+            It should return False.
+        """
+        # Arrange
+        a = LanDiscovery("ns-a")
+        b = LanDiscovery("ns-b")
+
+        # Act & assert
+        assert a != b
+
+    def test___eq___with_non_lan_discovery(self):
+        """Test equality with a non-LanDiscovery object.
+
+        Given:
+            A LanDiscovery instance and a non-LanDiscovery object.
+        When:
+            They are compared with ==.
+        Then:
+            It should not be equal.
+        """
+        # Act & assert
+        assert LanDiscovery("ns") != "not-a-discovery"
+
     def test_publisher_with_default_instance(self):
         """Test publisher property returns Publisher instance.
 
@@ -149,7 +232,7 @@ class TestLanDiscovery:
         subscriber = discovery.subscriber
 
         # Assert
-        assert isinstance(subscriber, LanDiscovery.Subscriber)
+        assert isinstance(subscriber, DiscoverySubscriberLike)
 
     @pytest.mark.asyncio
     async def test_subscribe_with_default_filter(self, worker_factory):
@@ -517,22 +600,6 @@ class TestLanDiscoverySubscriber:
     wool.runtime.discovery.lan.LanDiscovery.Subscriber
     """
 
-    def test_service_type_with_provided_value(self):
-        """Test Subscriber stores the provided service type.
-
-        Given:
-            A service type string
-        When:
-            Subscriber is instantiated with that service type
-        Then:
-            It should store the provided service type.
-        """
-        # Act
-        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE)
-
-        # Assert
-        assert subscriber.service_type == _TEST_SERVICE_TYPE
-
     @pytest.mark.asyncio
     async def test___aiter___discovers_added_worker(self, metadata):
         """Test async for yields worker-added event.
@@ -709,7 +776,7 @@ class TestLanDiscoverySubscriber:
         def filter_fn(w):
             return w.address.endswith(":50051")
 
-        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE, filter=filter_fn)
+        subscriber = afilter(filter_fn, LanDiscovery.Subscriber(_TEST_SERVICE_TYPE))
 
         worker_match = worker_factory(
             address="127.0.0.1:50051", tags=frozenset(["match"])
@@ -830,7 +897,7 @@ class TestLanDiscoverySubscriber:
         def filter_fn(w):
             return "gpu" in w.tags
 
-        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE, filter=filter_fn)
+        subscriber = afilter(filter_fn, LanDiscovery.Subscriber(_TEST_SERVICE_TYPE))
 
         worker = worker_factory(address="127.0.0.1:50051", tags=frozenset(["gpu"]))
 
@@ -896,7 +963,7 @@ class TestLanDiscoverySubscriber:
         def filter_fn(w):
             return "gpu" in w.tags
 
-        subscriber = LanDiscovery.Subscriber(_TEST_SERVICE_TYPE, filter=filter_fn)
+        subscriber = afilter(filter_fn, LanDiscovery.Subscriber(_TEST_SERVICE_TYPE))
 
         worker = worker_factory(address="127.0.0.1:50051", tags=frozenset(["cpu"]))
 
@@ -1079,9 +1146,12 @@ class TestLanDiscoverySubscriber:
                 except asyncio.CancelledError:
                     pass
 
-        # Assert
+        # Assert — events[-1] is the matched event (collect breaks
+        # after finding worker.uid); earlier entries may be stale
+        # because the shared Zeroconf browser persists across
+        # hypothesis examples.
         assert len(events) >= 1
-        event = events[0]
+        event = events[-1]
         assert event.metadata.uid == worker.uid
         assert event.metadata.pid == worker.pid
         assert event.metadata.version == worker.version

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -3,7 +3,6 @@ import struct
 import uuid
 from types import MappingProxyType
 
-import cloudpickle
 import portalocker
 import pytest
 from hypothesis import HealthCheck
@@ -11,8 +10,10 @@ from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
 
+from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.local import LocalDiscovery
+from wool.utilities.afilter import afilter
 
 
 @pytest.fixture
@@ -79,6 +80,87 @@ class TestLocalDiscovery:
         # Assert
         assert discovery.namespace == "my-namespace"
 
+    def test___hash___with_same_namespace(self):
+        """Test hash equality for same namespace.
+
+        Given:
+            Two LocalDiscovery instances with the same namespace.
+        When:
+            Their hashes are compared.
+        Then:
+            It should produce equal hashes.
+        """
+        # Arrange
+        a = LocalDiscovery("shared-ns")
+        b = LocalDiscovery("shared-ns")
+
+        # Act & assert
+        assert hash(a) == hash(b)
+
+    def test___hash___with_different_namespace(self):
+        """Test hash inequality for different namespaces.
+
+        Given:
+            Two LocalDiscovery instances with different namespaces.
+        When:
+            Their hashes are compared.
+        Then:
+            It should produce different hashes.
+        """
+        # Arrange
+        a = LocalDiscovery("ns-a")
+        b = LocalDiscovery("ns-b")
+
+        # Act & assert
+        assert hash(a) != hash(b)
+
+    def test___eq___with_same_namespace(self):
+        """Test equality for same namespace.
+
+        Given:
+            Two LocalDiscovery instances with the same namespace.
+        When:
+            They are compared with ==.
+        Then:
+            It should return True.
+        """
+        # Arrange
+        a = LocalDiscovery("shared-ns")
+        b = LocalDiscovery("shared-ns")
+
+        # Act & assert
+        assert a == b
+
+    def test___eq___with_different_namespace(self):
+        """Test inequality for different namespaces.
+
+        Given:
+            Two LocalDiscovery instances with different namespaces.
+        When:
+            They are compared with ==.
+        Then:
+            It should return False.
+        """
+        # Arrange
+        a = LocalDiscovery("ns-a")
+        b = LocalDiscovery("ns-b")
+
+        # Act & assert
+        assert a != b
+
+    def test___eq___with_non_local_discovery(self):
+        """Test equality with a non-LocalDiscovery object.
+
+        Given:
+            A LocalDiscovery instance and a non-LocalDiscovery object.
+        When:
+            They are compared with ==.
+        Then:
+            It should not be equal.
+        """
+        # Act & assert
+        assert LocalDiscovery("ns") != "not-a-discovery"
+
     def test_publisher_with_default_instance(self, namespace):
         """Test publisher property returns Publisher with matching namespace.
 
@@ -116,8 +198,7 @@ class TestLocalDiscovery:
         subscriber = discovery.subscriber
 
         # Assert
-        assert isinstance(subscriber, LocalDiscovery.Subscriber)
-        assert subscriber.namespace == namespace
+        assert isinstance(subscriber, DiscoverySubscriberLike)
 
     @pytest.mark.asyncio
     async def test_subscribe_with_default_filter(self, namespace):
@@ -694,7 +775,10 @@ class TestLocalDiscoveryPublisher:
         Then:
             All metadata fields should match the published values.
         """
-        # Arrange
+        # Arrange — use a per-example namespace so the subscriber
+        # singleton does not carry stale state across Hypothesis
+        # examples.
+        example_ns = f"{namespace}-{uuid.uuid4().hex[:8]}"
         worker = WorkerMetadata(
             uid=uuid.uuid4(),
             address=address,
@@ -711,9 +795,9 @@ class TestLocalDiscoveryPublisher:
                 discovered.set()
                 break
 
-        with LocalDiscovery(namespace):
-            publisher = LocalDiscovery.Publisher(namespace)
-            subscriber = LocalDiscovery.Subscriber(namespace, poll_interval=0.05)
+        with LocalDiscovery(example_ns):
+            publisher = LocalDiscovery.Publisher(example_ns)
+            subscriber = LocalDiscovery.Subscriber(example_ns, poll_interval=0.05)
 
             # Act
             async with publisher:
@@ -909,36 +993,6 @@ class TestLocalDiscoverySubscriber:
     Fully qualified name:
     wool.runtime.discovery.local.LocalDiscovery.Subscriber
     """
-
-    def test_namespace_with_provided_value(self, namespace):
-        """Test Subscriber.namespace property returns provided value.
-
-        Given:
-            A namespace string
-        When:
-            Subscriber is instantiated
-        Then:
-            It should return the provided namespace.
-        """
-        # Act
-        subscriber = LocalDiscovery.Subscriber(namespace)
-
-        # Assert
-        assert subscriber.namespace == namespace
-
-    def test___init___with_negative_poll_interval(self, namespace):
-        """Test Subscriber rejects negative poll_interval.
-
-        Given:
-            A negative poll_interval
-        When:
-            Subscriber is instantiated
-        Then:
-            It should raise ValueError.
-        """
-        # Act & assert
-        with pytest.raises(ValueError, match="Expected positive poll interval"):
-            LocalDiscovery.Subscriber(namespace, poll_interval=-1.0)
 
     @pytest.mark.asyncio
     async def test___aiter___discovers_added_worker(self, namespace, metadata):
@@ -1149,8 +1203,9 @@ class TestLocalDiscoverySubscriber:
 
         with LocalDiscovery(namespace):
             publisher = LocalDiscovery.Publisher(namespace)
-            subscriber = LocalDiscovery.Subscriber(
-                namespace, filter=filter_fn, poll_interval=0.05
+            subscriber = afilter(
+                filter_fn,
+                LocalDiscovery.Subscriber(namespace, poll_interval=0.05),
             )
 
             async with publisher:
@@ -1227,79 +1282,6 @@ class TestLocalDiscoverySubscriber:
         # Assert
         assert len(events) >= 1
         assert events[0].type == "worker-added"
-
-    @pytest.mark.asyncio
-    async def test___aiter___with_watchdog_notification(self, namespace, metadata):
-        """Test subscriber discovers workers via watchdog filesystem notification.
-
-        Given:
-            A subscriber with no poll_interval (watchdog-only, no polling fallback)
-        When:
-            A worker is published
-        Then:
-            It should yield the event promptly via filesystem notification,
-            proving the watchdog on_modified path comparison works with
-            resolved symlinks.
-        """
-        # Arrange
-        events = []
-        event_received = asyncio.Event()
-
-        async def collect(subscriber):
-            async for event in subscriber:
-                events.append(event)
-                event_received.set()
-                break
-
-        with LocalDiscovery(namespace):
-            publisher = LocalDiscovery.Publisher(namespace)
-            subscriber = LocalDiscovery.Subscriber(namespace)
-
-            async with publisher:
-                task = asyncio.create_task(collect(subscriber))
-                await asyncio.sleep(0.05)
-
-                # Act
-                await publisher.publish("worker-added", metadata)
-
-                try:
-                    await asyncio.wait_for(event_received.wait(), timeout=2.0)
-                except asyncio.TimeoutError:
-                    pytest.fail(
-                        "Worker not discovered via watchdog notification "
-                        "within timeout — symlink path mismatch? (see #115)"
-                    )
-                finally:
-                    task.cancel()
-                    try:
-                        await task
-                    except asyncio.CancelledError:
-                        pass
-
-        # Assert
-        assert len(events) == 1
-        assert events[0].type == "worker-added"
-        assert events[0].metadata.uid == metadata.uid
-
-    def test___reduce___pickle_roundtrip(self, namespace):
-        """Test Subscriber pickle roundtrip via cloudpickle.
-
-        Given:
-            A Subscriber instance
-        When:
-            Subscriber is pickled and unpickled via cloudpickle
-        Then:
-            It should preserve the namespace.
-        """
-        # Arrange
-        subscriber = LocalDiscovery.Subscriber(namespace, poll_interval=0.05)
-
-        # Act
-        pickled = cloudpickle.dumps(subscriber)
-        unpickled = cloudpickle.loads(pickled)
-
-        # Assert
-        assert unpickled.namespace == namespace
 
     @pytest.mark.asyncio
     async def test___aiter___with_concurrent_namespaces(self):

--- a/wool/tests/runtime/discovery/test_pool.py
+++ b/wool/tests/runtime/discovery/test_pool.py
@@ -1,0 +1,517 @@
+from __future__ import annotations
+
+import uuid
+
+import cloudpickle
+import pytest
+
+from wool.runtime.discovery import __subscriber_pool__
+from wool.runtime.discovery.base import DiscoveryEvent
+from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.discovery.pool import SubscriberMeta
+from wool.runtime.discovery.pool import _pool_factory
+from wool.runtime.discovery.pool import _SharedSubscription
+from wool.runtime.discovery.pool import _subscriber_factories
+from wool.runtime.resourcepool import ResourcePool
+
+
+class _StubSubscriber(metaclass=SubscriberMeta):
+    """Minimal subscriber stub for testing SubscriberMeta."""
+
+    def __init__(self, key_value: str) -> None:
+        self.key_value = key_value
+
+    @classmethod
+    def _cache_key(cls, key_value: str):
+        return (cls, key_value)
+
+    def __reduce__(self):
+        return type(self), (self.key_value,)
+
+    async def _shutdown(self) -> None:
+        pass
+
+    def __aiter__(self):
+        return self._event_stream()
+
+    async def _event_stream(self):
+        yield  # pragma: no cover
+
+
+def _make_event(event_type="worker-added", *, address="127.0.0.1:50051"):
+    return DiscoveryEvent(
+        event_type,
+        metadata=WorkerMetadata(
+            uid=uuid.uuid4(),
+            address=address,
+            pid=1,
+            version="1.0.0",
+        ),
+    )
+
+
+def _setup_pool():
+    """Ensure the subscriber pool exists for direct-construction tests."""
+    pool = __subscriber_pool__.get()
+    if pool is None:
+        pool = ResourcePool(factory=_pool_factory, ttl=0)
+        __subscriber_pool__.set(pool)
+    return pool
+
+
+def _make_shared(source, key="test-key"):
+    """Create a _SharedSubscription backed by a raw source via the pool."""
+    _setup_pool()
+    _subscriber_factories[key] = lambda _: source
+    return _SharedSubscription(key=key, reduce_info=(type(source), (), {}))
+
+
+class TestSubscriberMeta:
+    """Tests for SubscriberMeta metaclass.
+
+    Fully qualified name: wool.runtime.discovery.pool.SubscriberMeta
+    """
+
+    def test___new___with_shared_subscription_wrapping(self):
+        """Test SubscriberMeta returns a _SharedSubscription.
+
+        Given:
+            A subscriber class using SubscriberMeta.
+        When:
+            The class is instantiated.
+        Then:
+            It should return a _SharedSubscription wrapping the
+            cached raw subscriber.
+        """
+        # Act
+        result = _StubSubscriber("wrap-key")
+
+        # Assert
+        assert isinstance(result, _SharedSubscription)
+
+    @pytest.mark.asyncio
+    async def test___new___with_shared_fan_out(self):
+        """Test SubscriberMeta shares events across subscriptions.
+
+        Given:
+            A source that yields events and two subscriptions
+            created with the same key.
+        When:
+            Both consumers are initialised and one pulls a new
+            event.
+        Then:
+            The other should receive the same event via fan-out.
+        """
+        # Arrange
+        events = [_make_event(address=f"127.0.0.1:{50051 + i}") for i in range(3)]
+
+        class _EventStub(metaclass=SubscriberMeta):
+            def __init__(self, tag):
+                self.tag = tag
+
+            @classmethod
+            def _cache_key(cls, tag):
+                return (cls, tag)
+
+            async def _shutdown(self):
+                pass
+
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                for e in events:
+                    yield e
+
+        sub_a = _EventStub("shared")
+        sub_b = _EventStub("shared")
+        it_a = aiter(sub_a)
+        it_b = aiter(sub_b)
+
+        # Initialise both consumers — a pulls events[0] (b not
+        # registered yet), b gets a replay on its first pull.
+        await anext(it_a)
+        await anext(it_b)
+
+        # Act — b pulls events[1] from source, fans out to a
+        result_b = await anext(it_b)
+        result_a = await anext(it_a)
+
+        # Assert — same object via fan-out
+        assert result_a is result_b
+        assert result_a is events[1]
+
+    @pytest.mark.asyncio
+    async def test___new___with_different_keys(self):
+        """Test SubscriberMeta isolates different keys.
+
+        Given:
+            Two subscriptions created with different keys, each
+            backed by a distinct source.
+        When:
+            Both are iterated.
+        Then:
+            Events from one key should not appear in the other.
+        """
+        # Arrange
+        event_a = _make_event(address="10.0.0.1:1")
+        event_b = _make_event(address="10.0.0.2:2")
+
+        class _IsoStub(metaclass=SubscriberMeta):
+            def __init__(self, tag, event):
+                self.tag = tag
+                self._event = event
+
+            @classmethod
+            def _cache_key(cls, tag, event):
+                return (cls, tag)
+
+            async def _shutdown(self):
+                pass
+
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                yield self._event
+
+        sub_a = _IsoStub("key-a", event_a)
+        sub_b = _IsoStub("key-b", event_b)
+
+        # Act
+        result_a = await anext(aiter(sub_a))
+        result_b = await anext(aiter(sub_b))
+
+        # Assert
+        assert result_a is event_a
+        assert result_b is event_b
+
+    def test___new___with_lazy_pool_init(self):
+        """Test lazy pool initialization when ContextVar is None.
+
+        Given:
+            The __subscriber_pool__ ContextVar is explicitly set to
+            None.
+        When:
+            A subscriber is constructed via SubscriberMeta.
+        Then:
+            The ContextVar should be set to a ResourcePool.
+        """
+        # Arrange
+        __subscriber_pool__.set(None)
+
+        # Act
+        _StubSubscriber("lazy-init")
+
+        # Assert
+        assert __subscriber_pool__.get() is not None
+
+
+class TestSharedSubscription:
+    """Tests for _SharedSubscription class.
+
+    Fully qualified name: wool.runtime.discovery.pool._SharedSubscription
+    """
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_demand_driven_pull(self):
+        """Test iteration pulls from the source.
+
+        Given:
+            A _SharedSubscription backed by a source that yields
+            one event.
+        When:
+            The subscription is iterated.
+        Then:
+            It should return the event from the source.
+        """
+        # Arrange
+        event = _make_event()
+
+        class _Source:
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                yield event
+
+        shared = _make_shared(_Source())
+
+        # Act
+        result = await anext(aiter(shared))
+
+        # Assert
+        assert result is event
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_fan_out_to_multiple_consumers(self):
+        """Test events are fanned out to all iterators.
+
+        Given:
+            Two iterators from subscriptions sharing the same key,
+            both initialised.
+        When:
+            One iterator pulls a new event.
+        Then:
+            The other should receive the same event via fan-out.
+        """
+        # Arrange
+        events = [_make_event(address=f"127.0.0.1:{50051 + i}") for i in range(3)]
+
+        class _Source:
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                for e in events:
+                    yield e
+
+        _setup_pool()
+        key = "fan-out-key"
+        source = _Source()
+        _subscriber_factories[key] = lambda _: source
+
+        sub_a = _SharedSubscription(key=key, reduce_info=(type(source), (), {}))
+        sub_b = _SharedSubscription(key=key, reduce_info=(type(source), (), {}))
+        it_a = aiter(sub_a)
+        it_b = aiter(sub_b)
+
+        # Initialise both consumers
+        await anext(it_a)
+        await anext(it_b)
+
+        # Act — b pulls events[1] from source, fans out to a
+        result_b = await anext(it_b)
+        result_a = await anext(it_a)
+
+        # Assert — same object via fan-out
+        assert result_a is result_b
+        assert result_a is events[1]
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_independent_iterators(self):
+        """Test each __aiter__ call returns a distinct iterator.
+
+        Given:
+            A _SharedSubscription instance.
+        When:
+            __aiter__ is called twice.
+        Then:
+            It should return two distinct async generator instances.
+        """
+        # Arrange
+        shared = _StubSubscriber("iter-key")
+
+        # Act
+        a = aiter(shared)
+        b = aiter(shared)
+
+        # Assert
+        assert a is not b
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_resource_release_on_exhaustion(self):
+        """Test the pool resource is released when the source exhausts.
+
+        Given:
+            A _SharedSubscription backed by a finite source.
+        When:
+            The subscription is iterated to exhaustion.
+        Then:
+            The pool resource should be released.
+        """
+
+        # Arrange
+        class _Source:
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                yield _make_event()
+
+        shared = _make_shared(_Source())
+
+        # Act
+        collected = [event async for event in shared]
+
+        # Assert
+        assert len(collected) == 1
+        pool = __subscriber_pool__.get()
+        assert pool.stats.referenced_entries == 0
+
+    def test___reduce___pickle_roundtrip(self):
+        """Test _SharedSubscription pickle roundtrip via cloudpickle.
+
+        Given:
+            A _SharedSubscription wrapping a stub subscriber with
+            __reduce__.
+        When:
+            The subscription is pickled and unpickled.
+        Then:
+            It should produce a _SharedSubscription wrapping a
+            subscriber with the same key.
+        """
+        # Arrange
+        original = _StubSubscriber("pickle-key")
+
+        # Act
+        pickled = cloudpickle.dumps(original)
+        restored = cloudpickle.loads(pickled)
+
+        # Assert
+        assert isinstance(restored, _SharedSubscription)
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_late_joiner_replay(self):
+        """Test late-joining consumer receives replayed worker state.
+
+        Given:
+            A subscription that has pulled two events, tracking
+            two workers.
+        When:
+            A second subscription with the same key starts
+            iterating while the first is still active.
+        Then:
+            The second should receive replayed worker-added events
+            for all tracked workers.
+        """
+        # Arrange
+        events = [_make_event(address=f"127.0.0.1:{50051 + i}") for i in range(2)]
+
+        class _Source:
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                for e in events:
+                    yield e
+
+        _setup_pool()
+        key = "replay-key"
+        source = _Source()
+        _subscriber_factories[key] = lambda _: source
+
+        sub_a = _SharedSubscription(key=key, reduce_info=(type(source), (), {}))
+        sub_b = _SharedSubscription(key=key, reduce_info=(type(source), (), {}))
+
+        # A pulls both events, tracking two workers.
+        it_a = aiter(sub_a)
+        await anext(it_a)
+        await anext(it_a)
+
+        # Act — B joins while A is still active, gets replay.
+        collected_b = [event async for event in sub_b]
+
+        # Assert — B receives replayed worker-added events.
+        assert len(collected_b) == 2
+        assert all(e.type == "worker-added" for e in collected_b)
+        expected_uids = {str(e.metadata.uid) for e in events}
+        actual_uids = {str(e.metadata.uid) for e in collected_b}
+        assert actual_uids == expected_uids
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_no_pool(self):
+        """Test iteration raises RuntimeError when pool is absent.
+
+        Given:
+            A _SharedSubscription constructed directly with no
+            subscriber pool initialised.
+        When:
+            The subscription is iterated.
+        Then:
+            It should raise RuntimeError.
+        """
+        # Arrange
+        __subscriber_pool__.set(None)
+        shared = _SharedSubscription(key="no-pool", reduce_info=(object, (), {}))
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="subscriber pool not initialised"):
+            await anext(aiter(shared))
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_worker_dropped_tracking(self):
+        """Test worker-dropped events clear tracked worker state.
+
+        Given:
+            A subscription whose source yields worker-added then
+            worker-dropped events for the same worker.
+        When:
+            A second subscription starts iterating after the first
+            has processed both events.
+        Then:
+            The late joiner should receive no replay because the
+            worker was dropped.
+        """
+        # Arrange
+        worker_uid = __import__("uuid").uuid4()
+        metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="127.0.0.1:50051",
+            pid=1,
+            version="1.0.0",
+        )
+        add_event = DiscoveryEvent("worker-added", metadata=metadata)
+        drop_event = DiscoveryEvent("worker-dropped", metadata=metadata)
+
+        class _Source:
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                yield add_event
+                yield drop_event
+
+        _setup_pool()
+        key = "drop-key"
+        source = _Source()
+        _subscriber_factories[key] = lambda _: source
+
+        sub_a = _SharedSubscription(key=key, reduce_info=(type(source), (), {}))
+        sub_b = _SharedSubscription(key=key, reduce_info=(type(source), (), {}))
+
+        # A pulls both events — worker added then dropped.
+        it_a = aiter(sub_a)
+        await anext(it_a)
+        await anext(it_a)
+
+        # Act — B joins; worker was dropped so no replay.
+        collected_b = [event async for event in sub_b]
+
+        # Assert — B receives nothing (worker was removed).
+        assert collected_b == []
+
+    @pytest.mark.asyncio
+    async def test___aiter___after_cleanup(self):
+        """Test iteration raises StopAsyncIteration after cleanup.
+
+        Given:
+            A _SharedSubscription whose Fanout has been cleaned up.
+        When:
+            The subscription is iterated.
+        Then:
+            It should raise StopAsyncIteration.
+        """
+
+        # Arrange
+        class _Source:
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                while True:
+                    yield _make_event()  # pragma: no cover
+
+        shared = _make_shared(_Source())
+        it = aiter(shared)
+        await anext(it)  # initialise the fanout
+
+        # Retrieve and clean up the fanout
+        pool = __subscriber_pool__.get()
+        subscriber = pool._cache["test-key"].obj
+        fanout = _SharedSubscription._fanouts.get(subscriber)
+        await fanout.cleanup()
+
+        # Act & assert
+        with pytest.raises(StopAsyncIteration):
+            await anext(it)

--- a/wool/tests/utilities/test_afilter.py
+++ b/wool/tests/utilities/test_afilter.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import uuid
+
+import cloudpickle
+import pytest
+
+from wool.runtime.discovery.base import DiscoveryEvent
+from wool.runtime.discovery.base import WorkerMetadata
+from wool.utilities.afilter import afilter
+
+
+def _make_metadata(*, address: str = "127.0.0.1:50051", **kwargs):
+    defaults = dict(
+        uid=uuid.uuid4(),
+        address=address,
+        pid=1234,
+        version="1.0.0",
+    )
+    defaults.update(kwargs)
+    return WorkerMetadata(**defaults)
+
+
+class _Source:
+    """Async-iterable source that yields given events on each
+    ``__aiter__`` call."""
+
+    def __init__(self, *events: DiscoveryEvent):
+        self._events = events
+
+    def __aiter__(self):
+        return self._iter()
+
+    async def _iter(self):
+        for event in self._events:
+            yield event
+
+
+class Testafilter:
+    """Tests for the afilter utility class."""
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_single_matching_event(self):
+        """Test basic filtered iteration with one matching event.
+
+        Given:
+            A source yielding one worker-added event.
+        When:
+            afilter is iterated with a predicate that accepts the
+            worker.
+        Then:
+            It should yield the worker-added event.
+        """
+        # Arrange
+        worker = _make_metadata()
+        source = _Source(DiscoveryEvent("worker-added", metadata=worker))
+
+        # Act
+        events = []
+        async for e in afilter(lambda _: True, source):
+            events.append(e)
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].type == "worker-added"
+        assert events[0].metadata == worker
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_add_then_update(self):
+        """Test unfiltered passthrough of multiple events.
+
+        Given:
+            A source yielding worker-added then worker-updated.
+        When:
+            afilter is iterated with an accept-all predicate.
+        Then:
+            It should yield both events in order.
+        """
+        # Arrange
+        worker = _make_metadata()
+        source = _Source(
+            DiscoveryEvent("worker-added", metadata=worker),
+            DiscoveryEvent("worker-updated", metadata=worker),
+        )
+
+        # Act
+        events = []
+        async for e in afilter(lambda _: True, source):
+            events.append(e)
+
+        # Assert
+        assert len(events) == 2
+        assert events[0].type == "worker-added"
+        assert events[1].type == "worker-updated"
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_rejecting_filter(self):
+        """Test filter suppression of non-matching events.
+
+        Given:
+            A source yielding a worker-added event.
+        When:
+            afilter is iterated with a predicate that rejects the
+            worker.
+        Then:
+            It should yield no events.
+        """
+        # Arrange
+        worker = _make_metadata(address="127.0.0.1:9999")
+        source = _Source(DiscoveryEvent("worker-added", metadata=worker))
+
+        # Act
+        events = []
+        async for e in afilter(lambda w: w.address == "never", source):
+            events.append(e)
+
+        # Assert
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_filter_entry_transition(self):
+        """Test that a worker entering the filter emits worker-added.
+
+        Given:
+            A source yielding worker-added (fails filter) then
+            worker-updated (passes filter).
+        When:
+            afilter is iterated with a filter on tags.
+        Then:
+            It should yield worker-added for the now-matching worker.
+        """
+        # Arrange
+        uid = uuid.uuid4()
+        worker_v1 = _make_metadata(uid=uid, tags=frozenset())
+        worker_v2 = _make_metadata(uid=uid, tags=frozenset({"gpu"}))
+        source = _Source(
+            DiscoveryEvent("worker-added", metadata=worker_v1),
+            DiscoveryEvent("worker-updated", metadata=worker_v2),
+        )
+
+        # Act
+        events = []
+        async for e in afilter(lambda w: "gpu" in w.tags, source):
+            events.append(e)
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].type == "worker-added"
+        assert events[0].metadata == worker_v2
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_filter_exit_transition(self):
+        """Test that a worker leaving the filter emits worker-dropped.
+
+        Given:
+            A source yielding worker-added (passes filter) then
+            worker-updated (fails filter).
+        When:
+            afilter is iterated with a filter the worker initially
+            passes.
+        Then:
+            It should yield worker-added then worker-dropped.
+        """
+        # Arrange
+        uid = uuid.uuid4()
+        worker_v1 = _make_metadata(uid=uid, tags=frozenset({"gpu"}))
+        worker_v2 = _make_metadata(uid=uid, tags=frozenset())
+        source = _Source(
+            DiscoveryEvent("worker-added", metadata=worker_v1),
+            DiscoveryEvent("worker-updated", metadata=worker_v2),
+        )
+
+        # Act
+        events = []
+        async for e in afilter(lambda w: "gpu" in w.tags, source):
+            events.append(e)
+
+        # Assert
+        assert len(events) == 2
+        assert events[0].type == "worker-added"
+        assert events[1].type == "worker-dropped"
+        assert events[1].metadata == worker_v1
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_tracked_worker_dropped(self):
+        """Test worker-dropped for a tracked worker.
+
+        Given:
+            A source yielding worker-added then worker-dropped.
+        When:
+            afilter is iterated with an accept-all predicate.
+        Then:
+            It should yield worker-added then worker-dropped.
+        """
+        # Arrange
+        worker = _make_metadata()
+        source = _Source(
+            DiscoveryEvent("worker-added", metadata=worker),
+            DiscoveryEvent("worker-dropped", metadata=worker),
+        )
+
+        # Act
+        events = []
+        async for e in afilter(lambda _: True, source):
+            events.append(e)
+
+        # Assert
+        assert len(events) == 2
+        assert events[0].type == "worker-added"
+        assert events[1].type == "worker-dropped"
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_untracked_worker_dropped(self):
+        """Test worker-dropped for an untracked worker is ignored.
+
+        Given:
+            A source yielding worker-added (fails filter) then
+            worker-dropped for the same worker.
+        When:
+            afilter is iterated with a rejecting filter.
+        Then:
+            It should yield no events.
+        """
+        # Arrange
+        worker = _make_metadata()
+        source = _Source(
+            DiscoveryEvent("worker-added", metadata=worker),
+            DiscoveryEvent("worker-dropped", metadata=worker),
+        )
+
+        # Act
+        events = []
+        async for e in afilter(lambda _: False, source):
+            events.append(e)
+
+        # Assert
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_independent_iterations(self):
+        """Test that each __aiter__ call produces independent state.
+
+        Given:
+            An afilter wrapping a source that yields the same events
+            on each iteration.
+        When:
+            The afilter is iterated twice sequentially.
+        Then:
+            Each iteration should produce the same results with
+            independent tracked-worker state.
+        """
+        # Arrange
+        worker = _make_metadata()
+        source = _Source(
+            DiscoveryEvent("worker-added", metadata=worker),
+        )
+        filtered = afilter(lambda _: True, source)
+
+        # Act
+        first = [e async for e in filtered]
+        second = [e async for e in filtered]
+
+        # Assert
+        assert len(first) == 1
+        assert first[0].type == "worker-added"
+        assert len(second) == 1
+        assert second[0].type == "worker-added"
+
+    def test___reduce___pickle_roundtrip(self):
+        """Test afilter pickle roundtrip via cloudpickle.
+
+        Given:
+            An afilter wrapping a picklable subscriber.
+        When:
+            The filter is pickled and unpickled.
+        Then:
+            It should produce an afilter instance that can be
+            iterated.
+        """
+        # Arrange
+        from wool.runtime.discovery.local import LocalDiscovery
+
+        inner = LocalDiscovery.Subscriber("afilter-pickle-ns")
+        filtered = afilter(lambda w: True, inner)
+
+        # Act
+        pickled = cloudpickle.dumps(filtered)
+        restored = cloudpickle.loads(pickled)
+
+        # Assert
+        assert isinstance(restored, afilter)

--- a/wool/tests/utilities/test_fanout.py
+++ b/wool/tests/utilities/test_fanout.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from wool.utilities.fanout import Fanout
+from wool.utilities.fanout import FanoutConsumer
+
+
+class _Source:
+    """Async-iterable source that yields given items on each
+    ``__aiter__`` call."""
+
+    def __init__(self, *items):
+        self._items = items
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for item in self._items:
+            yield item
+
+
+class TestFanout:
+    """Tests for the Fanout class.
+
+    Fully qualified name: wool.utilities.fanout.Fanout
+    """
+
+    def test_consumer_with_new_instance(self):
+        """Test consumer creates a FanoutConsumer.
+
+        Given:
+            A Fanout wrapping a source.
+        When:
+            consumer is called.
+        Then:
+            It should return a FanoutConsumer instance.
+        """
+        # Arrange
+        fanout = Fanout(_Source("a"))
+
+        # Act
+        c = fanout.consumer()
+
+        # Assert
+        assert isinstance(c, FanoutConsumer)
+
+    def test_consumer_with_independent_instances(self):
+        """Test consumer returns distinct instances per call.
+
+        Given:
+            A Fanout wrapping a source.
+        When:
+            consumer is called twice.
+        Then:
+            It should return two distinct FanoutConsumer instances.
+        """
+        # Arrange
+        fanout = Fanout(_Source("a"))
+
+        # Act
+        a = fanout.consumer()
+        b = fanout.consumer()
+
+        # Assert
+        assert a is not b
+
+    @pytest.mark.asyncio
+    async def test_cleanup_with_active_consumer(self):
+        """Test cleanup terminates active consumers.
+
+        Given:
+            A Fanout with one registered consumer.
+        When:
+            cleanup is called.
+        Then:
+            It should cause the consumer to raise
+            StopAsyncIteration on next pull.
+        """
+        # Arrange
+        fanout = Fanout(_Source("a", "b"))
+        consumer = fanout.consumer()
+
+        # Act
+        await fanout.cleanup()
+
+        # Assert
+        with pytest.raises(StopAsyncIteration):
+            await anext(consumer)
+
+    @pytest.mark.asyncio
+    async def test_cleanup_with_open_iterator(self):
+        """Test cleanup closes the shared source iterator.
+
+        Given:
+            A Fanout whose shared iterator has been initialised by
+            a pull.
+        When:
+            cleanup is called.
+        Then:
+            It should close the shared iterator.
+        """
+        # Arrange
+        closed = False
+
+        class _TrackedSource:
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                nonlocal closed
+                try:
+                    while True:
+                        yield "item"
+                finally:
+                    closed = True
+
+        fanout = Fanout(_TrackedSource())
+        consumer = fanout.consumer()
+        await anext(consumer)  # initialise the iterator
+
+        # Act
+        await fanout.cleanup()
+
+        # Assert
+        assert closed
+
+    @pytest.mark.asyncio
+    async def test_cleanup_with_failing_aclose(self):
+        """Test cleanup swallows exceptions from the source iterator.
+
+        Given:
+            A Fanout whose source raises during aclose.
+        When:
+            cleanup is called.
+        Then:
+            It should swallow the exception and still signal
+            consumers with a sentinel.
+        """
+        # Arrange
+        class _FailingSource:
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                try:
+                    while True:
+                        yield "item"
+                finally:
+                    raise RuntimeError("aclose failed")
+
+        fanout = Fanout(_FailingSource())
+        consumer = fanout.consumer()
+        await anext(consumer)  # initialise the iterator
+
+        # Act
+        await fanout.cleanup()
+
+        # Assert — consumer is signalled despite the exception
+        with pytest.raises(StopAsyncIteration):
+            await anext(consumer)
+
+
+class TestFanoutConsumer:
+    """Tests for the FanoutConsumer class.
+
+    Fully qualified name: wool.utilities.fanout.FanoutConsumer
+    """
+
+    @pytest.mark.asyncio
+    async def test___aiter___with_self_return(self):
+        """Test async iteration protocol returns self.
+
+        Given:
+            A FanoutConsumer instance.
+        When:
+            aiter is called on it.
+        Then:
+            It should return the same instance.
+        """
+        # Arrange
+        consumer = Fanout(_Source("a")).consumer()
+
+        # Act
+        result = aiter(consumer)
+
+        # Assert
+        assert result is consumer
+
+    @pytest.mark.asyncio
+    async def test___anext___with_single_item(self):
+        """Test pulling a single item from the source.
+
+        Given:
+            A Fanout wrapping a source that yields one item.
+        When:
+            anext is called on a consumer.
+        Then:
+            It should return the item from the source.
+        """
+        # Arrange
+        fanout = Fanout(_Source("hello"))
+        consumer = fanout.consumer()
+
+        # Act
+        result = await anext(consumer)
+
+        # Assert
+        assert result == "hello"
+
+    @pytest.mark.asyncio
+    async def test___anext___with_fan_out_to_multiple_consumers(self):
+        """Test items are fanned out to all registered consumers.
+
+        Given:
+            Two consumers sharing the same Fanout source.
+        When:
+            One consumer triggers a pull via anext.
+        Then:
+            Both consumers should receive the item.
+        """
+        # Arrange
+        fanout = Fanout(_Source("event-1", "event-2"))
+        consumer_a = fanout.consumer()
+        consumer_b = fanout.consumer()
+
+        # Act — consumer_a pulls, fan-out to consumer_b
+        result_a = await anext(consumer_a)
+        result_b = await anext(consumer_b)
+
+        # Assert
+        assert result_a == "event-1"
+        assert result_b == "event-1"
+
+    @pytest.mark.asyncio
+    async def test___anext___with_exhausted_source(self):
+        """Test source exhaustion propagates to all consumers.
+
+        Given:
+            Two consumers sharing a source that yields two items.
+        When:
+            Both consumers iterate to exhaustion via async for.
+        Then:
+            Both consumers should receive both items and iteration
+            should terminate.
+        """
+        # Arrange
+        fanout = Fanout(_Source("a", "b"))
+        consumer_a = fanout.consumer()
+        consumer_b = fanout.consumer()
+
+        # Act
+        collected_a = [item async for item in consumer_a]
+        collected_b = [item async for item in consumer_b]
+
+        # Assert
+        assert collected_a == ["a", "b"]
+        assert collected_b == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test___anext___after_cleanup(self):
+        """Test anext raises StopAsyncIteration after cleanup.
+
+        Given:
+            A consumer registered against a Fanout that has been
+            cleaned up.
+        When:
+            anext is called on the consumer.
+        Then:
+            It should raise StopAsyncIteration.
+        """
+        # Arrange
+        fanout = Fanout(_Source("a"))
+        consumer = fanout.consumer()
+        await fanout.cleanup()
+
+        # Act & assert
+        with pytest.raises(StopAsyncIteration):
+            await anext(consumer)
+
+    def test_enqueue_with_direct_item(self):
+        """Test enqueue pushes an item into the consumer's queue.
+
+        Given:
+            A FanoutConsumer instance.
+        When:
+            enqueue is called with an item.
+        Then:
+            It should be retrievable on the next pull.
+        """
+        # Arrange
+        fanout = Fanout(_Source())
+        consumer = fanout.consumer()
+
+        # Act
+        consumer.enqueue("injected")
+
+        # Assert — item is in the queue (verified via queue size)
+        assert not consumer._queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_enqueue_with_pull_after_inject(self):
+        """Test enqueued items are returned before source items.
+
+        Given:
+            A FanoutConsumer with an enqueued item and a source
+            that also yields items.
+        When:
+            anext is called.
+        Then:
+            It should return the enqueued item first.
+        """
+        # Arrange
+        fanout = Fanout(_Source("from-source"))
+        consumer = fanout.consumer()
+        consumer.enqueue("injected")
+
+        # Act
+        first = await anext(consumer)
+        second = await anext(consumer)
+
+        # Assert
+        assert first == "injected"
+        assert second == "from-source"
+
+    @pytest.mark.asyncio
+    async def test___anext___with_late_registered_consumer(self):
+        """Test a late-registered consumer does not receive past items.
+
+        Given:
+            A Fanout where consumer_a has already pulled an item.
+        When:
+            A new consumer_b is created and pulls.
+        Then:
+            It should receive only subsequent items, not past ones.
+        """
+        # Arrange
+        fanout = Fanout(_Source("first", "second"))
+        consumer_a = fanout.consumer()
+        await anext(consumer_a)  # pull "first"
+
+        # Act
+        consumer_b = fanout.consumer()
+        result_b = await anext(consumer_b)
+
+        # Assert — consumer_b missed "first", gets "second"
+        # consumer_a also triggered fan-out of "second" during its pull
+        # but consumer_b wasn't registered yet. consumer_b's pull
+        # triggers the next source item.
+        assert result_b == "second"
+
+    @pytest.mark.asyncio
+    async def test___anext___with_concurrent_queue_fill(self):
+        """Test the lock double-check returns a queued item.
+
+        Given:
+            Two consumers sharing a Fanout whose source suspends
+            during iteration.
+        When:
+            Both consumers pull concurrently via asyncio.gather.
+        Then:
+            The consumer that waited for the lock should receive
+            the item from its queue via the double-check path.
+        """
+        # Arrange — source suspends so the event loop can
+        # schedule both consumers before the first completes.
+        class _SuspendingSource:
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                await asyncio.sleep(0)
+                yield "item"
+
+        fanout = Fanout(_SuspendingSource())
+        consumer_a = fanout.consumer()
+        consumer_b = fanout.consumer()
+
+        # Act — concurrent pulls force the double-check path
+        results = await asyncio.gather(
+            anext(consumer_a), anext(consumer_b)
+        )
+
+        # Assert — both receive the same item
+        assert results == ["item", "item"]
+
+    @pytest.mark.asyncio
+    async def test___anext___with_sentinel_in_double_check(self):
+        """Test the double-check path handles SENTINEL on exhaustion.
+
+        Given:
+            Two consumers sharing a Fanout whose source suspends
+            then exhausts without yielding any items.
+        When:
+            Both consumers pull concurrently via asyncio.gather.
+        Then:
+            Both should receive StopAsyncIteration — one directly
+            from the source, the other via the SENTINEL placed in
+            its queue during the lock double-check.
+        """
+        # Arrange — source suspends then exhausts, allowing the
+        # event loop to interleave both consumers before either
+        # completes.
+        class _SuspendExhaustSource:
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                await asyncio.sleep(0)
+                return
+                yield  # noqa: F841 — makes this an async gen
+
+        fanout = Fanout(_SuspendExhaustSource())
+        consumer_a = fanout.consumer()
+        consumer_b = fanout.consumer()
+
+        # Act — return_exceptions=True so gather doesn't cancel
+        # the second task when the first raises.
+        results = await asyncio.gather(
+            anext(consumer_a),
+            anext(consumer_b),
+            return_exceptions=True,
+        )
+
+        # Assert — both received StopAsyncIteration
+        assert all(isinstance(r, StopAsyncIteration) for r in results)

--- a/wool/tests/utilities/test_fanout.py
+++ b/wool/tests/utilities/test_fanout.py
@@ -106,19 +106,15 @@ class TestFanout:
         # Arrange
         closed = False
 
-        class _TrackedSource:
-            def __aiter__(self):
-                return self._gen()
+        async def tracked_source():
+            nonlocal closed
+            try:
+                while True:
+                    yield "item"
+            finally:
+                closed = True
 
-            async def _gen(self):
-                nonlocal closed
-                try:
-                    while True:
-                        yield "item"
-                finally:
-                    closed = True
-
-        fanout = Fanout(_TrackedSource())
+        fanout = Fanout(tracked_source())
         consumer = fanout.consumer()
         await anext(consumer)  # initialise the iterator
 
@@ -140,6 +136,7 @@ class TestFanout:
             It should swallow the exception and still signal
             consumers with a sentinel.
         """
+
         # Arrange
         class _FailingSource:
             def __aiter__(self):
@@ -365,6 +362,7 @@ class TestFanoutConsumer:
             The consumer that waited for the lock should receive
             the item from its queue via the double-check path.
         """
+
         # Arrange — source suspends so the event loop can
         # schedule both consumers before the first completes.
         class _SuspendingSource:
@@ -380,9 +378,7 @@ class TestFanoutConsumer:
         consumer_b = fanout.consumer()
 
         # Act — concurrent pulls force the double-check path
-        results = await asyncio.gather(
-            anext(consumer_a), anext(consumer_b)
-        )
+        results = await asyncio.gather(anext(consumer_a), anext(consumer_b))
 
         # Assert — both receive the same item
         assert results == ["item", "item"]
@@ -401,6 +397,7 @@ class TestFanoutConsumer:
             from the source, the other via the SENTINEL placed in
             its queue during the lock double-check.
         """
+
         # Arrange — source suspends then exhausts, allowing the
         # event loop to interleave both consumers before either
         # completes.


### PR DESCRIPTION
## Summary

Rewrite the subscriber pooling layer so that proxies sharing the same discovery protocol reuse a single underlying subscription with demand-driven multicast. Introduce a `Fanout` utility that wraps any async generator and distributes each item to multiple independent consumers via a leader/follower pull model — no background task required. Late-joining consumers receive a replay of all currently known workers so they start with a consistent view.

All class-level state uses `WeakKeyDictionary` so that entries cascade away automatically when their keys are garbage-collected — no manual cleanup needed beyond closing the async generator on shutdown.

Closes #55

## Proposed changes

### `Fanout` multicast utility

Add a generic `Fanout[T]` container that wraps a single `AsyncGenerator[T]` source and multicasts each pulled item to every registered `FanoutConsumer`. The first consumer whose queue is empty acquires a shared `asyncio.Lock`, pulls one item from the source via `anext`, distributes it to all other consumers' queues, and returns. Consumers are tracked in a `WeakSet`; when a consumer goes out of scope the weak reference expires and it is silently removed from the fan-out set. `cleanup()` closes the source generator and pushes a sentinel to all remaining consumer queues.

### Demand-driven `_SharedSubscription`

Add a `_SharedSubscription` wrapper that bridges a discovery subscriber and a `Fanout`. Each `__aiter__` call enters a `ResourcePool` resource, lazily wraps the raw subscriber in a shared `Fanout`, and iterates an independent `FanoutConsumer`. Worker state is tracked as a `dict[uid, WorkerMetadata]` per subscriber — only the latest metadata is stored, and entries are removed on `worker-dropped`. When a new consumer registers, it receives a replay of `worker-added` events for all currently known workers.

### `SubscriberMeta` via `__new__`

Switch from `__call__` to `__new__` on the metaclass. The metaclass's `__new__` (called at class definition time) injects a custom `__new__` onto the subscriber class that caches the raw subscriber in the `ResourcePool` and returns a `_SharedSubscription` wrapper. Since the returned object is not an instance of the subscriber class, `type.__call__` skips `__init__` — no double-initialization.

### Pickle support

Add `__reduce__` to `_SharedSubscription` (delegates to the raw subscriber's `__reduce__`, so unpickling goes through the metaclass and re-wraps automatically) and to `afilter` (pickles predicate + inner subscriber).

### Subscriber simplification

Remove the `_consume()` method from both `LanDiscovery.Subscriber` and `LocalDiscovery.Subscriber`. `__aiter__` now returns `_event_stream()` directly. `_shutdown` becomes async and delegates to `_SharedSubscription.cleanup`.

### Integration test: `DURABLE_SHARED` pool mode

Add a new pool arrangement where two `WorkerPool` instances share the same `LocalDiscovery`. The second pool discovers existing workers via late-joiner replay. Include pairwise filter and Hypothesis strategy updates so the new mode is covered across all dimension combinations.

## Test cases

| Test Suite | # | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| TestSubscriberMeta | SM-001 | A subscriber class using SubscriberMeta | The class is instantiated | It should return a _SharedSubscription wrapping the cached raw subscriber | __new__ wrapping |
| TestSubscriberMeta | SM-002 | Two construction calls with the same arguments | Instantiated twice | Both should wrap the same underlying raw subscriber | Singleton caching |
| TestSubscriberMeta | SM-003 | Two construction calls with different arguments | Instantiated with different keys | Underlying raw subscribers should be different objects | Key isolation |
| TestSubscriberMeta | SM-004 | The __subscriber_pool__ ContextVar is None | A subscriber is constructed | The ContextVar should be set to a ResourcePool | Lazy pool init |
| TestSharedSubscription | SS-001 | A _SharedSubscription wrapping a source that yields one event | anext is called on the consumer | It should return the event from the source | Demand-driven pull |
| TestSharedSubscription | SS-002 | Two registered consumers sharing the same source | One consumer triggers a pull via anext | Both consumers should receive the event | Fan-out to multiple consumers |
| TestSharedSubscription | SS-003 | A _SharedSubscription wrapping a subscriber | __aiter__ is called twice | It should return two distinct _SharedSubscription instances | Independent consumers |
| TestSharedSubscription | SS-004 | A registered consumer against a subscriber | cleanup is called | Iterator should be removed and sentinel pushed to consumer queues | Cleanup and shutdown |
| TestSharedSubscription | SS-005 | A _SharedSubscription wrapping a stub subscriber with __reduce__ | Pickled and unpickled via cloudpickle | It should produce a _SharedSubscription wrapping a subscriber with the same key | Pickle roundtrip |
| TestSharedSubscription | SS-006 | Two consumers sharing a finite source of 2 events | Both iterate to exhaustion | First consumer should get both events; second should get replay | Source exhaustion + late-joiner replay |
| TestSharedSubscription | SS-007 | A consumer registered against a cleaned-up subscriber | anext is called | It should raise StopAsyncIteration | Post-cleanup termination |
| Testafilter | AF-001 | A source yielding one matching worker-added event | afilter is iterated with an accepting predicate | It should yield the worker-added event | Single matching event |
| Testafilter | AF-002 | A source yielding worker-added then worker-updated | afilter is iterated with an accept-all predicate | It should yield both events in order | Unfiltered passthrough |
| Testafilter | AF-003 | A source yielding a worker-added event | afilter is iterated with a rejecting predicate | It should yield no events | Filter suppression |
| Testafilter | AF-004 | A source yielding worker-added (fails) then worker-updated (passes) | afilter is iterated with a tag filter | It should yield worker-added for the now-matching worker | Filter entry transition |
| Testafilter | AF-005 | A source yielding worker-added (passes) then worker-updated (fails) | afilter is iterated with a tag filter | It should yield worker-added then worker-dropped with prior metadata | Filter exit transition |
| Testafilter | AF-006 | A source yielding worker-added then worker-dropped | afilter is iterated with accept-all | It should yield both events | Tracked worker drop |
| Testafilter | AF-007 | A source yielding worker-added (fails) then worker-dropped | afilter is iterated with rejecting filter | It should yield no events | Untracked worker drop suppression |
| Testafilter | AF-008 | An afilter wrapping a repeatable source | __aiter__ is called twice sequentially | Each iteration should produce independent results | Independent iteration state |
| Testafilter | AF-009 | An afilter wrapping a picklable subscriber | Pickled and unpickled via cloudpickle | It should produce an afilter instance | Pickle roundtrip |
| TestPoolComposition | IC-001 | Two WorkerPool instances sharing the same LocalDiscovery | Both pools entered, coroutine dispatched through primary | It should discover the worker and return the correct result | Shared subscriber end-to-end |