### PR TITLE
Add upper-limit support to WorkerPool size — Closes #132

### DIFF
--- a/wool/README.md
+++ b/wool/README.md
@@ -142,7 +142,17 @@ async with wool.WorkerPool(size=4, discovery=wool.LanDiscovery()):
     result = await my_routine()
 ```
 
-`size` controls how many workers are spawned by the pool — it does not cap the total number of workers available. In Hybrid mode, additional workers may join via discovery beyond the initial `size`.
+`size` controls how many workers are spawned by the pool — it does not cap the total number of workers available. In Hybrid mode, additional workers may join via discovery beyond the initial `size`. The `lease` parameter caps how many additional discovered workers the pool will accept. The total pool capacity is `size + lease` when both are set. The lease count is a cap on admission, not a reservation — discovered workers may serve multiple pools simultaneously, and there is no guarantee that a leased slot will remain filled for the life of the pool:
+
+```python
+# Spawn 4 local workers, accept up to 4 more from discovery (8 total)
+async with wool.WorkerPool(size=4, lease=4, discovery=wool.LanDiscovery()):
+    result = await my_routine()
+
+# Durable pool capped at 10 discovered workers
+async with wool.WorkerPool(discovery=wool.LanDiscovery(), lease=10):
+    result = await my_routine()
+```
 
 ## Workers
 

--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -49,7 +49,19 @@ async with wool.WorkerPool(size=4, discovery=wool.LanDiscovery()):
     result = await my_routine()
 ```
 
-*Note: `size` controls how many workers are spawned by the pool — it does not cap the total number of workers available. In Hybrid mode, additional workers may join via discovery beyond the initial `size`.*
+> `size` controls how many workers are spawned by the pool — it does not cap the total number of workers available. In Hybrid mode, additional workers may join via discovery beyond the initial `size`. The `lease` parameter caps how many additional discovered workers the pool will accept. The total pool capacity is `size + lease` when both are set. The lease count is a cap on admission, not a reservation — discovered workers may serve multiple pools simultaneously, and there is no guarantee that a leased slot will remain filled for the life of the pool:
+>
+> ```python
+> import wool
+>
+> # Spawn 4 local workers, accept up to 4 more from discovery (8 total)
+> async with wool.WorkerPool(size=4, lease=4, discovery=wool.LanDiscovery()):
+>     result = await my_routine()
+>
+> # Durable pool capped at 10 discovered workers
+> async with wool.WorkerPool(discovery=wool.LanDiscovery(), lease=10):
+>     result = await my_routine()
+> ```
 
 ## Worker lifecycle
 

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -137,6 +137,10 @@ class WorkerPool:
         Capability tags for spawned workers.
     :param size:
         Number of workers to spawn (0 = CPU count).
+    :param lease:
+        Maximum number of additionally discovered workers to admit to the pool.
+        The total pool capacity is ``size + lease`` when both are set, or just
+        ``lease`` for external pools. Defaults to ``None`` (unbounded).
     :param worker:
         Worker factory callable. Defaults to :class:`LocalWorker`.
     :param loadbalancer:
@@ -163,6 +167,7 @@ class WorkerPool:
         self,
         *tags: str,
         size: int = 0,
