### PR TITLE
Remove parent-resolution from wool.routine wrapper — Closes #118

### DIFF
--- a/wool/src/wool/runtime/routine/wrapper.py
+++ b/wool/src/wool/runtime/routine/wrapper.py
@@ -6,14 +6,9 @@ from inspect import getsourcelines
 from inspect import isasyncgen
 from inspect import isasyncgenfunction
 from inspect import iscoroutinefunction
-from sys import modules
-from types import ModuleType
 from typing import TYPE_CHECKING
 from typing import AsyncGenerator
 from typing import Coroutine
-from typing import ParamSpec
-from typing import Tuple
-from typing import Type
 from typing import TypeVar
 from typing import cast
 from uuid import uuid4
@@ -27,8 +22,6 @@ if TYPE_CHECKING:
     from wool.runtime.worker.proxy import WorkerProxy
 
 C = TypeVar("C", bound=Callable[..., Coroutine | AsyncGenerator])
-P = ParamSpec("P")
-R = TypeVar("R")
 
 
 # public
@@ -140,37 +133,26 @@ def routine(fn: C) -> C:
                 async for value in fibonacci_series(10):
                     print(value)  # 0, 1, 1, 2, 3, 5, 8, 13, 21, 34
     """
-    # Check if function is a coroutine or async generator
-    is_valid = (
-        iscoroutinefunction(fn)
-        or isasyncgenfunction(fn)
-        or (
-            isinstance(fn, (classmethod, staticmethod))
-            and (iscoroutinefunction(fn.__func__) or isasyncgenfunction(fn.__func__))
-        )
-    )
-    if not is_valid:
-        raise ValueError("Expected a coroutine function or async generator function")
-
     if isinstance(fn, (classmethod, staticmethod)):
-        wrapped_fn = fn.__func__
-    else:
-        wrapped_fn = fn
+        raise ValueError(
+            "@wool.routine must be applied before "
+            "@classmethod/@staticmethod"
+        )
+
+    if not iscoroutinefunction(fn) and not isasyncgenfunction(fn):
+        raise ValueError(
+            "Expected a coroutine function or async generator function"
+        )
 
     try:
-        _, lineno = getsourcelines(wrapped_fn)
+        _, lineno = getsourcelines(fn)
     except OSError:
         lineno = 0
 
-    if isasyncgenfunction(wrapped_fn):
+    if isasyncgenfunction(fn):
 
-        @wraps(wrapped_fn)
+        @wraps(fn)
         async def async_generator_wrapper(*args, **kwargs):
-            # Handle static and class methods in a picklable way.
-            parent, function = _resolve(fn)
-            assert parent is not None
-            assert callable(function)
-
             if do_dispatch():
                 proxy = wool.__proxy__.get()
                 assert proxy
@@ -179,12 +161,12 @@ def routine(fn: C) -> C:
                     async_generator_wrapper.__module__,
                     async_generator_wrapper.__qualname__,
                     lineno,
-                    function,
+                    fn,
                     *args,
                     **kwargs,
                 )
             else:
-                stream = _stream(fn, parent, *args, **kwargs)
+                stream = _stream(fn, *args, **kwargs)
                 assert isasyncgen(stream)
 
             try:
@@ -212,13 +194,8 @@ def routine(fn: C) -> C:
 
     else:
 
-        @wraps(wrapped_fn)
+        @wraps(fn)
         async def coroutine_wrapper(*args, **kwargs):
-            # Handle static and class methods in a picklable way.
-            parent, function = _resolve(fn)
-            assert parent is not None
-            assert callable(function)
-
             if do_dispatch():
                 proxy = wool.__proxy__.get()
                 assert proxy
@@ -227,15 +204,13 @@ def routine(fn: C) -> C:
                     coroutine_wrapper.__module__,
                     coroutine_wrapper.__qualname__,
                     lineno,
-                    function,
+                    fn,
                     *args,
                     **kwargs,
                 )
-                coro = _stream_to_coroutine(stream)
+                return await _stream_to_coroutine(stream)
             else:
-                coro = _execute(fn, parent, *args, **kwargs)
-
-            return await coro
+                return await _execute(fn, *args, **kwargs)
 
         return cast(C, coroutine_wrapper)
 
@@ -262,13 +237,8 @@ def _dispatch(
     return proxy.dispatch(task, timeout=ctx.dispatch_timeout.get())
 
 
-async def _stream(fn, parent, *args, **kwargs):
-    if isinstance(fn, classmethod):
-        gen = fn.__func__(parent, *args, **kwargs)
-    elif isinstance(fn, staticmethod):
-        gen = fn.__func__(*args, **kwargs)
-    else:
-        gen = fn(*args, **kwargs)
+async def _stream(fn, *args, **kwargs):
+    gen = fn(*args, **kwargs)
     try:
         sent = None
         with do_dispatch(True):
@@ -294,28 +264,10 @@ async def _stream(fn, parent, *args, **kwargs):
         await gen.aclose()
 
 
-async def _execute(fn, parent, *args, **kwargs):
+async def _execute(fn, *args, **kwargs):
     with do_dispatch(True):
-        if isinstance(fn, classmethod):
-            return await fn.__func__(parent, *args, **kwargs)
-        elif isinstance(fn, staticmethod):
-            return await fn.__func__(*args, **kwargs)
-        else:
-            return await fn(*args, **kwargs)
+        return await fn(*args, **kwargs)
 
 
 async def _stream_to_coroutine(stream):
     return await anext(stream, None)
-
-
-def _resolve(
-    method: Callable[P, R] | classmethod | staticmethod,
-) -> Tuple[Type | ModuleType | None, Callable[P, R]]:
-    scope = modules[method.__module__]
-    parent = None
-    for name in method.__qualname__.split("."):
-        parent = scope
-        scope = getattr(scope, name)
-        assert scope
-    assert isinstance(parent, (Type, ModuleType))
-    return parent, cast(Callable[P, R], scope)

--- a/wool/src/wool/runtime/routine/wrapper.py
+++ b/wool/src/wool/runtime/routine/wrapper.py
@@ -40,14 +40,34 @@ def routine(fn: C) -> C:
         The decorated function that dispatches to the worker pool when
         called.
     :raises ValueError:
-        If the decorated function is not a coroutine function or async
-        generator function.
+        If the decorated function is a ``classmethod`` or
+        ``staticmethod`` descriptor (apply ``@wool.routine`` before
+        the descriptor decorator), or if the decorated function is
+        not a coroutine function or async generator function.
 
     .. note::
         Decorated functions behave like regular coroutines or async
         generators and can be awaited, iterated over, and cancelled
         normally. Task execution occurs transparently across the
         distributed worker pool.
+
+    .. note::
+        When using ``@wool.routine`` on a ``@classmethod`` or
+        ``@staticmethod``, apply ``@wool.routine`` first (innermost)
+        and the descriptor decorator second (outermost). The routine
+        decorator operates on the raw function and cannot unwrap
+        descriptor objects.
+
+        .. code-block:: python
+
+            class MyService:
+                @classmethod
+                @wool.routine
+                async def fetch(cls, key: str) -> bytes: ...
+
+                @staticmethod
+                @wool.routine
+                async def ping() -> bool: ...
 
     **Async Generator Support:**
 
@@ -135,14 +155,11 @@ def routine(fn: C) -> C:
     """
     if isinstance(fn, (classmethod, staticmethod)):
         raise ValueError(
-            "@wool.routine must be applied before "
-            "@classmethod/@staticmethod"
+            "@wool.routine must be applied before @classmethod/@staticmethod"
         )
 
     if not iscoroutinefunction(fn) and not isasyncgenfunction(fn):
