### PR TITLE
Accept cache key callable as a SubscriberMeta keyword argument — Closes #120

### DIFF
--- a/wool/src/wool/runtime/discovery/lan.py
+++ b/wool/src/wool/runtime/discovery/lan.py
@@ -323,7 +323,10 @@ class LanDiscovery(Discovery):
 
             return socket.inet_aton(socket.gethostbyname(host)), port
 
-    class Subscriber(metaclass=SubscriberMeta):
+    class Subscriber(
+        metaclass=SubscriberMeta,
+        key=lambda cls, service_type: (cls, service_type),
+    ):
         """Subscriber for receiving worker discovery events.
 
         Subscribes to worker :class:`discovery events
@@ -346,10 +349,6 @@ class LanDiscovery(Discovery):
 
         def __init__(self, service_type: str) -> None:
             self.service_type = service_type
-
-        @classmethod
-        def _cache_key(cls, service_type: str) -> tuple:
-            return (cls, service_type)
 
         async def _shutdown(self) -> None:
             """Clean up shared subscription state for this subscriber."""

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -560,7 +560,14 @@ class LocalDiscovery(Discovery):
                 pass  # pragma: no cover
             atexit.unregister(self._cleanups.pop(shared_memory.name))
 
-    class Subscriber(metaclass=SubscriberMeta):
+    class Subscriber(
+        metaclass=SubscriberMeta,
+        key=lambda cls, namespace, *, poll_interval=None: (
+            cls,
+            namespace,
+            poll_interval,
+        ),
+    ):
         """Subscriber for receiving worker discovery events.
 
         Subscribes to worker :class:`discovery events <~wool.DiscoveryEvent>`
@@ -599,10 +606,6 @@ class LocalDiscovery(Discovery):
             if poll_interval is not None and poll_interval < 0:
                 raise ValueError(f"Expected positive poll interval, got {poll_interval}")
             self._poll_interval = poll_interval
-
-        @classmethod
-        def _cache_key(cls, namespace: str, *, poll_interval: float | None = None):
-            return (cls, namespace, poll_interval)
 
         async def _shutdown(self) -> None:
             """Clean up shared subscription state for this subscriber."""

--- a/wool/src/wool/runtime/discovery/pool.py
+++ b/wool/src/wool/runtime/discovery/pool.py
@@ -108,9 +108,14 @@ class SubscriberMeta(type):
     :class:`~wool.runtime.resourcepool.Resource` is entered lazily
     on first iteration.
 