+        lease: int | None = None,
         worker: WorkerFactory = LocalWorker,
         discovery: None = None,
         loadbalancer: (
@@ -180,6 +185,7 @@ class WorkerPool:
     def __init__(
         self,
         *,
+        lease: int | None = None,
         discovery: DiscoveryLike | Factory[DiscoveryLike],
         loadbalancer: (
             LoadBalancerLike | Factory[LoadBalancerLike]
@@ -197,6 +203,7 @@ class WorkerPool:
         self,
         *tags: str,
         size: int = 0,
+        lease: int | None = None,
         worker: WorkerFactory = LocalWorker,
         discovery: DiscoveryLike | Factory[DiscoveryLike],
         loadbalancer: (
@@ -214,6 +221,7 @@ class WorkerPool:
         self,
         *tags: str,
         size: int | None = None,
+        lease: int | None = None,
         worker: WorkerFactory | None = None,
         discovery: DiscoveryLike | Factory[DiscoveryLike] | None = None,
         loadbalancer: (
@@ -224,15 +232,13 @@ class WorkerPool:
         self._workers = {}
         self._credentials = credentials
 
+        if lease is not None and lease < 0:
+            raise ValueError("Lease must be non-negative")
+
         match (size, discovery):
             case (size, discovery) if size is not None and discovery is not None:
-                if size == 0:
-                    cpu_count = os.cpu_count()
-                    if cpu_count is None:
-                        raise ValueError("Unable to determine CPU count")
-                    size = cpu_count
-                elif size < 0:
-                    raise ValueError("Size must be non-negative")
+                size = _resolve_size(size)
+                max_workers = size + lease if lease is not None else None
 
                 @asynccontextmanager
                 async def create_proxy():
@@ -253,19 +259,15 @@ class WorkerPool:
                                 discovery=discovery_svc.subscribe(_predicate(tags)),
                                 loadbalancer=loadbalancer,
                                 credentials=self._credentials,
+                                lease=max_workers,
                             ):
                                 yield
                     finally:
                         await self._exit_context(discovery_ctx)
 
             case (size, None) if size is not None:
-                if size == 0:
-                    cpu_count = os.cpu_count()
-                    if cpu_count is None:
-                        raise ValueError("Unable to determine CPU count")
-                    size = cpu_count
-                elif size < 0:
-                    raise ValueError("Size must be non-negative")
+                size = _resolve_size(size)
+                max_workers = size + lease if lease is not None else None
 
                 namespace = f"pool-{uuid.uuid4().hex}"
 
@@ -282,10 +284,13 @@ class WorkerPool:
                                 discovery=discovery.subscribe(_predicate(tags)),
                                 loadbalancer=loadbalancer,
                                 credentials=self._credentials,
+                                lease=max_workers,
                             ):
                                 yield
 
             case (None, discovery) if discovery is not None:
+                if lease is not None and lease == 0:
+                    raise ValueError("Lease must be positive for discovery-only pools")
 
                 @asynccontextmanager
                 async def create_proxy():
@@ -297,16 +302,15 @@ class WorkerPool:
                             discovery=discovery_svc.subscriber,
                             loadbalancer=loadbalancer,
                             credentials=self._credentials,
+                            lease=lease,
                         ):
                             yield
                     finally:
                         await self._exit_context(discovery_ctx)
 
             case (None, None):
-                cpu_count = os.cpu_count()
-                if cpu_count is None:
-                    raise ValueError("Unable to determine CPU count")
-                size = cpu_count
+                size = _resolve_size(0)
+                max_workers = size + lease if lease is not None else None
 
                 namespace = f"pool-{uuid.uuid4().hex}"
 
@@ -323,6 +327,7 @@ class WorkerPool:
                                 discovery=discovery.subscriber,
                                 loadbalancer=loadbalancer,
                                 credentials=self._credentials,
+                                lease=max_workers,
                             ):
                                 yield
 
@@ -415,6 +420,17 @@ class WorkerPool:
             await ctx.__aexit__(*sys.exc_info())
         elif isinstance(ctx, ContextManager):
             ctx.__exit__(*sys.exc_info())
+
+
+def _resolve_size(size: int) -> int:
+    if size == 0:
+        cpu_count = os.cpu_count()
+        if cpu_count is None:
+            raise ValueError("Unable to determine CPU count")
+        size = cpu_count
+    elif size < 0:
+        raise ValueError("Size must be non-negative")
+    return size
 
 
 def _predicate(tags):

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -174,6 +174,9 @@ class WorkerProxy:
         Load balancer instance, factory, or context manager.
     :param credentials:
         Optional channel credentials for TLS/mTLS connections to workers.
+    :param lease:
+        Maximum number of workers this proxy will admit from discovery.
+        Defaults to ``None`` (unbounded).
 
     .. caution::
 
@@ -204,6 +207,7 @@ class WorkerProxy:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
+        lease: int | None = None,
     ): ...
 
     @overload
@@ -215,6 +219,7 @@ class WorkerProxy:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
+        lease: int | None = None,
     ): ...
 
     @overload
@@ -226,6 +231,7 @@ class WorkerProxy:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
+        lease: int | None = None,
     ): ...
 
     def __init__(
@@ -240,6 +246,7 @@ class WorkerProxy:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
+        lease: int | None = None,
     ):
         if not (pool_uri or discovery or workers):
             raise ValueError(
@@ -247,9 +254,13 @@ class WorkerProxy:
                 "sequence of workers"
             )
 
