### PR TITLE
Expose all gRPC transport-layer options for worker connections — Closes #41

### DIFF
--- a/wool/README.md
+++ b/wool/README.md
@@ -156,7 +156,7 @@ Workers discover each other through pluggable discovery backends with no central
 
 ### Discovery events
 
-A `DiscoveryEvent` pairs a type — one of `worker-added`, `worker-dropped`, or `worker-updated` — with the affected worker's `WorkerMetadata` (UID, address, pid, version, tags, security flag). Discovery subscribers yield these events as the set of known workers changes.
+A `DiscoveryEvent` pairs a type — one of `worker-added`, `worker-dropped`, or `worker-updated` — with the affected worker's `WorkerMetadata` (UID, address, pid, version, tags, security flag, and transport options). Discovery subscribers yield these events as the set of known workers changes.
 
 ### Built-in protocols
 
@@ -185,17 +185,53 @@ async with wool.WorkerPool(size=4, loadbalancer=my_balancer):
 
 Transient errors are the gRPC status codes `UNAVAILABLE`, `DEADLINE_EXCEEDED`, and `RESOURCE_EXHAUSTED` — temporary conditions that may resolve on retry to the same or another worker. Non-transient errors are all other gRPC failures (e.g., `INVALID_ARGUMENT`, `PERMISSION_DENIED`) indicating persistent problems. The load balancer skips transient-error workers but evicts non-transient-error workers from the pool.
 
-### Worker connections
+### Self-describing worker connections
 
-A `WorkerConnection` is a gRPC client managing a pooled channel to a single worker address. It serializes and sends a task over a bidirectional stream, waits for an acknowledgment, then returns an async generator that streams results back. A semaphore caps concurrent dispatches, and gRPC errors are classified as transient or non-transient for the load balancer.
+Workers are self-describing: each worker advertises its gRPC transport configuration via `ChannelOptions` in its `WorkerMetadata`. When a client discovers a worker, it reads the advertised options and configures its channel to match — message sizes, keepalive intervals, concurrency limits, and compression are all set automatically. There is no separate client-side configuration step; the worker's metadata is the single source of truth for how to connect to it.
+
+A `WorkerConnection` is a gRPC client managing a pooled channel to a single worker address. It serializes and sends a task over a bidirectional stream, waits for an acknowledgment, then returns an async generator that streams results back. The channel's concurrency semaphore is sized by the worker's advertised `max_concurrent_streams`, and gRPC errors are classified as transient or non-transient for the load balancer.
 
 Channels are pooled with reference counting and a 60-second TTL. A dispatch acquires a pool reference, and the result stream holds its own reference to keep the channel alive during streaming. There is no pool-level health checking — dead channels are detected reactively when a dispatch attempt fails, and the failed worker is removed from the load balancer context by the error classification logic.
 
+### Transport configuration
+
+Transport options are split into two tiers:
+
+- **`ChannelOptions`** — settings that both the server and client apply symmetrically. Workers advertise these via `WorkerMetadata` so clients connect with identical settings. Includes message sizes (`max_receive_message_length`, `max_send_message_length`), keepalive (`keepalive_time_ms`, `keepalive_timeout_ms`, `keepalive_permit_without_calls`, `max_pings_without_data`), flow control (`max_concurrent_streams`), and compression (`compression`).
+
+- **`WorkerOptions`** — composes a `ChannelOptions` instance with server-only settings that are not communicated to clients: `http2_min_recv_ping_interval_without_data_ms` (minimum allowed client ping interval), `max_ping_strikes` (ping violations before GOAWAY), and optional connection lifecycle limits (`max_connection_idle_ms`, `max_connection_age_ms`, `max_connection_age_grace_ms`).
+
+All options default to gRPC's own defaults. Pass a `WorkerOptions` instance to `LocalWorker` or `WorkerProcess` to customize:
+
+```python
+from wool.runtime.worker.base import ChannelOptions, WorkerOptions
+from wool.runtime.worker.local import LocalWorker
+
+options = WorkerOptions(
+    channel=ChannelOptions(
+        keepalive_time_ms=10_000,
+        keepalive_timeout_ms=5_000,
+        max_concurrent_streams=50,
+    ),
+    max_connection_idle_ms=300_000,
+)
+
+async with wool.WorkerPool(
+    size=4,
+    worker=lambda *tags, credentials=None: LocalWorker(
+        *tags, credentials=credentials, options=options,
+    ),
+):
+    result = await my_routine()
+```
+
 ### Connection failure detection
 
-Wool does not actively monitor connection health — detection is reactive. When a connection breaks, the next gRPC read or write on the stream raises an `RpcError`, which flows through the same transient/non-transient classification as any other gRPC failure. On the client side, a dead worker typically surfaces as `UNAVAILABLE` (transient), causing the load balancer to skip to the next worker. On the worker side, a disconnected client is detected when the stream iterator terminates, at which point the worker closes the running generator if one is active.
+gRPC runs over HTTP/2, which provides connection-level error signaling via GOAWAY and RST_STREAM frames. When a peer drops abruptly, the OS eventually closes the TCP socket and the HTTP/2 layer surfaces the broken connection to gRPC as a stream error.
 
-gRPC runs over HTTP/2, which provides connection-level error signaling via GOAWAY and RST_STREAM frames. When a peer drops abruptly, the OS eventually closes the TCP socket and the HTTP/2 layer surfaces the broken connection to gRPC as a stream error. Wool does not currently configure gRPC keepalive pings, so a silently dead connection (no TCP reset) may not be detected until the next read or write attempt.
+Wool configures HTTP/2 keepalive pings on both client and server channels. When keepalive is enabled (the default), both sides send periodic PING frames and expect a PONG response within `keepalive_timeout_ms`. If no response arrives, the connection is considered dead and gRPC raises an error on the next operation. This detects silently dead connections — where the remote peer is unreachable but no TCP reset was received — without waiting for the next application-level read or write.
+
+On the client side, a dead worker surfaces as `UNAVAILABLE` (transient), causing the load balancer to skip to the next worker. On the worker side, a disconnected client is detected when the stream iterator terminates, at which point the worker closes the running generator if one is active.
 
 ## Security
 

--- a/wool/proto/wire.proto
+++ b/wool/proto/wire.proto
@@ -93,6 +93,37 @@ message WorkerMetadata {
 
     // Whether the worker requires secure TLS/mTLS connections
     bool secure = 7;
+
+    // gRPC channel configuration advertised by the worker.
+    // Clients use these settings when connecting to this worker.
+    ChannelOptions connection = 8;
+}
+
+message ChannelOptions {
+    // Maximum inbound message size in bytes.
+    int32 max_receive_message_length = 1;
+
+    // Maximum outbound message size in bytes.
+    int32 max_send_message_length = 2;
+
+    // Interval in milliseconds between HTTP/2 keepalive pings.
+    int32 keepalive_time_ms = 3;
+
+    // Time in milliseconds to wait for a keepalive pong before
+    // considering the connection dead.
+    int32 keepalive_timeout_ms = 4;
+
+    // Whether to send keepalive pings with no active RPCs.
+    bool keepalive_permit_without_calls = 5;
+
+    // Max keepalive pings allowed when no data/header frames are sent.
+    int32 max_pings_without_data = 6;
+
+    // Max concurrent HTTP/2 streams per connection.
+    int32 max_concurrent_streams = 7;
+
+    // Default compression algorithm (maps to grpc.Compression enum value).
+    int32 compression = 8;
 }
 
 message WorkerEndpoint {}

--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -13,7 +13,6 @@ from wool.runtime.discovery.base import DiscoveryLike
 from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.base import PredicateFunction
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.lan import LanDiscovery
 from wool.runtime.discovery.local import LocalDiscovery
 from wool.runtime.loadbalancer.base import LoadBalancerContextLike
@@ -36,6 +35,7 @@ from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.connection import UnexpectedResponse
 from wool.runtime.worker.connection import WorkerConnection
 from wool.runtime.worker.local import LocalWorker
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.pool import WorkerPool
 from wool.runtime.worker.proxy import WorkerProxy
 from wool.runtime.worker.service import WorkerService

--- a/wool/src/wool/protocol/__init__.py
+++ b/wool/src/wool/protocol/__init__.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 try:
     from wool.protocol.wire_pb2 import Ack
+    from wool.protocol.wire_pb2 import ChannelOptions
     from wool.protocol.wire_pb2 import Message
     from wool.protocol.wire_pb2 import Nack
     from wool.protocol.wire_pb2 import Request
