### PR TITLE
Fix drop-release auth to use git config extraheader — Closes #129

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -226,7 +226,7 @@ jobs:
           GH_TOKEN: ${{ steps.get-wool-labs-app-token.outputs.access-token }}
           REPO: ${{ github.repository }}
         run: |
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
           git fetch --unshallow
           if [[ -n $(git ls-remote --heads origin release) ]]; then
             git push origin --delete release


### PR DESCRIPTION
## Summary

Replace the `git remote set-url` authentication in the `drop-release` job with the `git config --local http.extraheader` approach that `cut-release.yaml` already uses successfully. The `drop-release` step was failing to authenticate when deleting the release branch, and this may fix it.

Closes #129

## Proposed changes

### Switch drop-release auth method (`publish-release.yaml`)

The `drop-release` job authenticated by embedding the app token in the remote URL via `git remote set-url`, which was failing. Replace it with `git config --local http.extraheader`, which sets an `AUTHORIZATION` header with a base64-encoded token — the same approach used in `cut-release.yaml:71`.

**Before:**
```yaml
git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
```

**After:**
```yaml
git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
```