### PR TITLE
Guard WorkerPool and WorkerProxy against reentrant context usage — Closes #145

### DIFF
--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -220,6 +220,20 @@ Proxies on worker subprocesses are lazy by default — the `WorkerPool` propagat
 
 When `lazy=True`, concurrent `dispatch()` calls use a double-checked lock to ensure the proxy starts exactly once. The `lazy` flag is preserved through `cloudpickle` serialization, so proxies sent to worker subprocesses as part of a task retain their laziness setting.
 
+### Context lifecycle
+
+Both `WorkerPool` and `WorkerProxy` are **single-use** async context managers. Once entered and exited, the same instance cannot be entered again — create a new instance instead. Attempting to call `enter()` or `__aenter__()` a second time raises `RuntimeError`. This prevents silent state corruption from reentrant or repeated context usage (e.g., accidentally nesting `async with proxy:` blocks or calling `enter()` in a retry loop).
+
+```python
+# Correct — one instance per context
+async with wool.WorkerPool(spawn=4):
+    await my_routine()
+
+# Need another pool? Create a new instance.
+async with wool.WorkerPool(spawn=4):
+    await my_routine()
+```
+
 ### Self-describing connections
 
 Workers are self-describing: each worker advertises its gRPC transport configuration via `ChannelOptions` in its `WorkerMetadata`. When a client discovers a worker, it reads the advertised options and configures its channel to match — message sizes, keepalive intervals, concurrency limits, and compression are all set automatically. There is no separate client-side configuration step; the worker's metadata is the single source of truth for how to connect to it.

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -26,6 +26,7 @@ from wool.runtime.worker.local import LocalWorker
 from wool.runtime.worker.proxy import LoadBalancerLike
 from wool.runtime.worker.proxy import RoundRobinLoadBalancer
 from wool.runtime.worker.proxy import WorkerProxy
+from wool.utilities.noreentry import noreentry
 
 
 # public
@@ -397,6 +398,7 @@ class WorkerPool:
 
         self._proxy_factory = create_proxy
 
+    @noreentry
     async def __aenter__(self) -> WorkerPool:
         """Starts the worker pool and its services, returning a session.
 
@@ -405,6 +407,10 @@ class WorkerPool:
 
         :returns:
             The :class:`WorkerPool` instance itself for method chaining.
+        :raises RuntimeError:
+            If the pool has already been entered.  ``WorkerPool``
+            contexts are single-use — create a new instance instead
+            of re-entering.
         """
         self._proxy_context = self._proxy_factory()
         await self._proxy_context.__aenter__()

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -33,6 +33,7 @@ from wool.runtime.worker.auth import CredentialContext
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.connection import WorkerConnection
 from wool.runtime.worker.metadata import WorkerMetadata
+from wool.utilities.noreentry import noreentry
 
 if TYPE_CHECKING:
     from contextvars import Token
@@ -413,6 +414,7 @@ class WorkerProxy:
         else:
             return []
 