@@ -44,6 +45,7 @@ add_to_server: dict[type[WorkerServicer], AddServicerToServerProtocol] = {
 
 __all__ = [
     "Ack",
+    "ChannelOptions",
     "Message",
     "Nack",
     "Request",

--- a/wool/src/wool/runtime/discovery/base.py
+++ b/wool/src/wool/runtime/discovery/base.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-import uuid
 from abc import ABC
 from abc import abstractmethod
-from dataclasses import dataclass
-from dataclasses import field
-from types import MappingProxyType
 from typing import AsyncIterator
 from typing import Callable
 from typing import Final
@@ -15,88 +11,12 @@ from typing import TypeAlias
 from typing import TypeVar
 from typing import runtime_checkable
 
-from wool.protocol import WorkerMetadata as WorkerMetadataProtobuf
+from wool.runtime.worker.metadata import WorkerMetadata
 
 T: Final = TypeVar("T")
 
 # public
 PredicateFunction: TypeAlias = Callable[[T], bool]
-
-
-# public
-@dataclass(frozen=True)
-class WorkerMetadata:
-    """Properties and metadata for a worker instance.
-
-    Contains identifying information and capabilities of a worker that
-    can be used for discovery, filtering, and routing decisions.
-
-    :param uid:
-        Unique identifier for the worker instance (UUID).
-    :param address:
-        gRPC target address (e.g. ``"host:port"``,
-        ``"unix:path"``).
-    :param pid:
-        Process ID of the worker.
-    :param version:
-        Version string of the worker software.
-    :param tags:
-        Frozenset of capability tags for worker filtering and
-        selection.
-    :param extra:
-        Additional arbitrary metadata as immutable key-value pairs.
-    :param secure:
-        Whether the worker requires secure TLS/mTLS connections.
-    """
-
-    uid: uuid.UUID
-    address: str = field(hash=False)
-    pid: int = field(hash=False)
-    version: str = field(hash=False)
-    tags: frozenset[str] = field(default_factory=frozenset, hash=False)
-    extra: MappingProxyType = field(
-        default_factory=lambda: MappingProxyType({}), hash=False
-    )
-    secure: bool = field(default=False, hash=False)
-
-    @classmethod
-    def from_protobuf(cls, protobuf: WorkerMetadataProtobuf) -> WorkerMetadata:
-        """Create a WorkerMetadata instance from a protobuf message.
-
-        :param protobuf:
-            The protobuf WorkerMetadata message to deserialize.
-        :returns:
-            A new WorkerMetadata instance with data from the protobuf message.
-        :raises ValueError:
-            If the UID in the protobuf message is not a valid UUID.
-        """
-
-        return cls(
-            uid=uuid.UUID(protobuf.uid),
-            address=protobuf.address,
-            pid=protobuf.pid,
-            version=protobuf.version,
-            tags=frozenset(protobuf.tags),
-            extra=MappingProxyType(dict(protobuf.extra)),
-            secure=protobuf.secure,
-        )
-
-    def to_protobuf(self) -> WorkerMetadataProtobuf:
-        """Convert this WorkerMetadata instance to a protobuf message.
-
-        :returns:
-            A protobuf WorkerMetadata message containing this instance's data.
-        """
-
-        return WorkerMetadataProtobuf(
-            uid=str(self.uid),
-            address=self.address,
-            pid=self.pid,
-            version=self.version,
-            tags=list(self.tags),
-            extra=dict(self.extra),
-            secure=self.secure,
-        )
 
 
 # public

--- a/wool/src/wool/runtime/discovery/lan.py
+++ b/wool/src/wool/runtime/discovery/lan.py
@@ -27,8 +27,8 @@ from wool.runtime.discovery.base import DiscoveryEventType
 from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.base import PredicateFunction
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.pool import SubscriberMeta
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.afilter import afilter
 
 

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -29,9 +29,9 @@ from wool.runtime.discovery.base import DiscoveryEventType
 from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.base import PredicateFunction
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.pool import SubscriberMeta
 from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.afilter import afilter
 
 REF_WIDTH: Final = 16

--- a/wool/src/wool/runtime/discovery/pool.py
+++ b/wool/src/wool/runtime/discovery/pool.py
@@ -8,8 +8,8 @@ from typing import ClassVar
 
 from wool.runtime.discovery import __subscriber_pool__
 from wool.runtime.discovery.base import DiscoveryEvent
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.fanout import Fanout
 
 _subscriber_factories: dict[Any, Callable[[Any], Any]] = {}

--- a/wool/src/wool/runtime/loadbalancer/base.py
+++ b/wool/src/wool/runtime/loadbalancer/base.py
@@ -7,8 +7,8 @@ from typing import Final
 from typing import Protocol
 from typing import runtime_checkable
 
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.metadata import WorkerMetadata
 
 if TYPE_CHECKING:
     from wool.runtime.routine.task import Task

--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -60,7 +60,7 @@ async with wool.WorkerPool(size=4, discovery=wool.LanDiscovery()):
 | Property | Type | Description |
 | -------- | ---- | ----------- |
 | `uid` | `UUID` | Unique identifier assigned at construction. |
-| `metadata` | `WorkerMetadata \| None` | Full metadata including address, tags, and version. `None` before `start()`. |
+| `metadata` | `WorkerMetadata \| None` | Full metadata including address, tags, version, and transport options. `None` before `start()`. |
 | `tags` | `set[str]` | Capability tags for filtering and selection. |
 | `extra` | `dict[str, Any]` | Arbitrary key-value metadata. |
 | `address` | `str \| None` | gRPC target address (e.g. `"host:port"`, `"unix:path"`). `None` before `start()`. |
@@ -195,9 +195,45 @@ Worker subprocesses can dispatch tasks to other workers. Each subprocess is conf
 | Discovery | `discovery` | Accepts any `DiscoverySubscriberLike` or `Factory` thereof. |
 | Static | `workers` | Takes a sequence of `WorkerMetadata` directly — no discovery needed. |
 
+### Self-describing connections
+
+Workers are self-describing: each worker advertises its gRPC transport configuration via `ChannelOptions` in its `WorkerMetadata`. When a client discovers a worker, it reads the advertised options and configures its channel to match — message sizes, keepalive intervals, concurrency limits, and compression are all set automatically. There is no separate client-side configuration step; the worker's metadata is the single source of truth for how to connect to it.
+
 ### Connection pooling
 
-`WorkerConnection` is a lightweight facade that dispatches tasks over pooled gRPC channels. Channels are cached at the module level in a `ResourcePool` keyed by `(target, credentials, limit)`, with a 60-second TTL — idle channels are finalized after the TTL expires. Each channel enforces semaphore-based concurrency limiting (default 100 concurrent dispatches).
+`WorkerConnection` is a lightweight facade that dispatches tasks over pooled gRPC channels. Channels are cached at the module level in a `ResourcePool` keyed by `(target, credentials, options)`, with a 60-second TTL — idle channels are finalized after the TTL expires. Each channel's concurrency semaphore is sized by the worker's advertised `max_concurrent_streams`.
+
+### Transport configuration
+
+Transport options are split into two tiers:
+
+- **`ChannelOptions`** — settings that both the server and client apply symmetrically. Workers advertise these via `WorkerMetadata` so clients connect with identical settings. Includes message sizes (`max_receive_message_length`, `max_send_message_length`), keepalive (`keepalive_time_ms`, `keepalive_timeout_ms`, `keepalive_permit_without_calls`, `max_pings_without_data`), flow control (`max_concurrent_streams`), and compression (`compression`).
+
+- **`WorkerOptions`** — composes a `ChannelOptions` instance with server-only settings that are not communicated to clients: `http2_min_recv_ping_interval_without_data_ms` (minimum allowed client ping interval), `max_ping_strikes` (ping violations before GOAWAY), and optional connection lifecycle limits (`max_connection_idle_ms`, `max_connection_age_ms`, `max_connection_age_grace_ms`).
+
+All options default to gRPC's own defaults. Pass a `WorkerOptions` instance to `LocalWorker` or `WorkerProcess` to customize:
+
+```python
+from wool.runtime.worker.base import ChannelOptions, WorkerOptions
+from wool.runtime.worker.local import LocalWorker
+
+options = WorkerOptions(
+    channel=ChannelOptions(
+        keepalive_time_ms=10_000,
+        keepalive_timeout_ms=5_000,
+        max_concurrent_streams=50,
+    ),
+    max_connection_idle_ms=300_000,
+)
+
+async with wool.WorkerPool(
+    size=4,
+    worker=lambda *tags, credentials=None: LocalWorker(
+        *tags, credentials=credentials, options=options,
+    ),
+):
+    result = await my_routine()
+```
 
 ### Error classification
 

--- a/wool/src/wool/runtime/worker/base.py
+++ b/wool/src/wool/runtime/worker/base.py
@@ -4,6 +4,7 @@ import uuid
 from abc import ABC
 from abc import abstractmethod
 from dataclasses import dataclass
+from dataclasses import field
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Final
@@ -11,29 +12,108 @@ from typing import Protocol
 from typing import final
 from typing import runtime_checkable
 
-from wool.runtime.discovery.base import WorkerMetadata
+import grpc
 
 if TYPE_CHECKING:
     from wool.runtime.worker.auth import WorkerCredentials
+    from wool.runtime.worker.metadata import WorkerMetadata
 
 
 # public
 @dataclass(frozen=True)
-class WorkerOptions:
-    """Options for gRPC worker server and channel configuration.
+class ChannelOptions:
+    """Options for gRPC channel configuration.
 
-    Controls the maximum message sizes for gRPC communication.
-    Defaults match the client-side channel factory values to
-    ensure symmetric limits between server and client.
+    Controls the maximum message sizes and keepalive behaviour for
+    gRPC channels.  Workers advertise these options via
+    :class:`~wool.runtime.discovery.base.WorkerMetadata` so that
+    clients connect with compatible settings automatically.
 
     :param max_receive_message_length:
         Maximum inbound message size in bytes.
     :param max_send_message_length:
         Maximum outbound message size in bytes.
+    :param keepalive_time_ms:
+        Interval in milliseconds between HTTP/2 keepalive pings.
+    :param keepalive_timeout_ms:
+        Time in milliseconds to wait for a keepalive ping response
+        before considering the connection dead.
+    :param keepalive_permit_without_calls:
+        If ``True``, send keepalive pings even when there are no
+        active RPCs.
+    :param max_pings_without_data:
+        Maximum keepalive pings allowed when no data or header
+        frames have been sent.
+    :param max_concurrent_streams:
+        Maximum concurrent HTTP/2 streams per connection.  Also
+        used by the client to size its per-channel concurrency
+        semaphore.
+    :param compression:
+        Default compression algorithm for messages.
     """
 
     max_receive_message_length: int = 100 * 1024 * 1024
     max_send_message_length: int = 100 * 1024 * 1024
+    keepalive_time_ms: int = 30_000
+    keepalive_timeout_ms: int = 30_000
+    keepalive_permit_without_calls: bool = True
+    max_pings_without_data: int = 2
+    max_concurrent_streams: int = 100
+    compression: grpc.Compression = grpc.Compression.NoCompression
+
+
+# public
+@dataclass(frozen=True)
+class WorkerOptions:
+    """Options for gRPC worker server configuration.
+
+    Composes :class:`ChannelOptions` (advertised to clients) with
+    server-side settings that are not communicated over the wire.
+
+    :param channel:
+        Channel options advertised to connecting clients.
+    :param http2_min_recv_ping_interval_without_data_ms:
+        Server-side minimum allowed interval in milliseconds
+        between client keepalive pings when there is no data
+        being sent.
+    :param max_ping_strikes:
+        Maximum keepalive ping violations before the server
+        sends GOAWAY.
+    :param max_connection_idle_ms:
+        Server idle timeout in milliseconds before closing the
+        connection.  ``None`` uses gRPC's default (infinite).
+    :param max_connection_age_ms:
+        Maximum connection lifespan in milliseconds before the
+        server forces a reconnect.  ``None`` uses gRPC's default
+        (infinite).
+    :param max_connection_age_grace_ms:
+        Grace period in milliseconds for in-flight RPCs after
+        max connection age is reached.  ``None`` uses gRPC's
+        default (infinite).
+    """
+
+    channel: ChannelOptions = field(default_factory=ChannelOptions)
+    http2_min_recv_ping_interval_without_data_ms: int = 30_000
+    max_ping_strikes: int = 2
+    max_connection_idle_ms: int | None = None
+    max_connection_age_ms: int | None = None
+    max_connection_age_grace_ms: int | None = None
+
+    def __post_init__(self):
+        """Validate keepalive option compatibility.
+
+        :raises ValueError:
+            If ``channel.keepalive_time_ms`` is less than
+            ``http2_min_recv_ping_interval_without_data_ms``.
+        """
+        if (
+            self.channel.keepalive_time_ms
+            < self.http2_min_recv_ping_interval_without_data_ms
+        ):
+            raise ValueError(
+                "keepalive_time_ms must be >= "
+                "http2_min_recv_ping_interval_without_data_ms"
+            )
 
 
 # public
@@ -49,7 +129,6 @@ class WorkerFactory(Protocol):
         self,
         *tags: str,
         credentials: WorkerCredentials | None = None,
-        options: WorkerOptions | None = None,
     ) -> WorkerLike:
         """Create a new worker instance.
 
@@ -158,7 +237,7 @@ class Worker(ABC):
     .. code-block:: python
 
         from wool.runtime.worker.base import Worker
-        from wool.runtime.discovery.base import WorkerMetadata
+        from wool.runtime.worker.metadata import WorkerMetadata
 
 
         class CustomWorker(Worker):

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -17,10 +17,10 @@ from wool import protocol
 from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.routine.task import PassthroughSerializer
 from wool.runtime.routine.task import Task
-from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.base import ChannelOptions
 
 _DispatchCall: TypeAlias = grpc.aio.StreamStreamCall[protocol.Request, protocol.Response]
-_PoolKey: TypeAlias = tuple[str, grpc.ChannelCredentials | None, int, WorkerOptions]
+_PoolKey: TypeAlias = tuple[str, grpc.ChannelCredentials | None, ChannelOptions]
 
 _T = TypeVar("_T")
 
@@ -42,21 +42,33 @@ def _channel_factory(key):
     """Create a new :class:`_Channel` for the given pool key.
 
     :param key:
-        Tuple of ``(target, credentials, limit, options)``.
+        Tuple of ``(target, credentials, options)``.
     :returns:
         A new :class:`_Channel` instance.
     """
-    target, credentials, limit, worker_options = key
-    options = [
-        ("grpc.max_receive_message_length", worker_options.max_receive_message_length),
-        ("grpc.max_send_message_length", worker_options.max_send_message_length),
+    target, credentials, options = key
+    grpc_options = [
+        ("grpc.max_receive_message_length", options.max_receive_message_length),
+        ("grpc.max_send_message_length", options.max_send_message_length),
+        ("grpc.keepalive_time_ms", options.keepalive_time_ms),
+        ("grpc.keepalive_timeout_ms", options.keepalive_timeout_ms),
+        (
+            "grpc.keepalive_permit_without_calls",
+            int(options.keepalive_permit_without_calls),
+        ),
+        ("grpc.http2.max_pings_without_data", options.max_pings_without_data),
+        ("grpc.max_concurrent_streams", options.max_concurrent_streams),
+        (
+            "grpc.default_compression_algorithm",
+            options.compression.value,
+        ),
     ]
     if credentials is not None:
-        channel = grpc.aio.secure_channel(target, credentials, options=options)
+        channel = grpc.aio.secure_channel(target, credentials, options=grpc_options)
     else:
-        channel = grpc.aio.insecure_channel(target, options=options)
+        channel = grpc.aio.insecure_channel(target, options=grpc_options)
     stub = protocol.WorkerStub(channel)
-    return _Channel(channel, stub, asyncio.Semaphore(limit))
+    return _Channel(channel, stub, asyncio.Semaphore(options.max_concurrent_streams))
 
 
 async def _channel_finalizer(channel: _Channel):
@@ -298,7 +310,7 @@ class WorkerConnection:
     """gRPC connection to a worker for task dispatch.
 
     Acquires pooled gRPC channels keyed by ``(target, credentials,
-    limit, options)``.  Each :meth:`dispatch` call obtains a reference-counted
+    options)``.  Each :meth:`dispatch` call obtains a reference-counted
     channel from the module-level pool, primes an async generator that
     holds its own reference, then releases the dispatch-scope reference.
     The channel stays alive until the caller finishes consuming the
@@ -323,13 +335,14 @@ class WorkerConnection:
         - ``unix:path`` - Unix domain socket
 
         Examples: ``localhost:50051``, ``192.0.2.1:50051``
-    :param limit:
-        Maximum concurrent task dispatches.
     :param credentials:
         Optional channel credentials for TLS/mTLS connections.
     :param options:
-        Optional worker options controlling gRPC message
-        size limits. See :class:`WorkerOptions` for defaults.
+        Optional channel options controlling gRPC message
+        size limits, keepalive, concurrency, and compression.
+        See :class:`ChannelOptions` for defaults.  The
+        ``max_concurrent_streams`` field sizes the per-channel
+        concurrency semaphore.
     """
 
     TRANSIENT_ERRORS: Final = {
@@ -342,18 +355,13 @@ class WorkerConnection:
         self,
         target: str,
         *,
-        limit: int = 100,
         credentials: grpc.ChannelCredentials | None = None,
-        options: WorkerOptions | None = None,
+        options: ChannelOptions | None = None,
     ):
-        if limit <= 0:
-            raise ValueError("Limit must be positive")
-
         self._target = target
         self._credentials = credentials
-        self._limit = limit
-        self._options = options if options is not None else WorkerOptions()
-        self._key = (target, credentials, limit, self._options)
+        self._options = options if options is not None else ChannelOptions()
+        self._key: _PoolKey = (target, credentials, self._options)
         self._uds_key: _PoolKey | None = None
 
     async def dispatch(
@@ -405,7 +413,7 @@ class WorkerConnection:
         ) is not None and metadata.address == self._target:
             serializer = PassthroughSerializer()
             if (uds_address := wool.__worker_uds_address__) is not None:
-                key = (uds_address, None, self._limit, self._options)
+                key = (uds_address, None, self._options)
                 self._uds_key = key
             else:
                 key = self._key

--- a/wool/src/wool/runtime/worker/metadata.py
+++ b/wool/src/wool/runtime/worker/metadata.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from dataclasses import field
+from types import MappingProxyType
+
+import grpc
+
+from wool.protocol import ChannelOptions as ChannelOptionsProtobuf
+from wool.protocol import WorkerMetadata as WorkerMetadataProtobuf
+from wool.runtime.worker.base import ChannelOptions
+
+
+# public
+@dataclass(frozen=True)
+class WorkerMetadata:
+    """Properties and metadata for a worker instance.
+
+    Contains identifying information and capabilities of a worker that
+    can be used for discovery, filtering, and routing decisions.
+
+    :param uid:
+        Unique identifier for the worker instance (UUID).
+    :param address:
+        gRPC target address (e.g. ``"host:port"``,
+        ``"unix:path"``).
+    :param pid:
+        Process ID of the worker.
+    :param version:
+        Version string of the worker software.
+    :param tags:
+        Frozenset of capability tags for worker filtering and
+        selection.
+    :param extra:
+        Additional arbitrary metadata as immutable key-value pairs.
+    :param secure:
+        Whether the worker requires secure TLS/mTLS connections.
+    :param options:
+        Transport configuration advertised by the worker.  Clients
+        use these settings when connecting.
+    """
+
+    uid: uuid.UUID
+    address: str = field(hash=False)
+    pid: int = field(hash=False)
+    version: str = field(hash=False)
+    tags: frozenset[str] = field(default_factory=frozenset, hash=False)
+    extra: MappingProxyType = field(
+        default_factory=lambda: MappingProxyType({}), hash=False
+    )
+    secure: bool = field(default=False, hash=False)
+    options: ChannelOptions = field(default_factory=ChannelOptions, hash=False)
+
+    @classmethod
+    def from_protobuf(cls, protobuf: WorkerMetadataProtobuf) -> WorkerMetadata:
+        """Create a WorkerMetadata instance from a protobuf message.
+
+        :param protobuf:
+            The protobuf WorkerMetadata message to deserialize.
+        :returns:
+            A new WorkerMetadata instance with data from the protobuf message.
+        :raises ValueError:
+            If the UID in the protobuf message is not a valid UUID.
+        """
+
+        return cls(
+            uid=uuid.UUID(protobuf.uid),
+            address=protobuf.address,
+            pid=protobuf.pid,
+            version=protobuf.version,
+            tags=frozenset(protobuf.tags),
+            extra=MappingProxyType(dict(protobuf.extra)),
+            secure=protobuf.secure,
+            options=cls._options_from_protobuf(protobuf),
+        )
+
+    def to_protobuf(self) -> WorkerMetadataProtobuf:
+        """Convert this WorkerMetadata instance to a protobuf message.
+
+        :returns:
+            A protobuf WorkerMetadata message containing this instance's data.
+        """
+
+        msg = WorkerMetadataProtobuf(
+            uid=str(self.uid),
+            address=self.address,
+            pid=self.pid,
+            version=self.version,
+            tags=list(self.tags),
+            extra=dict(self.extra),
+            secure=self.secure,
+        )
+        msg.connection.CopyFrom(
+            ChannelOptionsProtobuf(
+                max_receive_message_length=self.options.max_receive_message_length,
+                max_send_message_length=self.options.max_send_message_length,
+                keepalive_time_ms=self.options.keepalive_time_ms,
+                keepalive_timeout_ms=self.options.keepalive_timeout_ms,
+                keepalive_permit_without_calls=self.options.keepalive_permit_without_calls,
+                max_pings_without_data=self.options.max_pings_without_data,
+                max_concurrent_streams=self.options.max_concurrent_streams,
+                compression=self.options.compression.value,
+            )
+        )
+        return msg
+
+    @classmethod
+    def _options_from_protobuf(cls, protobuf: WorkerMetadataProtobuf) -> ChannelOptions:
+        """Reconstruct ChannelOptions from the protobuf connection config.
+
+        :param protobuf:
+            The protobuf WorkerMetadata message.
+        :returns:
+            A ChannelOptions instance.  Returns default ChannelOptions
+            when no connection config is present.
+        """
+        if not protobuf.HasField("connection"):
+            return ChannelOptions()
+
+        conn = protobuf.connection
+        return ChannelOptions(
+            max_receive_message_length=conn.max_receive_message_length,
+            max_send_message_length=conn.max_send_message_length,
+            keepalive_time_ms=conn.keepalive_time_ms,
+            keepalive_timeout_ms=conn.keepalive_timeout_ms,
+            keepalive_permit_without_calls=conn.keepalive_permit_without_calls,
+            max_pings_without_data=conn.max_pings_without_data,
+            max_concurrent_streams=conn.max_concurrent_streams,
+            compression=grpc.Compression(conn.compression),
+        )

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -19,7 +19,6 @@ from wool.runtime.typing import Factory
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerFactory
 from wool.runtime.worker.base import WorkerLike
-from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.local import LocalWorker
 from wool.runtime.worker.proxy import LoadBalancerLike
 from wool.runtime.worker.proxy import RoundRobinLoadBalancer
@@ -170,7 +169,6 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
-        options: WorkerOptions | None = None,
     ):
         """
         Create an ephemeral pool of workers, spawning the specified
@@ -205,7 +203,6 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
-        options: WorkerOptions | None = None,
     ):
         """
         Create a hybrid pool that spawns local workers and discovers
@@ -223,10 +220,8 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
-        options: WorkerOptions | None = None,
     ):
         self._workers = {}
-        self._options = options
         self._credentials = credentials
 
         match (size, discovery):
@@ -258,7 +253,6 @@ class WorkerPool:
                                 discovery=discovery_svc.subscribe(_predicate(tags)),
                                 loadbalancer=loadbalancer,
                                 credentials=self._credentials,
-                                options=self._options,
                             ):
                                 yield
                     finally:
@@ -288,7 +282,6 @@ class WorkerPool:
                                 discovery=discovery.subscribe(_predicate(tags)),
                                 loadbalancer=loadbalancer,
                                 credentials=self._credentials,
-                                options=self._options,
                             ):
                                 yield
 
@@ -304,7 +297,6 @@ class WorkerPool:
                             discovery=discovery_svc.subscriber,
                             loadbalancer=loadbalancer,
                             credentials=self._credentials,
-                            options=self._options,
                         ):
                             yield
                     finally:
@@ -331,7 +323,6 @@ class WorkerPool:
                                 discovery=discovery.subscriber,
                                 loadbalancer=loadbalancer,
                                 credentials=self._credentials,
-                                options=self._options,
                             ):
                                 yield
 
@@ -373,7 +364,7 @@ class WorkerPool:
 
         tasks = []
         for _ in range(size):
-            worker = factory(*tags, credentials=self._credentials, options=self._options)
+            worker = factory(*tags, credentials=self._credentials)
 
             async def start(worker):
                 await worker.start()
@@ -398,8 +389,8 @@ class WorkerPool:
             await self._exit_context(publisher_ctx)
 
     def _default_worker_factory(self):
-        def factory(*tags, credentials=None, options=None):
-            return LocalWorker(*tags, credentials=credentials, options=options)
+        def factory(*tags, credentials=None):
+            return LocalWorker(*tags, credentials=credentials)
 
         return factory
 

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -22,12 +22,12 @@ import grpc.aio
 
 import wool
 from wool import protocol
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.worker.auth import CredentialContext
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.interceptor import VersionInterceptor
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.service import WorkerService
 
 if TYPE_CHECKING:
@@ -230,13 +230,46 @@ class WorkerProcess(Process):
             else contextlib.nullcontext()
         )
         with creds_ctx:
+            channel = self._options.channel
             grpc_options = [
                 (
                     "grpc.max_receive_message_length",
-                    self._options.max_receive_message_length,
+                    channel.max_receive_message_length,
                 ),
-                ("grpc.max_send_message_length", self._options.max_send_message_length),
+                ("grpc.max_send_message_length", channel.max_send_message_length),
+                ("grpc.keepalive_time_ms", channel.keepalive_time_ms),
+                ("grpc.keepalive_timeout_ms", channel.keepalive_timeout_ms),
+                (
+                    "grpc.keepalive_permit_without_calls",
+                    int(channel.keepalive_permit_without_calls),
+                ),
+                ("grpc.http2.max_pings_without_data", channel.max_pings_without_data),
+                ("grpc.max_concurrent_streams", channel.max_concurrent_streams),
+                (
+                    "grpc.default_compression_algorithm",
+                    channel.compression.value,
+                ),
+                (
+                    "grpc.http2.min_recv_ping_interval_without_data_ms",
+                    self._options.http2_min_recv_ping_interval_without_data_ms,
+                ),
+                ("grpc.http2.max_ping_strikes", self._options.max_ping_strikes),
             ]
+            if self._options.max_connection_idle_ms is not None:
+                grpc_options.append(
+                    ("grpc.max_connection_idle_ms", self._options.max_connection_idle_ms)
+                )
+            if self._options.max_connection_age_ms is not None:
+                grpc_options.append(
+                    ("grpc.max_connection_age_ms", self._options.max_connection_age_ms)
+                )
+            if self._options.max_connection_age_grace_ms is not None:
+                grpc_options.append(
+                    (
+                        "grpc.max_connection_age_grace_ms",
+                        self._options.max_connection_age_grace_ms,
+                    )
+                )
             server = grpc.aio.server(
                 interceptors=[VersionInterceptor()], options=grpc_options
             )
@@ -277,6 +310,7 @@ class WorkerProcess(Process):
                         tags=self._tags,
                         extra=MappingProxyType(self._extra),
                         secure=self._credentials is not None,
+                        options=self._options.channel,
                     )
                     wool.__worker_metadata__ = metadata
                     wool.__worker_uds_address__ = uds_address

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -22,7 +22,6 @@ from packaging.version import Version
 import wool
 from wool.runtime.discovery.base import DiscoveryEvent
 from wool.runtime.discovery.base import DiscoverySubscriberLike
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.local import LocalDiscovery
 from wool.runtime.loadbalancer.base import LoadBalancerContext
 from wool.runtime.loadbalancer.base import LoadBalancerLike
@@ -32,8 +31,8 @@ from wool.runtime.typing import Undefined
 from wool.runtime.typing import UndefinedType
 from wool.runtime.worker.auth import CredentialContext
 from wool.runtime.worker.auth import WorkerCredentials
-from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.metadata import WorkerMetadata
 
 if TYPE_CHECKING:
     from wool.runtime.routine.task import Task
@@ -205,7 +204,6 @@ class WorkerProxy:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
-        options: WorkerOptions | None = None,
     ): ...
 
     @overload
@@ -217,7 +215,6 @@ class WorkerProxy:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
-        options: WorkerOptions | None = None,
     ): ...
 
     @overload