+        if lease is not None and lease < 1:
+            raise ValueError("Lease must be a positive, non-zero integer")
+
         self._id: uuid.UUID = uuid.uuid4()
         self._started = False
         self._loadbalancer = loadbalancer
+        self._lease = lease
 
         if isinstance(loadbalancer, (ContextManager, AsyncContextManager)):
             warnings.warn(
@@ -352,17 +363,23 @@ class WorkerProxy:
                     f"{name}=my_cm())."
                 )
 
-        def _restore_proxy(discovery, loadbalancer, proxy_id):
+        def _restore_proxy(discovery, loadbalancer, proxy_id, lease):
             proxy = WorkerProxy(
                 discovery=discovery,
                 loadbalancer=loadbalancer,
+                lease=lease,
             )
             proxy._id = proxy_id
             return proxy
 
         return (
             _restore_proxy,
-            (self._discovery, self._loadbalancer, self._id),
+            (
+                self._discovery,
+                self._loadbalancer,
+                self._id,
+                self._lease,
+            ),
         )
 
     @property
@@ -546,6 +563,12 @@ class WorkerProxy:
         async for event in self._discovery_stream:
             match event.type:
                 case "worker-added" | "worker-updated":
+                    if (
+                        event.type == "worker-added"
+                        and self._lease is not None
+                        and len(self._loadbalancer_context.workers) >= self._lease
+                    ):
+                        continue
                     connection = WorkerConnection(
                         event.metadata.address,
                         credentials=client_credentials,
@@ -553,7 +576,7 @@ class WorkerProxy:
                     )
                     if event.type == "worker-added":
                         self._loadbalancer_context.add_worker(event.metadata, connection)
-                    else:
+                    elif event.metadata in self._loadbalancer_context.workers:
                         self._loadbalancer_context.update_worker(
                             event.metadata, connection
                         )

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -1735,3 +1735,296 @@ class TestWorkerPool:
         mock_proxy_cls.assert_called_once()
         _, proxy_kwargs = mock_proxy_cls.call_args
         assert "options" not in proxy_kwargs
