### PR TITLE
Rename ResourcePool to ReferenceCountedCache — Closes #151

### DIFF
--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -5,6 +5,7 @@ from typing import Final
 
 from tblib import pickling_support
 
+from wool.runtime.cache import ReferenceCountedCache
 from wool.runtime.context import RuntimeContext
 from wool.runtime.discovery.base import Discovery
 from wool.runtime.discovery.base import DiscoveryEvent
@@ -19,7 +20,6 @@ from wool.runtime.loadbalancer.base import LoadBalancerContextLike
 from wool.runtime.loadbalancer.base import LoadBalancerLike
 from wool.runtime.loadbalancer.base import NoWorkersAvailable
 from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
-from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.routine.task import Serializer
 from wool.runtime.routine.task import Task
 from wool.runtime.routine.task import TaskException
@@ -51,8 +51,8 @@ except PackageNotFoundError:
 
 __proxy__: Final[ContextVar[WorkerProxy | None]] = ContextVar("__proxy__", default=None)
 
-__proxy_pool__: Final[ContextVar[ResourcePool[WorkerProxy] | None]] = ContextVar(
-    "__proxy_pool__", default=None
+__proxy_pool__: Final[ContextVar[ReferenceCountedCache[WorkerProxy] | None]] = (
+    ContextVar("__proxy_pool__", default=None)
 )
 
 __worker_metadata__: WorkerMetadata | None = None

--- a/wool/src/wool/runtime/cache.py
+++ b/wool/src/wool/runtime/cache.py
@@ -24,12 +24,12 @@ class Resource(Generic[T]):
     released again.
 
     :param pool:
-        The :class:`ResourcePool` this resource belongs to.
+        The :class:`ReferenceCountedCache` this resource belongs to.
     :param key:
         The cache key for this resource.
     """
 
-    def __init__(self, pool: ResourcePool[T], key):
+    def __init__(self, pool: ReferenceCountedCache[T], key):
         self._pool = pool
         self._key = key
         self._resource = None
@@ -91,7 +91,7 @@ class Resource(Generic[T]):
             await self._pool.release(self._key)
 
 
-class ResourcePool(Generic[T]):
+class ReferenceCountedCache(Generic[T]):
     """
     An asynchronous reference-counted cache with TTL-based cleanup.
 
@@ -127,7 +127,7 @@ class ResourcePool(Generic[T]):
     @dataclass
     class Stats:
         """
-        Statistics about the current state of the resource pool.
+        Statistics about the current state of the cache.
 
         :param total_entries:
             Total number of cached entries.
@@ -151,14 +151,14 @@ class ResourcePool(Generic[T]):
         self._factory = factory
         self._finalizer = finalizer
         self._ttl = ttl
-        self._cache: dict[Any, ResourcePool.CacheEntry] = {}
+        self._cache: dict[Any, ReferenceCountedCache.CacheEntry] = {}
         self._lock = asyncio.Lock()
 
     async def __aenter__(self):
         """Async context manager entry.
 
         :returns:
-            The ResourcePool instance itself.
+            The ReferenceCountedCache instance itself.
         """
         return self
 
@@ -184,7 +184,7 @@ class ResourcePool(Generic[T]):
             when not concurrently modifying the cache.
 
         :returns:
-            :class:`ResourcePool.Stats` containing current statistics.
+            :class:`ReferenceCountedCache.Stats` containing current statistics.
         """
         pending_cleanup = sum(
             1 for c in self.pending_cleanup.values() if c is not None and not c.done()

--- a/wool/src/wool/runtime/cache.py
+++ b/wool/src/wool/runtime/cache.py
@@ -15,18 +15,18 @@ from wool.runtime.typing import UndefinedType
 T = TypeVar("T")
 
 
-class Resource(Generic[T]):
+class Reference(Generic[T]):
     """
-    A single-use async context manager for resource acquisition.
+    A single-use async context manager for reference acquisition.
 
     This class can only be used once as an async context manager. After
     acquisition, it cannot be reacquired, and after release, it cannot be
     released again.
 
     :param pool:
-        The :class:`ReferenceCountedCache` this resource belongs to.
+        The :class:`ReferenceCountedCache` this reference belongs to.
     :param key:
-        The cache key for this resource.
+        The cache key for this reference.
     """
 
     def __init__(self, pool: ReferenceCountedCache[T], key):
@@ -210,17 +210,17 @@ class ReferenceCountedCache(Generic[T]):
             if v.cleanup is not None and not v.cleanup.done()
         }
 
-    def get(self, key: Any) -> Resource[T]:
+    def get(self, key: Any) -> Reference[T]:
         """
-        Get a resource acquisition that can be awaited or used as context
+        Get a reference acquisition that can be awaited or used as context
         manager.
 
         :param key:
             The cache key.
         :returns:
-            :class:`Resource` that can be awaited or used with 'async with'.
+            :class:`Reference` that can be awaited or used with 'async with'.
         """
-        return Resource(self, key)
+        return Reference(self, key)
 
     async def acquire(self, key: Any) -> T:
         """

--- a/wool/src/wool/runtime/discovery/__init__.py
+++ b/wool/src/wool/runtime/discovery/__init__.py
@@ -4,8 +4,8 @@ from contextvars import ContextVar
 from typing import Any
 from typing import Final
 
-from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.cache import ReferenceCountedCache
 
-__subscriber_pool__: Final[ContextVar[ResourcePool[Any] | None]] = ContextVar(
+__subscriber_pool__: Final[ContextVar[ReferenceCountedCache[Any] | None]] = ContextVar(
     "__subscriber_pool__", default=None
 )

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -23,6 +23,7 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from wool.protocol import WorkerMetadata as WorkerMetadataProtobuf
+from wool.runtime.cache import ReferenceCountedCache
 from wool.runtime.discovery.base import Discovery
 from wool.runtime.discovery.base import DiscoveryEvent
 from wool.runtime.discovery.base import DiscoveryEventType
@@ -30,7 +31,6 @@ from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.base import PredicateFunction
 from wool.runtime.discovery.pool import SubscriberMeta
-from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.afilter import afilter
 
@@ -339,7 +339,7 @@ class LocalDiscovery(Discovery):
         _block_size: int
         _cleanups: dict[str, Callable]
         _namespace: Final[str]
-        _shared_memory_pool: ResourcePool[SharedMemory]
+        _shared_memory_pool: ReferenceCountedCache[SharedMemory]
 
         def __init__(self, namespace: str, *, block_size: int = 512):
             if block_size < 0:
@@ -347,7 +347,7 @@ class LocalDiscovery(Discovery):
             self._namespace = namespace
             self._block_size = block_size
             self._cleanups = {}
-            self._shared_memory_pool = ResourcePool(
+            self._shared_memory_pool = ReferenceCountedCache(
                 factory=self._shared_memory_factory,
                 finalizer=self._shared_memory_finalizer,
                 ttl=0,

--- a/wool/src/wool/runtime/discovery/pool.py
+++ b/wool/src/wool/runtime/discovery/pool.py
@@ -30,7 +30,7 @@ class _SharedSubscription:
     """Adapter bridging a discovery subscriber and a :class:`Fanout`.
 
     Each ``__aiter__`` call returns an independent async generator
-    that enters a :class:`~wool.runtime.cache.Resource` from
+    that enters a :class:`~wool.runtime.cache.Reference` from
     the pool, wraps the raw subscriber in a shared
     :class:`~wool.utilities.fanout.Fanout`, and iterates a
     :class:`~wool.utilities.fanout.FanoutConsumer`.  The ``async
@@ -105,7 +105,7 @@ class SubscriberMeta(type):
     ``__new__`` onto the subscriber class.  The injected method
     registers a factory that creates raw subscribers, then returns a
     :class:`_SharedSubscription` whose pool
-    :class:`~wool.runtime.cache.Resource` is entered lazily
+    :class:`~wool.runtime.cache.Reference` is entered lazily
     on first iteration.
 
     Subscriber classes pass a ``key`` keyword argument at class

--- a/wool/src/wool/runtime/discovery/pool.py
+++ b/wool/src/wool/runtime/discovery/pool.py
@@ -6,9 +6,9 @@ from typing import AsyncIterator
 from typing import Callable
 from typing import ClassVar
 
+from wool.runtime.cache import ReferenceCountedCache
 from wool.runtime.discovery import __subscriber_pool__
 from wool.runtime.discovery.base import DiscoveryEvent
-from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.fanout import Fanout
 
@@ -30,7 +30,7 @@ class _SharedSubscription:
     """Adapter bridging a discovery subscriber and a :class:`Fanout`.
 
     Each ``__aiter__`` call returns an independent async generator
-    that enters a :class:`~wool.runtime.resourcepool.Resource` from
+    that enters a :class:`~wool.runtime.cache.Resource` from
     the pool, wraps the raw subscriber in a shared
     :class:`~wool.utilities.fanout.Fanout`, and iterates a
     :class:`~wool.utilities.fanout.FanoutConsumer`.  The ``async
@@ -42,7 +42,7 @@ class _SharedSubscription:
     so they start with a consistent view of the current state.
 
     :param key:
-        Cache key for the :class:`ResourcePool`.
+        Cache key for the :class:`ReferenceCountedCache`.
     :param reduce_info:
         ``(cls, args, kwargs)`` tuple used by :meth:`__reduce__` for
         pickle support.
@@ -105,7 +105,7 @@ class SubscriberMeta(type):
     ``__new__`` onto the subscriber class.  The injected method
     registers a factory that creates raw subscribers, then returns a
     :class:`_SharedSubscription` whose pool
-    :class:`~wool.runtime.resourcepool.Resource` is entered lazily
+    :class:`~wool.runtime.cache.Resource` is entered lazily
     on first iteration.
 
     Subscriber classes pass a ``key`` keyword argument at class
@@ -135,7 +135,7 @@ class SubscriberMeta(type):
             key = cls_arg._cache_key_fn(cls_arg, *args, **kwargs)  # type: ignore[attr-defined]
             pool = __subscriber_pool__.get()
             if pool is None:
-                pool = ResourcePool(
+                pool = ReferenceCountedCache(
                     factory=_pool_factory,
                     finalizer=_pool_finalizer,
                     ttl=0,
@@ -158,7 +158,7 @@ class SubscriberMeta(type):
 
 
 async def _pool_finalizer(subscriber: Any) -> None:
-    """Resource pool finalizer — clean up fanout and subscriber."""
+    """Cache finalizer — clean up fanout and subscriber."""
     fanout = _SharedSubscription._fanouts.pop(subscriber, None)
     if fanout is not None:
         await fanout.cleanup()

--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -193,7 +193,7 @@ Signal handlers map `SIGTERM` to timeout 0 (cancel immediately) and `SIGINT` to 
 
 ### Nested routines
 
-Worker subprocesses can dispatch tasks to other workers. Each subprocess is configured with a `ResourcePool` of `WorkerProxy` instances (via `wool.__proxy_pool__`), so `@wool.routine` calls within a task transparently route to the target pool. Spinning up a `WorkerProxy` is not free — it involves establishing a discovery subscription, starting a sentinel task, and opening gRPC connections — so the resource pool caches proxies with a configurable TTL (default 60 seconds, set via `proxy_pool_ttl` on `LocalWorker`). If the interval between dispatches for a given pool on a given worker is shorter than the TTL, the cached proxy is reused. If it exceeds the TTL, the proxy is finalized and must be recreated on the next dispatch. Tuning `proxy_pool_ttl` above the expected dispatch interval keeps proxies warm and avoids this cold-start overhead.
+Worker subprocesses can dispatch tasks to other workers. Each subprocess is configured with a `ReferenceCountedCache` of `WorkerProxy` instances (via `wool.__proxy_pool__`), so `@wool.routine` calls within a task transparently route to the target pool. Spinning up a `WorkerProxy` is not free — it involves establishing a discovery subscription, starting a sentinel task, and opening gRPC connections — so the cache stores proxies with a configurable TTL (default 60 seconds, set via `proxy_pool_ttl` on `LocalWorker`). If the interval between dispatches for a given pool on a given worker is shorter than the TTL, the cached proxy is reused. If it exceeds the TTL, the proxy is finalized and must be recreated on the next dispatch. Tuning `proxy_pool_ttl` above the expected dispatch interval keeps proxies warm and avoids this cold-start overhead.
 
 Proxies on worker subprocesses are lazy by default — the `WorkerPool` propagates its `lazy` flag to every `WorkerProxy` it constructs, and each task serializes the proxy (including the flag) so that workers receiving the task inherit the same laziness setting. A lazy proxy defers discovery subscription and sentinel setup until its first `dispatch()` call, so workers that never invoke nested routines pay no startup cost.
 
@@ -240,7 +240,7 @@ Workers are self-describing: each worker advertises its gRPC transport configura
 
 ### Connection pooling
 
-`WorkerConnection` is a lightweight facade that dispatches tasks over pooled gRPC channels. Channels are cached at the module level in a `ResourcePool` keyed by `(target, credentials, options)`, with a 60-second TTL — idle channels are finalized after the TTL expires. Each channel's concurrency semaphore is sized by the worker's advertised `max_concurrent_streams`.
+`WorkerConnection` is a lightweight facade that dispatches tasks over pooled gRPC channels. Channels are cached at the module level in a `ReferenceCountedCache` keyed by `(target, credentials, options)`, with a 60-second TTL — idle channels are finalized after the TTL expires. Each channel's concurrency semaphore is sized by the worker's advertised `max_concurrent_streams`.
 
 ### Transport configuration
 

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -14,7 +14,7 @@ import grpc.aio
 
 import wool
 from wool import protocol
-from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.cache import ReferenceCountedCache
 from wool.runtime.routine.task import PassthroughSerializer
 from wool.runtime.routine.task import Task
 from wool.runtime.worker.base import ChannelOptions
@@ -80,7 +80,7 @@ async def _channel_finalizer(channel: _Channel):
     await channel.close()
 
 
-_channel_pool: ResourcePool[_Channel] = ResourcePool(
+_channel_pool: ReferenceCountedCache[_Channel] = ReferenceCountedCache(
     factory=_channel_factory, finalizer=_channel_finalizer, ttl=60
 )
 

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -23,7 +23,7 @@ import grpc.aio
 
 import wool
 from wool import protocol
-from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.cache import ReferenceCountedCache
 from wool.runtime.worker.auth import CredentialContext
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerOptions
@@ -223,7 +223,7 @@ class WorkerProcess(Process):
         logger.info(f"Worker process starting on {self._host}:{self._port}")
 
         wool.__proxy_pool__.set(
-            ResourcePool(
+            ReferenceCountedCache(
                 factory=_proxy_factory,
                 finalizer=_proxy_finalizer,
                 ttl=self._proxy_pool_ttl,
@@ -413,14 +413,14 @@ def _sigint_handler(loop, service, signum, frame):
 
 
 async def _proxy_factory(proxy: WorkerProxy):
-    """Factory function for WorkerProxy instances in ResourcePool.
+    """Factory function for WorkerProxy instances in ReferenceCountedCache.
 
     Calls ``enter()`` on the proxy.  Lazy proxies defer actual
     startup until first dispatch; non-lazy proxies start eagerly.
     The proxy object itself is used as the cache key.
 
     :param proxy:
-        The WorkerProxy instance (passed as key from ResourcePool).
+        The WorkerProxy instance (passed as key from ReferenceCountedCache).
     :returns:
         The entered WorkerProxy instance.
     """
@@ -429,10 +429,10 @@ async def _proxy_factory(proxy: WorkerProxy):
 
 
 async def _proxy_finalizer(proxy: WorkerProxy):
-    """Finalizer function for WorkerProxy instances in ResourcePool.
+    """Finalizer function for WorkerProxy instances in ReferenceCountedCache.
 
     Exits the proxy context when it's being cleaned up from the
-    resource pool.  Lazy proxies that were never started are handled
+    cache.  Lazy proxies that were never started are handled
     gracefully by the proxy's own exit method.
 
     :param proxy:

--- a/wool/src/wool/runtime/worker/service.py
+++ b/wool/src/wool/runtime/worker/service.py
@@ -22,7 +22,7 @@ from grpc.aio import ServicerContext
 
 import wool
 from wool import protocol
-from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.cache import ReferenceCountedCache
 from wool.runtime.routine.task import Task
 from wool.runtime.routine.task import do_dispatch
 
@@ -147,7 +147,7 @@ class WorkerService(protocol.WorkerServicer):
     _stopped: asyncio.Event
     _stopping: asyncio.Event
     _task_completed: asyncio.Event
-    _loop_pool: ResourcePool[tuple[asyncio.AbstractEventLoop, threading.Thread]]
+    _loop_pool: ReferenceCountedCache[tuple[asyncio.AbstractEventLoop, threading.Thread]]
 
     def __init__(self, *, backpressure: BackpressureLike | None = None):
         self._stopped = asyncio.Event()
@@ -155,7 +155,7 @@ class WorkerService(protocol.WorkerServicer):
         self._task_completed = asyncio.Event()
         self._docket = set()
         self._backpressure = backpressure
-        self._loop_pool = ResourcePool(
+        self._loop_pool = ReferenceCountedCache(
             factory=self._create_worker_loop,
             finalizer=self._destroy_worker_loop,
             ttl=0,
@@ -267,7 +267,7 @@ class WorkerService(protocol.WorkerServicer):
         """Create a new event loop running on a dedicated daemon thread.
 
         :param key:
-            The :class:`ResourcePool` cache key (unused).
+            The :class:`ReferenceCountedCache` cache key (unused).
         :returns:
             A tuple of the event loop and the thread running it.
         """

--- a/wool/tests/conftest.py
+++ b/wool/tests/conftest.py
@@ -5,7 +5,7 @@ import debugpy
 import pytest
 
 import wool
-from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.cache import ReferenceCountedCache
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture
 def mock_worker_proxy_cache(mocker):
-    mock_pool = mocker.MagicMock(spec=ResourcePool)
+    mock_pool = mocker.MagicMock(spec=ReferenceCountedCache)
     mock_proxy = mocker.MagicMock()  # This will be returned by the context manager
     mock_pool.acquire.return_value.__aenter__ = mocker.AsyncMock(return_value=mock_proxy)
     mock_pool.acquire.return_value.__aexit__ = mocker.AsyncMock(return_value=False)

--- a/wool/tests/runtime/discovery/test_pool.py
+++ b/wool/tests/runtime/discovery/test_pool.py
@@ -5,13 +5,13 @@ import uuid
 import cloudpickle
 import pytest
 
+from wool.runtime.cache import ReferenceCountedCache
 from wool.runtime.discovery import __subscriber_pool__
 from wool.runtime.discovery.base import DiscoveryEvent
 from wool.runtime.discovery.pool import SubscriberMeta
 from wool.runtime.discovery.pool import _pool_factory
 from wool.runtime.discovery.pool import _SharedSubscription
 from wool.runtime.discovery.pool import _subscriber_factories
-from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.worker.metadata import WorkerMetadata
 
 
@@ -53,7 +53,7 @@ def _setup_pool():
     """Ensure the subscriber pool exists for direct-construction tests."""
     pool = __subscriber_pool__.get()
     if pool is None:
-        pool = ResourcePool(factory=_pool_factory, ttl=0)
+        pool = ReferenceCountedCache(factory=_pool_factory, ttl=0)
         __subscriber_pool__.set(pool)
     return pool
 
@@ -192,7 +192,7 @@ class TestSubscriberMeta:
         When:
             A subscriber is constructed via SubscriberMeta.
         Then:
-            The ContextVar should be set to a ResourcePool.
+            The ContextVar should be set to a ReferenceCountedCache.
         """
         # Arrange
         __subscriber_pool__.set(None)

--- a/wool/tests/runtime/test_cache.py
+++ b/wool/tests/runtime/test_cache.py
@@ -11,8 +11,8 @@ from hypothesis import given
 from hypothesis import strategies
 
 import wool.runtime.cache as cache_module
+from wool.runtime.cache import Reference
 from wool.runtime.cache import ReferenceCountedCache
-from wool.runtime.cache import Resource
 
 # Global tracking for factory and finalizer calls using function names as keys
 call_tracker = defaultdict(lambda: {"factory_calls": [], "finalizer_calls": []})
@@ -195,13 +195,17 @@ def mock_finalizer():
 @pytest.fixture
 def resource_pool_with_ttl(mock_resource_factory, mock_finalizer):
     """Create a resource pool configured for TTL testing."""
-    return ReferenceCountedCache(factory=mock_resource_factory, finalizer=mock_finalizer, ttl=0.1)
+    return ReferenceCountedCache(
+        factory=mock_resource_factory, finalizer=mock_finalizer, ttl=0.1
+    )
 
 
 @pytest.fixture
 def resource_pool_immediate_cleanup(mock_resource_factory, mock_finalizer):
     """Create a resource pool with TTL=0 for immediate cleanup testing."""
-    return ReferenceCountedCache(factory=mock_resource_factory, finalizer=mock_finalizer, ttl=0)
+    return ReferenceCountedCache(
+        factory=mock_resource_factory, finalizer=mock_finalizer, ttl=0
+    )
 
 
 @pytest.fixture
@@ -263,15 +267,15 @@ class TestReferenceCountedCache:
 
     @pytest.mark.asyncio
     @given(setup=setup())
-    async def test_get_returns_resource_instance(self, setup):
-        """Test that get returns a Resource instance.
+    async def test_get_returns_reference_instance(self, setup):
+        """Test that get returns a Reference instance.
 
         Given:
             A pool with various initial resource states
         When:
             get() is called with a test key
         Then:
-            Should return a Resource instance
+            Should return a Reference instance
         """
         # Arrange
         pool, _, _, _ = await setup()
@@ -280,10 +284,12 @@ class TestReferenceCountedCache:
         resource_acquisition = pool.get("test-key")
 
         # Assert
-        assert isinstance(resource_acquisition, Resource)
+        assert isinstance(resource_acquisition, Reference)
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
+    @pytest.mark.dependency(
+        "TestReferenceCountedCache::test_get_returns_reference_instance"
+    )
     async def test_release_decrements_reference_counts(self):
         """Test releasing resources decrements reference counts properly.
 
@@ -323,7 +329,9 @@ class TestReferenceCountedCache:
         assert pool.stats.referenced_entries == 0
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestReferenceCountedCache::test_release_decrements_reference_counts")
+    @pytest.mark.dependency(
+        "TestReferenceCountedCache::test_release_decrements_reference_counts"
+    )
     async def test_release_nonexistent_key_raises_error(self, counting_factory):
         """Test releasing nonexistent key raises KeyError.
 
@@ -355,7 +363,9 @@ class TestReferenceCountedCache:
         assert pool.stats.referenced_entries == 0
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestReferenceCountedCache::test_release_decrements_reference_counts")
+    @pytest.mark.dependency(
+        "TestReferenceCountedCache::test_release_decrements_reference_counts"
+    )
     async def test_release_zero_reference_count_raises_error(self):
         """Test releasing key with zero ref count raises ValueError.
 
@@ -372,7 +382,9 @@ class TestReferenceCountedCache:
         # so the resource stays in cache after release
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        ttl_pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
+        ttl_pool = ReferenceCountedCache(
+            factory=mock_factory, finalizer=mock_finalizer, ttl=60
+        )
 
         unique_key = "test-zero-ref-count"
         mock_resource = Mock()
@@ -392,7 +404,9 @@ class TestReferenceCountedCache:
             await ttl_pool.release(unique_key)
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
+    @pytest.mark.dependency(
+        "TestReferenceCountedCache::test_get_returns_reference_instance"
+    )
     async def test_clear_finalizes_all_resources(self):
         """Test clearing the pool calls finalizer on all resources.
 
@@ -406,7 +420,9 @@ class TestReferenceCountedCache:
         # Arrange - Create pool with TTL to keep resources after context exit
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
+        pool = ReferenceCountedCache(
+            factory=mock_factory, finalizer=mock_finalizer, ttl=60
+        )
 
         # Create some resources
         test_resources = []
@@ -431,7 +447,9 @@ class TestReferenceCountedCache:
         assert mock_finalizer.call_count == 3
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
+    @pytest.mark.dependency(
+        "TestReferenceCountedCache::test_get_returns_reference_instance"
+    )
     async def test_clear_key_removes_specific_resource(self, mock_finalizer):
         """Test clearing a specific key from the pool.
 
@@ -444,7 +462,9 @@ class TestReferenceCountedCache:
         """
         # Arrange
         mock_factory = Mock()
-        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
+        pool = ReferenceCountedCache(
+            factory=mock_factory, finalizer=mock_finalizer, ttl=60
+        )
 
         # Create multiple resources
         mock_resource1 = Mock()
@@ -490,7 +510,9 @@ class TestReferenceCountedCache:
         # Arrange
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
+        pool = ReferenceCountedCache(
+            factory=mock_factory, finalizer=mock_finalizer, ttl=60
+        )
 
         # Create one resource
         mock_resource = Mock()
@@ -513,7 +535,9 @@ class TestReferenceCountedCache:
         mock_finalizer.assert_not_called()
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
+    @pytest.mark.dependency(
+        "TestReferenceCountedCache::test_get_returns_reference_instance"
+    )
     async def test_ttl_cleanup_schedules_resource_removal(self):
         """Test TTL-based cleanup schedules and executes properly.
 
@@ -527,7 +551,9 @@ class TestReferenceCountedCache:
         # Arrange
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=0.1)
+        pool = ReferenceCountedCache(
+            factory=mock_factory, finalizer=mock_finalizer, ttl=0.1
+        )
 
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
@@ -573,7 +599,9 @@ class TestReferenceCountedCache:
         mock_finalizer.assert_called_once_with(mock_resource)
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
+    @pytest.mark.dependency(
+        "TestReferenceCountedCache::test_get_returns_reference_instance"
+    )
     async def test_ttl_cleanup_cancelled_on_reacquire(self):
         """Test TTL cleanup is cancelled when resource is reacquired.
 
@@ -587,7 +615,9 @@ class TestReferenceCountedCache:
         # Arrange
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=0.1)
+        pool = ReferenceCountedCache(
+            factory=mock_factory, finalizer=mock_finalizer, ttl=0.1
+        )
 
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
@@ -619,7 +649,9 @@ class TestReferenceCountedCache:
         assert pool.stats.referenced_entries == 0
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
+    @pytest.mark.dependency(
+        "TestReferenceCountedCache::test_get_returns_reference_instance"
+    )
     async def test_stats_returns_accurate_counts(self):
         """Test stats method returns accurate cache statistics.
 
@@ -634,7 +666,9 @@ class TestReferenceCountedCache:
         # Arrange
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=0.1)
+        pool = ReferenceCountedCache(
+            factory=mock_factory, finalizer=mock_finalizer, ttl=0.1
+        )
 
         # Start with empty pool
         stats = pool.stats
@@ -656,7 +690,9 @@ class TestReferenceCountedCache:
                     assert stats.pending_cleanup == 0  # None scheduled yet
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
+    @pytest.mark.dependency(
+        "TestReferenceCountedCache::test_get_returns_reference_instance"
+    )
     async def test_async_context_manager_clears_resources(self):
         """Test ReferenceCountedCache as async context manager clears all on exit.
 
@@ -672,7 +708,9 @@ class TestReferenceCountedCache:
         mock_finalizer = AsyncMock()
 
         # Act & assert
-        async with ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer) as pool:
+        async with ReferenceCountedCache(
+            factory=mock_factory, finalizer=mock_finalizer
+        ) as pool:
             mock_resource = Mock()
             mock_factory.return_value = mock_resource
 
@@ -718,7 +756,9 @@ class TestReferenceCountedCache:
 
             mock_finalizer = Mock(side_effect=mock_finalizer_func)
 
-            pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=ttl)
+            pool = ReferenceCountedCache(
+                factory=mock_factory, finalizer=mock_finalizer, ttl=ttl
+            )
 
             async with pool.get("test-key"):
                 pass