@@ -229,7 +226,6 @@ class WorkerProxy:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
-        options: WorkerOptions | None = None,
     ): ...
 
     def __init__(
@@ -244,7 +240,6 @@ class WorkerProxy:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
-        options: WorkerOptions | None = None,
     ):
         if not (pool_uri or discovery or workers):
             raise ValueError(
@@ -280,7 +275,6 @@ class WorkerProxy:
             self._credentials = CredentialContext.current()
         else:
             self._credentials = credentials
-        self._options = options
 
         # Create security filter based on resolved credentials
         security_filter = self._create_security_filter(self._credentials)
@@ -334,10 +328,10 @@ class WorkerProxy:
     def __reduce__(self) -> tuple:
         """Return constructor args for unpickling with proxy ID preserved.
 
-        Creates a new WorkerProxy instance with the same discovery stream,
-        load balancer type, and options, then sets the preserved proxy ID
-        on the new object.  Credentials are NOT serialized — the restored
-        proxy resolves them from the active credential context.
+        Creates a new WorkerProxy instance with the same discovery stream
+        and load balancer type, then sets the preserved proxy ID on the
+        new object.  Credentials are NOT serialized — the restored proxy
+        resolves them from the active credential context.
 
         :returns:
             Tuple of (callable, args) for unpickling.
@@ -358,18 +352,17 @@ class WorkerProxy:
                     f"{name}=my_cm())."
                 )
 
-        def _restore_proxy(discovery, loadbalancer, options, proxy_id):
+        def _restore_proxy(discovery, loadbalancer, proxy_id):
             proxy = WorkerProxy(
                 discovery=discovery,
                 loadbalancer=loadbalancer,
-                options=options,
             )
             proxy._id = proxy_id
             return proxy
 
         return (
             _restore_proxy,
-            (self._discovery, self._loadbalancer, self._options, self._id),
+            (self._discovery, self._loadbalancer, self._id),
         )
 
     @property
@@ -552,23 +545,17 @@ class WorkerProxy:
         )
         async for event in self._discovery_stream:
             match event.type:
-                case "worker-added":
-                    self._loadbalancer_context.add_worker(
-                        event.metadata,
-                        WorkerConnection(
-                            event.metadata.address,
-                            credentials=client_credentials,
-                            options=self._options,
-                        ),
+                case "worker-added" | "worker-updated":
+                    connection = WorkerConnection(
+                        event.metadata.address,
+                        credentials=client_credentials,
+                        options=event.metadata.options,
                     )
-                case "worker-updated":
-                    self._loadbalancer_context.update_worker(
-                        event.metadata,
-                        WorkerConnection(
-                            event.metadata.address,
-                            credentials=client_credentials,
-                            options=self._options,
-                        ),
-                    )
+                    if event.type == "worker-added":
+                        self._loadbalancer_context.add_worker(event.metadata, connection)
+                    else:
+                        self._loadbalancer_context.update_worker(
+                            event.metadata, connection
+                        )
                 case "worker-dropped":
                     self._loadbalancer_context.remove_worker(event.metadata)

--- a/wool/src/wool/utilities/afilter.py
+++ b/wool/src/wool/utilities/afilter.py
@@ -6,7 +6,7 @@ from typing import Final
 from wool.runtime.discovery.base import DiscoveryEvent
 from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.base import PredicateFunction
-from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.worker.metadata import WorkerMetadata
 
 
 class afilter:

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from dataclasses import fields
 from enum import Enum
 from enum import auto
+from functools import partial
 
 import grpc
 import pytest
@@ -33,6 +34,7 @@ from wool.runtime.context import RuntimeContext
 from wool.runtime.discovery.local import LocalDiscovery
 from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
 from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.base import ChannelOptions
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.local import LocalWorker
 from wool.runtime.worker.pool import WorkerPool
@@ -88,6 +90,7 @@ class CredentialType(Enum):
 class WorkerOptionsKind(Enum):
     DEFAULT = auto()
     RESTRICTIVE = auto()
+    KEEPALIVE = auto()
 
 
 class TimeoutKind(Enum):
@@ -188,11 +191,22 @@ async def build_pool_from_scenario(scenario, credentials_map):
 
     if scenario.options is WorkerOptionsKind.RESTRICTIVE:
         options = WorkerOptions(
-            max_receive_message_length=64 * 1024,
-            max_send_message_length=64 * 1024,
+            channel=ChannelOptions(
+                max_receive_message_length=64 * 1024,
+                max_send_message_length=64 * 1024,
+            ),
+        )
+    elif scenario.options is WorkerOptionsKind.KEEPALIVE:
+        options = WorkerOptions(
+            channel=ChannelOptions(
+                keepalive_time_ms=10000,
+                keepalive_timeout_ms=5000,
+                keepalive_permit_without_calls=True,
+            ),
+            http2_min_recv_ping_interval_without_data_ms=5000,
         )
     else:
-        options = None
+        options = WorkerOptions()
 
     lb: object
     match scenario.lb:
@@ -283,7 +297,7 @@ async def build_pool_from_scenario(scenario, credentials_map):
                 pool_kwargs = {
                     "loadbalancer": lb,
                     "credentials": creds,
-                    "options": options,
+                    "worker": partial(LocalWorker, options=options),
                 }
                 match scenario.pool_mode:
                     case PoolMode.DEFAULT:
@@ -316,7 +330,7 @@ async def build_pool_from_scenario(scenario, credentials_map):
                         nested_pool = WorkerPool(
                             size=nested_size,
                             credentials=creds,
-                            options=options,
+                            worker=partial(LocalWorker, options=options),
                         )
                         async with nested_pool:
                             yield pool
@@ -354,7 +368,6 @@ async def _durable_pool_context(lb, creds, options):
                         discovery=_DirectDiscovery(discovery),
                         loadbalancer=lb,
                         credentials=creds,
-                        options=options,
                     )
                     async with pool:
                         yield pool
@@ -388,13 +401,11 @@ async def _durable_shared_pool_context(lb, creds, options):
                         discovery=shared,
                         loadbalancer=lb,
                         credentials=creds,
-                        options=options,
                     )
                     pool_b = WorkerPool(
                         discovery=shared,
                         loadbalancer=lb,
                         credentials=creds,
-                        options=options,
                     )
                     async with pool_a:
                         async with pool_b:
@@ -469,7 +480,6 @@ async def _durable_joined_pool_context(discovery_factory, lb, creds, options):
                         discovery=joiner,
                         loadbalancer=lb,
                         credentials=creds,
-                        options=options,
                     )
                     async with pool:
                         yield pool

--- a/wool/tests/integration/test_integration.py
+++ b/wool/tests/integration/test_integration.py
@@ -82,6 +82,18 @@ async def test_dispatch_pairwise(scenario, credentials_map, retry_grpc_internal)
         RoutineBinding.MODULE_FUNCTION,
     )
 )
+@example(
+    scenario=Scenario(
+        RoutineShape.COROUTINE,
+        PoolMode.DEFAULT,
+        DiscoveryFactory.NONE,
+        LbFactory.CLASS_REF,
+        CredentialType.INSECURE,
+        WorkerOptionsKind.KEEPALIVE,
+        TimeoutKind.NONE,
+        RoutineBinding.MODULE_FUNCTION,
+    )
+)
 @given(scenario=scenarios_strategy())
 async def test_dispatch_hypothesis(scenario, credentials_map, retry_grpc_internal):
     """Test routine dispatch with Hypothesis-generated scenarios.

--- a/wool/tests/integration/test_pool_composition.py
+++ b/wool/tests/integration/test_pool_composition.py
@@ -207,6 +207,38 @@ class TestPoolComposition:
         assert result == 3
 
     @pytest.mark.asyncio
+    async def test_build_pool_from_scenario_with_keepalive_opts(self, credentials_map):
+        """Test building a pool with keepalive worker options.
+
+        Given:
+            A complete scenario using KEEPALIVE worker options (10s ping
+            interval, 5s timeout).
+        When:
+            A pool is built and a small-payload coroutine is dispatched.
+        Then:
+            It should return the correct result with keepalive options
+            active on both server and client.
+        """
+        # Arrange
+        scenario = Scenario(
+            shape=RoutineShape.COROUTINE,
+            pool_mode=PoolMode.DEFAULT,
+            discovery=DiscoveryFactory.NONE,
+            lb=LbFactory.CLASS_REF,
+            credential=CredentialType.INSECURE,
+            options=WorkerOptionsKind.KEEPALIVE,
+            timeout=TimeoutKind.NONE,
+            binding=RoutineBinding.MODULE_FUNCTION,
+        )
+
+        # Act
+        async with build_pool_from_scenario(scenario, credentials_map):
+            result = await invoke_routine(scenario)
+
+        # Assert
+        assert result == 3
+
+    @pytest.mark.asyncio
     async def test_build_pool_from_scenario_with_dispatch_timeout(self, credentials_map):
         """Test building a pool with dispatch_timeout via RuntimeContext.
 

--- a/wool/tests/runtime/discovery/test_base.py
+++ b/wool/tests/runtime/discovery/test_base.py
@@ -2,6 +2,7 @@ import uuid
 from types import MappingProxyType
 from typing import AsyncIterator
 
+import grpc
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
@@ -13,7 +14,8 @@ from wool.runtime.discovery.base import DiscoveryEventType
 from wool.runtime.discovery.base import DiscoveryLike
 from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.base import DiscoverySubscriberLike
-from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.worker.base import ChannelOptions
+from wool.runtime.worker.metadata import WorkerMetadata
 
 
 @pytest.fixture
@@ -92,6 +94,7 @@ class TestWorkerMetadata:
         # Assert
         assert worker.tags == frozenset()
         assert worker.extra == MappingProxyType({})
+        assert worker.options == ChannelOptions()
 
     def test_hash(self):
         """Test WorkerMetadata hash is based on uid only.
@@ -153,6 +156,7 @@ class TestWorkerMetadata:
         assert worker.version == "1.0.0"
         assert worker.tags == frozenset(["test", "worker"])
         assert worker.extra == MappingProxyType({"key": "value"})
+        assert worker.options == ChannelOptions()
 
     def test_from_protobuf_invalid_uuid(self):
         """Test from_protobuf() with invalid UUID string.
@@ -196,6 +200,98 @@ class TestWorkerMetadata:
         assert protobuf.version == "1.0.0"
         assert set(protobuf.tags) == {"test", "worker"}
         assert dict(protobuf.extra) == {"key": "value"}
+        assert protobuf.HasField("connection")
+
+    def test_to_protobuf_with_options(self):
+        """Test to_protobuf() sets connection sub-message with default options.
+
+        Given:
+            A WorkerMetadata with options=ChannelOptions()
+        When:
+            Converting to protobuf
+        Then:
+            It should populate the connection sub-message with default option values
+        """
+        # Arrange
+        worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="localhost:50051",
+            pid=12345,
+            version="1.0.0",
+            options=ChannelOptions(),
+        )
+
+        # Act
+        protobuf = worker.to_protobuf()
+
+        # Assert
+        assert protobuf.HasField("connection")
+        assert protobuf.connection.keepalive_time_ms == 30000
+        assert protobuf.connection.keepalive_timeout_ms == 30000
+        assert protobuf.connection.keepalive_permit_without_calls is True
+
+    def test_from_protobuf_with_options_roundtrip(self):
+        """Test options roundtrip through protobuf serialization.
+
+        Given:
+            A WorkerMetadata with options=ChannelOptions(keepalive_time_ms=60000)
+        When:
+            to_protobuf() and from_protobuf() roundtrip
+        Then:
+            It should preserve the ChannelOptions with keepalive_time_ms=60000
+        """
+        # Arrange
+        options = ChannelOptions(keepalive_time_ms=60000)
+        worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="localhost:50051",
+            pid=12345,
+            version="1.0.0",
+            options=options,
+        )
+
+        # Act
+        protobuf = worker.to_protobuf()
+        restored = WorkerMetadata.from_protobuf(protobuf)
+
+        # Assert
+        assert restored.options == options
+
+    def test_from_protobuf_with_transport_options_roundtrip(self):
+        """Test options roundtrip with all transport-layer fields.
+
+        Given:
+            A WorkerMetadata with options including max_pings_without_data,
+            max_concurrent_streams, and compression=Gzip
+        When:
+            to_protobuf() and from_protobuf() roundtrip
+        Then:
+            It should preserve all ChannelOptions fields including the
+            new transport-layer fields
+        """
+        # Arrange
+        options = ChannelOptions(
+            max_pings_without_data=5,
+            max_concurrent_streams=50,
+            compression=grpc.Compression.Gzip,
+        )
+        worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="localhost:50051",
+            pid=12345,
+            version="1.0.0",
+            options=options,
+        )
+
+        # Act
+        protobuf = worker.to_protobuf()
+        restored = WorkerMetadata.from_protobuf(protobuf)
+
+        # Assert
+        assert restored.options == options
+        assert restored.options.max_pings_without_data == 5
+        assert restored.options.max_concurrent_streams == 50
+        assert restored.options.compression is grpc.Compression.Gzip
 
     def test_to_protobuf_with_secure_flag_roundtrip(self):
         """Test secure=True roundtrip through protobuf serialization.
@@ -227,12 +323,27 @@ class TestWorkerMetadata:
         address=st.from_regex(r"^[a-zA-Z0-9._-]+:[0-9]+$", fullmatch=True),
         pid=st.integers(min_value=1, max_value=2147483647),
         version=st.text(min_size=1),
+        options=st.builds(
+            ChannelOptions,
+            max_receive_message_length=st.integers(
+                min_value=1, max_value=200 * 1024 * 1024
+            ),
+            max_send_message_length=st.integers(
+                min_value=1, max_value=200 * 1024 * 1024
+            ),
+            keepalive_time_ms=st.integers(min_value=1000, max_value=300_000),
+            keepalive_timeout_ms=st.integers(min_value=1000, max_value=300_000),
+            keepalive_permit_without_calls=st.booleans(),
+            max_pings_without_data=st.integers(min_value=0, max_value=10),
+            max_concurrent_streams=st.integers(min_value=1, max_value=1000),
+            compression=st.sampled_from(grpc.Compression),
+        ),
     )
-    def test_roundtrip_conversion(self, address, pid, version):
+    def test_roundtrip_conversion(self, address, pid, version, options):
         """Test round-trip conversion preserves WorkerMetadata data.
 
         Given:
-            A WorkerMetadata instance with arbitrary field values
+            A WorkerMetadata instance with arbitrary field values including optional ChannelOptions drawn from the full domain
         When:
             Converting to protobuf and back to WorkerMetadata
         Then:
@@ -245,6 +356,7 @@ class TestWorkerMetadata:
             address=address,
             pid=pid,
             version=version,
+            options=options,
         )
 
         # Act
@@ -258,6 +370,7 @@ class TestWorkerMetadata:
         assert deserialized.version == original.version
         assert deserialized.tags == original.tags
         assert deserialized.extra == original.extra
+        assert deserialized.options == original.options
 
 
 class TestDiscoveryEvent:

--- a/wool/tests/runtime/discovery/test_lan.py
+++ b/wool/tests/runtime/discovery/test_lan.py
@@ -11,8 +11,8 @@ from hypothesis import strategies as st
 from zeroconf import ServiceInfo
 
 from wool.runtime.discovery.base import DiscoverySubscriberLike
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.lan import LanDiscovery
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.afilter import afilter
 
 _TEST_NAMESPACE = "test-namespace"

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -11,8 +11,8 @@ from hypothesis import settings
 from hypothesis import strategies as st
 
 from wool.runtime.discovery.base import DiscoverySubscriberLike
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.afilter import afilter
 
 

--- a/wool/tests/runtime/discovery/test_pool.py
+++ b/wool/tests/runtime/discovery/test_pool.py
@@ -7,12 +7,12 @@ import pytest
 
 from wool.runtime.discovery import __subscriber_pool__
 from wool.runtime.discovery.base import DiscoveryEvent
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.pool import SubscriberMeta
 from wool.runtime.discovery.pool import _pool_factory
 from wool.runtime.discovery.pool import _SharedSubscription
 from wool.runtime.discovery.pool import _subscriber_factories
 from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.worker.metadata import WorkerMetadata
 
 
 class _StubSubscriber(metaclass=SubscriberMeta):

--- a/wool/tests/runtime/loadbalancer/test_base.py
+++ b/wool/tests/runtime/loadbalancer/test_base.py
@@ -4,11 +4,11 @@ from uuid import uuid4
 from hypothesis import given
 from hypothesis import strategies as st
 
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.loadbalancer.base import LoadBalancerContext
 from wool.runtime.loadbalancer.base import LoadBalancerContextLike
 from wool.runtime.loadbalancer.base import LoadBalancerLike
 from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.metadata import WorkerMetadata
 
 
 @st.composite

--- a/wool/tests/runtime/loadbalancer/test_roundrobin.py
+++ b/wool/tests/runtime/loadbalancer/test_roundrobin.py
@@ -9,7 +9,6 @@ from hypothesis import settings
 from hypothesis import strategies as st
 from pytest_mock import MockerFixture
 
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.loadbalancer.base import LoadBalancerContext
 from wool.runtime.loadbalancer.base import LoadBalancerLike
 from wool.runtime.loadbalancer.base import NoWorkersAvailable
@@ -19,6 +18,7 @@ from wool.runtime.routine.task import WorkerProxyLike
 from wool.runtime.worker.connection import RpcError
 from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.metadata import WorkerMetadata
 
 
 @st.composite

--- a/wool/tests/runtime/worker/conftest.py
+++ b/wool/tests/runtime/worker/conftest.py
@@ -31,8 +31,8 @@ from pytest_mock import MockerFixture
 
 import wool.runtime.worker.pool as wp
 from wool.runtime.discovery.base import DiscoveryEvent
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.metadata import WorkerMetadata
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/wool/tests/runtime/worker/test_base.py
+++ b/wool/tests/runtime/worker/test_base.py
@@ -2,50 +2,80 @@ import uuid
 from types import MappingProxyType
 from typing import Any
 
+import grpc
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.worker.base import ChannelOptions
 from wool.runtime.worker.base import Worker
 from wool.runtime.worker.base import WorkerFactory
 from wool.runtime.worker.base import WorkerLike
 from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.metadata import WorkerMetadata
 
 
-class TestWorkerOptions:
-    """Test suite for WorkerOptions dataclass."""
+class TestChannelOptions:
+    """Test suite for ChannelOptions dataclass."""
 
     def test___init___with_default_values(self):
-        """Test WorkerOptions default constructor yields 100 MB limits.
+        """Test ChannelOptions default constructor yields 100 MB limits.
 
         Given:
             No custom parameters
         When:
-            WorkerOptions is instantiated
+            ChannelOptions is instantiated
         Then:
-            Both max_receive_message_length and max_send_message_length
-            should be 100 MB
+            All fields should have their default values
         """
         # Act
-        opts = WorkerOptions()
+        opts = ChannelOptions()
 
         # Assert
         assert opts.max_receive_message_length == 100 * 1024 * 1024
         assert opts.max_send_message_length == 100 * 1024 * 1024
+        assert opts.keepalive_time_ms == 30_000
+        assert opts.keepalive_timeout_ms == 30_000
+        assert opts.keepalive_permit_without_calls is True
+        assert opts.max_pings_without_data == 2
+        assert opts.max_concurrent_streams == 100
+        assert opts.compression is grpc.Compression.NoCompression
 
-    def test___init___with_custom_values(self):
-        """Test WorkerOptions with custom values for both attributes.
+    def test___init___with_custom_transport_options(self):
+        """Test ChannelOptions with custom transport options.
+
+        Given:
+            Custom max_pings_without_data, max_concurrent_streams,
+            and compression values
+        When:
+            ChannelOptions is instantiated with those values
+        Then:
+            All three fields should reflect the provided values
+        """
+        # Act
+        opts = ChannelOptions(
+            max_pings_without_data=5,
+            max_concurrent_streams=50,
+            compression=grpc.Compression.Gzip,
+        )
+
+        # Assert
+        assert opts.max_pings_without_data == 5
+        assert opts.max_concurrent_streams == 50
+        assert opts.compression is grpc.Compression.Gzip
+
+    def test___init___with_custom_message_sizes(self):
+        """Test ChannelOptions with custom message size values.
 
         Given:
             Custom max_receive_message_length and max_send_message_length
         When:
-            WorkerOptions is instantiated with those values
+            ChannelOptions is instantiated with those values
         Then:
             Both attributes should reflect the custom values
         """
         # Act
-        opts = WorkerOptions(
+        opts = ChannelOptions(
             max_receive_message_length=50 * 1024 * 1024,
             max_send_message_length=25 * 1024 * 1024,
         )
@@ -55,22 +85,256 @@ class TestWorkerOptions:
         assert opts.max_send_message_length == 25 * 1024 * 1024
 
     def test___init___with_partial_override(self):
-        """Test WorkerOptions with only one attribute overridden.
+        """Test ChannelOptions with only one attribute overridden.
 
         Given:
             Custom max_receive_message_length only
         When:
-            WorkerOptions is instantiated with that value
+            ChannelOptions is instantiated with that value
         Then:
             max_receive_message_length should reflect the custom value
             and max_send_message_length should keep the default
         """
         # Act
-        opts = WorkerOptions(max_receive_message_length=200 * 1024 * 1024)
+        opts = ChannelOptions(max_receive_message_length=200 * 1024 * 1024)
 
         # Assert
         assert opts.max_receive_message_length == 200 * 1024 * 1024
         assert opts.max_send_message_length == 100 * 1024 * 1024
+
+    def test___init___with_keepalive_time_and_timeout(self):
+        """Test ChannelOptions with custom keepalive time and timeout.
+
+        Given:
+            Custom keepalive_time_ms and keepalive_timeout_ms values
+        When:
+            ChannelOptions is instantiated with those values
+        Then:
+            Both fields should reflect the custom values
+        """
+        # Act
+        opts = ChannelOptions(
+            keepalive_time_ms=30000,
+            keepalive_timeout_ms=10000,
+        )
+
+        # Assert
+        assert opts.keepalive_time_ms == 30000
+        assert opts.keepalive_timeout_ms == 10000
+
+    def test___init___with_keepalive_permit_without_calls_disabled(self):
+        """Test ChannelOptions with keepalive_permit_without_calls disabled.
+
+        Given:
+            keepalive_permit_without_calls set to False
+        When:
+            ChannelOptions is instantiated
+        Then:
+            It should store False for keepalive_permit_without_calls
+        """
+        # Act
+        opts = ChannelOptions(keepalive_permit_without_calls=False)
+
+        # Assert
+        assert opts.keepalive_permit_without_calls is False
+
+    def test___init___with_all_keepalive_options(self):
+        """Test ChannelOptions with all keepalive fields set.
+
+        Given:
+            All three keepalive parameters specified
+        When:
+            ChannelOptions is instantiated
+        Then:
+            All fields should reflect the provided values
+        """
+        # Act
+        opts = ChannelOptions(
+            keepalive_time_ms=30000,
+            keepalive_timeout_ms=10000,
+            keepalive_permit_without_calls=True,
+        )
+
+        # Assert
+        assert opts.keepalive_time_ms == 30000
+        assert opts.keepalive_timeout_ms == 10000
+        assert opts.keepalive_permit_without_calls is True
+
+
+class TestWorkerOptions:
+    """Test suite for WorkerOptions dataclass."""
+
+    def test___init___with_default_values(self):
+        """Test WorkerOptions default constructor yields default ChannelOptions.
+
+        Given:
+            No custom parameters
+        When:
+            WorkerOptions is instantiated
+        Then:
+            It should contain default ChannelOptions and default
+            http2_min_recv_ping_interval_without_data_ms
+        """
+        # Act
+        opts = WorkerOptions()
+
+        # Assert
+        assert opts.channel == ChannelOptions()
+        assert opts.http2_min_recv_ping_interval_without_data_ms == 30_000
+        assert opts.max_ping_strikes == 2
+        assert opts.max_connection_idle_ms is None
+        assert opts.max_connection_age_ms is None
+        assert opts.max_connection_age_grace_ms is None
+
+    def test___init___with_custom_server_only_options(self):
+        """Test WorkerOptions with custom server-only fields.
+
+        Given:
+            Custom max_ping_strikes and all three lifecycle options
+        When:
+            WorkerOptions is instantiated with those values
+        Then:
+            All four server-only fields should reflect the provided values
+        """
+        # Act
+        opts = WorkerOptions(
+            max_ping_strikes=5,
+            max_connection_idle_ms=60000,
+            max_connection_age_ms=120000,
+            max_connection_age_grace_ms=5000,
+        )
+
+        # Assert
+        assert opts.max_ping_strikes == 5
+        assert opts.max_connection_idle_ms == 60000
+        assert opts.max_connection_age_ms == 120000
+        assert opts.max_connection_age_grace_ms == 5000
+
+    def test___init___with_custom_channel_options(self):
+        """Test WorkerOptions with custom ChannelOptions.
+
+        Given:
+            A ChannelOptions instance with custom message sizes
+        When:
+            WorkerOptions is instantiated with that ChannelOptions
+        Then:
+            The channel field should reflect the custom values
+        """
+        # Act
+        channel = ChannelOptions(
+            max_receive_message_length=50 * 1024 * 1024,
+            max_send_message_length=25 * 1024 * 1024,
+        )
+        opts = WorkerOptions(channel=channel)
+
+        # Assert
+        assert opts.channel.max_receive_message_length == 50 * 1024 * 1024
+        assert opts.channel.max_send_message_length == 25 * 1024 * 1024
+
+    def test___init___with_custom_http2_min_ping_interval(self):
+        """Test WorkerOptions with custom http2_min_recv_ping_interval_without_data_ms.
+
+        Given:
+            A custom http2_min_recv_ping_interval_without_data_ms value
+        When:
+            WorkerOptions is instantiated
+        Then:
+            It should store the custom value
+        """
+        # Act
+        opts = WorkerOptions(http2_min_recv_ping_interval_without_data_ms=20000)
+
+        # Assert
+        assert opts.http2_min_recv_ping_interval_without_data_ms == 20000
+
+    def test___init___with_keepalive_time_below_min_ping_interval(self):
+        """Test WorkerOptions raises ValueError when channel.keepalive_time_ms < http2_min_recv_ping_interval_without_data_ms.
+
+        Given:
+            A ChannelOptions with keepalive_time_ms=5000 and http2_min_recv_ping_interval_without_data_ms=10000
+        When:
+            WorkerOptions is instantiated
+        Then:
+            It should raise ValueError
+        """
+        # Act & assert
+        with pytest.raises(
+            ValueError,
+            match="keepalive_time_ms must be >= http2_min_recv_ping_interval_without_data_ms",
+        ):
+            WorkerOptions(
+                channel=ChannelOptions(keepalive_time_ms=5000),
+                http2_min_recv_ping_interval_without_data_ms=10000,
+            )
+
+    def test___init___with_keepalive_time_equal_to_min_ping_interval(self):
+        """Test WorkerOptions accepts channel.keepalive_time_ms equal to http2_min_recv_ping_interval_without_data_ms.
+
+        Given:
+            A ChannelOptions with keepalive_time_ms=10000 and http2_min_recv_ping_interval_without_data_ms=10000
+        When:
+            WorkerOptions is instantiated
+        Then:
+            It should succeed without error
+        """
+        # Act
+        opts = WorkerOptions(
+            channel=ChannelOptions(keepalive_time_ms=10000),
+            http2_min_recv_ping_interval_without_data_ms=10000,
+        )
+
+        # Assert
+        assert opts.channel.keepalive_time_ms == 10000
+        assert opts.http2_min_recv_ping_interval_without_data_ms == 10000
+
+    def test___init___with_keepalive_time_above_min_ping_interval(self):
+        """Test WorkerOptions accepts channel.keepalive_time_ms above http2_min_recv_ping_interval_without_data_ms.
+
+        Given:
+            A ChannelOptions with keepalive_time_ms=20000 and http2_min_recv_ping_interval_without_data_ms=10000
+        When:
+            WorkerOptions is instantiated
+        Then:
+            It should succeed without error
+        """
+        # Act
+        opts = WorkerOptions(
+            channel=ChannelOptions(keepalive_time_ms=20000),
+            http2_min_recv_ping_interval_without_data_ms=10000,
+        )
+
+        # Assert
+        assert opts.channel.keepalive_time_ms == 20000
+        assert opts.http2_min_recv_ping_interval_without_data_ms == 10000
+
+    @given(
+        keepalive_time_ms=st.integers(min_value=1, max_value=300000),
+        min_ping_interval=st.integers(min_value=1, max_value=300000),
+    )
+    def test___init___validation_property(self, keepalive_time_ms, min_ping_interval):
+        """Test WorkerOptions validation invariant across arbitrary values.
+
+        Given:
+            Arbitrary positive keepalive_time_ms and http2_min_recv_ping_interval_without_data_ms
+        When:
+            WorkerOptions is instantiated
+        Then:
+            It should raise ValueError iff keepalive_time_ms < http2_min_recv_ping_interval_without_data_ms
+        """
+        # Act & assert
+        if keepalive_time_ms < min_ping_interval:
+            with pytest.raises(ValueError):
+                WorkerOptions(
+                    channel=ChannelOptions(keepalive_time_ms=keepalive_time_ms),
+                    http2_min_recv_ping_interval_without_data_ms=min_ping_interval,
+                )
+        else:
+            opts = WorkerOptions(
+                channel=ChannelOptions(keepalive_time_ms=keepalive_time_ms),
+                http2_min_recv_ping_interval_without_data_ms=min_ping_interval,
+            )
+            assert opts.channel.keepalive_time_ms == keepalive_time_ms
+            assert opts.http2_min_recv_ping_interval_without_data_ms == min_ping_interval
 
 
 class ConcreteWorker(Worker):

--- a/wool/tests/runtime/worker/test_connection.py
+++ b/wool/tests/runtime/worker/test_connection.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import cloudpickle
 import grpc
+import grpc.aio
 import pytest
 from hypothesis import HealthCheck
 from hypothesis import given
@@ -16,7 +17,7 @@ import wool
 from wool import protocol
 from wool.runtime.routine.task import Task
 from wool.runtime.routine.task import WorkerProxyLike
-from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.base import ChannelOptions
 from wool.runtime.worker.connection import RpcError
 from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.connection import UnexpectedResponse
@@ -106,22 +107,6 @@ def mock_grpc_call(mocker: MockerFixture):
 
 class TestWorkerConnection:
     @pytest.mark.asyncio
-    @given(limit=st.integers(max_value=0))
-    async def test___init___with_invalid_limit(self, limit: int):
-        """Test WorkerConnection initialization with invalid limit.
-
-        Given:
-            An invalid limit value (0 or negative)
-        When:
-            WorkerConnection is instantiated
-        Then:
-            It should raise ValueError with appropriate message
-        """
-        # Act & assert
-        with pytest.raises(ValueError, match="Limit must be positive"):
-            WorkerConnection("localhost:50051", limit=limit)
-
-    @pytest.mark.asyncio
     async def test_dispatch_task_that_returns(
         self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
     ):
@@ -150,7 +135,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act
         results = []
@@ -194,7 +181,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act & assert
         with pytest.raises(ValueError, match="task_error"):
@@ -229,7 +218,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act & assert
         with pytest.raises(UnexpectedResponse, match="Expected 'ack' response"):
