### PR TITLE
Remove unused WorkerEndpoint protobuf message — Closes #125

### DIFF
--- a/wool/proto/wire.proto
+++ b/wool/proto/wire.proto
@@ -126,6 +126,4 @@ message ChannelOptions {
     int32 compression = 8;
 }
 
-message WorkerEndpoint {}
-
 message Void {}

--- a/wool/src/wool/protocol/__init__.py
+++ b/wool/src/wool/protocol/__init__.py
@@ -23,7 +23,6 @@ try:
     from wool.protocol.wire_pb2 import Task
     from wool.protocol.wire_pb2 import TaskEnvelope
     from wool.protocol.wire_pb2 import Void
-    from wool.protocol.wire_pb2 import WorkerEndpoint
     from wool.protocol.wire_pb2 import WorkerMetadata
     from wool.protocol.wire_pb2_grpc import WorkerServicer
     from wool.protocol.wire_pb2_grpc import WorkerStub
@@ -55,7 +54,6 @@ __all__ = [
     "Task",
     "TaskEnvelope",
     "Void",
-    "WorkerEndpoint",
     "WorkerMetadata",
     "WorkerServicer",
     "WorkerStub",

--- a/wool/tests/protocol/test_wire.py
+++ b/wool/tests/protocol/test_wire.py
@@ -12,7 +12,6 @@ EXPECTED_MESSAGE_EXPORTS = [
     "Task",
     "TaskEnvelope",
     "Void",
-    "WorkerEndpoint",
     "WorkerMetadata",
 ]
 


### PR DESCRIPTION
## Summary

Remove the unused `WorkerEndpoint` protobuf message from the wire protocol definition and all associated exports and test references. The message was defined but never consumed anywhere in the codebase, creating a false impression that it was part of the active public API.

Closes #125

## Proposed changes

### Remove WorkerEndpoint from wire.proto

Delete the empty `message WorkerEndpoint {}` definition from `proto/wire.proto`. No other protobuf messages or services reference it.

### Remove export from wool.protocol

Drop the `WorkerEndpoint` import from `wire_pb2` and remove it from `__all__` in `src/wool/protocol/__init__.py`.

### Update test expectations

Remove `WorkerEndpoint` from the `EXPECTED_MESSAGE_EXPORTS` list in `tests/protocol/test_wire.py`. The existing parametrized export tests continue to validate all remaining protocol symbols.