@@ -899,15 +939,15 @@ class TestReferenceCountedCache:
         assert pool.stats.total_entries == 0
 
 
-class TestResource:
-    """Test suite for the Resource class."""
+class TestReference:
+    """Test suite for the Reference class."""
 
     @pytest.mark.asyncio
     async def test_context_manager_auto_releases(self):
-        """Test Resource as async context manager.
+        """Test Reference as async context manager.
 
         Given:
-            A Resource instance from a pool
+            A Reference instance from a pool
         When:
             Used as async context manager
         Then:
@@ -922,7 +962,7 @@ class TestResource:
         pool = ReferenceCountedCache(factory=mock_factory, ttl=0)
 
         # Act & assert
-        # Use Resource as context manager
+        # Use Reference as context manager
         async with pool.get("test-key") as resource:
             assert resource is mock_resource
             assert pool.stats.total_entries == 1
@@ -932,11 +972,11 @@ class TestResource:
         assert pool.stats.total_entries == 0
 
     @pytest.mark.asyncio
-    async def test_resource_has_no_manual_release_method(self):
-        """Test Resource has no manual release method.
+    async def test_reference_has_no_manual_release_method(self):
+        """Test Reference has no manual release method.
 
         Given:
-            A Resource instance
+            A Reference instance
         When:
             Checking for release method
         Then:
@@ -956,11 +996,11 @@ class TestResource:
         assert not hasattr(resource_acquisition, "release")
 
     @pytest.mark.asyncio
-    async def test_resource_lifecycle_with_ttl(self):
-        """Test Resource lifecycle with TTL keeps resource in cache.
+    async def test_reference_lifecycle_with_ttl(self):
+        """Test Reference lifecycle with TTL keeps resource in cache.
 
         Given:
-            A Resource instance with TTL pool
+            A Reference instance with TTL pool
         When:
             Used as context manager
         Then:
@@ -971,7 +1011,9 @@ class TestResource:
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
 
-        pool = ReferenceCountedCache(factory=mock_factory, ttl=60)  # Use TTL to keep resource
+        pool = ReferenceCountedCache(
+            factory=mock_factory, ttl=60
+        )  # Use TTL to keep resource
 
         resource_acquisition = pool.get("test-key")
 
@@ -986,10 +1028,10 @@ class TestResource:
 
     @pytest.mark.asyncio
     async def test_context_manager_only_usage_handles_lifecycle(self):
-        """Test using Resource only as context manager.
+        """Test using Reference only as context manager.
 
         Given:
-            A Resource instance
+            A Reference instance
         When:
             Used only as context manager
         Then:
@@ -1013,10 +1055,10 @@ class TestResource:
 
     @pytest.mark.asyncio
     async def test_acquire_twice(self):