+
+    def test___init___with_lease(self):
+        """Test instantiation with size and lease.
+
+        Given:
+            A size of 4 and lease of 8
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should create the pool successfully
+        """
+        # Act
+        pool = WorkerPool(size=4, lease=8)
+
+        # Assert
+        assert isinstance(pool, WorkerPool)
+
+    def test___init___with_lease_and_no_size(self, mocker: MockerFixture):
+        """Test lease without size in durable mode.
+
+        Given:
+            A discovery service and lease of 8 with no size specified
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should create the pool successfully
+        """
+        # Arrange
+        mock_discovery = mocker.MagicMock()
+
+        # Act
+        pool = WorkerPool(discovery=mock_discovery, lease=8)
+
+        # Assert
+        assert isinstance(pool, WorkerPool)
+
+    def test___init___with_zero_lease_and_size(self):
+        """Test zero lease with size is accepted.
+
+        Given:
+            A size of 4 and lease of 0
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should create the pool successfully
+        """
+        # Act
+        pool = WorkerPool(size=4, lease=0)
+
+        # Assert
+        assert isinstance(pool, WorkerPool)
+
+    def test___init___with_zero_lease_discovery_only(self, mocker: MockerFixture):
+        """Test zero lease with discovery-only pool is rejected.
+
+        Given:
+            A discovery service and lease of 0 with no size
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should raise ValueError
+        """
+        # Arrange
+        mock_discovery = mocker.MagicMock()
+
+        # Act & assert
+        with pytest.raises(
+            ValueError,
+            match="Lease must be positive for discovery-only pools",
+        ):
+            WorkerPool(discovery=mock_discovery, lease=0)
+
+    def test___init___with_negative_lease(self):
+        """Test negative lease is rejected.
+
+        Given:
+            A negative lease value
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should raise ValueError
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="Lease must be non-negative"):
+            WorkerPool(size=4, lease=-1)
+
+    @pytest.mark.asyncio
+    async def test___aenter___hybrid_mode_forwards_lease(
+        self,
+        mocker: MockerFixture,
+        mock_shared_memory,
+        mock_worker_proxy,
+        mock_local_worker,
+        mock_discovery_service_for_pool,
+    ):
+        """Test hybrid mode forwards lease to WorkerProxy.
+
+        Given:
+            A WorkerPool with size=2, lease=4, and discovery
+        When:
+            The pool context is entered
+        Then:
+            It should pass lease=6 (size + lease) to WorkerProxy
+        """
+        # Arrange
+        import wool.runtime.worker.pool as wp
+
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+        discovery_service = mock_discovery_service_for_pool
+
+        # Act
+        async with WorkerPool(size=2, lease=4, discovery=discovery_service):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["lease"] == 6  # size(2) + lease(4)
+
+    @pytest.mark.asyncio
+    async def test___aenter___ephemeral_mode_forwards_lease(
+        self,
+        mocker: MockerFixture,
+        mock_shared_memory,
+        mock_worker_proxy,
+        mock_local_worker,
+    ):
+        """Test ephemeral mode forwards lease to WorkerProxy.
+
+        Given:
+            A WorkerPool with size=2 and lease=4 without discovery
+        When:
+            The pool context is entered
+        Then:
+            It should pass lease=6 (size + lease) to WorkerProxy
+        """
+        # Arrange
+        import wool.runtime.worker.pool as wp
+
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+
+        # Act
+        async with WorkerPool(size=2, lease=4):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["lease"] == 6  # size(2) + lease(4)
+
+    @pytest.mark.asyncio
+    async def test___aenter___durable_mode_forwards_lease(
+        self,
+        mocker: MockerFixture,
+        mock_worker_proxy,
+        mock_discovery_service_for_pool,
+    ):
+        """Test durable mode forwards lease to WorkerProxy.
+
+        Given:
+            A WorkerPool with discovery only and lease=6
+        When:
+            The pool context is entered
+        Then:
+            It should pass lease=6 to WorkerProxy
+        """
+        # Arrange
+        import wool.runtime.worker.pool as wp
+
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+        discovery_service = mock_discovery_service_for_pool
+
+        # Act
+        async with WorkerPool(discovery=discovery_service, lease=6):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["lease"] == 6
+
+    @pytest.mark.asyncio
+    async def test___aenter___no_lease_forwards_none(
+        self,
+        mocker: MockerFixture,
+        mock_shared_memory,
+        mock_worker_proxy,
+        mock_local_worker,
+    ):
+        """Test no lease forwards lease=None to WorkerProxy.
+
+        Given:
+            A WorkerPool with plain int size and no lease
+        When:
+            The pool context is entered
+        Then:
+            It should pass lease=None to WorkerProxy
+        """
+        # Arrange
+        import wool.runtime.worker.pool as wp
+
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+
+        # Act
+        async with WorkerPool(size=2):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["lease"] is None
+
+    @pytest.mark.asyncio
+    async def test___aenter___default_mode_forwards_lease(
+        self,
+        mocker: MockerFixture,
+        mock_shared_memory,
+        mock_worker_proxy,
+        mock_local_worker,
+    ):
+        """Test default mode forwards size + lease to WorkerProxy.
+
+        Given:
+            A WorkerPool with no explicit size or discovery and lease=4
+        When:
+            The pool context is entered
+        Then:
+            It should pass lease=cpu_count + 4 to WorkerProxy
+        """
+        # Arrange
+        import os
+
+        import wool.runtime.worker.pool as wp
+
+        mocker.patch.object(os, "cpu_count", return_value=2)
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+
+        # Act
+        async with WorkerPool(lease=4):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["lease"] == 6  # cpu_count(2) + lease(4)
+
+    @given(
+        size=st.integers(min_value=1, max_value=20),
+        lease=st.integers(min_value=0, max_value=20),
+    )
+    def test___init___accepts_valid_size_and_lease(self, size, lease):
+        """Test valid size and lease combinations are accepted.
+
+        Given:
+            Any positive size and any non-negative lease
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should create pool successfully
+        """
+        # Act
+        pool = WorkerPool(size=size, lease=lease)
+
+        # Assert
+        assert isinstance(pool, WorkerPool)
+
+    @given(lease=st.integers(min_value=-100, max_value=-1))
+    def test___init___rejects_negative_lease_pbt(self, lease):
+        """Test negative lease values are rejected.
+
+        Given:
+            Any negative lease value
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should raise ValueError
+        """
+        # Act & assert
+        with pytest.raises(
+            ValueError,
+            match="Lease must be non-negative",
+        ):
+            WorkerPool(size=1, lease=lease)

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -33,6 +33,20 @@ from wool.runtime.worker.proxy import WorkerProxy
 from wool.runtime.worker.proxy import is_version_compatible
 from wool.runtime.worker.proxy import parse_version
 
+
+async def _drain_discovery(proxy, *, expect, timeout=2.0):
+    """Wait until proxy.workers reaches the expected count or times out.
+
+    Yields the event loop in a tight loop so the sentinel can process
+    events from a finite ReducibleAsyncIterator without a hard sleep.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while len(proxy.workers) != expect:
+        if asyncio.get_event_loop().time() > deadline:
+            break
+        await asyncio.sleep(0)
+
+
 # ============================================================================
 # Test Fixtures
 # ============================================================================