-        raise ValueError(
-            "Expected a coroutine function or async generator function"
-        )
+        raise ValueError("Expected a coroutine function or async generator function")
 
     try:
         _, lineno = getsourcelines(fn)

--- a/wool/tests/integration/routines.py
+++ b/wool/tests/integration/routines.py
@@ -113,27 +113,27 @@ class Routines:
         while True:
             yield "alive"
 
-    @wool.routine
     @classmethod
+    @wool.routine
     async def class_add(cls, a: int, b: int) -> int:
         """Class method coroutine."""
         return a + b
 
-    @wool.routine
     @classmethod
+    @wool.routine
     async def class_gen(cls, n: int):
         """Class method async generator."""
         for i in range(n):
             yield i
 
-    @wool.routine
     @staticmethod
+    @wool.routine
     async def static_add(a: int, b: int) -> int:
         """Static method coroutine."""
         return a + b
 
-    @wool.routine
     @staticmethod
+    @wool.routine
     async def static_gen(n: int):
         """Static method async generator."""
         for i in range(n):

--- a/wool/tests/runtime/routine/test_wrapper.py
+++ b/wool/tests/runtime/routine/test_wrapper.py
@@ -114,8 +114,8 @@ class Foo:
     assert foo.__qualname__ == "Foo.foo"
     assert foo.__module__ == "runtime.routine.test_wrapper"
 