-        """Test that re-acquiring the same Resource instance raises error.
+        """Test that re-acquiring the same Reference instance raises error.
 
         Given:
-            A Resource that has been used as context manager once
+            A Reference that has been used as context manager once
         When:
             Attempting to use it as context manager again
         Then:
@@ -1039,11 +1081,11 @@ class TestResource:
                 pass
 
     @pytest.mark.asyncio
-    async def test_resource_context_acquire_exception(self):
-        """Test Resource context manager handles acquire exceptions properly.
+    async def test_reference_context_acquire_exception(self):
+        """Test Reference context manager handles acquire exceptions properly.
 
         Given:
-            A Resource instance from a pool that fails during acquire
+            A Reference instance from a pool that fails during acquire
         When:
             Entering the context manager
         Then:
@@ -1053,9 +1095,9 @@ class TestResource:
         mock_pool = AsyncMock()
         mock_pool.acquire.side_effect = RuntimeError("Acquire failed")
 
-        from wool.runtime.cache import Resource
+        from wool.runtime.cache import Reference
 
-        resource = Resource(pool=mock_pool, key="test-key")
+        resource = Reference(pool=mock_pool, key="test-key")
 
         # Act & assert
         with pytest.raises(RuntimeError, match="Acquire failed"):
@@ -1066,21 +1108,21 @@ class TestResource:
         assert resource._acquired is False
 
     @pytest.mark.asyncio