@@ -1220,6 +1234,330 @@ class TestWorkerProxy:
 
         # Cleanup
         await proxy.stop()
+
+    def test___init___with_zero_lease_raises(self, mock_discovery_service):
+        """Test zero lease is rejected.
+
+        Given:
+            A discovery service and lease of 0
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should raise ValueError
+        """
+        # Act & assert
+        with pytest.raises(
+            ValueError,
+            match="Lease must be a positive, non-zero integer",
+        ):
+            WorkerProxy(discovery=mock_discovery_service, lease=0)
+
+    def test___init___with_negative_lease_raises(self, mock_discovery_service):
+        """Test negative lease is rejected.
+
+        Given:
+            A discovery service and lease of -1
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should raise ValueError
+        """
+        # Act & assert
+        with pytest.raises(
+            ValueError,
+            match="Lease must be a positive, non-zero integer",
+        ):
+            WorkerProxy(discovery=mock_discovery_service, lease=-1)
+
+    def test___init___with_positive_lease_accepted(self, mock_discovery_service):
+        """Test positive lease is accepted.
+
+        Given:
+            A discovery service and lease of 5
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should create the proxy successfully
+        """
+        # Act
+        proxy = WorkerProxy(discovery=mock_discovery_service, lease=5)
+
+        # Assert
+        assert isinstance(proxy, WorkerProxy)
+
+    @pytest.mark.asyncio
+    async def test_start_caps_discovered_workers_at_lease(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test sentinel respects lease cap on worker-added events.
+
+        Given:
+            A WorkerProxy with lease=2 and a discovery stream with
+            3 worker-added events
+        When:
+            The sentinel processes all events
+        Then:
+            It should accept only 2 workers, ignoring the 3rd
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+            )
+            for i in range(3)
+        ]
+        events = [DiscoveryEvent("worker-added", metadata=w) for w in workers]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lease=2)
+
+        # Act
+        await proxy.start()
+        await _drain_discovery(proxy, expect=2)
+
+        # Assert
+        assert len(proxy.workers) == 2
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_accepts_all_workers_when_lease_none(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test sentinel accepts all workers when lease is None.
+
+        Given:
+            A WorkerProxy with lease=None and a discovery stream
+            with 3 worker-added events
+        When:
+            The sentinel processes all events
+        Then:
+            It should accept all 3 workers
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+            )
+            for i in range(3)
+        ]
+        events = [DiscoveryEvent("worker-added", metadata=w) for w in workers]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lease=None)
+
+        # Act
+        await proxy.start()
+        await _drain_discovery(proxy, expect=3)
+
+        # Assert
+        assert len(proxy.workers) == 3
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_allows_worker_updated_at_capacity(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test sentinel processes worker-updated events even at capacity.
+
+        Given:
+            A WorkerProxy with lease=2, already at capacity,
+            receiving a worker-updated event
+        When:
+            The sentinel processes the update event
+        Then:
+            It should process the update without being blocked by the cap
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker1 = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        worker2 = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=worker1),
+            DiscoveryEvent("worker-added", metadata=worker2),
+            DiscoveryEvent("worker-updated", metadata=worker1),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lease=2)
+
+        # Act
+        await proxy.start()
+        await _drain_discovery(proxy, expect=2)
+
+        # Assert
+        assert len(proxy.workers) == 2
+        assert worker1 in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_accepts_worker_after_drop_frees_capacity(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test drop restores capacity for a subsequent worker-added event.
+
+        Given:
+            A WorkerProxy with lease=2, at capacity with 2 workers,
+            then one worker is dropped followed by a new worker-added
+        When:
+            The proxy processes all events
+        Then:
+            It should accept the new worker after the drop
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker1 = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        worker2 = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+        )
+        worker3 = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.3:50051",
+            pid=1003,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=worker1),
+            DiscoveryEvent("worker-added", metadata=worker2),
+            DiscoveryEvent("worker-dropped", metadata=worker1),
+            DiscoveryEvent("worker-added", metadata=worker3),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lease=2)
+
+        # Act
+        await proxy.start()
+        await _drain_discovery(proxy, expect=2)
+
+        # Assert — worker3 was accepted after worker1 was dropped
+        assert len(proxy.workers) == 2
+        assert worker2 in proxy.workers
+        assert worker3 in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_drops_update_for_rejected_worker(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test worker-updated for a cap-rejected worker is silently dropped.
+
+        Given:
+            A WorkerProxy with lease=1 and a discovery stream where
+            worker2 is rejected by the cap, then a worker-updated
+            event arrives for worker2
+        When:
+            The proxy processes all events
+        Then:
+            It should not add worker2 via the update event
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker1 = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        worker2 = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=worker1),
+            DiscoveryEvent("worker-added", metadata=worker2),  # rejected
+            DiscoveryEvent("worker-updated", metadata=worker2),  # dropped
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lease=1)
+
+        # Act
+        await proxy.start()
+        await _drain_discovery(proxy, expect=1)
+
+        # Assert — only worker1 is present; worker2 was never admitted
+        assert len(proxy.workers) == 1
+        assert worker1 in proxy.workers
+        assert worker2 not in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_cloudpickle_serialization_preserves_lease(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test pickle round-trip preserves lease cap behavior.
+
+        Given:
+            A WorkerProxy with lease=2 and a discovery stream
+            with 3 worker-added events
+        When:
+            The proxy is pickled, unpickled, started, and processes
+            the discovery events
+        Then:
+            It should cap at 2 workers, proving the limit survived
+            the round-trip
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+            )
+            for i in range(3)
+        ]
+        events = [DiscoveryEvent("worker-added", metadata=w) for w in workers]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(
+            discovery=discovery,
+            loadbalancer=wp.RoundRobinLoadBalancer,
+            lease=2,
+        )
+
+        # Act — pickle round-trip, then start the restored proxy
+        pickled_data = cloudpickle.dumps(proxy)
+        restored = cloudpickle.loads(pickled_data)
+        await restored.start()
+        await _drain_discovery(restored, expect=2)
+
+        # Assert — restored proxy enforces the cap
+        assert len(restored.workers) == 2
+        await restored.stop()
 
     @pytest.mark.asyncio
     async def test_dispatch_delegates_to_loadbalancer(


### PR DESCRIPTION
## Summary

Add a `lease` parameter to `WorkerPool` that caps how many additional discovered workers the pool will accept. The total pool capacity is `size + lease` when both are set, or just `lease` for durable (discovery-only) pools. Zero is allowed when `size` is set (caps at exactly the spawn count) but rejected for discovery-only pools. The lease count is a cap on admission, not a reservation — discovered workers may serve multiple pools simultaneously, and there is no guarantee that a leased slot will remain filled for the life of the pool. Omitting `lease` preserves existing behavior (unbounded).

The cap is enforced at the `WorkerProxy` sentinel level — the single point through which all discovered workers flow into the loadbalancer. `WorkerProxy` enforces `lease > 0` independently since it always receives the computed total (`size + lease`), never the raw zero. The sentinel guards `worker-updated` events for never-added workers to prevent stale updates leaking through the cap. The `lease` value survives pickling via `__reduce__` so the cap is preserved across nested routine dispatch.

Size resolution is extracted to a typed module-level `_resolve_size` helper to eliminate duplicated validation across match arms.

Closes #132

## Proposed changes

### Lease parameter and validation (pool.py)

Add `lease: int | None = None` to all three `__init__` overloads and the implementation signature. Reject negative lease values universally; reject zero lease only for discovery-only pools where it would be nonsensical. Extract a `_resolve_size(size: int) -> int` module-level helper that resolves `size=0` to CPU count and validates `size >= 0`. Compute `max_workers = size + lease` in each match arm after size resolution, forwarding the total to `WorkerProxy` in all four branches — including the durable branch which passes the raw `lease` since there is no spawn count to add.

### Cap enforcement in the worker sentinel (proxy.py)

Add a `lease: int | None` parameter to `WorkerProxy` with its own `< 1` validation and `:param` documentation. In the sentinel, skip `"worker-added"` discovery events when the loadbalancer already holds `>= lease` workers. Guard `"worker-updated"` events so updates for never-added workers (rejected by the cap) are silently dropped rather than passed to the loadbalancer. Include `lease` in `__reduce__` so the cap survives pickling for nested routine dispatch.

### Documentation (README.md, src/wool/runtime/worker/README.md)

Update both the root README and worker subpackage README to explain the `lease` parameter with code examples for hybrid and durable pool modes. Clarify that the lease count is a cap on admission, not a reservation.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerPool` | A size of 4 and lease of 8 | WorkerPool is instantiated | Creates pool successfully | Lease accepted with valid size |
| 2 | `TestWorkerPool` | A discovery service and lease of 8 with no size | WorkerPool is instantiated | Creates pool successfully | Durable mode with lease |
| 3 | `TestWorkerPool` | A size of 4 and lease of 0 | WorkerPool is instantiated | Creates pool successfully | Zero lease with size accepted |
| 4 | `TestWorkerPool` | A discovery service and lease of 0 with no size | WorkerPool is instantiated | Raises ValueError | Zero lease discovery-only rejected |
| 5 | `TestWorkerPool` | A negative lease | WorkerPool is instantiated | Raises ValueError | Negative lease rejected |
| 6 | `TestWorkerPool` | Size=2, lease=4, and discovery (hybrid mode) | Pool context is entered | WorkerProxy receives `lease=6` (size + lease) | Hybrid mode forwarding |
| 7 | `TestWorkerPool` | Size=2 and lease=4 without discovery (ephemeral) | Pool context is entered | WorkerProxy receives `lease=6` (size + lease) | Ephemeral mode forwarding |
| 8 | `TestWorkerPool` | Discovery only and lease=6 (durable mode) | Pool context is entered | WorkerProxy receives `lease=6` | Durable mode forwarding |
| 9 | `TestWorkerPool` | No explicit size or discovery, lease=4 (default) | Pool context is entered | WorkerProxy receives `lease=cpu_count+4` | Default mode forwarding |
| 10 | `TestWorkerPool` | Plain int size with no lease | Pool context is entered | WorkerProxy receives `lease=None` | No lease forwards None |
| 11 | `TestWorkerPool` | Any positive size and any non-negative lease | WorkerPool is instantiated | Creates pool successfully | Valid combinations accepted |
| 12 | `TestWorkerPool` | Any negative lease value | WorkerPool is instantiated | Raises ValueError | Negative lease rejected |
| 13 | `TestWorkerProxy` | Discovery and `lease=0` | WorkerProxy is instantiated | Raises ValueError | Zero lease rejected by proxy |
| 14 | `TestWorkerProxy` | Discovery and `lease=-1` | WorkerProxy is instantiated | Raises ValueError | Negative lease rejected by proxy |
| 15 | `TestWorkerProxy` | Discovery and `lease=5` | WorkerProxy is instantiated | Creates proxy successfully | Positive lease accepted by proxy |
| 16 | `TestWorkerProxy` | `lease=2` and 3 worker-added events | Proxy started, discovery drains | Only 2 workers accepted | Sentinel cap enforcement |
| 17 | `TestWorkerProxy` | `lease=None` and 3 worker-added events | Proxy started, discovery drains | All 3 workers accepted | No cap when None |
| 18 | `TestWorkerProxy` | `lease=2` at capacity, worker-updated event | Proxy started, discovery drains | Update processed without blocking | Updates bypass cap |
| 19 | `TestWorkerProxy` | `lease=2` at capacity, drop then add | Proxy started, discovery drains | New worker accepted after drop | Drop frees lease slot |
| 20 | `TestWorkerProxy` | `lease=1`, rejected worker then updated | Proxy started, discovery drains | Update for rejected worker silently dropped | Guard on unknown updates |
| 21 | `TestWorkerProxy` | WorkerProxy with `lease=2` | Pickle round-trip then start restored proxy | Only 2 workers accepted by restored proxy | Cap survives pickling |