### PR TITLE
Execute each SDLC skill in a subagent — Closes #161

### DIFF
--- a/llms/README.md
+++ b/llms/README.md
@@ -16,13 +16,23 @@ Every skill in this pipeline is collaborative, not autonomous. The LLM agent pro
 ```
 llms/
 ├── README.md            ← you are here
-├── skills/
+├── skills/              ← LLM-agnostic skill definitions (portable)
 │   ├── issue.md         ← /issue — draft and push a GitHub issue
 │   ├── pr.md            ← /pr — create a branch and draft PR from an issue
 │   ├── implement.md     ← /implement — implement a planned PR or issue
 │   ├── test.md          ← /test — generate test specifications
 │   ├── commit.md        ← /commit — stage and commit changes atomically
+│   ├── review.md        ← /review — review a PR for compliance and quality
 │   └── audit.md         ← /audit — post-skill compliance checker
+├── dispatchers/         ← harness-specific subagent dispatch wrappers
+│   └── claude/          ← Claude Code dispatchers
+│       ├── issue.md
+│       ├── implement.md
+│       ├── test.md
+│       ├── commit.md
+│       ├── pr.md
+│       ├── review.md
+│       └── audit.md
 ├── test-guides/
 │   └── python.md        ← Python testing conventions
 └── style-guides/
@@ -136,13 +146,19 @@ sequenceDiagram
 
 The `style-guides/` directory contains format-specific authoring conventions (e.g., Markdown, YAML). These are **always-on context** — agents MUST read every file in `llms/style-guides/` at the start of a session and treat their rules as active constraints. The directory may be empty; if so, agents SHOULD default to following established convention already present in the codebase.
 
+## Dispatchers
+
+The `dispatchers/` directory contains harness-specific wrappers that execute each skill inside a subagent. Dispatchers are organized by harness — e.g., `dispatchers/claude/` for Claude Code. Each dispatcher spawns a dedicated subagent, passes it the corresponding skill definition from `skills/`, and relays the summary back to the parent context. This keeps the parent conversation clean — only the final summary and next-step prompt appear, while all intermediate tool calls (file reads, diffs, git operations) stay isolated in the subagent.
+
+The skill definitions in `skills/` remain LLM-agnostic and portable. The dispatchers are the harness layer — they contain orchestration instructions specific to the coding assistant's subagent mechanism. Adding support for a new harness means creating a new subdirectory under `dispatchers/` with harness-specific wrappers that delegate to the same skill definitions.
+
 ## Registration mechanism
 
-Each agentic coding assistant has its own convention for discovering skills and instructions. The registration mechanism bridges the canonical `llms/` content into whatever directory structure a given tool expects, typically via symlinks or config files. For example, an assistant that discovers skills in `.assistant/skills/` would have symlinks like:
+Each agentic coding assistant has its own convention for discovering skills and instructions. The registration mechanism bridges the canonical `llms/` content into whatever directory structure a given tool expects, typically via symlinks or config files. Symlinks point to dispatchers (not directly to skills) so that every invocation runs in a subagent. For example, an assistant that discovers skills in `.assistant/skills/` would have symlinks like:
 
 ```