+    @noreentry
     async def enter(self) -> None:
         """Enter the proxy context.
 
@@ -421,6 +423,10 @@ class WorkerProxy:
         :meth:`dispatch` is first called.  When ``lazy=False``,
         calls :meth:`start` eagerly.
 
+        :raises RuntimeError:
+            If the proxy has already been entered.  ``WorkerProxy``
+            contexts are single-use — create a new instance instead
+            of re-entering.
         :raises RuntimeError:
             If the proxy has already been started and ``lazy`` is
             ``False``.

--- a/wool/src/wool/utilities/noreentry.py
+++ b/wool/src/wool/utilities/noreentry.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import asyncio.coroutines
+import functools
+import inspect
+import sys
+import weakref
+from typing import Never
+
+
+class _Token:
+    """Hashable, weakly-referenceable token for instance tracking."""
+
+    pass
+
+
+class NoReentryBoundMethod:
+    """Descriptor implementing single-use guard for bound methods.
+
+    On the first call the decorated method executes normally. Any
+    subsequent call raises :class:`RuntimeError`.
+
+    Guard state uses a per-instance token stored on the instance under
+    ``__noreentry_token__``. The token is unique, hashable, and tied to the
+    instance's lifetime. The descriptor tracks tokens in a WeakSet to auto-clean
+    when instances are garbage collected.
+
+    Works with both synchronous and asynchronous methods. Only supports
+    bound methods; using @noreentry on bare functions raises TypeError.
+    """
+
+    def __init__(self, fn, /):
+        functools.update_wrapper(self, fn)
+        if inspect.iscoroutinefunction(fn):
+            if sys.version_info >= (3, 12):
+                inspect.markcoroutinefunction(self)
+            else:
+                self._is_coroutine = asyncio.coroutines._is_coroutine
+        self._fn = fn
+        self._invocations = weakref.WeakSet()
+
+    def __call__(self, *args, **kwargs) -> Never:
+        raise TypeError("@noreentry only decorates methods, not bare functions")
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+
+        # Cache the wrapper on the instance to avoid recreating it on every access.
+        cache_key = f"__noreentry_wrapper_{id(self)}__"
+        return obj.__dict__.setdefault(cache_key, self._make_wrapper(obj))
+
+    def _make_wrapper(self, obj):
+        """Create the bound wrapper for an instance."""
+        guard = self._guard
+        fn = self._fn
+        if inspect.iscoroutinefunction(fn):
+
+            @functools.wraps(fn)
+            async def async_wrapper(*args, **kwargs):
+                guard(obj)
+                return await fn(obj, *args, **kwargs)
+
+            return async_wrapper
+        else:
+
+            @functools.wraps(fn)
+            def sync_wrapper(*args, **kwargs):
+                guard(obj)
+                return fn(obj, *args, **kwargs)
+
+            return sync_wrapper
+
+    def _guard(self, obj):
+        """Check and record invocation on the specified object."""
+        # Get or create a unique token for this object.
+        token = obj.__dict__.setdefault("__noreentry_token__", _Token())
+
+        # Check if this descriptor was invoked on this object already.
+        if token in self._invocations:
+            raise RuntimeError(
+                f"'{self._fn.__qualname__}' cannot be invoked more than once"
+            )
+
+        # Track invocation.
+        self._invocations.add(token)
+
+
+def noreentry(fn):
+    """Mark a method as single-use.
+
+    On the first call the decorated method executes normally. Any
+    subsequent call raises :class:`RuntimeError`.
+
+    Guard state uses a per-instance token stored on the instance under
+    ``__noreentry_token__``. The token is unique, hashable, and tied to the
+    instance's lifetime. The descriptor tracks tokens in a :class:`WeakSet`
+    to auto-clean when instances are garbage collected.
+
+    Works with both synchronous and asynchronous methods. Only supports
+    bound methods; using @noreentry on bare functions raises :class:`TypeError`
+    on the first invocation.
+
+    :param fn:
+        The bound instance or class method to decorate.
+    """
+    return NoReentryBoundMethod(fn)

--- a/wool/src/wool/utilities/noreentry.py
+++ b/wool/src/wool/utilities/noreentry.py
@@ -35,7 +35,7 @@ class NoReentryBoundMethod:
             if sys.version_info >= (3, 12):
                 inspect.markcoroutinefunction(self)
             else:
-                self._is_coroutine = asyncio.coroutines._is_coroutine
+                self._is_coroutine = asyncio.coroutines._is_coroutine  # type: ignore[attr-defined]
         self._fn = fn
         self._invocations = weakref.WeakSet()
 

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -555,6 +555,47 @@ class TestWorkerPool:
         assert exception_caught, "Exception should have been propagated"
 
     @pytest.mark.asyncio
+    async def test___aenter___already_entered_raises_error(self, mock_worker_factory):
+        """Test pool raises on reentrant entry.
+
+        Given:
+            A WorkerPool that is already entered via async with.
+        When:
+            The pool is entered a second time via async with.
+        Then:
+            It should raise RuntimeError.
+        """
+        # Arrange
+        pool = WorkerPool(worker=mock_worker_factory, spawn=2)
+
+        # Act & assert
+        async with pool:
+            with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+                async with pool:
+                    pass
+
+    @pytest.mark.asyncio
+    async def test___aenter___after_exit_raises_error(self, mock_worker_factory):
+        """Test pool raises when re-entered after exit.
+
+        Given:
+            A WorkerPool that has been entered and exited.
+        When:
+            The pool is entered again via async with.
+        Then:
+            It should raise RuntimeError because the context is single-use.
+        """
+        # Arrange
+        pool = WorkerPool(worker=mock_worker_factory, spawn=2)
+        async with pool:
+            pass
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+            async with pool:
+                pass
+
+    @pytest.mark.asyncio
     async def test___aenter___lifecycle_returns_pool_instance(
         self,
         mock_shared_memory,

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -798,6 +798,45 @@ class TestWorkerProxy:
         assert proxy.started
 
     @pytest.mark.asyncio
+    async def test_enter_already_entered_raises_error(self, mock_discovery_service):
+        """Test enter raises on reentrant call.
+
+        Given:
+            A lazy WorkerProxy that has already been entered.
+        When:
+            enter() is called a second time.
+        Then:
+            It should raise RuntimeError.
+        """
+        # Arrange
+        proxy = WorkerProxy(discovery=mock_discovery_service)
+        await proxy.enter()
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+            await proxy.enter()
+
+    @pytest.mark.asyncio
+    async def test_enter_after_exit_raises_error(self, mock_discovery_service):
+        """Test enter raises after a full enter/exit cycle.
+
+        Given:
+            A lazy WorkerProxy that has been entered and exited.
+        When:
+            enter() is called again.
+        Then:
+            It should raise RuntimeError because the context is single-use.
+        """
+        # Arrange
+        proxy = WorkerProxy(discovery=mock_discovery_service)
+        await proxy.enter()
+        await proxy.exit()
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+            await proxy.enter()
+
+    @pytest.mark.asyncio
     async def test_stop_clears_state(self, mock_discovery_service, mock_proxy_session):
         """Test clear workers and reset the started flag to False.
 

