### PR TITLE
Split unit and integration test coverage in CI — Closes #141

### DIFF
--- a/.github/actions/run-tests/action.yaml
+++ b/.github/actions/run-tests/action.yaml
@@ -1,0 +1,37 @@
+name: Run tests
+description: Checkout, install dependencies, and run pytest for a given namespace.
+inputs:
+  python-version:
+    required: true
+    type: string
+  namespace:
+    required: true
+    type: string
+  pytest-marker:
+    required: true
+    type: string
+  cov-fail-under:
+    required: true
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv and prepare python
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install packages
+      shell: bash
+      run: |
+        .github/scripts/install-python-packages.sh
+        uv pip install -e './${{ inputs.namespace }}[dev]'
+        uv pip freeze
+
+    - name: Run tests
+      shell: bash
+      run: |
+        ulimit -n 65536
+        cd ${{ inputs.namespace }}
+        uv run pytest -m "${{ inputs.pytest-marker }}" --cov-fail-under=${{ inputs.cov-fail-under }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -34,38 +34,35 @@ jobs:
           cd wool
           uv run pyright
 
-  run-tests:
-    name: Namespace ${{ matrix.namespace }} / Python ${{ matrix.python-version }}
+  unit-tests:
+    name: Unit / Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        namespace:
-          - 'wool'
-        python-version:
-          - '3.11'
-          - '3.12'
-          - '3.13'
+        namespace: ['wool']
+        python-version: ['3.11', '3.12', '3.13']
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install uv and prepare python
-        uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/run-tests
         with:
           python-version: ${{ matrix.python-version }}
+          namespace: ${{ matrix.namespace }}
+          pytest-marker: not integration
+          cov-fail-under: '98'
 
-      - name: Install packages
-        env:
-          NAMESPACE: ${{ matrix.namespace }}
-        run: |
-          .github/scripts/install-python-packages.sh
-          uv pip install -e './${{ env.NAMESPACE }}[dev]'
-          uv pip freeze
-
-      - name: Run tests
-        env:
-          NAMESPACE: ${{ matrix.namespace }}
-        run: |
-          ulimit -n 65536
-          cd ${{ env.NAMESPACE }}
-          uv run pytest
+  integration-tests:
+    name: Integration / Python ${{ matrix.python-version }}
+    needs: unit-tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        namespace: ['wool']
+        python-version: ['3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/run-tests
+        with:
+          python-version: ${{ matrix.python-version }}
+          namespace: ${{ matrix.namespace }}
+          pytest-marker: integration
+          cov-fail-under: '70'

--- a/wool/.coveragerc
+++ b/wool/.coveragerc
@@ -9,4 +9,3 @@ omit =
 [report]
 show_missing = true
 precision = 2
-fail_under = 98


### PR DESCRIPTION
## Summary

Replace the single `run-tests` job with two independent jobs — `unit-tests` and `integration-tests` — each filtering by pytest marker and enforcing its own coverage threshold (98% for unit, 70% for integration). The integration job declares `needs: unit-tests` so it only runs after unit tests pass. Extract the shared checkout, uv setup, install, and pytest steps into a `run-tests` composite action to eliminate duplication across both jobs. Move the `fail_under` setting out of `.coveragerc` into per-job `--cov-fail-under` CLI args to allow independent thresholds.

Closes #141

## Proposed changes

### Add run-tests composite action

Introduce `.github/actions/run-tests/action.yaml` — a composite action that accepts `python-version`, `namespace`, `pytest-marker`, and `cov-fail-under` as inputs. Bundle the four repeated steps (checkout, uv setup, package install, pytest run) into a single reusable action, following the existing pattern in `.github/actions/`.

### Split run-tests into unit-tests and integration-tests

Replace the `run-tests` job with two jobs that each call the `run-tests` composite action with different marker and threshold inputs. The `unit-tests` job runs `-m "not integration"` with `--cov-fail-under=98`. The `integration-tests` job runs `-m integration` with `--cov-fail-under=70` and gates on `needs: unit-tests`. The Python 3.11/3.12/3.13 matrix is preserved for both.

### Remove fail_under from .coveragerc

Remove the `fail_under = 98` line from `wool/.coveragerc` since coverage thresholds are now passed as CLI arguments per job.