### PR TITLE
Add PEP 702 static-analysis deprecation overloads for `size` parameter — Closes #136

### DIFF
--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -13,6 +13,8 @@ from typing import Coroutine
 from typing import Final
 from typing import overload
 
+from typing_extensions import deprecated
+
 from wool.runtime.discovery.base import DiscoveryLike
 from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.local import LocalDiscovery
@@ -220,6 +222,36 @@ class WorkerPool:
         remote workers through the specified discovery protocol.
         """
         ...
+
+    @overload
+    @deprecated("Use 'spawn' instead of 'size'.")
+    def __init__(
+        self,
+        *tags: str,
+        size: int,
+        lease: int | None = None,
+        worker: WorkerFactory = LocalWorker,
+        discovery: None = None,
+        loadbalancer: (
+            LoadBalancerLike | Factory[LoadBalancerLike]
+        ) = RoundRobinLoadBalancer,
+        credentials: WorkerCredentials | None = None,
+    ): ...
+
+    @overload
+    @deprecated("Use 'spawn' instead of 'size'.")
+    def __init__(
+        self,
+        *tags: str,
+        size: int,
+        lease: int | None = None,
+        worker: WorkerFactory = LocalWorker,
+        discovery: DiscoveryLike | Factory[DiscoveryLike],
+        loadbalancer: (
+            LoadBalancerLike | Factory[LoadBalancerLike]
+        ) = RoundRobinLoadBalancer,
+        credentials: WorkerCredentials | None = None,
+    ): ...
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary

Add two `@overload` declarations decorated with `@deprecated` from `typing_extensions` to `WorkerPool.__init__`, covering ephemeral and hybrid modes. Type checkers (pyright, mypy) now emit a deprecation diagnostic when `WorkerPool(size=...)` appears in source, complementing the runtime `DeprecationWarning` introduced in #135.

Closes #136

## Proposed changes

### Deprecated overloads for `size` parameter

Import `deprecated` from `typing_extensions` and add two new `@overload` stubs after the existing three overloads on `WorkerPool.__init__`:

- **Ephemeral mode** — `size: int` with `discovery: None` (mirrors the existing ephemeral `spawn` overload).
- **Hybrid mode** — `size: int` with `discovery: DiscoveryLike | Factory[DiscoveryLike]` (mirrors the existing hybrid `spawn` overload).

Both are decorated with `@deprecated("Use 'spawn' instead of 'size'.")`. The durable mode has no `spawn`/`size` parameter, so no deprecated overload is needed there.

`size` is declared as a required `int` (no default) because callers always pass it explicitly — a default would weaken the overload's discriminating power and match calls that should resolve to the non-deprecated `spawn` overloads.

No runtime behavior changes. The `@deprecated` decorator on `@overload` stubs is a static-analysis-only annotation; the existing runtime deprecation path is untouched.