@@ -273,7 +264,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act & assert
         with pytest.raises(
@@ -321,7 +314,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(side_effect=mock_rpc_error)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act & assert
         with pytest.raises(TransientRpcError):
@@ -367,7 +362,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(side_effect=mock_rpc_error)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act & assert
         with pytest.raises(RpcError):
@@ -388,7 +385,9 @@ class TestWorkerConnection:
             It should raise ValueError and not attempt dispatch
         """
         # Arrange
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         async def test_callable():
             return "test"
@@ -431,7 +430,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act & assert
         with pytest.raises(TimeoutError):
@@ -467,7 +468,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=long_running_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=1)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=1)
+        )
 
         async def consume_slot():
             async for _ in await connection.dispatch(sample_task):
@@ -532,7 +535,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act
         async def run_dispatch():
@@ -590,7 +595,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act
         async def run_dispatch():
@@ -619,7 +626,9 @@ class TestWorkerConnection:
             It should complete without error each time
         """
         # Arrange
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act & assert — should not raise on repeated calls
         await connection.close()
@@ -666,7 +675,9 @@ class TestWorkerConnection:
         mock_channel = mocker.AsyncMock()
         mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
 
-        connection = WorkerConnection(target, limit=10)
+        connection = WorkerConnection(
+            target, options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         async for _ in await connection.dispatch(sample_task):
             pass
@@ -683,8 +694,8 @@ class TestWorkerConnection:
         # Assert
         cleared_keys = [c.args[0] for c in clear_spy.call_args_list]
         assert len(cleared_keys) == 2
-        assert (target, None, 10, connection._options) in cleared_keys
-        assert (uds_target, None, 10, connection._options) in cleared_keys
+        assert (target, None, connection._options) in cleared_keys
+        assert (uds_target, None, connection._options) in cleared_keys
 
     @pytest.mark.asyncio
     async def test_dispatch_task_that_yields_multiple_results(
@@ -720,7 +731,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act
         results = []
@@ -765,7 +778,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act
         results = []
@@ -803,7 +818,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act
         results = []
@@ -840,7 +857,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act & assert
         with pytest.raises(RpcError, match="Task rejected by worker"):
@@ -919,7 +938,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act
         gen = await connection.dispatch(sample_task)
@@ -957,7 +978,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act — obtain the stream, then consume later
         stream = await connection.dispatch(sample_task)
@@ -997,7 +1020,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act
         async for _ in await connection.dispatch(sample_task):
@@ -1040,7 +1065,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act
         with pytest.raises(RuntimeError, match="boom"):
@@ -1080,7 +1107,9 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        connection = WorkerConnection("localhost:50051", limit=10)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         async for _ in await connection.dispatch(sample_task):
             pass
@@ -1119,8 +1148,12 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(side_effect=lambda: make_call())
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        conn_a = WorkerConnection("localhost:50051", limit=10)
-        conn_b = WorkerConnection("localhost:50051", limit=10)
+        conn_a = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
+        conn_b = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
 
         # Act
         async for _ in await conn_a.dispatch(sample_task):
@@ -1135,21 +1168,21 @@ class TestWorkerConnection:
     async def test_dispatch_with_default_options(
         self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
     ):
-        """Test dispatch creates gRPC channel with default WorkerOptions.
+        """Test dispatch creates gRPC channel with default ChannelOptions.
 
         Given:
             A WorkerConnection with no options parameter.
         When:
             A task is dispatched.
         Then:
-            It should create a gRPC channel with default WorkerOptions
+            It should create a gRPC channel with default ChannelOptions
             sizes.
         """
         # Arrange
-        defaults = WorkerOptions()
+        defaults = ChannelOptions()
         mock_channel = mocker.AsyncMock()
-        mock_insecure = mocker.patch(
-            "grpc.aio.insecure_channel", return_value=mock_channel
+        mock_insecure = mocker.patch.object(
+            grpc.aio, "insecure_channel", return_value=mock_channel
         )
 
         responses = (
@@ -1184,23 +1217,23 @@ class TestWorkerConnection:
     async def test_dispatch_with_custom_options(
         self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
     ):
-        """Test dispatch creates gRPC channel with custom WorkerOptions.
+        """Test dispatch creates gRPC channel with custom ChannelOptions.
 
         Given:
-            A WorkerConnection with custom WorkerOptions message sizes.
+            A WorkerConnection with custom ChannelOptions message sizes.
         When:
             A task is dispatched.
         Then:
             It should create a gRPC channel with the custom sizes.
         """
         # Arrange
-        custom_options = WorkerOptions(
+        custom_options = ChannelOptions(
             max_receive_message_length=200 * 1024 * 1024,
             max_send_message_length=50 * 1024 * 1024,
         )
         mock_channel = mocker.AsyncMock()
-        mock_insecure = mocker.patch(
-            "grpc.aio.insecure_channel", return_value=mock_channel
+        mock_insecure = mocker.patch.object(
+            grpc.aio, "insecure_channel", return_value=mock_channel
         )
 
         responses = (
@@ -1230,6 +1263,146 @@ class TestWorkerConnection:
             "grpc.max_send_message_length",
             50 * 1024 * 1024,
         ) in call_options
+
+    @pytest.mark.asyncio
+    async def test_dispatch_with_custom_keepalive_options(
+        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+    ):
+        """Test dispatch creates gRPC channel with custom keepalive options.
+
+        Given:
+            A WorkerConnection with custom keepalive options
+        When:
+            A task is dispatched
+        Then:
+            It should create a gRPC channel whose options include all
+            keepalive entries with the custom values
+        """
+        # Arrange
+        opts = ChannelOptions(
+            keepalive_time_ms=60000,
+            keepalive_timeout_ms=10000,
+            keepalive_permit_without_calls=False,
+        )
+        mock_channel = mocker.AsyncMock()
+        mock_insecure = mocker.patch.object(
+            grpc.aio, "insecure_channel", return_value=mock_channel
+        )
+
+        responses = (
+            protocol.Response(ack=protocol.Ack()),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("ok"))),
+        )
+        mock_call = mock_grpc_call(async_stream(responses))
+
+        mock_stub = mocker.MagicMock()
+        mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+
+        connection = WorkerConnection("localhost:50051", options=opts)
+
+        # Act
+        async for _ in await connection.dispatch(sample_task):
+            pass
+
+        # Assert
+        mock_insecure.assert_called_once()
+        call_options = mock_insecure.call_args[1]["options"]
+        assert ("grpc.keepalive_time_ms", 60000) in call_options
+        assert ("grpc.keepalive_timeout_ms", 10000) in call_options
+        assert ("grpc.keepalive_permit_without_calls", 0) in call_options
+
+    @pytest.mark.asyncio
+    async def test_dispatch_with_default_keepalive_options(
+        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+    ):
+        """Test dispatch includes default keepalive options in channel.
+
+        Given:
+            A WorkerConnection with default ChannelOptions
+        When:
+            A task is dispatched
+        Then:
+            It should include all keepalive options with default values
+        """
+        # Arrange
+        opts = ChannelOptions()
+        mock_channel = mocker.AsyncMock()
+        mock_insecure = mocker.patch.object(
+            grpc.aio, "insecure_channel", return_value=mock_channel
+        )
+
+        responses = (
+            protocol.Response(ack=protocol.Ack()),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("ok"))),
+        )
+        mock_call = mock_grpc_call(async_stream(responses))
+
+        mock_stub = mocker.MagicMock()
+        mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+
+        connection = WorkerConnection("localhost:50051", options=opts)
+
+        # Act
+        async for _ in await connection.dispatch(sample_task):
+            pass
+
+        # Assert
+        mock_insecure.assert_called_once()
+        call_options = mock_insecure.call_args[1]["options"]
+        assert ("grpc.keepalive_time_ms", 30000) in call_options
+        assert ("grpc.keepalive_timeout_ms", 30000) in call_options
+        assert ("grpc.keepalive_permit_without_calls", 1) in call_options
+
+    @pytest.mark.asyncio
+    async def test_dispatch_with_custom_transport_options(
+        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+    ):
+        """Test dispatch creates gRPC channel with custom transport options.
+
+        Given:
+            A WorkerConnection with custom max_pings_without_data,
+            max_concurrent_streams, and compression=Gzip
+        When:
+            A task is dispatched
+        Then:
+            It should create a gRPC channel whose options include all
+            three transport entries with the custom values
+        """
+        # Arrange
+        opts = ChannelOptions(
+            max_pings_without_data=5,
+            max_concurrent_streams=50,
+            compression=grpc.Compression.Gzip,
+        )
+        mock_channel = mocker.AsyncMock()
+        mock_insecure = mocker.patch.object(
+            grpc.aio, "insecure_channel", return_value=mock_channel
+        )
+
+        responses = (
+            protocol.Response(ack=protocol.Ack()),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("ok"))),
+        )
+        mock_call = mock_grpc_call(async_stream(responses))
+
+        mock_stub = mocker.MagicMock()
+        mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+
+        connection = WorkerConnection("localhost:50051", options=opts)
+
+        # Act
+        async for _ in await connection.dispatch(sample_task):
+            pass
+
+        # Assert
+        mock_insecure.assert_called_once()
+        call_options = mock_insecure.call_args[1]["options"]
+        assert ("grpc.http2.max_pings_without_data", 5) in call_options
+        assert ("grpc.max_concurrent_streams", 50) in call_options
+        assert ("grpc.default_compression_algorithm", 2) in call_options
 
     @pytest.mark.asyncio
     async def test_dispatch_with_self_dispatch(

--- a/wool/tests/runtime/worker/test_local.py
+++ b/wool/tests/runtime/worker/test_local.py
@@ -6,12 +6,13 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from wool import protocol
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.worker import local as local_module
 from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.base import ChannelOptions
 from wool.runtime.worker.base import WorkerLike
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.local import LocalWorker
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.process import WorkerProcess
 
 
@@ -150,8 +151,10 @@ class TestLocalWorker:
         # Arrange
         MockWorkerProcess = mocker.patch.object(local_module, "WorkerProcess")
         opts = WorkerOptions(
-            max_receive_message_length=50 * 1024 * 1024,
-            max_send_message_length=25 * 1024 * 1024,
+            channel=ChannelOptions(
+                max_receive_message_length=50 * 1024 * 1024,
+                max_send_message_length=25 * 1024 * 1024,
+            ),
         )
 
         # Act
@@ -261,7 +264,7 @@ class TestLocalWorker:
         # Arrange
         from types import MappingProxyType
 
-        from wool.runtime.discovery.base import WorkerMetadata
+        from wool.runtime.worker.metadata import WorkerMetadata
 
         expected_metadata = WorkerMetadata(
             uid=uuid4(),
@@ -324,7 +327,7 @@ class TestLocalWorker:
         # Arrange
         from types import MappingProxyType
 
-        from wool.runtime.discovery.base import WorkerMetadata
+        from wool.runtime.worker.metadata import WorkerMetadata
 
         mock_process = mocker.MagicMock(spec=WorkerProcess)
         mock_process.address = "0.0.0.0:8080"

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -22,9 +22,8 @@ from pytest_mock import MockerFixture
 from wool.runtime.discovery.base import DiscoveryLike
 from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.base import DiscoverySubscriberLike
-from wool.runtime.discovery.base import WorkerMetadata
-from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.local import LocalWorker
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.pool import WorkerPool
 
 
@@ -1704,21 +1703,21 @@ class TestWorkerPool:
                 pass
 
     @pytest.mark.asyncio
-    async def test___aenter___with_default_options(
+    async def test___aenter___does_not_pass_options_to_proxy(
         self,
         mocker: MockerFixture,
         mock_worker_factory,
         mock_local_worker,
         mock_worker_proxy,
     ):
-        """Test pool startup forwards options=None to WorkerProxy.
+        """Test pool startup does not pass options to WorkerProxy.
 
         Given:
-            A WorkerPool with no options parameter.
+            A WorkerPool with default configuration
         When:
-            The pool is entered as an async context.
+            The pool is entered as an async context
         Then:
-            It should forward options=None to WorkerProxy.
+            It should not pass an options parameter to WorkerProxy
         """
         # Arrange
         import wool.runtime.worker.pool as wp
@@ -1735,42 +1734,4 @@ class TestWorkerPool:
         # Assert
         mock_proxy_cls.assert_called_once()
         _, proxy_kwargs = mock_proxy_cls.call_args
-        assert proxy_kwargs.get("options") is None
-
-    @pytest.mark.asyncio
-    async def test___aenter___with_custom_options(
-        self,
-        mocker: MockerFixture,
-        mock_worker_factory,
-        mock_local_worker,
-        mock_worker_proxy,
-    ):
-        """Test pool startup forwards custom options to WorkerProxy.
-
-        Given:
-            A WorkerPool with a custom WorkerOptions instance.
-        When:
-            The pool is entered as an async context.
-        Then:
-            It should forward the custom options to WorkerProxy.
-        """
-        # Arrange
-        import wool.runtime.worker.pool as wp
-
-        custom_options = WorkerOptions(
-            max_receive_message_length=200 * 1024 * 1024,
-            max_send_message_length=50 * 1024 * 1024,
-        )
-        mock_proxy_cls = mocker.patch.object(
-            wp, "WorkerProxy", return_value=mock_worker_proxy
-        )
-        pool = WorkerPool(worker=mock_worker_factory, size=1, options=custom_options)
-
-        # Act
-        async with pool:
-            pass
-
-        # Assert
-        mock_proxy_cls.assert_called_once()
-        _, proxy_kwargs = mock_proxy_cls.call_args
-        assert proxy_kwargs["options"] is custom_options
+        assert "options" not in proxy_kwargs

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -11,11 +11,12 @@ from hypothesis import settings
 from hypothesis import strategies as st
 
 from wool import protocol
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.worker import process as process_module
 from wool.runtime.worker.auth import CredentialContext
 from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.base import ChannelOptions
 from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.process import WorkerProcess
 from wool.runtime.worker.process import _proxy_factory
 from wool.runtime.worker.process import _proxy_finalizer
@@ -860,7 +861,7 @@ class TestWorkerProcess:
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.stopped.wait = mocker.AsyncMock()
@@ -918,7 +919,7 @@ class TestWorkerProcess:
         mock_server.add_insecure_port = mocker.MagicMock(return_value=8080)
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.stopped.wait = mocker.AsyncMock()
@@ -969,7 +970,7 @@ class TestWorkerProcess:
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.stopped.wait = mocker.AsyncMock()
@@ -1066,7 +1067,7 @@ class TestWorkerProcess:
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.stopped.wait = mocker.AsyncMock()
@@ -1110,7 +1111,7 @@ class TestWorkerProcess:
         mock_server.start = mocker.AsyncMock()
         mock_stop = mocker.AsyncMock()
         mock_server.stop = mock_stop
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.stopped.wait = mocker.AsyncMock(
@@ -1152,7 +1153,7 @@ class TestWorkerProcess:
         mock_server.add_secure_port = mocker.MagicMock()
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.configure_server = mocker.AsyncMock(return_value=50051)
@@ -1201,7 +1202,7 @@ class TestWorkerProcess:
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
         mock_server.add_insecure_port = mocker.MagicMock()
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.configure_server = mocker.AsyncMock(return_value=50051)
@@ -1247,7 +1248,7 @@ class TestWorkerProcess:
         mock_server.add_secure_port = mocker.MagicMock(return_value=54321)
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.configure_server = mocker.AsyncMock(return_value=54321)
@@ -1292,7 +1293,7 @@ class TestWorkerProcess:
         mock_server.add_insecure_port = mocker.MagicMock(return_value=54322)
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.configure_server = mocker.AsyncMock(return_value=54322)
@@ -1348,7 +1349,7 @@ class TestWorkerProcess:
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
         mock_server.add_insecure_port = mocker.MagicMock()
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.configure_server = mocker.AsyncMock(return_value=50051)
@@ -1397,7 +1398,7 @@ class TestWorkerProcess:
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
         mock_server.add_insecure_port = mocker.MagicMock()
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.configure_server = mocker.AsyncMock(return_value=50051)
@@ -1450,7 +1451,7 @@ class TestWorkerProcess:
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
-        mocker.patch("grpc.aio.server", return_value=mock_server)
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
 
         mock_service = mocker.MagicMock()
         mock_service.configure_server = mocker.AsyncMock(return_value=50051)
@@ -1501,7 +1502,7 @@ class TestWorkerProcess:
         """Test WorkerProcess construction with custom WorkerOptions.
 
         Given:
-            A WorkerOptions instance with custom message sizes
+            A WorkerOptions instance with custom channel message sizes
         When:
             WorkerProcess is instantiated with that options parameter
         Then:
@@ -1509,8 +1510,10 @@ class TestWorkerProcess:
         """
         # Arrange
         opts = WorkerOptions(
-            max_receive_message_length=50 * 1024 * 1024,
-            max_send_message_length=25 * 1024 * 1024,
+            channel=ChannelOptions(
+                max_receive_message_length=50 * 1024 * 1024,
+                max_send_message_length=25 * 1024 * 1024,
+            ),
         )
 
         # Act
@@ -1539,7 +1542,9 @@ class TestWorkerProcess:
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
-        mock_grpc_server = mocker.patch("grpc.aio.server", return_value=mock_server)
+        mock_grpc_server = mocker.patch.object(
+            grpc.aio, "server", return_value=mock_server
+        )
 
         mock_service = mocker.MagicMock()
         mock_service.stopped.wait = mocker.AsyncMock()
@@ -1560,6 +1565,14 @@ class TestWorkerProcess:
         expected = [
             ("grpc.max_receive_message_length", 100 * 1024 * 1024),
             ("grpc.max_send_message_length", 100 * 1024 * 1024),
+            ("grpc.keepalive_time_ms", 30000),
+            ("grpc.keepalive_timeout_ms", 30000),
+            ("grpc.keepalive_permit_without_calls", 1),
+            ("grpc.http2.max_pings_without_data", 2),
+            ("grpc.max_concurrent_streams", 100),
+            ("grpc.default_compression_algorithm", 0),
+            ("grpc.http2.min_recv_ping_interval_without_data_ms", 30000),
+            ("grpc.http2.max_ping_strikes", 2),
         ]
         assert call_kwargs["options"] == expected
 
@@ -1567,7 +1580,7 @@ class TestWorkerProcess:
         """Test run passes custom WorkerOptions to gRPC server.
 
         Given:
-            A WorkerProcess with custom WorkerOptions
+            A WorkerProcess with custom channel message sizes
         When:
             run() is called
         Then:
@@ -1575,8 +1588,10 @@ class TestWorkerProcess:
         """
         # Arrange
         opts = WorkerOptions(
-            max_receive_message_length=50 * 1024 * 1024,
-            max_send_message_length=25 * 1024 * 1024,
+            channel=ChannelOptions(
+                max_receive_message_length=50 * 1024 * 1024,
+                max_send_message_length=25 * 1024 * 1024,
+            ),
         )
         process = WorkerProcess(options=opts)
 
@@ -1587,7 +1602,9 @@ class TestWorkerProcess:
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
         mock_server.start = mocker.AsyncMock()
         mock_server.stop = mocker.AsyncMock()
-        mock_grpc_server = mocker.patch("grpc.aio.server", return_value=mock_server)
+        mock_grpc_server = mocker.patch.object(
+            grpc.aio, "server", return_value=mock_server
+        )
 
         mock_service = mocker.MagicMock()
         mock_service.stopped.wait = mocker.AsyncMock()
@@ -1608,8 +1625,275 @@ class TestWorkerProcess:
         expected = [
             ("grpc.max_receive_message_length", 50 * 1024 * 1024),
             ("grpc.max_send_message_length", 25 * 1024 * 1024),
+            ("grpc.keepalive_time_ms", 30000),
+            ("grpc.keepalive_timeout_ms", 30000),
+            ("grpc.keepalive_permit_without_calls", 1),
+            ("grpc.http2.max_pings_without_data", 2),
+            ("grpc.max_concurrent_streams", 100),
+            ("grpc.default_compression_algorithm", 0),
+            ("grpc.http2.min_recv_ping_interval_without_data_ms", 30000),
+            ("grpc.http2.max_ping_strikes", 2),
         ]
         assert call_kwargs["options"] == expected
+
+    def test_run_with_all_keepalive_options(self, mocker):
+        """Test run passes all keepalive options to gRPC server.
+
+        Given:
+            A WorkerProcess with all four keepalive options set.
+        When:
+            run() is called.
+        Then:
+            It should pass all four keepalive options alongside message
+            sizes to grpc.aio.server.
+        """
+        # Arrange
+        opts = WorkerOptions(
+            channel=ChannelOptions(
+                keepalive_time_ms=30000,
+                keepalive_timeout_ms=10000,
+                keepalive_permit_without_calls=True,
+            ),
+            http2_min_recv_ping_interval_without_data_ms=20000,
+        )
+        process = WorkerProcess(options=opts)
+
+        mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
+        mocker.patch("wool.runtime.worker.process.ResourcePool")
+
+        mock_server = mocker.MagicMock()
+        mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
+        mock_server.start = mocker.AsyncMock()
+        mock_server.stop = mocker.AsyncMock()
+        mock_grpc_server = mocker.patch.object(
+            grpc.aio, "server", return_value=mock_server
+        )
+
+        mock_service = mocker.MagicMock()
+        mock_service.stopped.wait = mocker.AsyncMock()
+        mocker.patch(
+            "wool.runtime.worker.process.WorkerService",
+            return_value=mock_service,
+        )
+        mocker.patch("wool.runtime.worker.process._signal_handlers")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
+
+        # Act
+        process.run()
+
+        # Assert
+        mock_grpc_server.assert_called_once()
+        call_kwargs = mock_grpc_server.call_args.kwargs
+        options = call_kwargs["options"]
+        assert ("grpc.keepalive_time_ms", 30000) in options
+        assert ("grpc.keepalive_timeout_ms", 10000) in options
+        assert ("grpc.keepalive_permit_without_calls", 1) in options
+        assert (
+            "grpc.http2.min_recv_ping_interval_without_data_ms",
+            20000,
+        ) in options
+
+    def test_run_with_default_keepalive_options(self, mocker):
+        """Test run includes default keepalive options in gRPC server.
+
+        Given:
+            A WorkerProcess with default WorkerOptions
+        When:
+            run() is called
+        Then:
+            It should include all keepalive options with default values
+        """
+        # Arrange
+        process = WorkerProcess()
+
+        mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
+        mocker.patch("wool.runtime.worker.process.ResourcePool")
+
+        mock_server = mocker.MagicMock()
+        mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
+        mock_server.start = mocker.AsyncMock()
+        mock_server.stop = mocker.AsyncMock()
+        mock_grpc_server = mocker.patch.object(
+            grpc.aio, "server", return_value=mock_server
+        )
+
+        mock_service = mocker.MagicMock()
+        mock_service.stopped.wait = mocker.AsyncMock()
+        mocker.patch(
+            "wool.runtime.worker.process.WorkerService",
+            return_value=mock_service,
+        )
+        mocker.patch("wool.runtime.worker.process._signal_handlers")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
+
+        # Act
+        process.run()
+
+        # Assert
+        mock_grpc_server.assert_called_once()
+        call_kwargs = mock_grpc_server.call_args.kwargs
+        options = call_kwargs["options"]
+        assert ("grpc.keepalive_time_ms", 30000) in options
+        assert ("grpc.keepalive_timeout_ms", 30000) in options
+        assert ("grpc.keepalive_permit_without_calls", 1) in options
+        assert ("grpc.http2.min_recv_ping_interval_without_data_ms", 30000) in options
+
+    def test_run_with_lifecycle_options(self, mocker):
+        """Test run includes lifecycle options when set.
+
+        Given:
+            A WorkerProcess with max_connection_idle_ms=60000,
+            max_connection_age_ms=120000, and
+            max_connection_age_grace_ms=5000
+        When:
+            run() is called
+        Then:
+            It should include all three lifecycle options in the
+            gRPC server options
+        """
+        # Arrange
+        opts = WorkerOptions(
+            max_connection_idle_ms=60000,
+            max_connection_age_ms=120000,
+            max_connection_age_grace_ms=5000,
+        )
+        process = WorkerProcess(options=opts)
+
+        mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
+        mocker.patch("wool.runtime.worker.process.ResourcePool")
+
+        mock_server = mocker.MagicMock()
+        mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
+        mock_server.start = mocker.AsyncMock()
+        mock_server.stop = mocker.AsyncMock()
+        mock_grpc_server = mocker.patch.object(
+            grpc.aio, "server", return_value=mock_server
+        )
+
+        mock_service = mocker.MagicMock()
+        mock_service.stopped.wait = mocker.AsyncMock()
+        mocker.patch(
+            "wool.runtime.worker.process.WorkerService",
+            return_value=mock_service,
+        )
+        mocker.patch("wool.runtime.worker.process._signal_handlers")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
+
+        # Act
+        process.run()
+
+        # Assert
+        mock_grpc_server.assert_called_once()
+        call_kwargs = mock_grpc_server.call_args.kwargs
+        options = call_kwargs["options"]
+        assert ("grpc.max_connection_idle_ms", 60000) in options
+        assert ("grpc.max_connection_age_ms", 120000) in options
+        assert ("grpc.max_connection_age_grace_ms", 5000) in options
+
+    def test_run_without_lifecycle_options(self, mocker):
+        """Test run omits lifecycle options when None.
+
+        Given:
+            A WorkerProcess with default WorkerOptions (lifecycle=None)
+        When:
+            run() is called
+        Then:
+            It should not include any lifecycle options in the gRPC
+            server options
+        """
+        # Arrange
+        process = WorkerProcess()
+
+        mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
+        mocker.patch("wool.runtime.worker.process.ResourcePool")
+
+        mock_server = mocker.MagicMock()
+        mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
+        mock_server.start = mocker.AsyncMock()
+        mock_server.stop = mocker.AsyncMock()
+        mock_grpc_server = mocker.patch.object(
+            grpc.aio, "server", return_value=mock_server
+        )
+
+        mock_service = mocker.MagicMock()
+        mock_service.stopped.wait = mocker.AsyncMock()
+        mocker.patch(
+            "wool.runtime.worker.process.WorkerService",
+            return_value=mock_service,
+        )
+        mocker.patch("wool.runtime.worker.process._signal_handlers")
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
+
+        # Act
+        process.run()
+
+        # Assert
+        mock_grpc_server.assert_called_once()
+        call_kwargs = mock_grpc_server.call_args.kwargs
+        option_keys = [k for k, _ in call_kwargs["options"]]
+        assert "grpc.max_connection_idle_ms" not in option_keys
+        assert "grpc.max_connection_age_ms" not in option_keys
+        assert "grpc.max_connection_age_grace_ms" not in option_keys
+
+    def test_run_serializes_channel_options_in_metadata(self, mocker):
+        """Test run sets options on metadata matching the channel config.
+
+        Given:
+            A WorkerProcess with custom WorkerOptions containing
+            non-default ChannelOptions
+        When:
+            run() executes
+        Then:
+            It should send metadata via pipe whose options field
+            equals the custom ChannelOptions
+        """
+        # Arrange
+        channel = ChannelOptions(
+            max_receive_message_length=50 * 1024 * 1024,
+            keepalive_time_ms=60000,
+            keepalive_timeout_ms=15000,
+        )
+        opts = WorkerOptions(channel=channel)
+        process = WorkerProcess(options=opts)
+
+        mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
+        mocker.patch("wool.runtime.worker.process.ResourcePool")
+
+        mock_server = mocker.MagicMock()
+        mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
+        mock_server.start = mocker.AsyncMock()
+        mock_server.stop = mocker.AsyncMock()
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
+
+        mock_service = mocker.MagicMock()
+        mock_service.stopped.wait = mocker.AsyncMock()
+        mocker.patch(
+            "wool.runtime.worker.process.WorkerService",
+            return_value=mock_service,
+        )
+        mocker.patch("wool.runtime.worker.process._signal_handlers")
+
+        sent_metadata = []
+        mocker.patch.object(
+            process._set_metadata,
+            "send",
+            side_effect=lambda x: sent_metadata.append(x),
+        )
+        mocker.patch.object(process._set_metadata, "close")
+
+        # Act
+        process.run()
+
+        # Assert
+        assert len(sent_metadata) == 1
+        deserialized = WorkerMetadata.from_protobuf(
+            protocol.WorkerMetadata.FromString(sent_metadata[0])
+        )
+        assert deserialized.options == channel
 
     def test_run_sets_worker_credentials_contextvar(self, mocker):
         """Test run sets WorkerCredentials ContextVar when credentials are provided.

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -22,13 +22,13 @@ from pytest_mock import MockerFixture
 import wool.runtime.worker.proxy as wp
 from wool import protocol
 from wool.runtime.discovery.base import DiscoveryEvent
-from wool.runtime.discovery.base import WorkerMetadata
 from wool.runtime.discovery.local import LocalDiscovery
 from wool.runtime.loadbalancer.base import NoWorkersAvailable
 from wool.runtime.routine.task import Task
 from wool.runtime.worker.auth import CredentialContext
-from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.base import ChannelOptions
 from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.proxy import WorkerProxy
 from wool.runtime.worker.proxy import is_version_compatible
 from wool.runtime.worker.proxy import parse_version
@@ -1073,6 +1073,155 @@ class TestWorkerProxy:
         await proxy.stop()
 
     @pytest.mark.asyncio
+    async def test_sentinel_passes_metadata_options_to_connection(
+        self, mocker: MockerFixture
+    ):
+        """Test sentinel creates WorkerConnection with metadata options.
+
+        Given:
+            A WorkerProxy with a discovery stream yielding a worker-added
+            event whose metadata has options=ChannelOptions(keepalive_time_ms=60000)
+        When:
+            The sentinel processes the event
+        Then:
+            It should create WorkerConnection with
+            options=ChannelOptions(keepalive_time_ms=60000) from the
+            event metadata
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        channel_opts = ChannelOptions(keepalive_time_ms=60000)
+        metadata = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.100:50051",
+            pid=1001,
+            version="1.0.0",
+            options=channel_opts,
+        )
+        mock_conn_cls = mocker.patch.object(
+            wp, "WorkerConnection", return_value=mocker.MagicMock()
+        )
+        events = [DiscoveryEvent("worker-added", metadata=metadata)]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery)
+
+        # Act
+        await proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        mock_conn_cls.assert_called_once_with(
+            metadata.address,
+            credentials=None,
+            options=channel_opts,
+        )
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_sentinel_passes_none_options_for_legacy_workers(
+        self, mocker: MockerFixture
+    ):
+        """Test sentinel creates WorkerConnection with options=None for legacy workers.
+
+        Given:
+            A WorkerProxy with a discovery stream yielding a worker-added
+            event whose metadata has options=None
+        When:
+            The sentinel processes the event
+        Then:
+            It should create WorkerConnection with options=None
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        metadata = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.100:50051",
+            pid=1001,
+            version="1.0.0",
+            options=None,
+        )
+        mock_conn_cls = mocker.patch.object(
+            wp, "WorkerConnection", return_value=mocker.MagicMock()
+        )
+        events = [DiscoveryEvent("worker-added", metadata=metadata)]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery)
+
+        # Act
+        await proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        mock_conn_cls.assert_called_once_with(
+            metadata.address,
+            credentials=None,
+            options=None,
+        )
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_sentinel_passes_updated_options_on_worker_updated(
+        self, mocker: MockerFixture
+    ):
+        """Test sentinel creates WorkerConnection with updated metadata options.
+
+        Given:
+            A WorkerProxy with a discovery stream yielding a worker-added
+            event followed by a worker-updated event whose metadata has
+            options=ChannelOptions(keepalive_time_ms=90000)
+        When:
+            The sentinel processes the events
+        Then:
+            It should create WorkerConnection with
+            options=ChannelOptions(keepalive_time_ms=90000) for the
+            updated event
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker_uid = uuid.uuid4()
+        initial_opts = ChannelOptions(keepalive_time_ms=60000)
+        updated_opts = ChannelOptions(keepalive_time_ms=90000)
+        initial_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.100:50051",
+            pid=1001,
+            version="1.0.0",
+            options=initial_opts,
+        )
+        updated_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.100:50051",
+            pid=1001,
+            version="1.0.0",
+            options=updated_opts,
+        )
+        mock_conn_cls = mocker.patch.object(
+            wp, "WorkerConnection", return_value=mocker.MagicMock()
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=initial_metadata),
+            DiscoveryEvent("worker-updated", metadata=updated_metadata),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery)
+
+        # Act
+        await proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert mock_conn_cls.call_count == 2
+        _, updated_kwargs = mock_conn_cls.call_args_list[1]
+        assert updated_kwargs["options"] == updated_opts
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
     async def test_dispatch_delegates_to_loadbalancer(
         self,
         spy_loadbalancer_with_workers,
@@ -1588,29 +1737,24 @@ class TestWorkerProxy:
             assert unpickled_proxy.id == proxy.id
 
     @pytest.mark.asyncio
-    async def test_cloudpickle_serialization_preserves_options(
+    async def test_cloudpickle_serialization_preserves_proxy_id(
         self, mock_proxy_session, mocker: MockerFixture
     ):
-        """Test pickle roundtrip preserves options and proxy ID.
+        """Test pickle roundtrip preserves proxy ID.
 
         Given:
-            A started WorkerProxy with custom WorkerOptions.
+            A started WorkerProxy with discovery and load balancer.
         When:
             Cloudpickle serialization and deserialization are performed.
         Then:
-            It should preserve options and proxy ID on the restored proxy.
+            It should preserve the proxy ID on the restored proxy.
         """
         # Arrange
         mocker.patch.object(protocol, "__version__", "1.0.0")
-        options = WorkerOptions(
-            max_receive_message_length=50 * 1024 * 1024,
-            max_send_message_length=50 * 1024 * 1024,
-        )
         discovery_service = LocalDiscovery("test-pool").subscriber
         proxy = WorkerProxy(
             discovery=discovery_service,
             loadbalancer=wp.RoundRobinLoadBalancer,
-            options=options,
         )
 
         # Act
@@ -1622,8 +1766,7 @@ class TestWorkerProxy:
         assert isinstance(unpickled_proxy, WorkerProxy)
         assert unpickled_proxy.id == proxy.id
         assert unpickled_proxy.started is False
-        # Verify options survived: a second roundtrip still produces
-        # a valid proxy (options are picklable and preserved)
+        # Verify a second roundtrip still produces a valid proxy
         repickled = cloudpickle.loads(cloudpickle.dumps(unpickled_proxy))
         assert repickled.id == proxy.id
 
@@ -2287,92 +2430,6 @@ class TestWorkerProxy:
         # Assert
         assert isinstance(proxy, WorkerProxy)
         assert not proxy.started
-
-    @pytest.mark.asyncio
-    async def test___aenter___with_default_options(
-        self, mocker: MockerFixture, mock_discovery_service
-    ):
-        """Test proxy forwards options=None to WorkerConnection.
-
-        Given:
-            A WorkerProxy with no options parameter.
-        When:
-            The proxy is started and a worker-added event is processed.
-        Then:
-            It should create WorkerConnection with options=None.
-        """
-        # Arrange
-        mock_conn_cls = mocker.patch.object(
-            wp, "WorkerConnection", return_value=mocker.MagicMock()
-        )
-        await mock_discovery_service.start()
-
-        worker = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="192.168.1.100:50051",
-            pid=1001,
-            version="1.0.0",
-            tags=frozenset(["test"]),
-            extra=MappingProxyType({}),
-        )
-
-        # Act
-        proxy = WorkerProxy(discovery=mock_discovery_service)
-        async with proxy:
-            mock_discovery_service.inject_worker_added(worker)
-            await asyncio.sleep(0.2)
-
-        await mock_discovery_service.stop()
-
-        # Assert
-        mock_conn_cls.assert_called()
-        _, kwargs = mock_conn_cls.call_args
-        assert kwargs["options"] is None
-
-    @pytest.mark.asyncio
-    async def test___aenter___with_custom_options(
-        self, mocker: MockerFixture, mock_discovery_service
-    ):
-        """Test proxy forwards custom options to WorkerConnection.
-
-        Given:
-            A WorkerProxy with a custom WorkerOptions instance.
-        When:
-            The proxy is started and a worker-added event is processed.
-        Then:
-            It should create WorkerConnection with the custom options.
-        """
-        # Arrange
-        custom_options = WorkerOptions(
-            max_receive_message_length=200 * 1024 * 1024,
-            max_send_message_length=50 * 1024 * 1024,
-        )
-        mock_conn_cls = mocker.patch.object(
-            wp, "WorkerConnection", return_value=mocker.MagicMock()
-        )
-        await mock_discovery_service.start()
-
-        worker = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="192.168.1.100:50051",
-            pid=1001,
-            version="1.0.0",
-            tags=frozenset(["test"]),
-            extra=MappingProxyType({}),
-        )
-
-        # Act
-        proxy = WorkerProxy(discovery=mock_discovery_service, options=custom_options)
-        async with proxy:
-            mock_discovery_service.inject_worker_added(worker)
-            await asyncio.sleep(0.2)
-
-        await mock_discovery_service.stop()
-
-        # Assert
-        mock_conn_cls.assert_called()
-        _, kwargs = mock_conn_cls.call_args
-        assert kwargs["options"] is custom_options
 
 
 # ============================================================================