-    @routine
     @classmethod
+    @routine
     async def bar(cls, x):
         """Class method."""
         return x * 3
@@ -123,8 +123,8 @@ class Foo:
     assert bar.__qualname__ == "Foo.bar"
     assert bar.__module__ == "runtime.routine.test_wrapper"
 
-    @routine
     @staticmethod
+    @routine
     async def baz(x):
         """Static method."""
         return x * 4
@@ -141,8 +141,8 @@ class Foo:
     assert foo_gen.__qualname__ == "Foo.foo_gen"
     assert foo_gen.__module__ == "runtime.routine.test_wrapper"
 
-    @routine
     @classmethod
+    @routine
     async def bar_gen(cls, x):
         """Async generator class method."""
         for i in range(x):
@@ -151,8 +151,8 @@ class Foo:
     assert bar_gen.__qualname__ == "Foo.bar_gen"
     assert bar_gen.__module__ == "runtime.routine.test_wrapper"
 
-    @routine
     @staticmethod
+    @routine
     async def baz_gen(x):
         """Async generator static method."""
         for i in range(x):
@@ -200,6 +200,44 @@ def test_routine_with_invalid_types(function_type):
 
                 @routine  # type: ignore[arg-type]
                 class InvalidFoo: ...
+
+
+@settings(
+    max_examples=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    descriptor_type=st.sampled_from(["classmethod", "staticmethod"]),
+)
+def test_routine_with_descriptor_types(descriptor_type):
+    """Test @routine rejects classmethod and staticmethod descriptors.
+
+    Given:
+        The @routine decorator applied to a classmethod or
+        staticmethod descriptor (wrong decorator order).
+    When:
+        The decorator is applied.
+    Then:
+        It should raise ``ValueError`` indicating the correct
+        decorator order.
+    """
+    # Arrange, act, & assert
+    with pytest.raises(ValueError, match="@wool.routine must be applied before"):
+        match descriptor_type:
+            case "classmethod":
+
+                @routine  # type: ignore[arg-type]
+                @classmethod
+                async def invalid_cls(cls):
+                    return cls
+
+            case "staticmethod":
+
+                @routine  # type: ignore[arg-type]
+                @staticmethod
+                async def invalid_static():
+                    return True
 
 
 @settings(
@@ -807,12 +845,8 @@ async def test_routine_with_athrow_no_deprecation_warning():
             await gen.athrow(Resettable)
 
         # Assert
-        deprecations = [
-            w for w in caught if issubclass(w.category, DeprecationWarning)
-        ]
-        assert deprecations == [], (
-            f"Unexpected DeprecationWarning(s): {deprecations}"
-        )
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecations == [], f"Unexpected DeprecationWarning(s): {deprecations}"
         await gen.aclose()
 
 

--- a/wool/tests/runtime/worker/test_connection.py
+++ b/wool/tests/runtime/worker/test_connection.py
@@ -655,9 +655,7 @@ class TestWorkerConnection:
 
         responses = (
             protocol.Response(ack=protocol.Ack()),
-            protocol.Response(
-                result=protocol.Message(dump=cloudpickle.dumps("result"))
-            ),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("result"))),
         )
         mock_call = mock_grpc_call(async_stream(responses))
 
@@ -666,9 +664,7 @@ class TestWorkerConnection:
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
         mock_channel = mocker.AsyncMock()
-        mocker.patch.object(
-            grpc.aio, "insecure_channel", return_value=mock_channel
-        )
+        mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
 
         connection = WorkerConnection(target, limit=10)
 

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -344,7 +344,6 @@ def test_is_version_compatible_different_major():
 class TestWorkerProxy:
     """Comprehensive test suite for WorkerProxy."""
 
-
     def test___init___discovery_and_loadbalancer(
         self, mock_discovery_service, mock_load_balancer_factory
     ):
