### PR TITLE
Integrate knowledge graph context into SDLC lifecycle skills — Closes #158

### DIFF
--- a/llms/skills/commit.md
+++ b/llms/skills/commit.md
@@ -28,10 +28,11 @@ This skill is part of the development workflow pipeline: `/issue` → `/implemen
 1. Verify git state
 2. Create a staging branch
 3. Analyze the full diff
-4. Plan the commits
-5. Stage and commit sequentially
-6. Review and present
-7. Prompt the user to move onto the PR step
+4. Gather knowledge graph context
+5. Plan the commits
+6. Stage and commit sequentially
+7. Review and present
+8. Prompt the user to move onto the PR step
 
 ### 1. Verify git state
 
@@ -74,7 +75,17 @@ The diff MUST be read carefully. For each changed file, note:
 
 A commit plan MUST be built before touching anything. The goal is a sequence of commits where each one represents exactly one logical change.
 
-### 4. Plan the commits
+### 4. Gather knowledge graph context
+
+Check whether a knowledge graph exists:
+
+```bash
+test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
+```
+
+If the graph exists, invoke `/understand-chat` with a query listing the changed file paths from the diff to gather architectural context — component summaries, relationships, and layer assignments — that reveals component boundaries for logical commit grouping. If the graph does not exist, skip this step and continue.
+
+### 5. Plan the commits
 
 Group files and hunks into commits. The categories to use as a guide:
 
@@ -93,7 +104,7 @@ Mixed changes in a single file are common and MUST be handled with partial stagi
 
 Logical ordering MUST be considered: if commit B depends on commit A, A comes first. Generally: refactoring before feature work, build changes before code that uses them, tests after (or alongside) the code they test.
 
-### 5. Stage and commit sequentially
+### 6. Stage and commit sequentially
 
 For each planned commit, stage exactly the right changes and commit.
 
@@ -139,7 +150,7 @@ git commit -F /tmp/commit_msg.txt
 
 Repeat for each planned commit.
 
-### 6. Review and present
+### 7. Review and present
 
 After all commits:
 
@@ -161,7 +172,7 @@ Or if they prefer to review as a PR first, they can push the staging branch and 
 
 ---
 
-### 7. Prompt the user to move onto the PR step
+### 8. Prompt the user to move onto the PR step
 
 The user MUST be prompted with the next pipeline step: "Ready to create the PR? Run `/pr <number>` to review the changes and open a draft pull request." DO NOT proceed on your own.
 

--- a/llms/skills/implement.md
+++ b/llms/skills/implement.md
@@ -122,6 +122,7 @@ The `--repo <target>` flag MUST be included when the target repo differs from th
 
 Before entering plan mode, read enough of the codebase to plan confidently:
 
+- Check whether `.understand-anything/knowledge-graph.json` exists. If it does, invoke `/understand-chat` with a query synthesized from the issue title and body to gather architectural context — component summaries, relationships, and layer assignments — that informs the planning phase by revealing which files, components, and layers are relevant to the issue. If the graph does not exist, skip this bullet and continue.
 - Read source files referenced in the issue's description.
 - Read existing tests for the affected modules.
 - Read the project test guide (`@llm/guides/testguide-python.md`) to internalize testing conventions.

--- a/llms/skills/issue.md
+++ b/llms/skills/issue.md
@@ -23,13 +23,14 @@ This skill is part of the development workflow pipeline: `/issue` → `/implemen
 
 1. Determine the source
 2. Resolve target repository
-3. Draft interactively
-4. Suggest labels
-5. Show draft for approval
-6. Push the issue
-7. Clean up `.issue.md` (if applicable)
-8. Return the issue URL
-9. Prompt the user to move onto the implement step
+3. Gather knowledge graph context
+4. Draft interactively
+5. Suggest labels
+6. Show draft for approval
+7. Push the issue
+8. Clean up `.issue.md` (if applicable)
+9. Return the issue URL
+10. Prompt the user to move onto the implement step
 
 ### 1. Determine the source
 
@@ -54,7 +55,17 @@ If `isFork` is `true`, extract `parent.owner.login` and `parent.name` to form th
 
 All `gh` commands in subsequent steps that reference issues or PRs MUST include `--repo <target>` when the target repo differs from the current repo.
 