--- a/wool/tests/utilities/test_noreentry.py
+++ b/wool/tests/utilities/test_noreentry.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from wool.utilities.noreentry import noreentry
+
+
+# Test helpers (not fixtures)
+class _SyncDummy:
+    """Class with a sync @noreentry method."""
+
+    @noreentry
+    def run(self):
+        return "ok"
+
+
+class _AsyncDummy:
+    """Class with an async @noreentry method."""
+
+    @noreentry
+    async def run(self):
+        return "ok"
+
+
+class _MultiMethodDummy:
+    """Class with multiple @noreentry methods."""
+
+    @noreentry
+    def first(self):
+        return "first"
+
+    @noreentry
+    def second(self):
+        return "second"
+
+
+class TestNoReentry:
+    """Tests for the noreentry decorator."""
+
+    def test_noreentry_sync_method_first_invocation(self):
+        """Test sync method executes normally on first invocation.
+
+        Given:
+            A class with a sync @noreentry method.
+        When:
+            The method is called for the first time.
+        Then:
+            It should return normally.
+        """
+        # Arrange
+        obj = _SyncDummy()
+
+        # Act
+        result = obj.run()
+
+        # Assert
+        assert result == "ok"
+
+    def test_noreentry_sync_method_second_invocation_raises(self):
+        """Test sync method raises RuntimeError on second invocation.
+
+        Given:
+            A class with a sync @noreentry method called once.
+        When:
+            The method is called a second time on the same instance.
+        Then:
+            It should raise RuntimeError.
+        """
+        # Arrange
+        obj = _SyncDummy()
+        obj.run()
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+            obj.run()
+
+    @pytest.mark.asyncio
+    async def test_noreentry_async_method_first_invocation(self):
+        """Test async method executes normally on first invocation.
+
+        Given:
+            A class with an async @noreentry method.
+        When:
+            The method is awaited for the first time.
+        Then:
+            It should return normally.
+        """
+        # Arrange
+        obj = _AsyncDummy()
+
+        # Act
+        result = await obj.run()
+
+        # Assert
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_noreentry_async_method_second_invocation_raises(self):
+        """Test async method raises RuntimeError on second invocation.
+
+        Given:
+            A class with an async @noreentry method awaited once.
+        When:
+            The method is awaited a second time on the same instance.
+        Then:
+            It should raise RuntimeError.
+        """
+        # Arrange
+        obj = _AsyncDummy()
+        await obj.run()
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+            await obj.run()
+
+    def test_noreentry_separate_instances_independent(self):
+        """Test instances track guard state independently.
+
+        Given:
+            Two instances of a class with a @noreentry method.
+        When:
+            The method is called on the first instance.
+        Then:
+            The method remains callable on the second instance.
+        """
+        # Arrange
+        a = _SyncDummy()
+        b = _SyncDummy()
+        a.run()
+
+        # Act
+        result = b.run()
+
+        # Assert
+        assert result == "ok"
+
+    def test_noreentry_error_message_qualname(self):
+        """Test RuntimeError includes the method's qualified name.
+
+        Given:
+            A class with a @noreentry method called once.
+        When:
+            The method is called a second time.
+        Then:
+            The RuntimeError message should include the method's __qualname__.
+        """
+        # Arrange
+        obj = _SyncDummy()
+        obj.run()
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="_SyncDummy.run"):
+            obj.run()
+
+    def test_noreentry_preserves_coroutinefunction_check(self):
+        """Test decorator preserves async function detection.
+
+        Given:
+            A class with an async @noreentry method.
+        When:
+            asyncio.iscoroutinefunction is called on the method.
+        Then:
+            It should return True.
+        """
+        # Act & assert
+        assert asyncio.iscoroutinefunction(_AsyncDummy.run)
+
+    def test_noreentry_preserves_wrapped_function_name(self):
+        """Test decorator preserves the original function name.
+
+        Given:
+            A class with a @noreentry method.
+        When:
+            The decorated method's __name__ is inspected.
+        Then:
+            It should equal the original function name.
+        """
+        # Act & assert
+        assert _SyncDummy.run.__name__ == "run"
+
+    def test_noreentry_multiple_methods_independent(self):
+        """Test guard on one method does not affect other methods.
+
+        Given:
+            A class with two @noreentry methods where the first
+            has been guarded (called twice).
+        When:
+            The second method is called.
+        Then:
+            The second method executes normally.
+        """
+        # Arrange
+        obj = _MultiMethodDummy()
+        obj.first()
+        with pytest.raises(RuntimeError):
+            obj.first()
+
+        # Act
+        result = obj.second()
+
+        # Assert
+        assert result == "second"
+
+    def test_noreentry_unbound_access_returns_descriptor(self):
+        """Test accessing decorated method via class returns descriptor.
+
+        Given:
+            A class with a @noreentry method.
+        When:
+            The method is accessed through the class (unbound).
+        Then:
+            It should return the descriptor itself.
+        """
+        # Act
+        unbound = _SyncDummy.run
+
+        # Assert
+        assert unbound is not None
+
+    def test_noreentry_bare_function_raises_error(self):
+        """Test decorator rejects application to bare functions.
+
+        Given:
+            A @noreentry-decorated function called without a bound instance.
+        When:
+            The descriptor is called directly.
+        Then:
+            It should raise TypeError.
+        """
+        # Arrange
+        unbound = _SyncDummy.run
+
+        # Act & assert
+        with pytest.raises(
+            TypeError, match="only decorates methods, not bare functions"
+        ):
+            unbound()


