### PR TITLE
Pull understand-chat skill into project and reference it directly in SDLC skills — Closes #163

### DIFF
--- a/llms/skills/commit.md
+++ b/llms/skills/commit.md
@@ -83,7 +83,7 @@ Check whether a knowledge graph exists:
 test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
 ```
 
-If the graph exists, invoke `/understand-chat` with a query listing the changed file paths from the diff to gather architectural context — component summaries, relationships, and layer assignments — that reveals component boundaries for logical commit grouping. If the graph does not exist, skip this step and continue.
+If the graph exists, read and follow `llms/skills/understand-chat.md` with a query listing the changed file paths from the diff to gather architectural context — component summaries, relationships, and layer assignments — that reveals component boundaries for logical commit grouping. If the graph does not exist, skip this step and continue.
 
 ### 5. Plan the commits
 

--- a/llms/skills/implement.md
+++ b/llms/skills/implement.md
@@ -122,7 +122,7 @@ The `--repo <target>` flag MUST be included when the target repo differs from th
 
 Before entering plan mode, read enough of the codebase to plan confidently:
 
-- Check whether `.understand-anything/knowledge-graph.json` exists. If it does, invoke `/understand-chat` with a query synthesized from the issue title and body to gather architectural context — component summaries, relationships, and layer assignments — that informs the planning phase by revealing which files, components, and layers are relevant to the issue. If the graph does not exist, skip this bullet and continue.
+- Check whether `.understand-anything/knowledge-graph.json` exists. If it does, read and follow `llms/skills/understand-chat.md` with a query synthesized from the issue title and body to gather architectural context — component summaries, relationships, and layer assignments — that informs the planning phase by revealing which files, components, and layers are relevant to the issue. If the graph does not exist, skip this bullet and continue.
 - Read source files referenced in the issue's description.
 - Read existing tests for the affected modules.
 - Read the project test guide (`@llm/guides/testguide-python.md`) to internalize testing conventions.

--- a/llms/skills/issue.md
+++ b/llms/skills/issue.md
@@ -63,7 +63,7 @@ Check whether a knowledge graph exists:
 test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
 ```
 
