### PR TITLE
Gate run-tests workflow on code changes — Closes #160

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -12,8 +12,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    name: Detect code changes
+    runs-on: ubuntu-latest
+    outputs:
+      has_code_changes: ${{ steps.get-touched-files.outputs.touched && 'true' || 'false' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get touched files
+        id: get-touched-files
+        uses: ./.github/actions/get-touched-files
+        with:
+          pathspec: 'wool/src/ wool/tests/ wool/pyproject.toml proto/ .github/'
+
   lint:
     name: Lint / pyright
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_code_changes == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -36,6 +53,8 @@ jobs:
 
   unit-tests:
     name: Unit / Python ${{ matrix.python-version }}
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_code_changes == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -52,7 +71,8 @@ jobs:
 
   integration-tests:
     name: Integration / Python ${{ matrix.python-version }}
-    needs: unit-tests
+    needs: [detect-changes, unit-tests]
+    if: needs.detect-changes.outputs.has_code_changes == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Add a `detect-changes` gate job to the `run-tests` workflow that reuses the existing `get-touched-files` composite action. When a PR only touches documentation, skill definitions, or other non-code files, the lint, unit-test, and integration-test matrices are skipped entirely — saving CI minutes without affecting branch protection (skipped jobs count as passing). Include an explicit `actions/checkout@v4` step before invoking the local composite action so the repository contents are available at runtime.

Supersedes #162, which failed CI due to the missing checkout step.

Closes #160

## Proposed changes

### `detect-changes` job

Add a leading job that checks out the repository and invokes `get-touched-files` with pathspec `wool/src/ wool/tests/ wool/pyproject.toml proto/ .github/`. Expose a `has_code_changes` boolean output derived from the composite action's `touched` output. The explicit `actions/checkout@v4` step is required because the `get-touched-files` composite action is a local action that must be resolved from the repository's working tree.

### Conditional gates on existing jobs

Add `needs: detect-changes` and `if: needs.detect-changes.outputs.has_code_changes == 'true'` to the `lint`, `unit-tests`, and `integration-tests` jobs. The `integration-tests` job retains its existing `unit-tests` dependency alongside the new `detect-changes` dependency to preserve sequential ordering when tests do run.

## Test cases

No test cases — this PR modifies only CI workflow configuration (YAML), not application or library code.