### PR DESCRIPTION
## Summary

Adds single-use enforcement to `WorkerPool` and `WorkerProxy` context managers so that any second entry — whether reentrant or after a full enter/exit cycle — raises `RuntimeError` immediately rather than silently corrupting state.

The implementation introduces a generic `@noreentry` descriptor class in `src/wool/utilities/noreentry.py`. The descriptor exclusively decorates instance methods (bare functions and unbound calls are static errors caught at the type-check level via `__call__ -> Never`). Guard state for each instance is tracked via a `weakref.WeakSet` on the descriptor, keeping instances clean without namespace pollution. `functools.update_wrapper` and `inspect.markcoroutinefunction` ensure the wrapper is transparent to introspection. The decorator is applied to `WorkerProxy.enter()` and `WorkerPool.__aenter__()`. Both READMEs are updated to document the single-use contract.

Closes #145.

## Proposed changes

### `src/wool/utilities/noreentry.py` — new `@noreentry` descriptor

Implements `noreentry` as a descriptor class for single-use method guards. The decorator uses the descriptor protocol's `__get__` to return a bound wrapper on instance access, and `__call__ -> Never` to reject bare function usage at the type-check level.

Guard state is tracked via a `weakref.WeakSet` on the descriptor instance — when an instance's guarded method is called, that instance is added to the WeakSet. Any subsequent call to the same method on the same instance detects the instance in the set and raises `RuntimeError`. This approach avoids polluting instance namespaces and automatically cleans up references when instances are garbage collected.

