### PR TITLE
Add PR template and teach the PR skill to use it — Closes #88

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- A recap of what was implemented, the high-level approach, and any trade-offs worth noting. End with "Closes #<number>" to link the issue. -->
+
+## Proposed changes
+
+<!-- Subsections for each logical change. Include design rationale where useful. -->
+
+## Test cases
+
+<!-- An enumerated Given-When-Then table summarizing test coverage from committed test files. -->
+
+| # | Test Suite | Given | When | Then | Coverage Target |
+|---|------------|-------|------|------|-----------------|

--- a/llms/skills/pr.md
+++ b/llms/skills/pr.md
@@ -87,23 +87,42 @@ Analyze all committed source and test changes. Understand what was implemented, 
 
 ### 4. Draft the PR description
 
+#### 4a. Detect a PR template
+
+Before drafting, check whether the repository provides a PR template:
+
+```bash
+cat "$(git rev-parse --show-toplevel)/.github/pull_request_template.md" 2>/dev/null
+```
+
+- **If the file exists** — read its section headings (lines starting with `##`) and use them as the scaffold for the PR body. Populate each section contextually based on the diff analysis from step 3. Any guidance inside HTML comments (`<!-- ... -->`) informs what content belongs in that section but MUST NOT appear in the final PR body.
+- **If the file does not exist** — fall back to the built-in three-section format defined below.
+
+The remaining rules in this step apply regardless of whether a template is used.
+
+#### 4b. Title
+
 The PR title MUST match the associated issue title exactly with ` — Closes #<number>` appended to the end.
+
+#### 4c. Body prose rules
 
 All PR description prose MUST be written in the imperative mood — "Add retry logic" not "Adds retry logic" or "Added retry logic". This applies to the title, summary, and proposed changes. Descriptions of the current state of the system are exempt and SHOULD use present tense — "The registry stores entries in memory" not "Store entries in memory".
 
 Prose in PR descriptions MUST NOT be hard-wrapped at a fixed column width. Write each sentence or logical phrase as a single unwrapped line. Markdown renderers handle line wrapping automatically — manual line breaks inside paragraphs create unnecessary diffs and awkward rendering.
 
-The PR description MUST contain a **Summary** and **Proposed changes** section. A **Test cases** section MUST be included when the PR contains code changes; it MAY be omitted for PRs that only modify documentation, configuration, or other non-code files.
+#### 4d. Built-in section format (fallback)
+
+When no PR template file is detected, the PR description MUST contain a **Summary** and **Proposed changes** section. A **Test cases** section MUST be included when the PR contains code changes; it MAY be omitted for PRs that only modify documentation, configuration, or other non-code files.
 
 **Summary** — A recap of what was implemented, the high-level approach, and any trade-offs worth noting. The summary is based on the actual diff, not the issue body. The summary MUST end with `Closes #<number>` to link the issue.
 
-**Proposed changes** — Subsections for each logical change, derived from the committed diff. Design rationale and before/after code snippets SHOULD be included where useful.
+**Proposed changes** — Subsections for each logical change, derived from the committed diff. Design rationale SHOULD be included where useful.
 
-**Test cases** (code changes only) — A Given-When-Then table summarizing the test coverage from committed test files. Read the test files and generate a table in this format:
+**Test cases** (code changes only) — An enumerated Given-When-Then table summarizing the test coverage from committed test files. Read the test files and generate a table in this format:
 
-| Test Suite | Test ID | Given | When | Then | Coverage Target |
-|------------|---------|-------|------|------|-----------------|
-| `TestParser` | PA-001 | A parser with default config | Empty input is processed | Returns an empty result | Default behavior |
+| # | Test Suite | Given | When | Then | Coverage Target |
+|---|------------|-------|------|------|-----------------|
+| 1 | `TestParser` | A parser with default config | Empty input is processed | Returns an empty result | Default behavior |
 
 The first word of every plain-language table entry MUST be capitalized. Table entries MUST NOT end with punctuation (no trailing periods, commas, etc.). Code spans in entries (e.g., `` `foo.bar()` is called ``) are exempt from the capitalization rule.
 


### PR DESCRIPTION
## Summary

Add a `.github/pull_request_template.md` that defines the project's standard PR section structure (Summary, Proposed changes, Test cases) with HTML comment guidance for each section. Update the `/pr` skill to detect this template at draft time and use its section headings as the body scaffold, falling back to the built-in three-section format when no template is present. This decouples the project's preferred PR layout from the skill logic, letting maintainers iterate on the template independently and ensuring PRs opened outside the skill follow the same structure.

Closes #88

## Proposed changes

### Add `.github/pull_request_template.md`

Introduce a new PR template with three `##`-level sections — Summary, Proposed changes, and Test cases — each containing an HTML comment that describes what belongs in the section. GitHub automatically pre-fills this template when a PR is opened via the web UI, so PRs created outside the skill also follow the same structure.

### Restructure step 4 of the PR skill (`llms/skills/pr.md`)

Split the monolithic step 4 ("Draft the PR description") into four substeps:

- **4a — Detect a PR template:** Read `.github/pull_request_template.md` from the repo root. If present, use its section headings as the body scaffold and strip HTML comments from the final output. If absent, fall back to the built-in format.
- **4b — Title:** Unchanged title rule (issue title + ` — Closes #<number>`).
- **4c — Body prose rules:** Unchanged imperative mood and no-hard-wrap rules.
- **4d — Built-in section format (fallback):** The existing three-section specification, now scoped as the fallback when no template file is detected.