-    async def test_resource_context_release_not_acquired(self):
-        """Test Resource release when not acquired raises RuntimeError.
+    async def test_reference_context_release_not_acquired(self):
+        """Test Reference release when not acquired raises RuntimeError.
 
         Given:
-            A Resource instance that was never acquired
+            A Reference instance that was never acquired
         When:
             Attempting to exit context without entering properly
         Then:
-            Should raise RuntimeError indicating resource was not acquired
+            Should raise RuntimeError indicating reference was not acquired
         """
         # Arrange
         mock_pool = AsyncMock()
-        from wool.runtime.cache import Resource
+        from wool.runtime.cache import Reference
 
-        resource = Resource(pool=mock_pool, key="test-key")
+        resource = Reference(pool=mock_pool, key="test-key")
 
         # Act & assert - manually call __aexit__ without calling __aenter__
         with pytest.raises(
@@ -1089,24 +1131,24 @@ class TestResource:
             await resource.__aexit__(None, None, None)
 
     @pytest.mark.asyncio
-    async def test_resource_context_release_already_released(self):
-        """Test Resource release when already released raises RuntimeError.
+    async def test_reference_context_release_already_released(self):
+        """Test Reference release when already released raises RuntimeError.
 
         Given:
-            A Resource instance that was already released
+            A Reference instance that was already released
         When:
             Attempting to exit context again after normal usage
         Then:
-            Should raise RuntimeError indicating resource was already released
+            Should raise RuntimeError indicating reference was already released
         """
         # Arrange
         mock_pool = AsyncMock()
         mock_resource = Mock()
         mock_pool.acquire.return_value = mock_resource
 
-        from wool.runtime.cache import Resource
+        from wool.runtime.cache import Reference
 