@@ -519,11 +518,7 @@ class TestWorkerProxy:
         with pytest.raises(ValueError, match="Must specify either a workerpool URI"):
             WorkerProxy()
 
-
-
-    def test___init___with_sync_cm_loadbalancer_warns(
-        self, mock_discovery_service
-    ):
+    def test___init___with_sync_cm_loadbalancer_warns(self, mock_discovery_service):
         """Test UserWarning for sync CM loadbalancer.
 
         Given:
@@ -533,6 +528,7 @@ class TestWorkerProxy:
         Then:
             It should emit a UserWarning mentioning 'loadbalancer'.
         """
+
         # Arrange
         class SyncCM:
             def __enter__(self):
@@ -543,13 +539,9 @@ class TestWorkerProxy:
 
         # Act & assert
         with pytest.warns(UserWarning, match="loadbalancer"):
-            WorkerProxy(
-                discovery=mock_discovery_service, loadbalancer=SyncCM()
-            )
+            WorkerProxy(discovery=mock_discovery_service, loadbalancer=SyncCM())
 
-    def test___init___with_async_cm_loadbalancer_warns(
-        self, mock_discovery_service
-    ):
+    def test___init___with_async_cm_loadbalancer_warns(self, mock_discovery_service):
         """Test UserWarning for async CM loadbalancer.
 
         Given:
@@ -559,6 +551,7 @@ class TestWorkerProxy:
         Then:
             It should emit a UserWarning mentioning 'loadbalancer'.
         """
+
         # Arrange
         class AsyncCM:
             async def __aenter__(self):
@@ -569,9 +562,7 @@ class TestWorkerProxy:
 
         # Act & assert
         with pytest.warns(UserWarning, match="loadbalancer"):
-            WorkerProxy(
-                discovery=mock_discovery_service, loadbalancer=AsyncCM()
-            )
+            WorkerProxy(discovery=mock_discovery_service, loadbalancer=AsyncCM())
 
     def test___init___with_sync_cm_discovery_warns(self):
         """Test UserWarning for sync CM discovery.
@@ -583,6 +574,7 @@ class TestWorkerProxy:
         Then:
             It should emit a UserWarning mentioning 'discovery'.
         """
+
         # Arrange
         class SyncCM:
             def __enter__(self):
@@ -605,6 +597,7 @@ class TestWorkerProxy:
         Then:
             It should emit a UserWarning mentioning 'discovery'.
         """
+
         # Arrange
         class AsyncCM:
             async def __aenter__(self):
@@ -637,9 +630,7 @@ class TestWorkerProxy:
                 loadbalancer=wp.RoundRobinLoadBalancer,
             )
 
-        user_warnings = [
-            w for w in caught if issubclass(w.category, UserWarning)
-        ]
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
         assert user_warnings == []
 
     @pytest.mark.asyncio
@@ -945,7 +936,6 @@ class TestWorkerProxy:
         # Cleanup
         await proxy.stop()
 
-
     @pytest.mark.asyncio
     async def test_discovers_workers_from_service(self, mock_discovery_service):
         """Test the proxy discovers them.
@@ -1081,7 +1071,6 @@ class TestWorkerProxy:
 
         # Cleanup
         await proxy.stop()