The decorator works with both sync and async methods. Attempting to use it on bare functions or call it directly (unbound style) raises `TypeError` at runtime and is flagged as a static type error via the `Never` return annotation on `__call__`.

### `src/wool/runtime/worker/proxy.py` and `pool.py` — apply guard

`@noreentry` is applied to `WorkerProxy.enter()` and `WorkerPool.__aenter__()`. The `:raises RuntimeError:` docstring on each method is updated to document single-use semantics.

### Documentation

`README.md` and `src/wool/runtime/worker/README.md` each receive a note on the single-use contract with a brief code example showing the correct pattern (create a new instance for a new context).

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestNoReentry` | A class with a sync `@noreentry` method | Method is called for the first time | Returns normally | First-call success for bound sync method |
| 2 | `TestNoReentry` | A class with a sync `@noreentry` method called once | Method is called a second time on the same instance | Raises `RuntimeError` | Guard on second sync call |
| 3 | `TestNoReentry` | A class with an async `@noreentry` method | Method is awaited for the first time | Returns normally | First-call success for bound async method |
| 4 | `TestNoReentry` | A class with an async `@noreentry` method awaited once | Method is awaited a second time | Raises `RuntimeError` | Guard on second async call |
| 5 | `TestNoReentry` | Two instances of a class with a `@noreentry` method, first called | Method is called on the second instance | Returns normally | Per-instance isolation |
| 6 | `TestNoReentry` | A sync `@noreentry` method called once | Method is called a second time | `RuntimeError` message includes the method's `__qualname__` | Error message content |
| 7 | `TestNoReentry` | A class with an async `@noreentry` method | `asyncio.iscoroutinefunction` is called on the method | Returns `True` | Coroutine function introspection transparency |
| 8 | `TestNoReentry` | A class with a sync `@noreentry` method | `__name__` is inspected on the decorated method | Equals the original function name | `functools.wraps` preservation |
| 9 | `TestNoReentry` | A class with two `@noreentry` methods; first called twice | Second method is called | Returns normally | Per-method dict key independence |
| 10 | `TestNoReentry` | A class with a `@noreentry` method | Method is accessed through the class (unbound) | Returns the descriptor itself | Descriptor protocol for unbound access |
| 11 | `TestNoReentry` | A `@noreentry` descriptor accessed unbound | Descriptor is called directly | Raises `TypeError` | Rejection of bare function usage |
| 12 | `TestWorkerProxy` | A `WorkerProxy` that has already been entered | `enter()` is called a second time | Raises `RuntimeError` | Reentrant entry guard on proxy |
| 13 | `TestWorkerProxy` | A `WorkerProxy` that has been entered and exited | `enter()` is called again | Raises `RuntimeError` | Post-exit re-entry guard on proxy |
| 14 | `TestWorkerPool` | A `WorkerPool` already entered via `async with` | Pool is entered again via `async with` | Raises `RuntimeError` | Reentrant entry guard on pool |
| 15 | `TestWorkerPool` | A `WorkerPool` entered and exited via `async with` | Pool is entered again via `async with` | Raises `RuntimeError` | Post-exit re-entry guard on pool |