-        resource = Resource(pool=mock_pool, key="test-key")
+        resource = Reference(pool=mock_pool, key="test-key")
 
         # Use normally once (which sets _released = True)
         async with resource:

--- a/wool/tests/runtime/test_cache.py
+++ b/wool/tests/runtime/test_cache.py
@@ -10,9 +10,9 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies
 
-import wool.runtime.resourcepool as rp
-from wool.runtime.resourcepool import Resource
-from wool.runtime.resourcepool import ResourcePool
+import wool.runtime.cache as cache_module
+from wool.runtime.cache import ReferenceCountedCache
+from wool.runtime.cache import Resource
 
 # Global tracking for factory and finalizer calls using function names as keys
 call_tracker = defaultdict(lambda: {"factory_calls": [], "finalizer_calls": []})
@@ -195,13 +195,13 @@ def mock_finalizer():
 @pytest.fixture
 def resource_pool_with_ttl(mock_resource_factory, mock_finalizer):
     """Create a resource pool configured for TTL testing."""
-    return ResourcePool(factory=mock_resource_factory, finalizer=mock_finalizer, ttl=0.1)
+    return ReferenceCountedCache(factory=mock_resource_factory, finalizer=mock_finalizer, ttl=0.1)
 
 
 @pytest.fixture
 def resource_pool_immediate_cleanup(mock_resource_factory, mock_finalizer):
     """Create a resource pool with TTL=0 for immediate cleanup testing."""
-    return ResourcePool(factory=mock_resource_factory, finalizer=mock_finalizer, ttl=0)
+    return ReferenceCountedCache(factory=mock_resource_factory, finalizer=mock_finalizer, ttl=0)
 
 
 @pytest.fixture
@@ -219,11 +219,11 @@ def counting_factory():
     return CountingFactory()
 
 
-class TestResourcePool:
+class TestReferenceCountedCache:
     @staticmethod
     @strategies.composite
     def setup(draw, *, max_key_count=5):
-        """Generate a ResourcePool with varied initial resource states.
+        """Generate a ReferenceCountedCache with varied initial resource states.
 
         Creates a pool with 0-max_key_count resources using the public API
         to create realistic pool states for property-based testing.
@@ -234,11 +234,11 @@ class TestResourcePool:
             Maximum number of keys to create resources for.
         :returns:
             An async function that when called returns a tuple of
-            (ResourcePool, factory, list of resources, list of keys).
+            (ReferenceCountedCache, factory, list of resources, list of keys).
         """
         factory = draw(factory_functions())
         finalizer = draw(finalizer_functions())
-        pool = ResourcePool(factory=factory, finalizer=finalizer, ttl=0)
+        pool = ReferenceCountedCache(factory=factory, finalizer=finalizer, ttl=0)
         created_resources = []
         keys = []
 
@@ -283,7 +283,7 @@ class TestResourcePool:
         assert isinstance(resource_acquisition, Resource)
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_returns_resource_instance")
+    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
     async def test_release_decrements_reference_counts(self):
         """Test releasing resources decrements reference counts properly.
 
@@ -296,7 +296,7 @@ class TestResourcePool:
         """
         # Arrange - Create pool with TTL to keep resources after context exit
         mock_factory = Mock()
-        pool = ResourcePool(factory=mock_factory, ttl=60)
+        pool = ReferenceCountedCache(factory=mock_factory, ttl=60)
 
         # Create some test resources
         test_keys = ["key1", "key2", "key3"]
@@ -323,7 +323,7 @@ class TestResourcePool:
         assert pool.stats.referenced_entries == 0
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_release_decrements_reference_counts")
+    @pytest.mark.dependency("TestReferenceCountedCache::test_release_decrements_reference_counts")
     async def test_release_nonexistent_key_raises_error(self, counting_factory):
         """Test releasing nonexistent key raises KeyError.
 
@@ -335,7 +335,7 @@ class TestResourcePool:
             Should exit without affecting existing resources
         """
         # Arrange
-        pool = ResourcePool(factory=counting_factory, ttl=1.0)
+        pool = ReferenceCountedCache(factory=counting_factory, ttl=1.0)
 
         # Create some resources to establish initial state
         keys = ["key1", "key2"]
@@ -355,7 +355,7 @@ class TestResourcePool:
         assert pool.stats.referenced_entries == 0
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_release_decrements_reference_counts")
+    @pytest.mark.dependency("TestReferenceCountedCache::test_release_decrements_reference_counts")
     async def test_release_zero_reference_count_raises_error(self):
         """Test releasing key with zero ref count raises ValueError.
 
@@ -372,7 +372,7 @@ class TestResourcePool:
         # so the resource stays in cache after release
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        ttl_pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
+        ttl_pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
 
         unique_key = "test-zero-ref-count"
         mock_resource = Mock()
@@ -392,7 +392,7 @@ class TestResourcePool:
             await ttl_pool.release(unique_key)
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_returns_resource_instance")
+    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
     async def test_clear_finalizes_all_resources(self):
         """Test clearing the pool calls finalizer on all resources.
 
@@ -406,7 +406,7 @@ class TestResourcePool:
         # Arrange - Create pool with TTL to keep resources after context exit
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
+        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
 
         # Create some resources
         test_resources = []
@@ -431,7 +431,7 @@ class TestResourcePool:
         assert mock_finalizer.call_count == 3
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_returns_resource_instance")
+    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
     async def test_clear_key_removes_specific_resource(self, mock_finalizer):
         """Test clearing a specific key from the pool.
 
@@ -444,7 +444,7 @@ class TestResourcePool:
         """
         # Arrange
         mock_factory = Mock()
-        pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
+        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
 
         # Create multiple resources
         mock_resource1 = Mock()
@@ -490,7 +490,7 @@ class TestResourcePool:
         # Arrange
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
+        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
 
         # Create one resource
         mock_resource = Mock()
@@ -513,7 +513,7 @@ class TestResourcePool:
         mock_finalizer.assert_not_called()
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_returns_resource_instance")
+    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
     async def test_ttl_cleanup_schedules_resource_removal(self):
         """Test TTL-based cleanup schedules and executes properly.
 
@@ -527,7 +527,7 @@ class TestResourcePool:
         # Arrange
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=0.1)
+        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=0.1)
 
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
@@ -541,7 +541,7 @@ class TestResourcePool:
             # Wait for the test to signal that sleep should complete
             await sleep_event.wait()
 
-        with patch.object(rp.asyncio, "sleep", side_effect=mock_sleep):
+        with patch.object(cache_module.asyncio, "sleep", side_effect=mock_sleep):
             # Act
             # Acquire and immediately release
             async with pool.get(key) as resource:
@@ -573,7 +573,7 @@ class TestResourcePool:
         mock_finalizer.assert_called_once_with(mock_resource)
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_returns_resource_instance")
+    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
     async def test_ttl_cleanup_cancelled_on_reacquire(self):
         """Test TTL cleanup is cancelled when resource is reacquired.
 
@@ -587,7 +587,7 @@ class TestResourcePool:
         # Arrange
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=0.1)
+        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=0.1)
 
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
@@ -619,7 +619,7 @@ class TestResourcePool:
         assert pool.stats.referenced_entries == 0
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_returns_resource_instance")
+    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
     async def test_stats_returns_accurate_counts(self):
         """Test stats method returns accurate cache statistics.
 
@@ -634,7 +634,7 @@ class TestResourcePool:
         # Arrange
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
-        pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=0.1)
+        pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=0.1)
 
         # Start with empty pool
         stats = pool.stats
@@ -656,12 +656,12 @@ class TestResourcePool:
                     assert stats.pending_cleanup == 0  # None scheduled yet
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_returns_resource_instance")
+    @pytest.mark.dependency("TestReferenceCountedCache::test_get_returns_resource_instance")
     async def test_async_context_manager_clears_resources(self):
-        """Test ResourcePool as async context manager clears all on exit.
+        """Test ReferenceCountedCache as async context manager clears all on exit.
 
         Given:
-            A ResourcePool with resources
+            A ReferenceCountedCache with resources
         When:
             Used as async context manager and then exited
         Then:
@@ -672,7 +672,7 @@ class TestResourcePool:
         mock_finalizer = AsyncMock()
 
         # Act & assert
-        async with ResourcePool(factory=mock_factory, finalizer=mock_finalizer) as pool:
+        async with ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer) as pool:
             mock_resource = Mock()
             mock_factory.return_value = mock_resource
 
@@ -718,7 +718,7 @@ class TestResourcePool:
 
             mock_finalizer = Mock(side_effect=mock_finalizer_func)
 
-            pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=ttl)
+            pool = ReferenceCountedCache(factory=mock_factory, finalizer=mock_finalizer, ttl=ttl)
 
             async with pool.get("test-key"):
                 pass
@@ -770,7 +770,7 @@ class TestResourcePool:
         async def failing_finalizer(_):
             raise ValueError("Finalizer failed")
 
-        pool = ResourcePool(factory=mock_factory, finalizer=failing_finalizer)
+        pool = ReferenceCountedCache(factory=mock_factory, finalizer=failing_finalizer)
 
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
@@ -798,7 +798,7 @@ class TestResourcePool:
         """
         # Arrange
         mock_factory = Mock(return_value=Mock())
-        pool = ResourcePool(factory=mock_factory, ttl=0)
+        pool = ReferenceCountedCache(factory=mock_factory, ttl=0)
 
         # Create one resource first
         async with pool.get("valid-key"):
@@ -821,7 +821,7 @@ class TestResourcePool:
             Resource pool should maintain consistency and not leak resources
         """
         # Arrange
-        pool = ResourcePool(factory=counting_factory, ttl=0.1)
+        pool = ReferenceCountedCache(factory=counting_factory, ttl=0.1)
 
         # Act
         async def acquire_release_worker():
@@ -888,7 +888,7 @@ class TestResourcePool:
         mock_factory = Mock()
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
-        pool = ResourcePool(factory=mock_factory, ttl=0)
+        pool = ReferenceCountedCache(factory=mock_factory, ttl=0)
 
         # Act & assert
         # None should be treated as a valid key
@@ -919,7 +919,7 @@ class TestResource:
         mock_resource.name = "context-resource"
         mock_factory.return_value = mock_resource
 
-        pool = ResourcePool(factory=mock_factory, ttl=0)
+        pool = ReferenceCountedCache(factory=mock_factory, ttl=0)
 
         # Act & assert
         # Use Resource as context manager
@@ -947,7 +947,7 @@ class TestResource:
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
 
-        pool = ResourcePool(factory=mock_factory, ttl=0)
+        pool = ReferenceCountedCache(factory=mock_factory, ttl=0)
 
         resource_acquisition = pool.get("test-key")
 
@@ -971,7 +971,7 @@ class TestResource:
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
 
-        pool = ResourcePool(factory=mock_factory, ttl=60)  # Use TTL to keep resource
+        pool = ReferenceCountedCache(factory=mock_factory, ttl=60)  # Use TTL to keep resource
 
         resource_acquisition = pool.get("test-key")
 
@@ -1000,7 +1000,7 @@ class TestResource:
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
 
-        pool = ResourcePool(factory=mock_factory, ttl=0)
+        pool = ReferenceCountedCache(factory=mock_factory, ttl=0)
 
         # Act & assert
         # Use only as context manager
@@ -1026,7 +1026,7 @@ class TestResource:
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
 
-        pool = ResourcePool(factory=mock_factory, ttl=0)
+        pool = ReferenceCountedCache(factory=mock_factory, ttl=0)
         resource_acquisition = pool.get("test-key")
 
         # First use as context manager
@@ -1053,7 +1053,7 @@ class TestResource:
         mock_pool = AsyncMock()
         mock_pool.acquire.side_effect = RuntimeError("Acquire failed")
 
-        from wool.runtime.resourcepool import Resource
+        from wool.runtime.cache import Resource
 
         resource = Resource(pool=mock_pool, key="test-key")
 