-    Subscriber classes using this metaclass must define a
-    ``_cache_key`` classmethod that returns a hashable key from the
-    constructor arguments.
+    Subscriber classes pass a ``key`` keyword argument at class
+    definition time.  The callable receives ``(cls, *args, **kwargs)``
+    and must return a hashable cache key.
+
+    Example::
+
+        class Sub(metaclass=SubscriberMeta, key=lambda cls, ns: (cls, ns)):
+            def __init__(self, ns: str) -> None: ...
     """
 
     def __new__(
@@ -118,12 +123,16 @@ class SubscriberMeta(type):
         name: str,
         bases: tuple[type, ...],
         namespace: dict[str, Any],
+        **kwargs: Any,
     ) -> SubscriberMeta:
-        cls = super().__new__(mcs, name, bases, namespace)
+        key_fn: Callable[..., Any] | None = kwargs.pop("key", None)
+        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        if key_fn is not None:
+            cls._cache_key_fn = key_fn  # type: ignore[attr-defined]
         original_init = cls.__init__  # type: ignore[misc]
 
         def _subscriber_new(cls_arg: type, *args: Any, **kwargs: Any) -> Any:
-            key = cls_arg._cache_key(*args, **kwargs)  # type: ignore[attr-defined]
+            key = cls_arg._cache_key_fn(cls_arg, *args, **kwargs)  # type: ignore[attr-defined]
             pool = __subscriber_pool__.get()
             if pool is None:
                 pool = ResourcePool(

--- a/wool/tests/runtime/discovery/test_pool.py
+++ b/wool/tests/runtime/discovery/test_pool.py
@@ -15,15 +15,14 @@ from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.worker.metadata import WorkerMetadata
 
 
-class _StubSubscriber(metaclass=SubscriberMeta):
+class _StubSubscriber(
+    metaclass=SubscriberMeta,
+    key=lambda cls, key_value: (cls, key_value),
+):
     """Minimal subscriber stub for testing SubscriberMeta."""
 
     def __init__(self, key_value: str) -> None:
         self.key_value = key_value
-
-    @classmethod
-    def _cache_key(cls, key_value: str):
-        return (cls, key_value)
 
     def __reduce__(self):
         return type(self), (self.key_value,)
@@ -105,13 +104,12 @@ class TestSubscriberMeta:
         # Arrange
         events = [_make_event(address=f"127.0.0.1:{50051 + i}") for i in range(3)]
 
-        class _EventStub(metaclass=SubscriberMeta):
+        class _EventStub(
+            metaclass=SubscriberMeta,
+            key=lambda cls, tag: (cls, tag),
+        ):
             def __init__(self, tag):
                 self.tag = tag
-
-            @classmethod
-            def _cache_key(cls, tag):
-                return (cls, tag)
 
             async def _shutdown(self):
                 pass
@@ -157,14 +155,13 @@ class TestSubscriberMeta:
         event_a = _make_event(address="10.0.0.1:1")
         event_b = _make_event(address="10.0.0.2:2")
 
-        class _IsoStub(metaclass=SubscriberMeta):
+        class _IsoStub(
+            metaclass=SubscriberMeta,
+            key=lambda cls, tag, event: (cls, tag),
+        ):
             def __init__(self, tag, event):
                 self.tag = tag
                 self._event = event
-
-            @classmethod
-            def _cache_key(cls, tag, event):
-                return (cls, tag)
 
             async def _shutdown(self):
                 pass
@@ -205,6 +202,89 @@ class TestSubscriberMeta:
 
         # Assert
         assert __subscriber_pool__.get() is not None
+
+    def test___new___with_key_callable_receiving_cls(self):
+        """Test key callable receives the class as its first argument.
+
+        Given:
+            A subscriber class defined with a key callable that
+            includes cls in the returned tuple.
+        When:
+            The class is instantiated.
+        Then:
+            It should produce a _SharedSubscription whose cache key
+            was computed using the class itself.
+        """
+        # Arrange
+        captured = {}
+
+        def capture_key(cls, value):
+            captured["cls"] = cls
+            captured["value"] = value
+            return (cls, value)
+
+        class _CaptureSub(
+            metaclass=SubscriberMeta,
+            key=capture_key,
+        ):
+            def __init__(self, value):
+                self.value = value
+
+            async def _shutdown(self):
+                pass
+
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                yield  # pragma: no cover
+
+        # Act
+        result = _CaptureSub("test-val")
+
+        # Assert
+        assert isinstance(result, _SharedSubscription)
+        assert captured["cls"] is _CaptureSub
+        assert captured["value"] == "test-val"
+
+    def test___new___with_inherited_key(self):
+        """Test subclass inherits key callable from parent.
+
+        Given:
+            A parent subscriber class defined with a key callable
+            and a subclass that does not pass its own key.
+        When:
+            The subclass is instantiated.
+        Then:
+            It should inherit the parent's key callable and return
+            a _SharedSubscription.
+        """
+
+        # Arrange
+        class _Parent(
+            metaclass=SubscriberMeta,
+            key=lambda cls, tag: (cls, tag),
+        ):
+            def __init__(self, tag):
+                self.tag = tag
+
+            async def _shutdown(self):
+                pass
+
+            def __aiter__(self):
+                return self._gen()
+
+            async def _gen(self):
+                yield  # pragma: no cover
+
+        class _Child(_Parent):
+            pass
+
+        # Act
+        result = _Child("child-tag")
+
+        # Assert
+        assert isinstance(result, _SharedSubscription)
 
 
 class TestSharedSubscription:


### PR DESCRIPTION
## Summary

Replace the `_cache_key` classmethod convention on subscriber classes with a `key` keyword argument passed at class definition time. `SubscriberMeta.__new__` now pops `key` from the metaclass keyword arguments, stores it on the class, and invokes it in the injected `__new__` to compute the `ResourcePool` cache key. The `_cache_key` classmethod is removed from all subscriber implementations.

Closes #120

## Proposed changes

### Accept `key` kwarg in `SubscriberMeta.__new__`

Add `**kwargs` to the metaclass `__new__` signature and pop a `key` entry before forwarding remaining kwargs to `type.__new__`. When present, store the callable on the class as `_cache_key_fn`. The injected `_subscriber_new` calls `cls_arg._cache_key_fn(cls_arg, *args, **kwargs)` instead of the old `cls_arg._cache_key(...)`.

The `key` callable is a plain function (not a classmethod), so `cls` must be passed explicitly as the first argument. This matches the convention of `sorted(key=...)` and similar stdlib APIs.

Before:
```python
class Subscriber(metaclass=SubscriberMeta):
    @classmethod
    def _cache_key(cls, namespace):
        return (cls, namespace)
```

After:
```python
class Subscriber(metaclass=SubscriberMeta, key=lambda cls, namespace: (cls, namespace)):
    ...
```

### Update subscriber classes

Remove the `_cache_key` classmethod from `LocalDiscovery.Subscriber` and `LanDiscovery.Subscriber`, passing the equivalent lambda via `key=` in their class definitions.

### Update and add tests

Update existing test stubs to use `key=` instead of `_cache_key`. Add two new tests: one verifying the key callable receives `cls` as its first argument, another verifying subclass inheritance of the parent's key callable.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestSubscriberMeta` | A subscriber class using SubscriberMeta with `key=` | The class is instantiated | Returns a `_SharedSubscription` | Metaclass wrapping |
| 2 | `TestSubscriberMeta` | A source yielding events and two subscriptions with the same key | Both consumers iterate | Events are fanned out to both | Shared fan-out |
| 3 | `TestSubscriberMeta` | Two subscriptions with different keys | Both are iterated | Events are isolated per key | Key isolation |
| 4 | `TestSubscriberMeta` | The subscriber pool ContextVar is None | A subscriber is constructed | The ContextVar is set to a ResourcePool | Lazy pool init |
| 5 | `TestSubscriberMeta` | A subscriber class with a key callable that captures cls | The class is instantiated | The key callable receives the class as its first argument | Explicit cls passing |
| 6 | `TestSubscriberMeta` | A parent class with `key=` and a subclass without | The subclass is instantiated | It inherits the parent's key callable | Key inheritance |