--- a/wool/tests/utilities/test_afilter.py
+++ b/wool/tests/utilities/test_afilter.py
@@ -6,7 +6,7 @@ import cloudpickle
 import pytest
 
 from wool.runtime.discovery.base import DiscoveryEvent
-from wool.runtime.discovery.base import WorkerMetadata
+from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.afilter import afilter
 
 


### PR DESCRIPTION
## Summary

Expose all gRPC HTTP/2 transport-layer options and adopt a self-describing worker model where workers advertise their connection configuration via `WorkerMetadata` so clients connect with compatible settings automatically. Introduce a two-tier options model: `ChannelOptions` holds advertised settings (message sizes, keepalive, concurrency, compression) serialized in a `ChannelOptions` protobuf message, while `WorkerOptions` composes `ChannelOptions` with server-only settings (ping enforcement, connection lifecycle). Remove the `options` and `limit` parameters from `WorkerProxy`, `WorkerPool`, and `WorkerConnection` — clients derive all connection settings from discovered worker metadata.

Closes #41

## Proposed changes

### New ChannelOptions protobuf message

Add a `ChannelOptions` message to `wire.proto` with fields for message sizes, keepalive, max pings without data, max concurrent streams, and compression algorithm. Embed it as an optional `connection` field on `WorkerMetadata` so workers advertise their channel configuration over the wire.