-.assistant/skills/commit/SKILL.md    → ../../../llms/skills/commit.md
-.assistant/skills/implement/SKILL.md → ../../../llms/skills/implement.md
+.assistant/skills/commit.md    → ../../llms/dispatchers/<harness>/commit.md
+.assistant/skills/implement.md → ../../llms/dispatchers/<harness>/implement.md
 ```
 
 Guides are similarly symlinked where needed (e.g., `.assistant/skills/implement/TESTGUIDE.md → ../../../llms/test-guides/python.md`). This keeps the canonical content in `llms/` while letting each tool's skill discovery find it automatically.

--- a/llms/dispatchers/claude/audit.md
+++ b/llms/dispatchers/claude/audit.md
@@ -1,0 +1,26 @@
+---
+name: audit
+description: >
+  Post-skill compliance checker. Use this skill whenever the user says
+  "/audit <skill-name>", "audit the last skill run", "check compliance",
+  or similar. Spawns a fresh subagent with no shared context to evaluate
+  whether a skill's MUST/SHALL requirements were actually met, using binary
+  checklist decomposition for unbiased assessment.
+---
+
+# Subagent Dispatch
+
+Execute the **audit** skill in an isolated subagent to preserve parent context.
+
+Spawn a general-purpose subagent with the following brief:
+
+> You are executing the **audit** skill from the SDLC pipeline. This is a cross-cutting quality gate invoked after any pipeline stage.
+>
+> **Argument:** <the argument value from ARGUMENTS below>
+>
+> 1. Read the project instructions in `CLAUDE.md`.
+> 2. Read and execute the complete workflow defined in `llms/skills/audit.md`.
+> 3. Follow every step faithfully. When a step requires user approval (e.g., remediation decision), surface it to the user and wait for their response.
+> 4. When done, return the full verification report including the pass/fail verdicts and overall compliance status.
+
+When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/commit.md
+++ b/llms/dispatchers/claude/commit.md
@@ -1,0 +1,29 @@
+---
+name: commit
+description: >
+  Stages and commits uncommitted changes in a git repository using a disciplined,
+  atomic commit workflow. Use this skill whenever the user asks to "commit my changes",
+  "clean up my git state", "stage and commit", "make commits from my changes", or
+  anything similar. Also trigger when the user has described a body of work and says
+  something like "can you commit this properly" or "let's checkpoint this". The skill
+  creates a staging branch, analyzes the full diff, groups changes by logical kind,
+  and commits them sequentially with well-formed messages — without ever mixing
+  unrelated changes into a single commit.
+---
+
+# Subagent Dispatch
+
+Execute the **commit** skill in an isolated subagent to preserve parent context.
+
+Spawn a general-purpose subagent with the following brief:
+
+> You are executing the **commit** skill from the SDLC pipeline (issue → implement → test → commit → pr → review).
+>
+> **Argument:** <the argument value from ARGUMENTS below, if any>
+>
+> 1. Read the project instructions in `CLAUDE.md`.
+> 2. Read and execute the complete workflow defined in `llms/skills/commit.md`.
+> 3. Follow every step faithfully. When a step requires user approval (e.g., commit plan approval, final commit review), surface it to the user and wait for their response.
+> 4. When done, return a structured summary: what was accomplished, key artifacts (commit SHAs, commit messages, branch names), and the next pipeline step prompt from the skill definition.
+
+When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/implement.md
+++ b/llms/dispatchers/claude/implement.md
@@ -1,0 +1,27 @@
+---
+name: implement
+description: >
+  Implement a GitHub issue. Use this skill whenever the user says
+  "/implement <number>", "implement #N", "start implementing #N", or similar.
+  Accepts an issue number, fetches the issue, creates a branch, gathers
+  context, and enters plan mode to design a concrete execution plan before
+  writing code. On re-invocation after a PR exists, addresses unresolved
+  review feedback.
+---
+
+# Subagent Dispatch
+
+Execute the **implement** skill in an isolated subagent to preserve parent context.
+
+Spawn a general-purpose subagent with the following brief:
+
+> You are executing the **implement** skill from the SDLC pipeline (issue → implement → test → commit → pr → review).
+>
+> **Argument:** <the argument value from ARGUMENTS below>
+>
+> 1. Read the project instructions in `CLAUDE.md`.
+> 2. Read and execute the complete workflow defined in `llms/skills/implement.md`.
+> 3. Follow every step faithfully. When a step requires user approval (e.g., plan approval), surface it to the user and wait for their response.
+> 4. When done, return a structured summary: what was accomplished, key artifacts (branch names, PR URLs, commit SHAs, etc.), and the next pipeline step prompt from the skill definition.
+
+When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/issue.md
+++ b/llms/dispatchers/claude/issue.md
@@ -1,0 +1,25 @@
+---
+name: issue
+description: >
+  Draft and push a GitHub issue. Use this skill whenever the user says "/issue",
+  "file an issue", "create an issue", "open a bug report", or similar. If
+  `.issue.md` exists in the repo root, it is used as the source. Otherwise the
+  issue is drafted interactively from the conversation.
+---
+
+# Subagent Dispatch
+
+Execute the **issue** skill in an isolated subagent to preserve parent context.
+
+Spawn a general-purpose subagent with the following brief:
+
+> You are executing the **issue** skill from the SDLC pipeline (issue → implement → test → commit → pr → review).
+>
+> **Argument:** <the argument value from ARGUMENTS below, if any>
+>
+> 1. Read the project instructions in `CLAUDE.md`.
+> 2. Read and execute the complete workflow defined in `llms/skills/issue.md`.
+> 3. Follow every step faithfully. When a step requires user approval (e.g., draft approval, label approval), surface it to the user and wait for their response.
+> 4. When done, return a structured summary: what was accomplished, key artifacts (issue URL, issue number, labels applied), and the next pipeline step prompt from the skill definition.
+
+When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/pr.md
+++ b/llms/dispatchers/claude/pr.md
@@ -1,0 +1,25 @@
+---
+name: pr
+description: >
+  Review committed changes on a branch and create a draft pull request. Use
+  this skill whenever the user says "/pr <number>", "create a PR for #N",
+  "open a PR", or similar. Accepts an issue number, reviews the branch diff,
+  and drafts a PR description based on what was actually implemented.
+---
+
+# Subagent Dispatch
+
+Execute the **pr** skill in an isolated subagent to preserve parent context.
+
+Spawn a general-purpose subagent with the following brief:
+
+> You are executing the **pr** skill from the SDLC pipeline (issue → implement → test → commit → pr → review).
+>
+> **Argument:** <the argument value from ARGUMENTS below>
+>
+> 1. Read the project instructions in `CLAUDE.md`.
+> 2. Read and execute the complete workflow defined in `llms/skills/pr.md`.
+> 3. Follow every step faithfully. When a step requires user approval (e.g., PR description approval), surface it to the user and wait for their response.
+> 4. When done, return a structured summary: what was accomplished, key artifacts (PR URL, PR number, branch name), and the next pipeline step prompt from the skill definition.
+
+When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/review.md
+++ b/llms/dispatchers/claude/review.md
@@ -1,0 +1,27 @@
+---
+name: review
+description: >
+  Review an open pull request for guide compliance, correctness, and code
+  quality. Use this skill whenever the user says "/review <number>",
+  "review PR #N", "review this PR", or similar. Fetches the PR diff and
+  metadata, reads the project guides and source files under review, analyzes
+  findings by severity, presents them for approval, and posts an inline
+  review via the GitHub API.
+---
+
+# Subagent Dispatch
+
+Execute the **review** skill in an isolated subagent to preserve parent context.
+
+Spawn a general-purpose subagent with the following brief:
+
+> You are executing the **review** skill from the SDLC pipeline (issue → implement → test → commit → pr → review).
+>
+> **Argument:** <the argument value from ARGUMENTS below>
+>
+> 1. Read the project instructions in `CLAUDE.md`.
+> 2. Read and execute the complete workflow defined in `llms/skills/review.md`.
+> 3. Follow every step faithfully. When a step requires user approval (e.g., review findings approval), surface it to the user and wait for their response.
+> 4. When done, return a structured summary: what was accomplished, key artifacts (review event posted, findings count, PR number), and the next pipeline step prompt from the skill definition.
+
+When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/test.md
+++ b/llms/dispatchers/claude/test.md
@@ -1,0 +1,26 @@
+---
+name: test
+description: >
+  Analyze code changes for an issue, evaluate existing test coverage, plan
+  and implement tests. Use this skill whenever the user says "/test <number>",
+  "write tests for #N", "test #N", or similar. Accepts an issue number,
+  resolves the branch, diffs against the base, evaluates existing tests, and
+  writes new or updated tests to achieve comprehensive coverage.
+---
+
+# Subagent Dispatch
+
+Execute the **test** skill in an isolated subagent to preserve parent context.
+
+Spawn a general-purpose subagent with the following brief:
+
+> You are executing the **test** skill from the SDLC pipeline (issue → implement → test → commit → pr → review).
+>
+> **Argument:** <the argument value from ARGUMENTS below>
+>
+> 1. Read the project instructions in `CLAUDE.md`.
+> 2. Read and execute the complete workflow defined in `llms/skills/test.md`.
+> 3. Follow every step faithfully. When a step requires user approval (e.g., test plan approval), surface it to the user and wait for their response.
+> 4. When done, return a structured summary: what was accomplished, key artifacts (test files created or modified, test results), and the next pipeline step prompt from the skill definition.
+
+When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.


### PR DESCRIPTION
## Summary

Introduce a dispatcher layer (`llms/dispatchers/claude/`) that wraps each SDLC pipeline skill in a dedicated subagent. Symlinks in `.claude/commands/` now point to dispatchers instead of directly to skill definitions. Each dispatcher spawns a general-purpose subagent that reads and executes the corresponding skill from `llms/skills/`, keeping the parent conversation context clean for multi-step pipeline sessions. Skill definitions remain LLM-agnostic — subagent dispatch is an orchestration concern scoped to the harness-specific dispatcher layer. Dispatchers are organized by harness (`dispatchers/claude/`), leaving room for other harness implementations.

Closes #161

## Proposed changes

### Subagent dispatchers

Add 7 dispatcher files in `llms/dispatchers/claude/` — one for each SDLC skill (issue, implement, test, commit, pr, review, audit). Each dispatcher preserves the same frontmatter as its skill definition (maintaining command registration and trigger behavior) and contains a body that instructs the parent to spawn a subagent with the skill definition and arguments. The subagent handles all work — repository operations, file reads, planning, code generation, user approvals — and returns a structured summary.

### Documentation

Update `llms/README.md` to document the new `dispatchers/claude/` directory in the layout tree, add a Dispatchers section explaining the pattern and harness-scoped organization, and update the registration mechanism section to reflect that symlinks now target dispatchers. Also add the previously missing `review.md` entry to the skills directory listing.