-If the graph exists, invoke `/understand-chat` with a query synthesized from the conversation context (the user's description of the problem or feature) to gather architectural context — component summaries, relationships, and layer assignments — that helps scope the issue by revealing which components and layers are relevant. If the graph does not exist, skip this step and continue.
+If the graph exists, read and follow `llms/skills/understand-chat.md` with a query synthesized from the conversation context (the user's description of the problem or feature) to gather architectural context — component summaries, relationships, and layer assignments — that helps scope the issue by revealing which components and layers are relevant. If the graph does not exist, skip this step and continue.
 
 ### 4. Draft interactively
 

--- a/llms/skills/pr.md
+++ b/llms/skills/pr.md
@@ -94,7 +94,7 @@ Check whether a knowledge graph exists:
 test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
 ```
 
-If the graph exists, invoke `/understand-chat` with a query listing the changed files and branch diff summary to gather architectural context — component summaries, relationships, and layer assignments — that provides architectural context for writing the PR description. If the graph does not exist, skip this step and continue.
+If the graph exists, read and follow `llms/skills/understand-chat.md` with a query listing the changed files and branch diff summary to gather architectural context — component summaries, relationships, and layer assignments — that provides architectural context for writing the PR description. If the graph does not exist, skip this step and continue.
 
 ### 5. Draft the PR description
 

--- a/llms/skills/review.md
+++ b/llms/skills/review.md
@@ -84,7 +84,7 @@ Check whether a knowledge graph exists:
 test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
 ```
 
-If the graph exists, invoke `/understand-chat` with a query listing the changed file paths from the PR diff to gather architectural context — component summaries, relationships, and layer assignments — that reveals how changed components fit into the broader architecture and informs review quality. If the graph does not exist, skip this step and continue.
+If the graph exists, read and follow `llms/skills/understand-chat.md` with a query listing the changed file paths from the PR diff to gather architectural context — component summaries, relationships, and layer assignments — that reveals how changed components fit into the broader architecture and informs review quality. If the graph does not exist, skip this step and continue.
 
 ### 6. Analyze the diff
 

--- a/llms/skills/test.md
+++ b/llms/skills/test.md
@@ -77,7 +77,7 @@ Check whether a knowledge graph exists:
 test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
 ```
 
-If the graph exists, invoke `/understand-chat` with a query listing the changed file paths to gather architectural context — component summaries, relationships, and layer assignments — that reveals which components interact with the changed code and informs test coverage planning. If the graph does not exist, skip this step and continue.
+If the graph exists, read and follow `llms/skills/understand-chat.md` with a query listing the changed file paths to gather architectural context — component summaries, relationships, and layer assignments — that reveals which components interact with the changed code and informs test coverage planning. If the graph does not exist, skip this step and continue.
 
 ### 3. Analyze code changes
 

--- a/llms/skills/understand-chat.md
+++ b/llms/skills/understand-chat.md
@@ -1,0 +1,57 @@
+---
+name: understand-chat
+description: >
+  Answer questions about a codebase using the knowledge graph at
+  `.understand-anything/knowledge-graph.json`. Use this skill to gather
+  architectural context — component summaries, relationships, and layer
+  assignments — that informs planning, scoping, and review across SDLC
+  stages.
+---
+
+# Understand Chat Skill
+
+Answer questions about this codebase using the knowledge graph at `.understand-anything/knowledge-graph.json`.
+
+## Graph Structure Reference
+
+The knowledge graph JSON has this structure:
+- `project` — {name, description, languages, frameworks, analyzedAt, gitCommitHash}
+- `nodes[]` — each has {id, type, name, filePath, summary, tags[], complexity, languageNotes?}
+  - Node types: file, function, class, module, concept
+  - IDs: `file:path`, `function:path:name`, `class:path:name`
+- `edges[]` — each has {source, target, type, direction, weight}
+  - Key types: imports, contains, calls, depends_on
+- `layers[]` — each has {id, name, description, nodeIds[]}
+- `tour[]` — each has {order, title, description, nodeIds[]}
+
+## How to Read Efficiently
+
+1. Use Grep to search within the JSON for relevant entries BEFORE reading the full file
+2. Only read sections you need — don't dump the entire graph into context
+3. Node names and summaries are the most useful fields for understanding
+4. Edges tell you how components connect — follow imports and calls for dependency chains
+
+## Instructions
+
+1. Check that `.understand-anything/knowledge-graph.json` exists in the current project root. If not, tell the user to run `/understand` first.
+
+2. **Read project metadata only** — use Grep or Read with a line limit to extract just the `"project"` section from the top of the file for context (name, description, languages, frameworks).
+
+3. **Search for relevant nodes** — use Grep to search the knowledge graph file for the query provided by the calling context.
+   - Search `"name"` fields with case-insensitive Grep in the graph file
+   - Search `"summary"` fields for semantic matches
+   - Search `"tags"` arrays for topic matches
+   - Note the `id` values of all matching nodes
+
+4. **Find connected edges** — for each matched node ID, Grep for that ID in the `edges` section to find:
+   - What it imports or depends on (downstream)
+   - What calls or imports it (upstream)
+   - This gives you the 1-hop subgraph around the query
+
+5. **Read layer context** — Grep for `"layers"` to understand which architectural layers the matched nodes belong to.
+
+6. **Answer the query** using only the relevant subgraph:
+   - Reference specific files, functions, and relationships from the graph
+   - Explain which layer(s) are relevant and why
+   - Be concise but thorough — link concepts to actual code locations
+   - If the query doesn't match any nodes, say so and suggest related terms from the graph


### PR DESCRIPTION
## Summary

Add a local understand-chat skill definition at `llms/skills/understand-chat.md` and update all six SDLC lifecycle skills to reference it directly instead of invoking the external `/understand-chat` slash command from the understand-anything plugin. This removes the implicit plugin dependency and gives the project full control over the knowledge graph querying behavior used during SDLC stages.

Closes #163

## Proposed changes

### Add local understand-chat skill definition

Introduce `llms/skills/understand-chat.md` containing the complete skill definition for querying the `.understand-anything/knowledge-graph.json` knowledge graph. The skill includes graph structure reference documentation, efficient reading instructions, and a step-by-step workflow for searching nodes, following edges, reading layer context, and answering queries using the relevant subgraph.

### Update SDLC skill references

Replace the `invoke /understand-chat` directive in all six SDLC skills (`commit.md`, `implement.md`, `issue.md`, `pr.md`, `review.md`, `test.md`) with `read and follow llms/skills/understand-chat.md`. Each change is a single-line substitution that points to the local skill file instead of the external slash command. No functional change to the querying behavior itself.

## Test cases

N/A