### Split WorkerOptions into ChannelOptions + WorkerOptions

Replace the flat `WorkerOptions` dataclass with two frozen dataclasses in `worker/base.py`:

- `ChannelOptions` — advertised settings: message sizes, keepalive (time, timeout, permit-without-calls), max pings without data, max concurrent streams, and compression (`grpc.Compression` enum). Default to gRPC's own defaults.
- `WorkerOptions` — composes a `ChannelOptions` instance with server-only settings: `http2_min_recv_ping_interval_without_data_ms`, `max_ping_strikes`, and optional lifecycle options (`max_connection_idle_ms`, `max_connection_age_ms`, `max_connection_age_grace_ms`). Validate that `keepalive_time_ms >= http2_min_recv_ping_interval_without_data_ms` in `__post_init__`.

### Move WorkerMetadata to worker/metadata.py

Move `WorkerMetadata` from `discovery/base.py` into a dedicated `worker/metadata.py` module. `WorkerMetadata` is worker configuration — it belongs in the worker subpackage, not discovery. The discovery module imports it from the new location.

### Make WorkerMetadata.options non-optional

Change `WorkerMetadata.options` from `ChannelOptions | None` to `ChannelOptions` with a default of `ChannelOptions()`. Workers always advertise their transport configuration; `to_protobuf()` always serializes the connection field; `from_protobuf()` returns default `ChannelOptions()` for legacy protobufs without a connection field.

### Self-describing workers via WorkerMetadata

Workers serialize their `ChannelOptions` into the protobuf `ChannelOptions` sub-message; clients reconstruct it on deserialization. The proxy's `_worker_sentinel` reads `event.metadata.options` directly from discovery events when creating `WorkerConnection` instances, making configuration automatic.

### Channel factory passes all advertised options

Update `_channel_factory` in `connection.py` to include all `ChannelOptions` fields in the gRPC channel options list. Use `max_concurrent_streams` to size the per-channel concurrency semaphore, replacing the removed `limit` parameter.

### Server-side options in WorkerProcess

Update `WorkerProcess._serve()` to pass all options to `grpc.aio.server()`: advertised options from `ChannelOptions`, plus server-only options from `WorkerOptions`. Lifecycle options (`max_connection_idle_ms`, `max_connection_age_ms`, `max_connection_age_grace_ms`) are conditionally included only when not None.

### Remove options from WorkerProxy and WorkerPool

Remove the `options` parameter from `WorkerProxy.__init__`, `WorkerPool.__init__`, `WorkerFactory`, and `__reduce__`. Remove the `limit` parameter from `WorkerConnection.__init__`. The proxy's `_worker_sentinel` reads `event.metadata.options` directly from discovery events, making configuration automatic.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestChannelOptions` | No custom parameters | `ChannelOptions` is instantiated | All fields have default values including transport fields | Default constructor |
| 2 | `TestChannelOptions` | Custom message sizes | `ChannelOptions` is instantiated | Both size fields reflect custom values | Custom message sizes |
| 3 | `TestChannelOptions` | Only max_receive_message_length overridden | `ChannelOptions` is instantiated | Overridden field is custom, other is default | Partial override |
| 4 | `TestChannelOptions` | Custom keepalive_time_ms and keepalive_timeout_ms | `ChannelOptions` is instantiated | Both keepalive fields reflect custom values | Keepalive time and timeout |
| 5 | `TestChannelOptions` | keepalive_permit_without_calls=False | `ChannelOptions` is instantiated | Field stores False | Permit without calls disabled |
| 6 | `TestChannelOptions` | All three keepalive parameters | `ChannelOptions` is instantiated | All fields reflect provided values | All keepalive options |
| 7 | `TestChannelOptions` | Custom max_pings_without_data, max_concurrent_streams, and compression=Gzip | `ChannelOptions` is instantiated | All three fields reflect provided values | New transport fields |
| 8 | `TestWorkerOptions` | No custom parameters | `WorkerOptions` is instantiated | Contains default ChannelOptions and default server-only fields | Default constructor |
| 9 | `TestWorkerOptions` | Custom max_ping_strikes and all three lifecycle options | `WorkerOptions` is instantiated | All four server-only fields reflect provided values | New server-only fields |
| 10 | `TestWorkerOptions` | Custom ChannelOptions with smaller sizes | `WorkerOptions` is instantiated | Channel field reflects custom values | Custom channel |
| 11 | `TestWorkerOptions` | Custom http2_min_recv_ping_interval_without_data_ms | `WorkerOptions` is instantiated | Field stores custom value | Custom min ping interval |
| 12 | `TestWorkerOptions` | keepalive_time_ms=5000, min_ping=10000 | `WorkerOptions` is instantiated | Raises ValueError | Validation: time < min ping |
| 13 | `TestWorkerOptions` | keepalive_time_ms=10000, min_ping=10000 | `WorkerOptions` is instantiated | Succeeds without error | Validation: time == min ping |
| 14 | `TestWorkerOptions` | keepalive_time_ms=20000, min_ping=10000 | `WorkerOptions` is instantiated | Succeeds without error | Validation: time > min ping |
| 15 | `TestWorkerOptions` | Arbitrary positive keepalive_time_ms and min_ping | `WorkerOptions` is instantiated | Raises ValueError iff time < min_ping | Property-based validation invariant |
| 16 | `TestWorkerMetadata` | WorkerMetadata with default options | `to_protobuf()` is called | Connection sub-message is populated with default values | to_protobuf always serializes |
| 17 | `TestWorkerMetadata` | WorkerMetadata with options=ChannelOptions(keepalive_time_ms=60000) | `to_protobuf()` then `from_protobuf()` | Restored options equal original ChannelOptions | Options roundtrip |
| 18 | `TestWorkerMetadata` | WorkerMetadata with max_pings_without_data=5, max_concurrent_streams=50, compression=Gzip | `to_protobuf()` then `from_protobuf()` | Restored options equal original including all transport fields | Transport fields roundtrip |
| 19 | `TestWorkerMetadata` | Arbitrary ChannelOptions drawn from the full domain | `to_protobuf()` then `from_protobuf()` | All fields preserved including options | Property-based roundtrip |
| 20 | `TestWorkerConnection` | WorkerConnection with custom keepalive options | A task is dispatched | gRPC channel options include custom keepalive values | Custom keepalive in channel |
| 21 | `TestWorkerConnection` | WorkerConnection with default ChannelOptions | A task is dispatched | gRPC channel options include default keepalive values | Default keepalive in channel |
| 22 | `TestWorkerConnection` | WorkerConnection with max_pings_without_data=5, max_concurrent_streams=50, compression=Gzip | A task is dispatched | gRPC channel options include all three transport entries | New transport fields in channel |
| 23 | `TestWorkerProcess` | WorkerProcess with all keepalive options set | `run()` is called | gRPC server receives all keepalive and transport options | All options in server |
| 24 | `TestWorkerProcess` | WorkerProcess with default WorkerOptions | `run()` is called | gRPC server receives default values for all options | Default options in server |
| 25 | `TestWorkerProcess` | WorkerProcess with lifecycle options set | `run()` is called | gRPC server options include all three lifecycle entries | Lifecycle options present |
| 26 | `TestWorkerProcess` | WorkerProcess with default WorkerOptions (lifecycle=None) | `run()` is called | gRPC server options do not contain lifecycle entries | Lifecycle options omitted |
| 27 | `TestWorkerProcess` | WorkerProcess with custom ChannelOptions | `run()` executes | Metadata sent via pipe includes matching ChannelOptions | Metadata includes channel options |
| 28 | `TestWorkerProxy` | Discovery yields worker-added with options=ChannelOptions(keepalive_time_ms=60000) | Sentinel processes event | WorkerConnection created with matching options | Sentinel passes metadata options |
| 29 | `TestWorkerProxy` | Discovery yields worker-added with default options | Sentinel processes event | WorkerConnection created with default ChannelOptions | Sentinel handles default options |
| 30 | `TestWorkerProxy` | Discovery yields worker-added then worker-updated with new options | Sentinel processes events | Second WorkerConnection uses updated options | Sentinel passes updated options |
| 31 | `TestWorkerPool` | WorkerPool with default configuration | Pool is entered as async context | WorkerProxy is not passed an options parameter | Options removed from pool |
| 32 | `TestPoolComposition` | KEEPALIVE worker options (10s ping, 5s timeout) | Pool built and coroutine dispatched | Correct result returned | Integration: KEEPALIVE options end-to-end |
| 33 | `test_dispatch_hypothesis` | Explicit @example with WorkerOptionsKind.KEEPALIVE | Hypothesis example runs | Passes deterministically | Integration: KEEPALIVE smoke test |