-### 3. Draft interactively
+### 3. Gather knowledge graph context
+
+Check whether a knowledge graph exists:
+
+```bash
+test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
+```
+
+If the graph exists, invoke `/understand-chat` with a query synthesized from the conversation context (the user's description of the problem or feature) to gather architectural context — component summaries, relationships, and layer assignments — that helps scope the issue by revealing which components and layers are relevant. If the graph does not exist, skip this step and continue.
+
+### 4. Draft interactively
 
 Based on conversation context, determine the issue type and draft using the matching template. All templates share the same structure — only the field names and auto-label differ.
 
@@ -176,7 +187,7 @@ When the project defines a GitHub issue form template in `.github/ISSUE_TEMPLATE
 
 The draft MUST be shown to the user and iterated until they approve.
 
-### 4. Suggest labels
+### 5. Suggest labels
 
 The issue content MUST be analyzed and one or more labels suggested from the repository's label set:
 
@@ -193,11 +204,11 @@ Each label SHOULD only be applied when the issue's **primary focus** matches tha
 
 The suggested labels MUST be shown alongside the draft for user approval.
 
-### 5. Show draft for approval
+### 6. Show draft for approval
 
 The full issue (title, body, labels) MUST be presented to the user. The issue MUST NOT be pushed until the user explicitly approves.
 
-### 6. Push the issue
+### 7. Push the issue
 
 A heredoc MUST be used for the body to avoid shell escaping issues:
 
@@ -210,7 +221,7 @@ EOF
 
 The `--repo <target>` flag MUST be included when the target repo differs from the current repo (as resolved in step 2). The `--assignee` flag MUST NOT be used — issues are not auto-assigned.
 
-### 7. Clean up `.issue.md`
+### 8. Clean up `.issue.md`
 
 If the issue was created from `.issue.md`, the user MUST be asked whether to delete the file now that the issue has been pushed. If they agree:
 
@@ -218,12 +229,12 @@ If the issue was created from `.issue.md`, the user MUST be asked whether to del
 rm .issue.md
 ```
 
-### 8. Return the issue URL
+### 9. Return the issue URL
 
 The issue URL returned by `gh issue create` MUST be printed so the user can access it directly.
 
 The user SHOULD be prompted with the next pipeline step: "Ready to implement? Run `/implement <number>` to create a branch and start planning."
 
-### 9. Prompt the user to move onto the implement step
+### 10. Prompt the user to move onto the implement step
 
 The user MUST be prompted with the next pipeline step: "Ready to implement? Run `/implement <number>` to create a branch and start planning." When working from a fork, note that `<number>` refers to the issue on the upstream repo. DO NOT proceed on your own.

--- a/llms/skills/pr.md
+++ b/llms/skills/pr.md
@@ -28,10 +28,11 @@ An issue number MUST be provided as the sole argument (e.g., `/pr 103`). The iss
 1. Resolve target repository
 2. Identify the issue and branch
 3. Review the branch diff
-4. Draft the PR description
-5. Show draft for approval
-6. Push and create the draft PR
-7. Return the PR URL
+4. Gather knowledge graph context
+5. Draft the PR description
+6. Show draft for approval
+7. Push and create the draft PR
+8. Return the PR URL
 
 ### 1. Resolve target repository
 
@@ -85,7 +86,17 @@ git diff <merge-base>..HEAD --stat
 
 Analyze all committed source and test changes. Understand what was implemented, what was refactored, what tests were added or modified.
 
-### 4. Draft the PR description
+### 4. Gather knowledge graph context
+
+Check whether a knowledge graph exists:
+
+```bash
+test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
+```
+
+If the graph exists, invoke `/understand-chat` with a query listing the changed files and branch diff summary to gather architectural context — component summaries, relationships, and layer assignments — that provides architectural context for writing the PR description. If the graph does not exist, skip this step and continue.
+
+### 5. Draft the PR description
 
 #### 4a. Detect a PR template
 
@@ -126,11 +137,11 @@ When no PR template file is detected, the PR description MUST contain a **Summar
 
 The first word of every plain-language table entry MUST be capitalized. Table entries MUST NOT end with punctuation (no trailing periods, commas, etc.). Code spans in entries (e.g., `` `foo.bar()` is called ``) are exempt from the capitalization rule.
 
-### 5. Show draft for approval
+### 6. Show draft for approval
 
 The full PR (title, body, branch name) MUST be presented to the user. The PR MUST NOT be created until the user explicitly approves.
 
-### 6. Push and create the draft PR
+### 7. Push and create the draft PR
 
 Push the branch if not already pushed:
 
@@ -174,7 +185,7 @@ EOF
 
 The `--repo <target>` flag MUST be included when the target repo differs from the current repo.
 
-### 7. Return the PR URL
+### 8. Return the PR URL
 
 The PR URL MUST be printed so the user can access it directly.
 

--- a/llms/skills/review.md
+++ b/llms/skills/review.md
@@ -31,11 +31,12 @@ A PR number MUST be provided as the sole argument (e.g., `/review 146`).
 2. Fetch the PR metadata and diff
 3. Read project guides and styles
 4. Read source files under review
-5. Analyze the diff
-6. Categorize findings
-7. Present findings for approval
-8. Post the review
-9. Prompt the user with next steps
+5. Gather knowledge graph context
+6. Analyze the diff
+7. Categorize findings
+8. Present findings for approval
+9. Post the review
+10. Prompt the user with next steps
 
 ### 1. Resolve target repository
 
@@ -75,7 +76,17 @@ For each changed file in the PR:
 - Read the full file at its current HEAD revision so that surrounding context is available.
 - If the changed file is a test file, also read the corresponding source module it tests (and vice versa).
 
-### 5. Analyze the diff
+### 5. Gather knowledge graph context
+
+Check whether a knowledge graph exists:
+
+```bash
+test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
+```
+
+If the graph exists, invoke `/understand-chat` with a query listing the changed file paths from the PR diff to gather architectural context — component summaries, relationships, and layer assignments — that reveals how changed components fit into the broader architecture and informs review quality. If the graph does not exist, skip this step and continue.
+
+### 6. Analyze the diff
 
 Review every hunk in the diff against the guides read in step 3 and the source context read in step 4. Check for:
 
@@ -87,7 +98,7 @@ Review every hunk in the diff against the guides read in step 3 and the source c
 
 Each finding MUST reference the specific file and line range in the diff where the issue occurs.
 
-### 6. Categorize findings
+### 7. Categorize findings
 
 Every finding MUST be assigned exactly one severity:
 
@@ -96,7 +107,7 @@ Every finding MUST be assigned exactly one severity:
 
 Present findings grouped by severity, with blocking findings first.
 
-### 7. Present findings for approval
+### 8. Present findings for approval
 
 The complete list of findings MUST be presented to the user before posting. For each finding, show:
 
@@ -114,7 +125,7 @@ The user MUST be given the opportunity to:
 
 The review MUST NOT be posted until the user explicitly approves the final set of findings.
 
-### 8. Post the review
+### 9. Post the review
 
 Construct a review payload and post it via the GitHub API. The payload MUST be written to a temporary file to avoid shell escaping issues:
 
@@ -159,7 +170,7 @@ gh api repos/<owner>/<repo>/pulls/<number>/reviews \
 
 The `<owner>` and `<repo>` values MUST be resolved from step 1. When working from a fork, these refer to the upstream repo's owner and name (unless the user explicitly targeted the fork).
 
-### 9. Prompt the user with next steps
+### 10. Prompt the user with next steps
 
 After the review is posted, prompt the user with the appropriate next step:
 

--- a/llms/skills/test.md
+++ b/llms/skills/test.md
@@ -35,12 +35,13 @@ An issue number MUST be provided as the sole argument (e.g., `/test 103`).
 ### TL;DR
 
 1. Resolve issue, PR, and branch
-2. Analyze code changes
-3. Evaluate existing tests
-4. Generate test plan
-5. Enter plan mode
-6. Implement tests after approval
-7. Prompt the user to move onto the commit step
+2. Gather knowledge graph context
+3. Analyze code changes
+4. Evaluate existing tests
+5. Generate test plan
+6. Enter plan mode
+7. Implement tests after approval
+8. Prompt the user to move onto the commit step
 
 ### 1. Resolve issue, PR, and branch
 
@@ -68,7 +69,17 @@ git checkout <branch>
 
 If the branch does not exist, inform the user that the implement skill must be run first and stop. The test skill MUST NOT create branches.
 
-### 2. Analyze code changes
+### 2. Gather knowledge graph context
+
+Check whether a knowledge graph exists:
+
+```bash
+test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
+```
+
+If the graph exists, invoke `/understand-chat` with a query listing the changed file paths to gather architectural context — component summaries, relationships, and layer assignments — that reveals which components interact with the changed code and informs test coverage planning. If the graph does not exist, skip this step and continue.
+
+### 3. Analyze code changes
 
 Determine the base branch and diff against it:
 
@@ -80,7 +91,7 @@ git diff <merge-base>..HEAD
 
 Read every changed source file to understand what was implemented. Note which modules have new or modified public APIs.
 
-### 3. Evaluate existing tests
+### 4. Evaluate existing tests
 
 Read the current test files for all affected modules. For each existing test:
 
@@ -89,7 +100,7 @@ Read the current test files for all affected modules. For each existing test:
 - Identify tests that **no longer apply** due to removed or significantly changed functionality — flag these for removal or rewriting.
 - Note gaps that require **new** test cases.
 
-### 4. Generate test plan
+### 5. Generate test plan
 
 Generate a Given-When-Then test plan internally. This plan is an agent planning artifact — do NOT write spec files to disk. The plan MUST:
 
@@ -98,7 +109,7 @@ Generate a Given-When-Then test plan internally. This plan is an agent planning 
 - Follow the structure in [Table Format](#table-format) below.
 - Follow the project test guide conventions.
 
-### 5. Enter plan mode
+### 6. Enter plan mode
 
 Call `EnterPlanMode` to present the test plan to the user for approval. The plan MUST clearly distinguish between:
 
@@ -107,7 +118,7 @@ Call `EnterPlanMode` to present the test plan to the user for approval. The plan
 - **Existing tests to remove** — no longer apply due to removed or changed functionality
 - **New tests to add** — cover genuinely uncovered behavior
 
-### 6. Implement tests after approval
+### 7. Implement tests after approval
 
 Once the user approves the plan, implement the test files:
 
@@ -115,7 +126,7 @@ Once the user approves the plan, implement the test files:
 - Add new test cases where the plan identifies coverage gaps.
 - Follow the project test guide for file naming, class organization, and test conventions.
 
-### 7. Prompt the user to move onto the commit step
+### 8. Prompt the user to move onto the commit step
 
 The user MUST be prompted with the next pipeline step: "Ready to commit? Run `/commit` to stage and commit the changes." DO NOT proceed on your own.
 


### PR DESCRIPTION
## Summary

Add a "Gather knowledge graph context" step to each SDLC lifecycle skill (`/issue`, `/implement`, `/test`, `/commit`, `/pr`, `/review`) that invokes `/understand-chat` as a sub-step during context gathering. When `.understand-anything/knowledge-graph.json` exists, each skill queries it with task-appropriate keywords before planning or analyzing code. When no graph exists, the step is skipped silently and the skill continues as before.

The graph query logic lives exclusively in `/understand-chat` — no duplication across skills.

Closes #158

## Proposed changes

### Knowledge graph context step in five skills

Add a new numbered step "Gather knowledge graph context" to `/issue` (step 3), `/test` (step 2), `/commit` (step 4), `/pr` (step 4), and `/review` (step 5). Each step checks for the graph file, invokes `/understand-chat` with a skill-derived query, and provides a purpose statement explaining what the context informs. TL;DR lists and subsequent step numbers are renumbered accordingly.

The query source varies per skill:
- `/issue` — conversation context (the user's description)
- `/test` — changed file paths
- `/commit` — changed file paths from the diff
- `/pr` — changed files and branch diff summary
- `/review` — changed file paths from the PR diff

### Knowledge graph context bullet in `/implement`

Add a bullet to the existing "Gather context" step (step 6) rather than a new numbered step, since `/implement` already has a dedicated context-gathering phase. The bullet invokes `/understand-chat` with the issue title and body.