@@ -1078,7 +1078,7 @@ class TestResource:
         """
         # Arrange
         mock_pool = AsyncMock()
-        from wool.runtime.resourcepool import Resource
+        from wool.runtime.cache import Resource
 
         resource = Resource(pool=mock_pool, key="test-key")
 
@@ -1104,7 +1104,7 @@ class TestResource:
         mock_resource = Mock()
         mock_pool.acquire.return_value = mock_resource
 
-        from wool.runtime.resourcepool import Resource
+        from wool.runtime.cache import Resource
 
         resource = Resource(pool=mock_pool, key="test-key")
 

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -762,7 +762,8 @@ class TestWorkerProcess:
 
         mock_resource_pool = mocker.MagicMock()
         mock_resource_pool_class = mocker.patch(
-            "wool.runtime.worker.process.ResourcePool", return_value=mock_resource_pool
+            "wool.runtime.worker.process.ReferenceCountedCache",
+            return_value=mock_resource_pool,
         )
 
         mock_server = mocker.MagicMock()
@@ -821,7 +822,7 @@ class TestWorkerProcess:
         process = WorkerProcess(host="0.0.0.0", port=8080)
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch("wool.runtime.worker.process.ResourcePool")
+        mocker.patch("wool.runtime.worker.process.ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=8080)
@@ -872,7 +873,7 @@ class TestWorkerProcess:
         )
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch("wool.runtime.worker.process.ResourcePool")
+        mocker.patch("wool.runtime.worker.process.ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
@@ -921,7 +922,7 @@ class TestWorkerProcess:
         process = WorkerProcess(extra={"key": "value"})
 
         mocker.patch.object(process_module.wool, "__proxy_pool__")
-        mocker.patch.object(process_module, "ResourcePool")
+        mocker.patch.object(process_module, "ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
@@ -969,7 +970,7 @@ class TestWorkerProcess:
         process = WorkerProcess()
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch("wool.runtime.worker.process.ResourcePool")
+        mocker.patch("wool.runtime.worker.process.ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
@@ -1012,7 +1013,7 @@ class TestWorkerProcess:
         process = WorkerProcess(shutdown_grace_period=45.0)
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch("wool.runtime.worker.process.ResourcePool")
+        mocker.patch("wool.runtime.worker.process.ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
@@ -1465,7 +1466,7 @@ class TestWorkerProcess:
         process = WorkerProcess()
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch("wool.runtime.worker.process.ResourcePool")
+        mocker.patch("wool.runtime.worker.process.ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
@@ -1525,7 +1526,7 @@ class TestWorkerProcess:
         process = WorkerProcess(options=opts)
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch("wool.runtime.worker.process.ResourcePool")
+        mocker.patch("wool.runtime.worker.process.ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
@@ -1588,7 +1589,7 @@ class TestWorkerProcess:
         process = WorkerProcess(options=opts)
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch("wool.runtime.worker.process.ResourcePool")
+        mocker.patch("wool.runtime.worker.process.ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
@@ -1637,7 +1638,7 @@ class TestWorkerProcess:
         process = WorkerProcess()
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch("wool.runtime.worker.process.ResourcePool")
+        mocker.patch("wool.runtime.worker.process.ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
@@ -1691,7 +1692,7 @@ class TestWorkerProcess:
         process = WorkerProcess(options=opts)
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch("wool.runtime.worker.process.ResourcePool")
+        mocker.patch("wool.runtime.worker.process.ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
@@ -1737,7 +1738,7 @@ class TestWorkerProcess:
         process = WorkerProcess()
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch("wool.runtime.worker.process.ResourcePool")
+        mocker.patch("wool.runtime.worker.process.ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
@@ -1790,7 +1791,7 @@ class TestWorkerProcess:
         process = WorkerProcess(options=opts)
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch("wool.runtime.worker.process.ResourcePool")
+        mocker.patch("wool.runtime.worker.process.ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
@@ -1847,7 +1848,7 @@ class TestWorkerProcess:
         captured_current = []
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch.object(process_module, "ResourcePool")
+        mocker.patch.object(process_module, "ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_secure_port = mocker.MagicMock(return_value=50051)
@@ -1892,7 +1893,7 @@ class TestWorkerProcess:
         captured_current = []
 
         mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
-        mocker.patch.object(process_module, "ResourcePool")
+        mocker.patch.object(process_module, "ReferenceCountedCache")
 
         mock_server = mocker.MagicMock()
         mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)


### PR DESCRIPTION
## Summary

Rename the internal `ResourcePool` class to `ReferenceCountedCache` and its companion `Resource` class to `Reference`. Rename the module from `resourcepool.py` to `cache.py`. The previous names implied a pre-allocated pool of homogeneous resources (like a connection pool), but the actual abstraction is a lazily-created, keyed, reference-counted cache with TTL-based idle eviction. Similarly, `Resource` was a single-use acquisition handle rather than a resource in the traditional sense -- `Reference` better describes its role as a reference-counted handle into the cache. All internal references -- imports, type annotations, variable names, docstrings, and test mocks -- are updated accordingly. No behavioral changes.

Closes #151

## Proposed changes

### Rename module and classes

Rename `src/wool/runtime/resourcepool.py` to `src/wool/runtime/cache.py`, rename the `ResourcePool` class to `ReferenceCountedCache`, and rename the `Resource` class to `Reference`. The `CacheEntry` nested dataclass retains its name since it already describes its purpose accurately.

### Update all internal references

Update every import, type annotation, variable name, docstring cross-reference, and mock patch target across the codebase to reference the new module path (`wool.runtime.cache`) and class names (`ReferenceCountedCache`, `Reference`). Affected modules span the runtime core (`__init__.py`), discovery layer (`discovery/__init__.py`, `discovery/local.py`, `discovery/pool.py`), worker layer (`worker/connection.py`, `worker/process.py`, `worker/service.py`), and internal documentation (`worker/README.md`).

### Update test references

Rename `tests/runtime/test_resourcepool.py` to `tests/runtime/test_cache.py`. Rename test classes: `TestResourcePool` to `TestReferenceCountedCache` and `TestResource` to `TestReference`. Update all imports, mock patch targets, dependency markers, and docstring references within the test suite. No test logic is changed.

## Test cases

All test changes are mechanical renames with no behavioral modifications. The existing test suite validates the same invariants under the new names.

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestReferenceCountedCache` | A cache with a factory | `get()` is called with a key | Returns a `Reference` instance | Acquire semantics |
| 2 | `TestReferenceCountedCache` | A cache with active resources | Resources are released | Reference counts decrement to zero | Release semantics |
| 3 | `TestReferenceCountedCache` | A cache with unreferenced entries | TTL expires | Finalizer is called and entry is removed | TTL eviction |
| 4 | `TestReferenceCountedCache` | A cache with a pending TTL cleanup | Resource is reacquired before expiry | Cleanup task is cancelled | Reacquire cancellation |
| 5 | `TestReferenceCountedCache` | A cache with multiple entries | `clear()` is called | All entries are finalized | Full cleanup |
| 6 | `TestReferenceCountedCache` | A cache with multiple entries | `clear(key)` is called | Only the targeted entry is finalized | Key-specific cleanup |
| 7 | `TestReferenceCountedCache` | A cache with varied entry states | `stats` is accessed | Accurate counts for total, referenced, and pending entries | Statistics accuracy |
| 8 | `TestReferenceCountedCache` | A cache used as async context manager | Context is exited | All resources are cleared | Context manager lifecycle |
| 9 | `TestReferenceCountedCache` | A cache under concurrent access | Multiple tasks acquire and release | Pool invariants hold and no resources leak | Concurrency safety |
| 10 | `TestReference` | A `Reference` from a cache | Used as async context manager | Acquires on enter, releases on exit | Context manager protocol |
| 11 | `TestReference` | A `Reference` that has already been entered | Entered a second time | Raises `RuntimeError` | Acquire-once enforcement |
| 12 | `TestReference` | A `Reference` from a pool that fails during acquire | Entering the context manager | Raises the underlying error and does not mark as acquired | Acquire failure handling |
| 13 | `TestReference` | A `Reference` that was never acquired | Attempting to exit context | Raises `RuntimeError` | Release-without-acquire guard |
| 14 | `TestReference` | A `Reference` that was already released | Attempting to exit context again | Raises `RuntimeError` | Double-release guard |
| 15 | `TestSubscriberMeta` | No subscriber pool in ContextVar | A subscriber is constructed | A `ReferenceCountedCache` is set in the ContextVar | Auto-pool initialization |