-
 
     @pytest.mark.asyncio
     async def test_dispatch_delegates_to_loadbalancer(
@@ -1338,7 +1327,6 @@ class TestWorkerProxy:
         # Cleanup
         await proxy.stop()
 
-
     @pytest.mark.asyncio
     async def test_proxy_with_static_workers_list(self):
         """Test it starts and stops correctly.
@@ -1401,7 +1389,6 @@ class TestWorkerProxy:
 
         # After exit, proxy should be stopped
         assert not proxy.started
-
 
     @pytest.mark.asyncio
     async def test_workers_property_returns_workers_list(
@@ -1503,7 +1490,6 @@ class TestWorkerProxy:
 
         # Proxy should not equal non-WorkerProxy objects
         assert proxy1 != non_proxy
-
 
     @pytest.mark.asyncio
     async def test_cloudpickle_serialization_with_services(self):
@@ -1744,6 +1730,7 @@ class TestWorkerProxy:
         Then:
             It should raise TypeError mentioning 'loadbalancer'.
         """
+
         # Arrange
         class SyncCM:
             def __enter__(self):
@@ -1775,6 +1762,7 @@ class TestWorkerProxy:
         Then:
             It should raise TypeError mentioning 'loadbalancer'.
         """
+
         # Arrange
         class AsyncCM:
             async def __aenter__(self):
@@ -1804,6 +1792,7 @@ class TestWorkerProxy:
         Then:
             It should raise TypeError mentioning 'discovery'.
         """
+
         # Arrange
         class SyncCM:
             def __enter__(self):
@@ -1830,6 +1819,7 @@ class TestWorkerProxy:
         Then:
             It should raise TypeError mentioning 'discovery'.
         """
+
         # Arrange
         class AsyncCM:
             async def __aenter__(self):
@@ -1844,6 +1834,7 @@ class TestWorkerProxy:
         # Act & assert
         with pytest.raises(TypeError, match="discovery"):
             cloudpickle.dumps(proxy)
+
     @pytest.mark.asyncio
     async def test_explicit_credentials_parameter_overrides_contextvar(
         self, mock_proxy_session, worker_credentials, mocker: MockerFixture
@@ -1982,8 +1973,6 @@ class TestWorkerProxy:
         assert secure_worker not in proxy.workers
         await proxy.stop()
 
-
-
     @pytest.mark.asyncio
     async def test_start_invalid_loadbalancer_type_raises_error(
         self, mocker: MockerFixture
@@ -2033,7 +2022,6 @@ class TestWorkerProxy:
         # Act & assert
         with pytest.raises(ValueError):
             await proxy.start()
-
 
     @pytest.mark.asyncio
     async def test_security_filter_with_credentials(
@@ -2140,7 +2128,6 @@ class TestWorkerProxy:
             secure=True,
         )
         assert filter_fn(secure_matching) is False
-
 
     @given(worker_count=st.integers(min_value=0, max_value=10))
     @settings(


### PR DESCRIPTION
## Summary

Remove `_resolve()` and its associated `classmethod`/`staticmethod` descriptor handling from `wool.routine`. The decorator now operates directly on the raw function passed to it, eliminating the per-invocation `sys.modules` walk that produced distinct class objects across workers and broke exception identity in nested dispatch scenarios.

`@wool.routine` now raises `ValueError` when applied to a `classmethod` or `staticmethod` descriptor. The correct decorator order is `@classmethod @wool.routine` (descriptor outer, routine inner). An info admonition documenting this requirement is added to the `routine()` docstring.

Closes #118

## Proposed changes

### Remove _resolve and simplify dispatch internals

`_resolve()` walked `sys.modules[fn.__module__]` using `fn.__qualname__` to re-resolve the decorated function on every call. On spawned workers the re-imported module lives under `__mp_main__`, producing a different function object whose globals reference different class objects — breaking `isinstance` checks and `except` clauses for user-defined exceptions in nested dispatch.

With `_resolve` removed, the wrappers pass `fn` (the original closure-captured function) directly to `_dispatch`, `_stream`, and `_execute`. The `parent` parameter and the `classmethod`/`staticmethod` branch logic in `_stream` and `_execute` are also removed since the decorator now always receives the raw function.

### Add descriptor guard with clear error message

A new guard at the top of `routine()` raises `ValueError("@wool.routine must be applied before @classmethod/@staticmethod")` when passed a descriptor object. This gives an actionable error message instead of the generic "Expected a coroutine function" that would otherwise fire.

### Update decorator order in test fixtures and integration routines

All `@routine @classmethod` / `@routine @staticmethod` usages in test fixtures and integration routine definitions are flipped to the correct `@classmethod @routine` / `@staticmethod @routine` order.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | (module) | `@routine` applied to a classmethod descriptor | Decorator is evaluated | `ValueError` with message about correct order | Descriptor guard (classmethod) |
| 2 | (module) | `@routine` applied to a staticmethod descriptor | Decorator is evaluated | `ValueError` with message about correct order | Descriptor guard (staticmethod) |
| 3 | (module) | `@routine` on various function types with dispatch enabled | Decorated function is called | Task is dispatched and result returned correctly | Dispatch path for all 8 function types |
| 4 | (module) | `@routine` on various function types with dispatch disabled | Decorated function is called | Function executes locally and result returned correctly | Local execution path for all 8 function types |