### PR TITLE
Make worker proxy start lazily on dispatch by default — Closes #54

### DIFF
--- a/wool/README.md
+++ b/wool/README.md
@@ -156,6 +156,14 @@ async with wool.WorkerPool(discovery=wool.LanDiscovery(), lease=10):
     result = await my_routine()
 ```
 
+`lazy` controls whether the pool's internal `WorkerProxy` defers startup until the first task is dispatched. Defaults to `True`. The pool propagates this flag to every `WorkerProxy` it constructs, and each task serializes the proxy (including the flag) so that workers receiving the task inherit the same laziness setting. With `lazy=True`, worker subprocesses that never invoke nested `@wool.routine` calls avoid the cost of discovery subscription and sentinel setup entirely. Set `lazy=False` to start proxies eagerly — useful when you want connections established before the first dispatch.
+
+```python
+# Eager proxy startup — connections established before first dispatch
+async with wool.WorkerPool(spawn=4, lazy=False):
+    result = await my_routine()
+```
+
 ## Workers
 
 A worker is a separate OS process hosting a gRPC server with two RPCs: `dispatch` (bidirectional streaming for task execution) and `stop` (graceful shutdown). Tasks execute on a dedicated asyncio event loop in a separate daemon thread, so that long-running or CPU-intensive task code does not block the main gRPC event loop. This keeps the worker responsive to new dispatches, stop requests, and concurrent streaming interactions with in-flight tasks.

--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -193,7 +193,9 @@ Signal handlers map `SIGTERM` to timeout 0 (cancel immediately) and `SIGINT` to 
 
 ### Nested routines
 
-Worker subprocesses can dispatch tasks to other workers. Each subprocess is configured with a `ResourcePool` of `WorkerProxy` instances (via `wool.__proxy_pool__`), so `@wool.routine` calls within a task transparently route to the target pool. Spinning up a `WorkerProxy` is not free — it involves establishing a discovery subscription and opening gRPC connections — so the resource pool caches proxies with a configurable TTL (default 60 seconds, set via `proxy_pool_ttl` on `LocalWorker`). If the interval between dispatches for a given pool on a given worker is shorter than the TTL, the cached proxy is reused. If it exceeds the TTL, the proxy is finalized and must be recreated on the next dispatch. Tuning `proxy_pool_ttl` above the expected dispatch interval keeps proxies warm and avoids this cold-start overhead.
+Worker subprocesses can dispatch tasks to other workers. Each subprocess is configured with a `ResourcePool` of `WorkerProxy` instances (via `wool.__proxy_pool__`), so `@wool.routine` calls within a task transparently route to the target pool. Spinning up a `WorkerProxy` is not free — it involves establishing a discovery subscription, starting a sentinel task, and opening gRPC connections — so the resource pool caches proxies with a configurable TTL (default 60 seconds, set via `proxy_pool_ttl` on `LocalWorker`). If the interval between dispatches for a given pool on a given worker is shorter than the TTL, the cached proxy is reused. If it exceeds the TTL, the proxy is finalized and must be recreated on the next dispatch. Tuning `proxy_pool_ttl` above the expected dispatch interval keeps proxies warm and avoids this cold-start overhead.
+
+Proxies on worker subprocesses are lazy by default — the `WorkerPool` propagates its `lazy` flag to every `WorkerProxy` it constructs, and each task serializes the proxy (including the flag) so that workers receiving the task inherit the same laziness setting. A lazy proxy defers discovery subscription and sentinel setup until its first `dispatch()` call, so workers that never invoke nested routines pay no startup cost.
 
 ## Connections
 
@@ -206,6 +208,17 @@ Worker subprocesses can dispatch tasks to other workers. Each subprocess is conf
 | Pool URI | `pool_uri` | Subscribes to `LocalDiscovery` with the URI as namespace and tag filter. |
 | Discovery | `discovery` | Accepts any `DiscoverySubscriberLike` or `Factory` thereof. |
 | Static | `workers` | Takes a sequence of `WorkerMetadata` directly — no discovery needed. |
+
+### Lazy startup
+
+`WorkerProxy` accepts a `lazy` parameter (default `True`) that controls when the proxy actually starts — i.e., when it subscribes to discovery, launches the worker sentinel task, and initializes the load balancer context.
+
+| `lazy` | `start()` / `__aenter__` | `dispatch()` | `stop()` on un-started proxy |
+| ------ | ------------------------ | ------------- | ---------------------------- |
+| `True` | No-op | Starts the proxy on first call, then dispatches | No-op (safe to call) |
+| `False` | Starts eagerly | Raises `RuntimeError` if not started | Raises `RuntimeError` |
+
+When `lazy=True`, concurrent `dispatch()` calls use a double-checked lock to ensure the proxy starts exactly once. The `lazy` flag is preserved through `cloudpickle` serialization, so proxies sent to worker subprocesses as part of a task retain their laziness setting.
 
 ### Self-describing connections
 

--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -213,10 +213,10 @@ Proxies on worker subprocesses are lazy by default — the `WorkerPool` propagat
 
 `WorkerProxy` accepts a `lazy` parameter (default `True`) that controls when the proxy actually starts — i.e., when it subscribes to discovery, launches the worker sentinel task, and initializes the load balancer context.
 
-| `lazy` | `start()` / `__aenter__` | `dispatch()` | `stop()` on un-started proxy |
-| ------ | ------------------------ | ------------- | ---------------------------- |
-| `True` | No-op | Starts the proxy on first call, then dispatches | No-op (safe to call) |
-| `False` | Starts eagerly | Raises `RuntimeError` if not started | Raises `RuntimeError` |
+| `lazy` | `enter()` / `__aenter__` | `dispatch()` | `exit()` on un-started proxy |
+| ------ | ------------------------ | ------------- | ----------------------------- |
+| `True` | Sets context var only | Calls `start()` on first call, then dispatches | No-op (safe to call) |
+| `False` | Sets context var, calls `start()` | Raises `RuntimeError` if not started | Raises `RuntimeError` |
 
 When `lazy=True`, concurrent `dispatch()` calls use a double-checked lock to ensure the proxy starts exactly once. The `lazy` flag is preserved through `cloudpickle` serialization, so proxies sent to worker subprocesses as part of a task retain their laziness setting.
 

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -180,6 +180,7 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
+        lazy: bool = True,
     ):
         """
         Create an ephemeral pool of workers, spawning the specified
@@ -197,6 +198,7 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
+        lazy: bool = True,
     ):
         """
         Connect to an existing pool of workers discovered by the
@@ -216,6 +218,7 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
+        lazy: bool = True,
     ):
         """
         Create a hybrid pool that spawns local workers and discovers
@@ -236,6 +239,7 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
+        lazy: bool = True,
     ): ...
 
     @overload
@@ -251,6 +255,7 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
+        lazy: bool = True,
     ): ...
 
     def __init__(
@@ -265,9 +270,11 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
+        lazy: bool = True,
     ):
         self._workers = {}
         self._credentials = credentials
+        self._lazy = lazy
 
         if size is not None and spawn is not None:
             raise TypeError(
@@ -310,6 +317,7 @@ class WorkerPool:
                                 loadbalancer=loadbalancer,
                                 credentials=self._credentials,
                                 lease=max_workers,
+                                lazy=self._lazy,
                             ):
                                 yield
                     finally:
@@ -335,6 +343,7 @@ class WorkerPool:
                                 loadbalancer=loadbalancer,
                                 credentials=self._credentials,
                                 lease=max_workers,
+                                lazy=self._lazy,
                             ):
                                 yield
 
@@ -353,6 +362,7 @@ class WorkerPool:
                             loadbalancer=loadbalancer,
                             credentials=self._credentials,
                             lease=lease,
+                            lazy=self._lazy,
                         ):
                             yield
                     finally:
@@ -378,6 +388,7 @@ class WorkerPool:
                                 loadbalancer=loadbalancer,
                                 credentials=self._credentials,
                                 lease=max_workers,
+                                lazy=self._lazy,
                             ):
                                 yield
 

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -390,30 +390,30 @@ def _sigint_handler(loop, service, signum, frame):
 async def _proxy_factory(proxy: WorkerProxy):
     """Factory function for WorkerProxy instances in ResourcePool.
 
-    Calls ``start()`` on the proxy. Lazy proxies treat this as a
-    no-op and defer startup until first dispatch. Non-lazy proxies
-    start eagerly. The proxy object itself is used as the cache key.
+    Calls ``enter()`` on the proxy.  Lazy proxies defer actual
+    startup until first dispatch; non-lazy proxies start eagerly.
+    The proxy object itself is used as the cache key.
 
     :param proxy:
         The WorkerProxy instance (passed as key from ResourcePool).
     :returns:
-        The started (or lazy) WorkerProxy instance.
+        The entered WorkerProxy instance.
     """
-    await proxy.start()
+    await proxy.enter()
     return proxy
 
 
 async def _proxy_finalizer(proxy: WorkerProxy):
     """Finalizer function for WorkerProxy instances in ResourcePool.
 
-    Stops the proxy when it's being cleaned up from the resource pool.
-    Lazy proxies that were never started are handled gracefully by
-    the proxy's own stop method.
+    Exits the proxy context when it's being cleaned up from the
+    resource pool.  Lazy proxies that were never started are handled
+    gracefully by the proxy's own exit method.
 
     :param proxy:
         The WorkerProxy instance to clean up.
     """
     try:
-        await proxy.stop()
+        await proxy.exit()
     except Exception:
         pass

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -390,17 +390,16 @@ def _sigint_handler(loop, service, signum, frame):
 async def _proxy_factory(proxy: WorkerProxy):
     """Factory function for WorkerProxy instances in ResourcePool.
 
-    Starts the proxy if not already started and returns it.
-    The proxy object itself is used as the cache key.
+    Calls ``start()`` on the proxy. Lazy proxies treat this as a
+    no-op and defer startup until first dispatch. Non-lazy proxies
+    start eagerly. The proxy object itself is used as the cache key.
 
     :param proxy:
-        The WorkerProxy instance to start (passed as key from
-        ResourcePool).
+        The WorkerProxy instance (passed as key from ResourcePool).
     :returns:
-        The started WorkerProxy instance.
+        The started (or lazy) WorkerProxy instance.
     """
-    if not proxy.started:
-        await proxy.start()
+    await proxy.start()
     return proxy
 
 
@@ -408,7 +407,8 @@ async def _proxy_finalizer(proxy: WorkerProxy):
     """Finalizer function for WorkerProxy instances in ResourcePool.
 
     Stops the proxy when it's being cleaned up from the resource pool.
-    Based on the cleanup logic from WorkerProxyCache._delayed_cleanup.
+    Lazy proxies that were never started are handled gracefully by
+    the proxy's own stop method.
 
     :param proxy:
         The WorkerProxy instance to clean up.

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -35,6 +35,8 @@ from wool.runtime.worker.connection import WorkerConnection
 from wool.runtime.worker.metadata import WorkerMetadata
 
 if TYPE_CHECKING:
+    from contextvars import Token
+
     from wool.runtime.routine.task import Task
 
 T = TypeVar("T")
@@ -208,6 +210,7 @@ class WorkerProxy:
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
         lease: int | None = None,
+        lazy: bool = True,
     ): ...
 
     @overload
@@ -220,6 +223,7 @@ class WorkerProxy:
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
         lease: int | None = None,
+        lazy: bool = True,
     ): ...
 
     @overload
@@ -232,6 +236,7 @@ class WorkerProxy:
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
         lease: int | None = None,
+        lazy: bool = True,
     ): ...
 
     def __init__(
@@ -247,6 +252,7 @@ class WorkerProxy:
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
         lease: int | None = None,
+        lazy: bool = True,
     ):
         if not (pool_uri or discovery or workers):
             raise ValueError(
@@ -259,8 +265,11 @@ class WorkerProxy:
 
         self._id: uuid.UUID = uuid.uuid4()
         self._started = False
+        self._lazy = lazy
+        self._start_lock = asyncio.Lock() if lazy else None
         self._loadbalancer = loadbalancer
         self._lease = lease
+        self._proxy_token: Token[WorkerProxy | None] | None = None
 
         if isinstance(loadbalancer, (ContextManager, AsyncContextManager)):
             warnings.warn(
@@ -363,11 +372,12 @@ class WorkerProxy:
                     f"{name}=my_cm())."
                 )
 
-        def _restore_proxy(discovery, loadbalancer, proxy_id, lease):
+        def _restore_proxy(discovery, loadbalancer, proxy_id, lease, lazy):
             proxy = WorkerProxy(
                 discovery=discovery,
                 loadbalancer=loadbalancer,
                 lease=lease,
+                lazy=lazy,
             )
             proxy._id = proxy_id
             return proxy
@@ -379,6 +389,7 @@ class WorkerProxy:
                 self._loadbalancer,
                 self._id,
                 self._lease,
+                self._lazy,
             ),
         )
 
@@ -391,6 +402,10 @@ class WorkerProxy:
         return self._started
 
     @property
+    def lazy(self) -> bool:
+        return self._lazy
+
+    @property
     def workers(self) -> list[WorkerMetadata]:
         """A list of the currently discovered worker gRPC stubs."""
         if self._loadbalancer_context:
@@ -401,9 +416,21 @@ class WorkerProxy:
     async def start(self) -> None:
         """Starts the proxy by initiating the worker discovery process.
 
+        Always sets this proxy as the active context variable.  When
+        ``lazy=True``, defers discovery and load-balancer startup
+        until :meth:`dispatch` is first called.  When ``lazy=False``,
+        starts eagerly.
+
         :raises RuntimeError:
-            If the proxy has already been started.
+            If the proxy has already been started and ``lazy`` is
+            ``False``.
         """
+        self._proxy_token = wool.__proxy__.set(self)
+        if self._lazy:
+            return
+        await self._start()
+
+    async def _start(self) -> None:
         if self._started:
             raise RuntimeError("Proxy already started")
 
@@ -421,7 +448,6 @@ class WorkerProxy:
         if not isinstance(self._discovery_stream, DiscoverySubscriberLike):
             raise ValueError
 
-        self._proxy_token = wool.__proxy__.set(self)
         self._loadbalancer_context = LoadBalancerContext()
         self._sentinel_task = asyncio.create_task(self._worker_sentinel())
         self._started = True
@@ -429,25 +455,34 @@ class WorkerProxy:
     async def stop(self, *args) -> None:
         """Stops the proxy, terminating discovery and clearing connections.
 
+        When ``lazy=True``, calling stop on an un-started proxy resets
+        only the context variable. When ``lazy=False``, raises
+        :class:`RuntimeError`.
+
         :raises RuntimeError:
-            If the proxy was not started first.
+            If the proxy was not started first and ``lazy`` is
+            ``False``.
         """
+        if self._proxy_token is not None:
+            wool.__proxy__.reset(self._proxy_token)
+            self._proxy_token = None
         if not self._started:
-            raise RuntimeError("Proxy not started - call start() first")
+            if not self._lazy:
+                raise RuntimeError("Proxy not started - call start() first")
+            return
+        else:
+            await self._exit_context(self._discovery_context_manager, *args)
+            await self._exit_context(self._loadbalancer_context_manager, *args)
 
-        await self._exit_context(self._discovery_context_manager, *args)
-        await self._exit_context(self._loadbalancer_context_manager, *args)
-
-        wool.__proxy__.reset(self._proxy_token)
-        if self._sentinel_task:
-            self._sentinel_task.cancel()
-            try:
-                await self._sentinel_task
-            except asyncio.CancelledError:
-                pass
-            self._sentinel_task = None
-        self._loadbalancer_context = None
-        self._started = False
+            if self._sentinel_task:
+                self._sentinel_task.cancel()
+                try:
+                    await self._sentinel_task
+                except asyncio.CancelledError:
+                    pass
+                self._sentinel_task = None
+            self._loadbalancer_context = None
+            self._started = False
 
     async def dispatch(
         self, task: Task, *, timeout: float | None = None
@@ -456,7 +491,8 @@ class WorkerProxy:
 
         This method selects a worker using a round-robin strategy. If no
         workers are available within the timeout period, it raises an
-        exception.
+        exception. When ``lazy=True``, the proxy is started automatically
+        on first dispatch.
 
         :param task:
             The :class:`Task` object to be dispatched.
@@ -465,12 +501,17 @@ class WorkerProxy:
         :returns:
             A protobuf result object from the worker.
         :raises RuntimeError:
-            If the proxy is not started.
+            If the proxy is not started and ``lazy`` is ``False``.
         :raises asyncio.TimeoutError:
             If no worker is available within the timeout period.
         """
         if not self._started:
-            raise RuntimeError("Proxy not started - call start() first")
+            if not self._lazy:
+                raise RuntimeError("Proxy not started - call start() first")
+            assert self._start_lock is not None
+            async with self._start_lock:
+                if not self._started:
+                    await self._start()
 
         await asyncio.wait_for(self._await_workers(), 60)
 

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -331,13 +331,13 @@ class WorkerProxy:
         self._loadbalancer_context: LoadBalancerContext | None = None
 
     async def __aenter__(self):
-        """Starts the proxy and sets it as the active context."""
-        await self.start()
+        """Enters the proxy context and sets it as the active proxy."""
+        await self.enter()
         return self
 
     async def __aexit__(self, *args):
-        """Stops the proxy and resets the active context."""
-        await self.stop(*args)
+        """Exits the proxy context and resets the active proxy."""
+        await self.exit(*args)
 
     def __hash__(self) -> int:
         return hash(str(self.id))
@@ -413,13 +413,13 @@ class WorkerProxy:
         else:
             return []
 
-    async def start(self) -> None:
-        """Starts the proxy by initiating the worker discovery process.
+    async def enter(self) -> None:
+        """Enter the proxy context.
 
-        Always sets this proxy as the active context variable.  When
-        ``lazy=True``, defers discovery and load-balancer startup
-        until :meth:`dispatch` is first called.  When ``lazy=False``,
-        starts eagerly.
+        Sets this proxy as the active context variable.  When
+        ``lazy=True``, defers resource acquisition until
+        :meth:`dispatch` is first called.  When ``lazy=False``,
+        calls :meth:`start` eagerly.
 
         :raises RuntimeError:
             If the proxy has already been started and ``lazy`` is
@@ -428,9 +428,17 @@ class WorkerProxy:
         self._proxy_token = wool.__proxy__.set(self)
         if self._lazy:
             return
-        await self._start()
+        await self.start()
 
-    async def _start(self) -> None:
+    async def start(self) -> None:
+        """Start the proxy by initiating discovery and load balancing.
+
+        Subscribes to worker discovery, initializes the load-balancer
+        context, and launches the worker sentinel task.
+
+        :raises RuntimeError:
+            If the proxy has already been started.
+        """
         if self._started:
             raise RuntimeError("Proxy already started")
 
@@ -452,12 +460,12 @@ class WorkerProxy:
         self._sentinel_task = asyncio.create_task(self._worker_sentinel())
         self._started = True
 
-    async def stop(self, *args) -> None:
-        """Stops the proxy, terminating discovery and clearing connections.
+    async def exit(self, *args) -> None:
+        """Exit the proxy context.
 
-        When ``lazy=True``, calling stop on an un-started proxy resets
-        only the context variable. When ``lazy=False``, raises
-        :class:`RuntimeError`.
+        Resets the context variable.  If the proxy was started,
+        delegates to :meth:`stop` to release resources.  Calling
+        ``exit()`` on an un-started lazy proxy is a safe no-op.
 
         :raises RuntimeError:
             If the proxy was not started first and ``lazy`` is
@@ -470,19 +478,29 @@ class WorkerProxy:
             if not self._lazy:
                 raise RuntimeError("Proxy not started - call start() first")
             return
-        else:
-            await self._exit_context(self._discovery_context_manager, *args)
-            await self._exit_context(self._loadbalancer_context_manager, *args)
+        await self.stop(*args)
 
-            if self._sentinel_task:
-                self._sentinel_task.cancel()
-                try:
-                    await self._sentinel_task
-                except asyncio.CancelledError:
-                    pass
-                self._sentinel_task = None
-            self._loadbalancer_context = None
-            self._started = False
+    async def stop(self, *args) -> None:
+        """Stop the proxy, terminating discovery and clearing connections.
+
+        :raises RuntimeError:
+            If the proxy was not started first.
+        """
+        if not self._started:
+            raise RuntimeError("Proxy not started - call start() first")
+
+        await self._exit_context(self._discovery_context_manager, *args)
+        await self._exit_context(self._loadbalancer_context_manager, *args)
+
+        if self._sentinel_task:
+            self._sentinel_task.cancel()
+            try:
+                await self._sentinel_task
+            except asyncio.CancelledError:
+                pass
+            self._sentinel_task = None
+        self._loadbalancer_context = None
+        self._started = False
 
     async def dispatch(
         self, task: Task, *, timeout: float | None = None
@@ -511,7 +529,7 @@ class WorkerProxy:
             assert self._start_lock is not None
             async with self._start_lock:
                 if not self._started:
-                    await self._start()
+                    await self.start()
 
         await asyncio.wait_for(self._await_workers(), 60)
 

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -105,6 +105,11 @@ class RoutineBinding(Enum):
     STATICMETHOD = auto()
 
 
+class LazyMode(Enum):
+    LAZY = auto()
+    EAGER = auto()
+
+
 @dataclass(frozen=True)
 class Scenario:
     """Composable scenario describing one integration test configuration.
@@ -121,6 +126,7 @@ class Scenario:
     options: WorkerOptionsKind | None = None
     timeout: TimeoutKind | None = None
     binding: RoutineBinding | None = None
+    lazy: LazyMode | None = None
 
     def __or__(self, other: Scenario) -> Scenario:
         """Merge two partial scenarios. Right side wins on ``None`` fields.
@@ -141,7 +147,7 @@ class Scenario:
 
     @property
     def is_complete(self) -> bool:
-        """True when all 8 dimensions are set."""
+        """True when all 9 dimensions are set."""
         return all(getattr(self, f.name) is not None for f in fields(self))
 
     def __str__(self) -> str:
@@ -277,20 +283,24 @@ async def build_pool_from_scenario(scenario, credentials_map):
     if scenario.timeout is TimeoutKind.VIA_RUNTIME_CONTEXT:
         runtime_ctx = RuntimeContext(dispatch_timeout=30.0)
 
+    lazy = scenario.lazy is LazyMode.LAZY
+
     try:
         if runtime_ctx is not None:
             runtime_ctx.__enter__()
 
         try:
             if scenario.pool_mode is PoolMode.DURABLE:
-                async with _durable_pool_context(lb, creds, options) as pool:
+                async with _durable_pool_context(lb, creds, options, lazy) as pool:
                     yield pool
             elif scenario.pool_mode is PoolMode.DURABLE_SHARED:
-                async with _durable_shared_pool_context(lb, creds, options) as pool:
+                async with _durable_shared_pool_context(
+                    lb, creds, options, lazy
+                ) as pool:
                     yield pool
             elif scenario.pool_mode is PoolMode.DURABLE_JOINED:
                 async with _durable_joined_pool_context(
-                    scenario.discovery, lb, creds, options
+                    scenario.discovery, lb, creds, options, lazy
                 ) as pool:
                     yield pool
             else:
@@ -298,6 +308,7 @@ async def build_pool_from_scenario(scenario, credentials_map):
                     "loadbalancer": lb,
                     "credentials": creds,
                     "worker": partial(LocalWorker, options=options),
+                    "lazy": lazy,
                 }
                 match scenario.pool_mode:
                     case PoolMode.DEFAULT:
@@ -345,7 +356,7 @@ async def build_pool_from_scenario(scenario, credentials_map):
 
 
 @asynccontextmanager
-async def _durable_pool_context(lb, creds, options):
+async def _durable_pool_context(lb, creds, options, lazy):
     """Manually start a worker, register it, then create a DURABLE pool.
 
     DURABLE pools don't spawn workers — they only discover external
@@ -368,6 +379,7 @@ async def _durable_pool_context(lb, creds, options):
                         discovery=_DirectDiscovery(discovery),
                         loadbalancer=lb,
                         credentials=creds,
+                        lazy=lazy,
                     )
                     async with pool:
                         yield pool
@@ -378,7 +390,7 @@ async def _durable_pool_context(lb, creds, options):
 
 
 @asynccontextmanager
-async def _durable_shared_pool_context(lb, creds, options):
+async def _durable_shared_pool_context(lb, creds, options, lazy):
     """Create two pools sharing the same LocalDiscovery subscriber.
 
     Exercises ``SubscriberMeta`` singleton caching and
@@ -401,11 +413,13 @@ async def _durable_shared_pool_context(lb, creds, options):
                         discovery=shared,
                         loadbalancer=lb,
                         credentials=creds,
+                        lazy=lazy,
                     )
                     pool_b = WorkerPool(
                         discovery=shared,
                         loadbalancer=lb,
                         credentials=creds,
+                        lazy=lazy,
                     )
                     async with pool_a:
                         async with pool_b:
@@ -455,7 +469,7 @@ def _resolve_joiner(namespace, factory):
 
 
 @asynccontextmanager
-async def _durable_joined_pool_context(discovery_factory, lb, creds, options):
+async def _durable_joined_pool_context(discovery_factory, lb, creds, options, lazy):
     """Create a DURABLE pool that joins an externally owned namespace.
 
     Sets up an owner ``LocalDiscovery`` that creates workers and publishes
@@ -480,6 +494,7 @@ async def _durable_joined_pool_context(discovery_factory, lb, creds, options):
                         discovery=joiner,
                         loadbalancer=lb,
                         credentials=creds,
+                        lazy=lazy,
                     )
                     async with pool:
                         yield pool
@@ -704,6 +719,7 @@ PAIRWISE_SCENARIOS = [
         options=row[5],
         timeout=row[6],
         binding=row[7],
+        lazy=row[8],
     )
     for row in AllPairs(
         [
@@ -715,6 +731,7 @@ PAIRWISE_SCENARIOS = [
             list(WorkerOptionsKind),
             list(TimeoutKind),
             list(RoutineBinding),
+            list(LazyMode),
         ],
         filter_func=_pairwise_filter,
     )
@@ -774,6 +791,8 @@ def scenarios_strategy(draw):
     else:
         binding = draw(st.sampled_from(RoutineBinding))
 
+    lazy = draw(st.sampled_from(LazyMode))
+
     return Scenario(
         shape=shape,
         pool_mode=pool_mode,
@@ -783,6 +802,7 @@ def scenarios_strategy(draw):
         options=options,
         timeout=timeout,
         binding=binding,
+        lazy=lazy,
     )
 
 

--- a/wool/tests/integration/test_integration.py
+++ b/wool/tests/integration/test_integration.py
@@ -11,6 +11,7 @@ from hypothesis import settings
 from .conftest import PAIRWISE_SCENARIOS
 from .conftest import CredentialType
 from .conftest import DiscoveryFactory
+from .conftest import LazyMode
 from .conftest import LbFactory
 from .conftest import PoolMode
 from .conftest import RoutineBinding
@@ -68,6 +69,7 @@ async def test_dispatch_pairwise(scenario, credentials_map, retry_grpc_internal)
         WorkerOptionsKind.DEFAULT,
         TimeoutKind.NONE,
         RoutineBinding.MODULE_FUNCTION,
+        LazyMode.LAZY,
     )
 )
 @example(
@@ -80,6 +82,7 @@ async def test_dispatch_pairwise(scenario, credentials_map, retry_grpc_internal)
         WorkerOptionsKind.DEFAULT,
         TimeoutKind.NONE,
         RoutineBinding.MODULE_FUNCTION,
+        LazyMode.LAZY,
     )
 )
 @example(
@@ -92,6 +95,7 @@ async def test_dispatch_pairwise(scenario, credentials_map, retry_grpc_internal)
         WorkerOptionsKind.KEEPALIVE,
         TimeoutKind.NONE,
         RoutineBinding.MODULE_FUNCTION,
+        LazyMode.LAZY,
     )
 )
 @given(scenario=scenarios_strategy())

--- a/wool/tests/integration/test_pool_composition.py
+++ b/wool/tests/integration/test_pool_composition.py
@@ -4,6 +4,7 @@ import pytest
 
 from .conftest import CredentialType
 from .conftest import DiscoveryFactory
+from .conftest import LazyMode
 from .conftest import LbFactory
 from .conftest import PoolMode
 from .conftest import RoutineBinding
@@ -39,6 +40,7 @@ class TestPoolComposition:
             options=WorkerOptionsKind.DEFAULT,
             timeout=TimeoutKind.NONE,
             binding=RoutineBinding.MODULE_FUNCTION,
+            lazy=LazyMode.LAZY,
         )
 
         # Act
@@ -53,7 +55,8 @@ class TestPoolComposition:
         """Test building a pool with EPHEMERAL mode and size=2.
 
         Given:
-            A complete scenario using EPHEMERAL pool mode with 2 workers.
+            A complete scenario using EPHEMERAL pool mode with 2 workers
+            and eager proxy start.
         When:
             A pool is built and a coroutine routine is dispatched.
         Then:
@@ -69,6 +72,7 @@ class TestPoolComposition:
             options=WorkerOptionsKind.DEFAULT,
             timeout=TimeoutKind.NONE,
             binding=RoutineBinding.MODULE_FUNCTION,
+            lazy=LazyMode.EAGER,
         )
 
         # Act
@@ -100,6 +104,7 @@ class TestPoolComposition:
             options=WorkerOptionsKind.DEFAULT,
             timeout=TimeoutKind.NONE,
             binding=RoutineBinding.MODULE_FUNCTION,
+            lazy=LazyMode.LAZY,
         )
 
         # Act
@@ -131,6 +136,7 @@ class TestPoolComposition:
             options=WorkerOptionsKind.DEFAULT,
             timeout=TimeoutKind.NONE,
             binding=RoutineBinding.MODULE_FUNCTION,
+            lazy=LazyMode.LAZY,
         )
 
         # Act
@@ -166,6 +172,7 @@ class TestPoolComposition:
             options=WorkerOptionsKind.DEFAULT,
             timeout=TimeoutKind.NONE,
             binding=RoutineBinding.MODULE_FUNCTION,
+            lazy=LazyMode.LAZY,
         )
 
         # Act
@@ -197,6 +204,7 @@ class TestPoolComposition:
             options=WorkerOptionsKind.RESTRICTIVE,
             timeout=TimeoutKind.NONE,
             binding=RoutineBinding.MODULE_FUNCTION,
+            lazy=LazyMode.LAZY,
         )
 
         # Act
@@ -229,6 +237,7 @@ class TestPoolComposition:
             options=WorkerOptionsKind.KEEPALIVE,
             timeout=TimeoutKind.NONE,
             binding=RoutineBinding.MODULE_FUNCTION,
+            lazy=LazyMode.LAZY,
         )
 
         # Act
@@ -260,6 +269,7 @@ class TestPoolComposition:
             options=WorkerOptionsKind.DEFAULT,
             timeout=TimeoutKind.VIA_RUNTIME_CONTEXT,
             binding=RoutineBinding.MODULE_FUNCTION,
+            lazy=LazyMode.LAZY,
         )
 
         # Act
@@ -294,6 +304,7 @@ class TestPoolComposition:
             options=WorkerOptionsKind.DEFAULT,
             timeout=TimeoutKind.NONE,
             binding=RoutineBinding.MODULE_FUNCTION,
+            lazy=LazyMode.LAZY,
         )
 
         # Act

--- a/wool/tests/integration/test_scenario.py
+++ b/wool/tests/integration/test_scenario.py
@@ -4,6 +4,7 @@ import pytest
 
 from .conftest import CredentialType
 from .conftest import DiscoveryFactory
+from .conftest import LazyMode
 from .conftest import LbFactory
 from .conftest import PoolMode
 from .conftest import RoutineBinding
@@ -102,7 +103,7 @@ class TestScenario:
         """Test that a fully populated scenario reports complete.
 
         Given:
-            A scenario with all 8 dimensions set.
+            A scenario with all 9 dimensions set.
         When:
             ``is_complete`` is checked.
         Then:
@@ -118,6 +119,7 @@ class TestScenario:
             options=WorkerOptionsKind.DEFAULT,
             timeout=TimeoutKind.NONE,
             binding=RoutineBinding.MODULE_FUNCTION,
+            lazy=LazyMode.LAZY,
         )
 
         # Act & assert
@@ -163,4 +165,4 @@ class TestScenario:
         result = str(scenario)
 
         # Assert
-        assert result == "COROUTINE-DEFAULT-_-_-_-_-_-_"
+        assert result == "COROUTINE-DEFAULT-_-_-_-_-_-_-_"

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -18,8 +18,6 @@ from wool.runtime.worker.base import ChannelOptions
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.process import WorkerProcess
-from wool.runtime.worker.process import _proxy_factory
-from wool.runtime.worker.process import _proxy_finalizer
 from wool.runtime.worker.process import _sigint_handler
 from wool.runtime.worker.process import _signal_handlers
 from wool.runtime.worker.process import _sigterm_handler
@@ -213,73 +211,6 @@ async def test__signal_handlers_restores_handlers_even_on_exception(mocker):
     assert len(signal_calls) == 4
     assert signal_calls[2] == (signal.SIGTERM, old_sigterm)
     assert signal_calls[3] == (signal.SIGINT, old_sigint)
-
-
-@pytest.mark.asyncio
-async def test__proxy_factory_with_proxy(mocker):
-    """Test _proxy_factory calls start and returns the proxy.
-
-    Given:
-        A WorkerProxy instance.
-    When:
-        _proxy_factory() is called.
-    Then:
-        It should call start() and return the proxy.
-    """
-    # Arrange
-    mock_proxy = mocker.MagicMock()
-    mock_proxy.start = mocker.AsyncMock()
-
-    # Act
-    result = await _proxy_factory(mock_proxy)
-
-    # Assert
-    mock_proxy.start.assert_called_once()
-    assert result is mock_proxy
-
-
-@pytest.mark.asyncio
-async def test__proxy_finalizer_with_proxy(mocker):
-    """Test _proxy_finalizer calls stop on the proxy.
-
-    Given:
-        A proxy that stops successfully.
-    When:
-        _proxy_finalizer() is called.
-    Then:
-        It should call proxy.stop().
-    """
-    # Arrange
-    mock_proxy = mocker.MagicMock()
-    mock_proxy.stop = mocker.AsyncMock()
-
-    # Act
-    await _proxy_finalizer(mock_proxy)
-
-    # Assert
-    mock_proxy.stop.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test__proxy_finalizer_with_stop_exception(mocker):
-    """Test _proxy_finalizer handles exception from proxy.stop() gracefully.
-
-    Given:
-        A proxy that raises an exception on stop.
-    When:
-        _proxy_finalizer() is called.
-    Then:
-        It should catch the exception and complete without propagating it.
-    """
-    # Arrange
-    mock_proxy = mocker.MagicMock()
-    mock_proxy.stop = mocker.AsyncMock(side_effect=Exception("Stop failed"))
-
-    # Act — should not raise exception
-    await _proxy_finalizer(mock_proxy)
-
-    # Assert
-    mock_proxy.stop.assert_called_once()
 
 
 class TestWorkerProcess:

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -215,6 +215,73 @@ async def test__signal_handlers_restores_handlers_even_on_exception(mocker):
     assert signal_calls[3] == (signal.SIGINT, old_sigint)
 
 
+@pytest.mark.asyncio
+async def test__proxy_factory_with_proxy(mocker):
+    """Test _proxy_factory calls start and returns the proxy.
+
+    Given:
+        A WorkerProxy instance.
+    When:
+        _proxy_factory() is called.
+    Then:
+        It should call start() and return the proxy.
+    """
+    # Arrange
+    mock_proxy = mocker.MagicMock()
+    mock_proxy.start = mocker.AsyncMock()
+
+    # Act
+    result = await _proxy_factory(mock_proxy)
+
+    # Assert
+    mock_proxy.start.assert_called_once()
+    assert result is mock_proxy
+
+
+@pytest.mark.asyncio
+async def test__proxy_finalizer_with_proxy(mocker):
+    """Test _proxy_finalizer calls stop on the proxy.
+
+    Given:
+        A proxy that stops successfully.
+    When:
+        _proxy_finalizer() is called.
+    Then:
+        It should call proxy.stop().
+    """
+    # Arrange
+    mock_proxy = mocker.MagicMock()
+    mock_proxy.stop = mocker.AsyncMock()
+
+    # Act
+    await _proxy_finalizer(mock_proxy)
+
+    # Assert
+    mock_proxy.stop.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test__proxy_finalizer_with_stop_exception(mocker):
+    """Test _proxy_finalizer handles exception from proxy.stop() gracefully.
+
+    Given:
+        A proxy that raises an exception on stop.
+    When:
+        _proxy_finalizer() is called.
+    Then:
+        It should catch the exception and complete without propagating it.
+    """
+    # Arrange
+    mock_proxy = mocker.MagicMock()
+    mock_proxy.stop = mocker.AsyncMock(side_effect=Exception("Stop failed"))
+
+    # Act — should not raise exception
+    await _proxy_finalizer(mock_proxy)
+
+    # Assert
+    mock_proxy.stop.assert_called_once()
+
+
 class TestWorkerProcess:
     """Test suite for WorkerProcess."""
 
@@ -745,96 +812,6 @@ class TestWorkerProcess:
         assert process.metadata.extra == MappingProxyType({"key": "value"})
         assert isinstance(process.metadata.extra, MappingProxyType)
         assert process.metadata.tags == frozenset({"gpu"})
-
-    @pytest.mark.asyncio
-    async def test__proxy_factory_starts_proxy_when_not_started(self, mocker):
-        """Test _proxy_factory starts proxy when not already started.
-
-        Given:
-            A WorkerProcess and a proxy with started=False
-        When:
-            _proxy_factory() is called
-        Then:
-            It should call proxy.start() and return the proxy
-        """
-        # Arrange
-        mock_proxy = mocker.MagicMock()
-        mock_proxy.started = False
-        mock_proxy.start = mocker.AsyncMock()
-
-        # Act
-        result = await _proxy_factory(mock_proxy)
-
-        # Assert
-        mock_proxy.start.assert_called_once()
-        assert result is mock_proxy
-
-    @pytest.mark.asyncio
-    async def test__proxy_factory_does_not_start_proxy_when_already_started(
-        self, mocker
-    ):
-        """Test _proxy_factory does not start proxy when already started.
-
-        Given:
-            A WorkerProcess and a proxy with started=True
-        When:
-            _proxy_factory() is called
-        Then:
-            It should not call proxy.start() but still return the proxy
-        """
-        # Arrange
-        mock_proxy = mocker.MagicMock()
-        mock_proxy.started = True
-        mock_proxy.start = mocker.AsyncMock()
-
-        # Act
-        result = await _proxy_factory(mock_proxy)
-
-        # Assert
-        mock_proxy.start.assert_not_called()
-        assert result is mock_proxy
-
-    @pytest.mark.asyncio
-    async def test__proxy_finalizer_successfully_stops_proxy(self, mocker):
-        """Test _proxy_finalizer successfully stops proxy.
-
-        Given:
-            A WorkerProcess and a proxy that stops successfully
-        When:
-            _proxy_finalizer() is called
-        Then:
-            It should call proxy.stop() and complete without error
-        """
-        # Arrange
-        mock_proxy = mocker.MagicMock()
-        mock_proxy.stop = mocker.AsyncMock()
-
-        # Act
-        await _proxy_finalizer(mock_proxy)
-
-        # Assert
-        mock_proxy.stop.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test__proxy_finalizer_handles_exception_gracefully(self, mocker):
-        """Test _proxy_finalizer handles exception from proxy.stop() gracefully.
-
-        Given:
-            A WorkerProcess and a proxy that raises exception on stop
-        When:
-            _proxy_finalizer() is called
-        Then:
-            It should catch the exception and complete without propagating it
-        """
-        # Arrange
-        mock_proxy = mocker.MagicMock()
-        mock_proxy.stop = mocker.AsyncMock(side_effect=Exception("Stop failed"))
-
-        # Act — should not raise exception
-        await _proxy_finalizer(mock_proxy)
-
-        # Assert
-        mock_proxy.stop.assert_called_once()
 
     def test_run_sets_up_proxy_pool_and_starts_server(self, mocker):
         """Test run method sets up proxy pool and starts gRPC server.

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -756,13 +756,13 @@ class TestWorkerProxy:
         assert proxy.started
 
     @pytest.mark.asyncio
-    async def test_start_with_lazy_proxy(self, mock_discovery_service):
-        """Test start is a no-op for lazy proxies.
+    async def test_enter_with_lazy_proxy(self, mock_discovery_service):
+        """Test enter defers startup for lazy proxies.
 
         Given:
-            A lazy WorkerProxy that has not been started.
+            A lazy WorkerProxy that has not been entered.
         When:
-            start() is called.
+            enter() is called.
         Then:
             It should remain un-started.
         """
@@ -770,24 +770,46 @@ class TestWorkerProxy:
         proxy = WorkerProxy(discovery=mock_discovery_service)
 
         # Act
-        await proxy.start()
+        await proxy.enter()
 
         # Assert
         assert not proxy.started
+
+    @pytest.mark.asyncio
+    async def test_enter_with_non_lazy_proxy(
+        self, mock_discovery_service, mock_proxy_session
+    ):
+        """Test enter eagerly starts a non-lazy proxy.
+
+        Given:
+            A non-lazy WorkerProxy that has not been entered.
+        When:
+            enter() is called.
+        Then:
+            It should set started to True.
+        """
+        # Arrange
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+
+        # Act
+        await proxy.enter()
+
+        # Assert
+        assert proxy.started
 
     @pytest.mark.asyncio
     async def test_stop_clears_state(self, mock_discovery_service, mock_proxy_session):
         """Test clear workers and reset the started flag to False.
 
         Given:
-            A started WorkerProxy with registered workers
+            A started WorkerProxy with registered workers.
         When:
-            Stop is called
+            stop() is called.
         Then:
-            It should clear workers and reset the started flag to False
+            It should clear workers and reset the started flag to False.
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
         await proxy.start()
 
         # Act
@@ -819,31 +841,31 @@ class TestWorkerProxy:
             await proxy.start()
 
     @pytest.mark.asyncio
-    async def test_stop_not_started_raises_error(self, mock_discovery_service):
+    async def test_exit_not_started_raises_error(self, mock_discovery_service):
         """Test raise RuntimeError.
 
         Given:
-            A non-lazy WorkerProxy that is not started
+            A non-lazy WorkerProxy that is not started.
         When:
-            Stop is called
+            exit() is called.
         Then:
-            It should raise RuntimeError
+            It should raise RuntimeError.
         """
         # Arrange
         proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
 
         # Act & assert
         with pytest.raises(RuntimeError, match="Proxy not started"):
-            await proxy.stop()
+            await proxy.exit()
 
     @pytest.mark.asyncio
-    async def test_stop_with_unstarted_lazy_proxy(self, mock_discovery_service):
-        """Test stop is a no-op on an un-started lazy proxy.
+    async def test_exit_with_unstarted_lazy_proxy(self, mock_discovery_service):
+        """Test exit is a no-op on an un-started lazy proxy.
 
         Given:
             A lazy WorkerProxy that was never started.
         When:
-            stop() is called.
+            exit() is called.
         Then:
             It should return without raising.
         """
@@ -851,7 +873,32 @@ class TestWorkerProxy:
         proxy = WorkerProxy(discovery=mock_discovery_service)
 
         # Act & assert — should not raise
-        await proxy.stop()
+        await proxy.exit()
+
+    @pytest.mark.asyncio
+    async def test_exit_stops_started_lazy_proxy(
+        self, mock_discovery_service, mock_proxy_session
+    ):
+        """Test exit stops a lazy proxy that was started.
+
+        Given:
+            A lazy WorkerProxy that was entered and subsequently started.
+        When:
+            exit() is called.
+        Then:
+            It should stop the proxy and set started to False.
+        """
+        # Arrange
+        proxy = WorkerProxy(discovery=mock_discovery_service)
+        await proxy.enter()
+        await proxy.start()
+        assert proxy.started
+
+        # Act
+        await proxy.exit()
+
+        # Assert
+        assert not proxy.started
 
     @pytest.mark.asyncio
     async def test___aenter___enter_starts_proxy(
@@ -1637,8 +1684,8 @@ class TestWorkerProxy:
         assert len(restored.workers) == 2
         await restored.stop()
 
-    def test_cloudpickle_serialization_preserves_lazy(self, mock_discovery_service):
-        """Test pickle round-trip preserves the lazy flag.
+    def test_cloudpickle_serialization_with_lazy_false(self, mock_discovery_service):
+        """Test pickle round-trip with explicit lazy=False.
 
         Given:
             A WorkerProxy with lazy=False.
@@ -1659,6 +1706,46 @@ class TestWorkerProxy:
 
         # Assert
         assert restored.lazy is False
+
+    def test_cloudpickle_serialization_with_default_lazy(self, mock_discovery_service):
+        """Test pickle round-trip with default lazy=True.
+
+        Given:
+            A WorkerProxy with default lazy=True.
+        When:
+            The proxy is pickled and unpickled.
+        Then:
+            It should preserve lazy as True on the restored proxy.
+        """
+        # Arrange
+        proxy = WorkerProxy(
+            discovery=mock_discovery_service,
+            loadbalancer=wp.RoundRobinLoadBalancer,
+        )
+
+        # Act
+        restored = cloudpickle.loads(cloudpickle.dumps(proxy))
+
+        # Assert
+        assert restored.lazy is True
+
+    @given(lazy=st.booleans())
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test___init___with_arbitrary_lazy_value(self, mock_discovery_service, lazy):
+        """Test instantiation with an arbitrary lazy value.
+
+        Given:
+            An arbitrary boolean value for lazy.
+        When:
+            WorkerProxy is instantiated with that value.
+        Then:
+            It should set the lazy property to the given value.
+        """
+        # Act
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=lazy)
+
+        # Assert
+        assert proxy.lazy is lazy
 
     @pytest.mark.asyncio
     async def test_dispatch_delegates_to_loadbalancer(

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -647,19 +647,51 @@ class TestWorkerProxy:
         user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
         assert user_warnings == []
 
+    def test___init___with_default_lazy(self, mock_discovery_service):
+        """Test WorkerProxy defaults to lazy initialization.
+
+        Given:
+            A discovery service.
+        When:
+            WorkerProxy is instantiated with default parameters.
+        Then:
+            It should have lazy set to True.
+        """
+        # Act
+        proxy = WorkerProxy(discovery=mock_discovery_service)
+
+        # Assert
+        assert proxy.lazy is True
+
+    def test___init___with_lazy_false(self, mock_discovery_service):
+        """Test WorkerProxy accepts explicit lazy=False.
+
+        Given:
+            A discovery service and lazy=False.
+        When:
+            WorkerProxy is instantiated.
+        Then:
+            It should have lazy set to False.
+        """
+        # Act
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+
+        # Assert
+        assert proxy.lazy is False
+
     @pytest.mark.asyncio
     async def test___aenter___lifecycle(self, mock_discovery_service):
         """Test it starts and stops correctly.
 
         Given:
-            A WorkerProxy configured with discovery service
+            A non-lazy WorkerProxy configured with discovery service
         When:
             The proxy is used as a context manager
         Then:
             It starts and stops correctly
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
         entered = False
         exited = False
 
@@ -708,11 +740,31 @@ class TestWorkerProxy:
         """Test set the started flag to True.
 
         Given:
-            An unstarted WorkerProxy instance
+            A non-lazy unstarted WorkerProxy instance
         When:
             Start is called
         Then:
             It should set the started flag to True
+        """
+        # Arrange
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+
+        # Act
+        await proxy.start()
+
+        # Assert
+        assert proxy.started
+
+    @pytest.mark.asyncio
+    async def test_start_with_lazy_proxy(self, mock_discovery_service):
+        """Test start is a no-op for lazy proxies.
+
+        Given:
+            A lazy WorkerProxy that has not been started.
+        When:
+            start() is called.
+        Then:
+            It should remain un-started.
         """
         # Arrange
         proxy = WorkerProxy(discovery=mock_discovery_service)
@@ -721,7 +773,7 @@ class TestWorkerProxy:
         await proxy.start()
 
         # Assert
-        assert proxy.started
+        assert not proxy.started
 
     @pytest.mark.asyncio
     async def test_stop_clears_state(self, mock_discovery_service, mock_proxy_session):
@@ -752,14 +804,14 @@ class TestWorkerProxy:
         """Test raise RuntimeError.
 
         Given:
-            A WorkerProxy that is already started
+            A non-lazy WorkerProxy that is already started
         When:
             Start is called again
         Then:
             It should raise RuntimeError
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
         await proxy.start()
 
         # Act & assert
@@ -771,18 +823,35 @@ class TestWorkerProxy:
         """Test raise RuntimeError.
 
         Given:
-            A WorkerProxy that is not started
+            A non-lazy WorkerProxy that is not started
         When:
             Stop is called
         Then:
             It should raise RuntimeError
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
 
         # Act & assert
         with pytest.raises(RuntimeError, match="Proxy not started"):
             await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_with_unstarted_lazy_proxy(self, mock_discovery_service):
+        """Test stop is a no-op on an un-started lazy proxy.
+
+        Given:
+            A lazy WorkerProxy that was never started.
+        When:
+            stop() is called.
+        Then:
+            It should return without raising.
+        """
+        # Arrange
+        proxy = WorkerProxy(discovery=mock_discovery_service)
+
+        # Act & assert — should not raise
+        await proxy.stop()
 
     @pytest.mark.asyncio
     async def test___aenter___enter_starts_proxy(
@@ -791,14 +860,14 @@ class TestWorkerProxy:
         """Test automatically start the proxy.
 
         Given:
-            An unstarted WorkerProxy
+            A non-lazy unstarted WorkerProxy
         When:
             The async context manager is entered
         Then:
             It should automatically start the proxy
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
 
         # Act & assert
         async with proxy as p:
@@ -811,14 +880,14 @@ class TestWorkerProxy:
         """Test automatically stop the proxy.
 
         Given:
-            A WorkerProxy within async context
+            A non-lazy WorkerProxy within async context
         When:
             The async context manager exits
         Then:
             It should automatically stop the proxy
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
 
         # Act
         async with proxy:
@@ -834,8 +903,8 @@ class TestWorkerProxy:
         """Test start/stop with sync context manager load balancer.
 
         Given:
-            A WorkerProxy with a load balancer provided as a sync
-            context manager.
+            A non-lazy WorkerProxy with a load balancer provided as a
+            sync context manager.
         When:
             start() then stop() are called.
         Then:
@@ -859,7 +928,9 @@ class TestWorkerProxy:
                 self.exited = True
 
         cm = SyncCM()
-        proxy = WorkerProxy(discovery=mock_discovery_service, loadbalancer=cm)
+        proxy = WorkerProxy(
+            discovery=mock_discovery_service, loadbalancer=cm, lazy=False
+        )
 
         # Act
         await proxy.start()
@@ -879,8 +950,8 @@ class TestWorkerProxy:
         """Test start/stop with async context manager load balancer.
 
         Given:
-            A WorkerProxy with a load balancer provided as an async
-            context manager.
+            A non-lazy WorkerProxy with a load balancer provided as an
+            async context manager.
         When:
             start() then stop() are called.
         Then:
@@ -904,7 +975,9 @@ class TestWorkerProxy:
                 self.exited = True
 
         cm = AsyncCM()
-        proxy = WorkerProxy(discovery=mock_discovery_service, loadbalancer=cm)
+        proxy = WorkerProxy(
+            discovery=mock_discovery_service, loadbalancer=cm, lazy=False
+        )
 
         # Act
         await proxy.start()
@@ -924,8 +997,8 @@ class TestWorkerProxy:
         """Test start with an awaitable load balancer.
 
         Given:
-            A WorkerProxy with a load balancer provided as a bare
-            awaitable (coroutine object).
+            A non-lazy WorkerProxy with a load balancer provided as a
+            bare awaitable (coroutine object).
         When:
             start() is called.
         Then:
@@ -939,7 +1012,9 @@ class TestWorkerProxy:
         async def make_lb():
             return mock_lb
 
-        proxy = WorkerProxy(discovery=mock_discovery_service, loadbalancer=make_lb())
+        proxy = WorkerProxy(
+            discovery=mock_discovery_service, loadbalancer=make_lb(), lazy=False
+        )
 
         # Act
         await proxy.start()
@@ -1055,7 +1130,7 @@ class TestWorkerProxy:
         """Test the proxy handles worker-updated events.
 
         Given:
-            A started WorkerProxy with a discovered worker.
+            A non-lazy, started WorkerProxy with a discovered worker.
         When:
             A "worker-updated" event is received for that worker.
         Then:
@@ -1074,7 +1149,7 @@ class TestWorkerProxy:
             DiscoveryEvent("worker-updated", metadata=metadata),
         ]
         discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery)
+        proxy = WorkerProxy(discovery=discovery, lazy=False)
 
         # Act
         await proxy.start()
@@ -1093,8 +1168,9 @@ class TestWorkerProxy:
         """Test sentinel creates WorkerConnection with metadata options.
 
         Given:
-            A WorkerProxy with a discovery stream yielding a worker-added
-            event whose metadata has options=ChannelOptions(keepalive_time_ms=60000)
+            A non-lazy WorkerProxy with a discovery stream yielding a
+            worker-added event whose metadata has
+            options=ChannelOptions(keepalive_time_ms=60000)
         When:
             The sentinel processes the event
         Then:
@@ -1117,7 +1193,7 @@ class TestWorkerProxy:
         )
         events = [DiscoveryEvent("worker-added", metadata=metadata)]
         discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery)
+        proxy = WorkerProxy(discovery=discovery, lazy=False)
 
         # Act
         await proxy.start()
@@ -1140,8 +1216,8 @@ class TestWorkerProxy:
         """Test sentinel creates WorkerConnection with options=None for legacy workers.
 
         Given:
-            A WorkerProxy with a discovery stream yielding a worker-added
-            event whose metadata has options=None
+            A non-lazy WorkerProxy with a discovery stream yielding a
+            worker-added event whose metadata has options=None
         When:
             The sentinel processes the event
         Then:
@@ -1161,7 +1237,7 @@ class TestWorkerProxy:
         )
         events = [DiscoveryEvent("worker-added", metadata=metadata)]
         discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery)
+        proxy = WorkerProxy(discovery=discovery, lazy=False)
 
         # Act
         await proxy.start()
@@ -1184,9 +1260,9 @@ class TestWorkerProxy:
         """Test sentinel creates WorkerConnection with updated metadata options.
 
         Given:
-            A WorkerProxy with a discovery stream yielding a worker-added
-            event followed by a worker-updated event whose metadata has
-            options=ChannelOptions(keepalive_time_ms=90000)
+            A non-lazy WorkerProxy with a discovery stream yielding a
+            worker-added event followed by a worker-updated event whose
+            metadata has options=ChannelOptions(keepalive_time_ms=90000)
         When:
             The sentinel processes the events
         Then:
@@ -1221,7 +1297,7 @@ class TestWorkerProxy:
             DiscoveryEvent("worker-updated", metadata=updated_metadata),
         ]
         discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery)
+        proxy = WorkerProxy(discovery=discovery, lazy=False)
 
         # Act
         await proxy.start()
@@ -1292,8 +1368,8 @@ class TestWorkerProxy:
         """Test sentinel respects lease cap on worker-added events.
 
         Given:
-            A WorkerProxy with lease=2 and a discovery stream with
-            3 worker-added events
+            A non-lazy WorkerProxy with lease=2 and a discovery stream
+            with 3 worker-added events
         When:
             The sentinel processes all events
         Then:
@@ -1312,7 +1388,7 @@ class TestWorkerProxy:
         ]
         events = [DiscoveryEvent("worker-added", metadata=w) for w in workers]
         discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery, lease=2)
+        proxy = WorkerProxy(discovery=discovery, lease=2, lazy=False)
 
         # Act
         await proxy.start()
@@ -1331,8 +1407,8 @@ class TestWorkerProxy:
         """Test sentinel accepts all workers when lease is None.
 
         Given:
-            A WorkerProxy with lease=None and a discovery stream
-            with 3 worker-added events
+            A non-lazy WorkerProxy with lease=None and a discovery
+            stream with 3 worker-added events
         When:
             The sentinel processes all events
         Then:
@@ -1351,7 +1427,7 @@ class TestWorkerProxy:
         ]
         events = [DiscoveryEvent("worker-added", metadata=w) for w in workers]
         discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery, lease=None)
+        proxy = WorkerProxy(discovery=discovery, lease=None, lazy=False)
 
         # Act
         await proxy.start()
@@ -1370,7 +1446,7 @@ class TestWorkerProxy:
         """Test sentinel processes worker-updated events even at capacity.
 
         Given:
-            A WorkerProxy with lease=2, already at capacity,
+            A non-lazy WorkerProxy with lease=2, already at capacity,
             receiving a worker-updated event
         When:
             The sentinel processes the update event
@@ -1397,7 +1473,7 @@ class TestWorkerProxy:
             DiscoveryEvent("worker-updated", metadata=worker1),
         ]
         discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery, lease=2)
+        proxy = WorkerProxy(discovery=discovery, lease=2, lazy=False)
 
         # Act
         await proxy.start()
@@ -1417,8 +1493,9 @@ class TestWorkerProxy:
         """Test drop restores capacity for a subsequent worker-added event.
 
         Given:
-            A WorkerProxy with lease=2, at capacity with 2 workers,
-            then one worker is dropped followed by a new worker-added
+            A non-lazy WorkerProxy with lease=2, at capacity with 2
+            workers, then one worker is dropped followed by a new
+            worker-added
         When:
             The proxy processes all events
         Then:
@@ -1451,7 +1528,7 @@ class TestWorkerProxy:
             DiscoveryEvent("worker-added", metadata=worker3),
         ]
         discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery, lease=2)
+        proxy = WorkerProxy(discovery=discovery, lease=2, lazy=False)
 
         # Act
         await proxy.start()
@@ -1472,8 +1549,8 @@ class TestWorkerProxy:
         """Test worker-updated for a cap-rejected worker is silently dropped.
 
         Given:
-            A WorkerProxy with lease=1 and a discovery stream where
-            worker2 is rejected by the cap, then a worker-updated
+            A non-lazy WorkerProxy with lease=1 and a discovery stream
+            where worker2 is rejected by the cap, then a worker-updated
             event arrives for worker2
         When:
             The proxy processes all events
@@ -1500,7 +1577,7 @@ class TestWorkerProxy:
             DiscoveryEvent("worker-updated", metadata=worker2),  # dropped
         ]
         discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery, lease=1)
+        proxy = WorkerProxy(discovery=discovery, lease=1, lazy=False)
 
         # Act
         await proxy.start()
@@ -1521,7 +1598,7 @@ class TestWorkerProxy:
         """Test pickle round-trip preserves lease cap behavior.
 
         Given:
-            A WorkerProxy with lease=2 and a discovery stream
+            A non-lazy WorkerProxy with lease=2 and a discovery stream
             with 3 worker-added events
         When:
             The proxy is pickled, unpickled, started, and processes
@@ -1547,6 +1624,7 @@ class TestWorkerProxy:
             discovery=discovery,
             loadbalancer=wp.RoundRobinLoadBalancer,
             lease=2,
+            lazy=False,
         )
 
         # Act — pickle round-trip, then start the restored proxy
@@ -1558,6 +1636,29 @@ class TestWorkerProxy:
         # Assert — restored proxy enforces the cap
         assert len(restored.workers) == 2
         await restored.stop()
+
+    def test_cloudpickle_serialization_preserves_lazy(self, mock_discovery_service):
+        """Test pickle round-trip preserves the lazy flag.
+
+        Given:
+            A WorkerProxy with lazy=False.
+        When:
+            The proxy is pickled and unpickled.
+        Then:
+            It should preserve lazy as False on the restored proxy.
+        """
+        # Arrange
+        proxy = WorkerProxy(
+            discovery=mock_discovery_service,
+            loadbalancer=wp.RoundRobinLoadBalancer,
+            lazy=False,
+        )
+
+        # Act
+        restored = cloudpickle.loads(cloudpickle.dumps(proxy))
+
+        # Assert
+        assert restored.lazy is False
 
     @pytest.mark.asyncio
     async def test_dispatch_delegates_to_loadbalancer(
@@ -1610,19 +1711,110 @@ class TestWorkerProxy:
         """Test raise RuntimeError.
 
         Given:
-            A WorkerProxy that is not started
+            A non-lazy WorkerProxy that is not started
         When:
             Dispatch is called
         Then:
             It should raise RuntimeError
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
 
         # Act & assert
         with pytest.raises(RuntimeError, match="Proxy not started"):
             async for _ in await proxy.dispatch(mock_wool_task):
                 pass
+
+    @pytest.mark.asyncio
+    async def test_dispatch_with_lazy_auto_start(
+        self,
+        spy_loadbalancer_with_workers,
+        spy_discovery_with_events,
+        mock_worker_connection,
+        mock_wool_task,
+        mock_proxy_session,
+        mocker,
+    ):
+        """Test dispatch auto-starts a lazy proxy on first call.
+
+        Given:
+            A lazy WorkerProxy that has not been started.
+        When:
+            dispatch() is called.
+        Then:
+            It should auto-start the proxy and dispatch the task.
+        """
+        # Arrange
+        discovery, metadata = spy_discovery_with_events
+
+        proxy = WorkerProxy(
+            discovery=discovery,
+            loadbalancer=spy_loadbalancer_with_workers,
+        )
+
+        spy_loadbalancer_with_workers.worker_added_callback(
+            mock_worker_connection, metadata
+        )
+
+        assert not proxy.started
+
+        # Act
+        result_iterator = await proxy.dispatch(mock_wool_task)
+        results = [result async for result in result_iterator]
+
+        # Assert
+        assert proxy.started
+        assert results == ["test_result"]
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_with_lazy_concurrent_start(
+        self,
+        spy_loadbalancer_with_workers,
+        spy_discovery_with_events,
+        mock_worker_connection,
+        mock_proxy_session,
+        mocker,
+    ):
+        """Test concurrent dispatch calls start the proxy only once.
+
+        Given:
+            A lazy WorkerProxy that has not been started.
+        When:
+            Two dispatch() calls are made concurrently.
+        Then:
+            It should start the proxy and both dispatches should succeed.
+        """
+        # Arrange
+        discovery, metadata = spy_discovery_with_events
+
+        proxy = WorkerProxy(
+            discovery=discovery,
+            loadbalancer=spy_loadbalancer_with_workers,
+        )
+
+        spy_loadbalancer_with_workers.worker_added_callback(
+            mock_worker_connection, metadata
+        )
+
+        task = mocker.MagicMock(spec=Task)
+        spy_loadbalancer_with_workers.dispatch = mocker.AsyncMock(
+            return_value=mocker.AsyncMock(
+                __aiter__=mocker.Mock(return_value=mocker.AsyncMock()),
+                __anext__=mocker.AsyncMock(side_effect=StopAsyncIteration),
+            )
+        )
+
+        # Act
+        await asyncio.gather(
+            proxy.dispatch(task),
+            proxy.dispatch(task),
+        )
+
+        # Assert
+        assert proxy.started
+        assert spy_loadbalancer_with_workers.dispatch.call_count == 2
+        await proxy.stop()
 
     @pytest.mark.asyncio
     async def test_dispatch_propagates_loadbalancer_errors(
@@ -1845,7 +2037,7 @@ class TestWorkerProxy:
             ),
         ]
 
-        proxy = WorkerProxy(workers=workers)
+        proxy = WorkerProxy(workers=workers, lazy=False)
 
         # Act & assert
         async with proxy as p:
@@ -1860,14 +2052,14 @@ class TestWorkerProxy:
         """Test it starts and stops correctly.
 
         Given:
-            A WorkerProxy configured with a pool URI
+            A non-lazy WorkerProxy configured with a pool URI
         When:
             The proxy is used as a context manager
         Then:
             It starts and stops correctly
         """
         # Arrange
-        proxy = WorkerProxy("test://pool")
+        proxy = WorkerProxy("test://pool", lazy=False)
 
         # Act & assert
         async with proxy as p:
@@ -1902,7 +2094,7 @@ class TestWorkerProxy:
         await mock_discovery_service.start()
         mock_discovery_service.inject_worker_added(metadata)
 
-        proxy = WorkerProxy(discovery=mock_discovery_service)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
 
         # Act
         async with proxy:
@@ -1996,7 +2188,9 @@ class TestWorkerProxy:
         # Arrange - Use real objects instead of mocks for cloudpickle test
         discovery_service = LocalDiscovery("test-pool").subscriber
         proxy = WorkerProxy(
-            discovery=discovery_service, loadbalancer=wp.RoundRobinLoadBalancer
+            discovery=discovery_service,
+            loadbalancer=wp.RoundRobinLoadBalancer,
+            lazy=False,
         )
 
         # Act & assert
@@ -2018,7 +2212,7 @@ class TestWorkerProxy:
         in an unstarted state.
 
         Given:
-            A started WorkerProxy with only discovery service
+            A non-lazy started WorkerProxy with only discovery service
         When:
             Cloudpickle serialization and deserialization are performed within
             context
@@ -2028,7 +2222,7 @@ class TestWorkerProxy:
         """
         # Arrange - Use real objects instead of mocks for cloudpickle test
         discovery_service = LocalDiscovery("test-pool").subscriber
-        proxy = WorkerProxy(discovery=discovery_service)
+        proxy = WorkerProxy(discovery=discovery_service, lazy=False)
 
         # Act & assert
         async with proxy:
@@ -2049,7 +2243,7 @@ class TestWorkerProxy:
         in an unstarted state and preserved ID.
 
         Given:
-            A started WorkerProxy created with only a URI
+            A non-lazy started WorkerProxy created with only a URI
         When:
             Cloudpickle serialization and deserialization are performed within
             context
@@ -2058,7 +2252,7 @@ class TestWorkerProxy:
             proxy in an unstarted state and preserved ID
         """
         # Arrange - Use real objects - this creates a LocalDiscovery internally
-        proxy = WorkerProxy("pool-1")
+        proxy = WorkerProxy("pool-1", lazy=False)
 
         # Act & assert
         async with proxy:
@@ -2189,6 +2383,7 @@ class TestWorkerProxy:
             # static workers — default credentials resolve from ContextVar.
             restored_proxy = WorkerProxy(
                 workers=[secure_worker, insecure_worker],
+                lazy=False,
             )
 
         # Assert — resolved credentials from ContextVar: only secure workers
@@ -2324,7 +2519,8 @@ class TestWorkerProxy:
 
         Given:
             A WorkerCredentials context is active with mTLS credentials
-            and a mix of secure and insecure static workers.
+            and a non-lazy WorkerProxy with a mix of secure and insecure
+            static workers.
         When:
             WorkerProxy is created with explicit None credentials.
         Then:
@@ -2353,6 +2549,7 @@ class TestWorkerProxy:
             proxy = WorkerProxy(
                 workers=[secure_worker, insecure_worker],
                 credentials=None,
+                lazy=False,
             )
 
         await proxy.start()
@@ -2370,8 +2567,9 @@ class TestWorkerProxy:
         """Test default credentials resolves from ContextVar.
 
         Given:
-            A WorkerCredentials context is active and a mix of secure
-            and insecure static workers.
+            A WorkerCredentials context is active and a non-lazy
+            WorkerProxy with a mix of secure and insecure static
+            workers.
         When:
             WorkerProxy is created without explicit credentials.
         Then:
@@ -2399,6 +2597,7 @@ class TestWorkerProxy:
         with CredentialContext(worker_credentials):
             proxy = WorkerProxy(
                 workers=[secure_worker, insecure_worker],
+                lazy=False,
             )
 
         await proxy.start()
@@ -2416,8 +2615,9 @@ class TestWorkerProxy:
         """Test credentials resolve to None when no context is set.
 
         Given:
-            No WorkerCredentials context is active and a mix of secure
-            and insecure static workers.
+            No WorkerCredentials context is active and a non-lazy
+            WorkerProxy with a mix of secure and insecure static
+            workers.
         When:
             WorkerProxy is created without explicit credentials.
         Then:
@@ -2444,6 +2644,7 @@ class TestWorkerProxy:
         # Act
         proxy = WorkerProxy(
             workers=[secure_worker, insecure_worker],
+            lazy=False,
         )
 
         await proxy.start()
@@ -2461,7 +2662,8 @@ class TestWorkerProxy:
         """Test raise ValueError.
 
         Given:
-            A WorkerProxy with a loadbalancer that doesn't implement LoadBalancerLike
+            A non-lazy WorkerProxy with a loadbalancer that doesn't
+            implement LoadBalancerLike
         When:
             Start() is called
         Then:
@@ -2475,7 +2677,9 @@ class TestWorkerProxy:
         invalid_loadbalancer = NotALoadBalancer()
 
         proxy = WorkerProxy(
-            pool_uri="test-pool", loadbalancer=lambda: invalid_loadbalancer
+            pool_uri="test-pool",
+            loadbalancer=lambda: invalid_loadbalancer,
+            lazy=False,
         )
 
         # Act & assert
@@ -2489,7 +2693,8 @@ class TestWorkerProxy:
         """Test raise ValueError.
 
         Given:
-            A WorkerProxy with a discovery that doesn't implement AsyncIterator
+            A non-lazy WorkerProxy with a discovery that doesn't
+            implement AsyncIterator
         When:
             Start() is called
         Then:
@@ -2498,7 +2703,7 @@ class TestWorkerProxy:
         # Arrange - use a simple string which is definitely not an AsyncIterator
         invalid_discovery = "not_an_async_iterator"
 
-        proxy = WorkerProxy(discovery=lambda: invalid_discovery)
+        proxy = WorkerProxy(discovery=lambda: invalid_discovery, lazy=False)
 
         # Act & assert
         with pytest.raises(ValueError):
@@ -2511,8 +2716,8 @@ class TestWorkerProxy:
         """Test only secure workers are discovered with credentials.
 
         Given:
-            A WorkerProxy instantiated with credentials and a mix
-            of secure and insecure static workers.
+            A non-lazy WorkerProxy instantiated with credentials and a
+            mix of secure and insecure static workers.
         When:
             The proxy is started and discovery events are processed.
         Then:
@@ -2538,6 +2743,7 @@ class TestWorkerProxy:
         proxy = WorkerProxy(
             workers=[secure_worker, insecure_worker],
             credentials=worker_credentials,
+            lazy=False,
         )
 
         # Act


### PR DESCRIPTION
## Summary

Add a `lazy` parameter (default `True`) to `WorkerProxy` and `WorkerPool` that defers discovery subscription, sentinel task creation, and load-balancer initialization until the first `dispatch()` call. Most worker subprocesses never invoke nested `@wool.routine` calls, so eager proxy startup wastes resources on discovery overhead that is never used. With lazy startup, workers only pay the cost of proxy initialization when they actually dispatch sub-tasks.

Separate `WorkerProxy`'s lifecycle into two layers: `enter()`/`exit()` manage the `wool.__proxy__` context variable, while `start()`/`stop()` manage the actual resource lifecycle (discovery, load balancer, sentinel). This split makes lazy behavior easy to reason about — `enter()` always sets the context variable, then either calls `start()` eagerly or defers it to the first `dispatch()`. A double-checked lock in `dispatch()` ensures the proxy starts exactly once under concurrent access. The `lazy` flag is preserved through `cloudpickle` serialization, so workers receiving tasks inherit the same laziness setting from the pool that dispatched them.

Closes #54

## Proposed changes

### Context management layer: enter and exit

Add `enter()` and `exit()` methods that own the `wool.__proxy__` context variable token. `enter()` unconditionally sets the context var; when `lazy=False`, it also calls `start()`. `exit()` resets the context var, then delegates to `stop()` if the proxy was started. `__aenter__`/`__aexit__` delegate to `enter()`/`exit()` respectively.

The `_proxy_token` is initialized to `None` in `__init__` and set exactly once in `enter()`, eliminating the token leak that would occur if multiple methods called `wool.__proxy__.set(self)`.

### Resource lifecycle: start and stop

`start()` (formerly `_start()`) acquires resources: subscribes to discovery, initializes the load-balancer context, and launches the worker sentinel task. `stop()` releases them. Both raise `RuntimeError` when called in an invalid state. These methods are now public, making the resource lifecycle explicit and independently callable from the context management layer.

### Lazy parameter on WorkerProxy and WorkerPool

`WorkerProxy.__init__` accepts a new `lazy` parameter (default `True`). `WorkerPool.__init__` accepts the same parameter and forwards it to every `WorkerProxy` it constructs across all pool modes (default, ephemeral, durable, durable-shared, durable-joined, hybrid). The flag flows through `__reduce__` so that pickled proxies sent to worker subprocesses preserve the laziness setting.

### Simplified proxy factory

`_proxy_factory` in `process.py` now calls `proxy.enter()` instead of `proxy.start()`, and `_proxy_finalizer` calls `proxy.exit()`. This correctly enters the context management layer, letting lazy proxies defer startup and non-lazy proxies start eagerly.

### Integration test dimension

`LazyMode` (LAZY, EAGER) is added as a ninth dimension to the pairwise scenario matrix, ensuring lazy and eager proxy behavior are exercised across all existing pool mode, discovery, credential, and timeout combinations.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerProxy` | A discovery service | WorkerProxy is instantiated with defaults | Lazy is True | Default lazy parameter |
| 2 | `TestWorkerProxy` | A discovery service and lazy=False | WorkerProxy is instantiated | Lazy is False | Explicit eager parameter |
| 3 | `TestWorkerProxy` | An arbitrary boolean value for lazy | WorkerProxy is instantiated with that value | The lazy property matches the constructor argument | Property-based lazy round-trip |
| 4 | `TestWorkerProxy` | A lazy WorkerProxy not yet entered | `enter()` is called | Proxy remains un-started | Lazy enter defers startup |
| 5 | `TestWorkerProxy` | A non-lazy WorkerProxy not yet entered | `enter()` is called | Started is True | Eager enter starts immediately |
| 6 | `TestWorkerProxy` | A non-lazy WorkerProxy not started | `exit()` is called | Raises RuntimeError | Non-lazy exit requires prior start |
| 7 | `TestWorkerProxy` | A lazy WorkerProxy never started | `exit()` is called | Returns without raising | Graceful exit on un-started lazy proxy |
| 8 | `TestWorkerProxy` | A lazy WorkerProxy that was entered and started | `exit()` is called | Stops the proxy, started is False | Exit delegates to stop for started lazy proxy |
| 9 | `TestWorkerProxy` | A WorkerProxy with lazy=False | Pickled and unpickled | Lazy flag is preserved as False | Serialization round-trip for lazy=False |
| 10 | `TestWorkerProxy` | A WorkerProxy with default lazy=True | Pickled and unpickled | Lazy flag is preserved as True | Serialization round-trip for lazy=True |
| 11 | `TestWorkerProxy` | A lazy WorkerProxy not yet started | `dispatch()` is called | Auto-starts and dispatches the task | Lazy auto-start on first dispatch |
| 12 | `TestWorkerProxy` | A lazy WorkerProxy not yet started | Two `dispatch()` calls are made concurrently | Proxy starts once, both dispatches succeed | Double-checked locking under concurrency |
| 13 | `TestWorkerPool` | No explicit lazy parameter | WorkerPool is instantiated with spawn=2 | Constructed without error | Default lazy accepted |
| 14 | `TestWorkerPool` | Explicit lazy=False | WorkerPool is instantiated with spawn=2 | Constructed without error | Explicit lazy=False accepted |
| 15 | `TestPoolComposition` | Scenarios with LazyMode.LAZY | Pools are built and routines dispatched | Correct results returned | End-to-end lazy proxy across pool modes |
| 16 | `TestPoolComposition` | A scenario with LazyMode.EAGER | Pool is built and routine dispatched | Correct result returned | End-to-end eager proxy |
| 17 | `test_integration` | Pairwise scenarios including LazyMode dimension | Routines are dispatched | Correct results across all combinations | Pairwise coverage of lazy/eager with all other dimensions |