### PR TITLE
Add quorum parameter to WorkerPool and WorkerProxy — Closes #144

### DIFF
--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -18,12 +18,19 @@ from typing_extensions import deprecated
 from wool.runtime.context import install_task_factory
 from wool.runtime.discovery.base import DiscoveryLike
 from wool.runtime.discovery.base import DiscoveryPublisherLike
+from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.local import LocalDiscovery
 from wool.runtime.typing import Factory
+from wool.runtime.typing import Undefined
+from wool.runtime.typing import UndefinedType
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import WorkerFactory
 from wool.runtime.worker.base import WorkerLike
 from wool.runtime.worker.local import LocalWorker
+from wool.runtime.worker.proxy import DEFAULT_LAZY
+from wool.runtime.worker.proxy import DEFAULT_QUORUM
+from wool.runtime.worker.proxy import DEFAULT_QUORUM_TIMEOUT
+from wool.runtime.worker.proxy import IneffectiveQuorumTimeoutWarning
 from wool.runtime.worker.proxy import LoadBalancerLike
 from wool.runtime.worker.proxy import RoundRobinLoadBalancer
 from wool.runtime.worker.proxy import WorkerProxy
@@ -138,6 +145,15 @@ class WorkerPool:
         async with WorkerPool(discovery=custom_discovery):
             result = await task()
 
+    **Quorum gate:**
+
+    .. code-block:: python
+
+        # Spawn 4 workers, block on context entry until all 4 are
+        # admitted, and time out after 30s if not.
+        async with WorkerPool(spawn=4, quorum=4, quorum_timeout=30, lazy=False):
+            result = await task()
+
     :param tags:
         Capability tags for spawned workers.
     :param spawn:
@@ -151,14 +167,42 @@ class WorkerPool:
         ``lease`` for external pools. Defaults to ``None`` (unbounded).
     :param worker:
         Worker factory callable. Defaults to :class:`LocalWorker`.
-    :param loadbalancer:
-        Load balancer instance, factory, or context manager.
     :param discovery:
         Discovery service instance, factory, or context manager.
+    :param loadbalancer:
+        Load balancer instance, factory, or context manager.
     :param credentials:
         Optional channel credentials for TLS/mTLS connections to workers.
+    :param quorum:
+        Minimum number of workers that must be discovered before the proxy
+        considers itself ready. Defaults to ``1`` — block until at least
+        one worker is admitted, preserving the pre-quorum implicit-wait
+        behaviour. Pass a larger integer to require more workers, or
+        ``None``/``0`` to disable the gate entirely (``dispatch`` may
+        then raise immediately if no workers have been discovered yet).
+        When ``lazy=True`` (default), the quorum wait is deferred to the
+        first dispatch; with ``lazy=False`` it blocks at context entry.
+    :param quorum_timeout:
+        Seconds to wait for ``quorum`` workers to be discovered before
+        raising :class:`asyncio.TimeoutError`. Only meaningful when
+        ``quorum`` is a positive integer; supplying it with
+        ``quorum=None`` or ``quorum=0`` records the value but never
+        consults it, accompanied by an
+        :class:`~wool.runtime.worker.proxy.IneffectiveQuorumTimeoutWarning`.
+        Defaults to ``60``; pass ``None`` to wait indefinitely. On
+        timeout the pool instance becomes unusable (single-use
+        semantics); construct a new pool to retry.
+    :param lazy:
+        When ``True`` (default), defer discovery setup and the quorum
+        wait to the first :meth:`WorkerProxy.dispatch`.  When ``False``,
+        eagerly enter the underlying proxy at ``__aenter__`` time and
+        run the quorum wait there.
     :raises ValueError:
         If configuration is invalid or CPU count unavailable.
+    :raises asyncio.TimeoutError:
+        If the quorum wait does not complete within ``quorum_timeout``
+        — raised by the underlying :class:`WorkerProxy` at context
+        entry (``lazy=False``) or first dispatch (``lazy=True``).
 
     .. caution::
 
@@ -182,7 +226,9 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
-        lazy: bool = True,
+        quorum: int | None = DEFAULT_QUORUM,
+        quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        lazy: bool = DEFAULT_LAZY,
     ):
         """
         Create an ephemeral pool of workers, spawning the specified
@@ -200,10 +246,12 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
-        lazy: bool = True,
+        quorum: int | None = DEFAULT_QUORUM,
+        quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        lazy: bool = DEFAULT_LAZY,
     ):
         """
-        Connect to an existing pool of workers discovered by the
+        Connect to an external pool of workers discovered by the
         specified discovery protocol.
         """
         ...
@@ -220,7 +268,9 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
-        lazy: bool = True,
+        quorum: int | None = DEFAULT_QUORUM,
+        quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        lazy: bool = DEFAULT_LAZY,
     ):
         """
         Create a hybrid pool that spawns local workers and discovers
@@ -241,7 +291,9 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
-        lazy: bool = True,
+        quorum: int | None = DEFAULT_QUORUM,
+        quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        lazy: bool = DEFAULT_LAZY,
     ): ...
 
     @overload
@@ -257,7 +309,9 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
-        lazy: bool = True,
+        quorum: int | None = DEFAULT_QUORUM,
+        quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        lazy: bool = DEFAULT_LAZY,
     ): ...
 
     def __init__(
@@ -272,7 +326,9 @@ class WorkerPool:
             LoadBalancerLike | Factory[LoadBalancerLike]
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None = None,
-        lazy: bool = True,
+        quorum: int | None = DEFAULT_QUORUM,
+        quorum_timeout: float | None | UndefinedType = Undefined,
+        lazy: bool = DEFAULT_LAZY,
     ):
         self._workers = {}
         self._credentials = credentials
@@ -294,10 +350,28 @@ class WorkerPool:
         if lease is not None and lease < 0:
             raise ValueError("Lease must be non-negative")
 
+        # Warn when `quorum_timeout` is supplied alongside a falsy `quorum`;
+        # the value is recorded but never consulted.  The warning is
+        # emitted at the pool layer because `_make_proxy` elides
+        # `quorum_timeout` when forwarding to the proxy in those cases,
+        # so WorkerProxy never sees that the pool's user supplied one.
+        # Other quorum/quorum_timeout validations are delegated to
+        # WorkerProxy.
+        if quorum_timeout is Undefined:
+            quorum_timeout = DEFAULT_QUORUM_TIMEOUT
+        elif not quorum:
+            warnings.warn(
+                "'quorum_timeout' has no effect when 'quorum' is None or 0; "
+                "the value is recorded but never consulted",
+                IneffectiveQuorumTimeoutWarning,
+                stacklevel=2,
+            )
+
         match (spawn, discovery):
             case (spawn, discovery) if spawn is not None and discovery is not None:
                 spawn = _resolve_spawn(spawn)
                 max_workers = spawn + lease if lease is not None else None
+                self._validate_quorum(quorum, max_workers)
 
                 @asynccontextmanager
                 async def create_proxy():
@@ -314,11 +388,12 @@ class WorkerPool:
                             factory=worker,
                             publisher=discovery_svc.publisher,
                         ):
-                            async with WorkerProxy(
+                            async with self._make_proxy(
                                 discovery=discovery_svc.subscribe(_predicate(tags)),
                                 loadbalancer=loadbalancer,
-                                credentials=self._credentials,
                                 lease=max_workers,
+                                quorum=quorum,
+                                quorum_timeout=quorum_timeout,
                                 lazy=self._lazy,
                             ):
                                 yield
@@ -328,6 +403,7 @@ class WorkerPool:
             case (spawn, None) if spawn is not None:
                 spawn = _resolve_spawn(spawn)
                 max_workers = spawn + lease if lease is not None else None
+                self._validate_quorum(quorum, max_workers)
 
                 namespace = f"pool-{uuid.uuid4().hex}"
 
@@ -340,11 +416,12 @@ class WorkerPool:
                             factory=worker,
                             publisher=discovery.publisher,
                         ):
-                            async with WorkerProxy(
+                            async with self._make_proxy(
                                 discovery=discovery.subscribe(_predicate(tags)),
                                 loadbalancer=loadbalancer,
-                                credentials=self._credentials,
                                 lease=max_workers,
+                                quorum=quorum,
+                                quorum_timeout=quorum_timeout,
                                 lazy=self._lazy,
                             ):
                                 yield
@@ -359,11 +436,12 @@ class WorkerPool:
                     if not isinstance(discovery_svc, DiscoveryLike):
                         raise ValueError
                     try:
-                        async with WorkerProxy(
+                        async with self._make_proxy(
                             discovery=discovery_svc.subscriber,
                             loadbalancer=loadbalancer,
-                            credentials=self._credentials,
                             lease=lease,
+                            quorum=quorum,
+                            quorum_timeout=quorum_timeout,
                             lazy=self._lazy,
                         ):
                             yield
@@ -373,6 +451,7 @@ class WorkerPool:
             case (None, None):
                 spawn = _resolve_spawn(0)
                 max_workers = spawn + lease if lease is not None else None
+                self._validate_quorum(quorum, max_workers)
 
                 namespace = f"pool-{uuid.uuid4().hex}"
 
@@ -385,11 +464,12 @@ class WorkerPool:
                             factory=worker,
                             publisher=discovery.publisher,
                         ):
-                            async with WorkerProxy(
+                            async with self._make_proxy(
                                 discovery=discovery.subscriber,
-                                loadbalancer=loadbalancer,
-                                credentials=self._credentials,
                                 lease=max_workers,
+                                loadbalancer=loadbalancer,
+                                quorum=quorum,
+                                quorum_timeout=quorum_timeout,
                                 lazy=self._lazy,
                             ):
                                 yield
@@ -398,6 +478,19 @@ class WorkerPool:
                 raise RuntimeError
 
         self._proxy_factory = create_proxy
+
+    @staticmethod
+    def _validate_quorum(quorum: int | None, max_workers: int | None) -> None:
+        """Reject a quorum that exceeds the pool's bounded capacity.
+
+        No-op when either side is ``None`` (an unset quorum or an
+        unbounded ``max_workers``).
+        """
+        if max_workers is not None and quorum is not None and quorum > max_workers:
+            raise ValueError(
+                f"Quorum ({quorum}) cannot exceed pool capacity "
+                f"({max_workers}) — the quorum would never be satisfied"
+            )
 
     @noreentry
     async def __aenter__(self) -> WorkerPool:
@@ -467,6 +560,43 @@ class WorkerPool:
             return LocalWorker(*tags, credentials=credentials)
 
         return factory
+
+    def _make_proxy(
+        self,
+        *,
+        discovery: DiscoverySubscriberLike,
+        loadbalancer: LoadBalancerLike | Factory[LoadBalancerLike],
+        lease: int | None,
+        quorum: int | None,
+        quorum_timeout: float | None,
+        lazy: bool,
+    ) -> WorkerProxy:
+        """Construct a :class:`WorkerProxy` for this pool's discovery.
+
+        Selects :class:`WorkerProxy`'s typed overload via narrowing:
+        when ``quorum`` is truthy, forwards both ``quorum`` and
+        ``quorum_timeout``; otherwise normalizes ``quorum=0`` and
+        ``quorum=None`` to literal ``None`` (which the pool's user
+        contract documents as equivalent) and drops ``quorum_timeout``.
+        """
+        if quorum:
+            return WorkerProxy(
+                discovery=discovery,
+                loadbalancer=loadbalancer,
+                credentials=self._credentials,
+                lease=lease,
+                quorum=quorum,
+                quorum_timeout=quorum_timeout,
+                lazy=lazy,
+            )
+        return WorkerProxy(
+            discovery=discovery,
+            loadbalancer=loadbalancer,
+            credentials=self._credentials,
+            lease=lease,
+            quorum=None,
+            lazy=lazy,
+        )
 
     async def _enter_context(self, factory):
         ctx = None

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 import warnings
+from contextlib import AsyncExitStack
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import AsyncContextManager
@@ -11,6 +12,7 @@ from typing import AsyncIterator
 from typing import Awaitable
 from typing import Callable
 from typing import ContextManager
+from typing import Final
 from typing import Generic
 from typing import NoReturn
 from typing import Sequence
@@ -110,17 +112,43 @@ class ReducibleAsyncIterator(Generic[T]):
 WorkerUri: TypeAlias = str
 
 
+DEFAULT_QUORUM: Final[int] = 1
+"""Default minimum worker count required before dispatch."""
+
+DEFAULT_QUORUM_TIMEOUT: Final[float] = 60.0
+"""Default seconds to wait for ``quorum`` workers before raising :class:`asyncio.TimeoutError`."""
+
+DEFAULT_LAZY: Final[bool] = True
+"""Default lazy-start behavior: defer discovery setup and the quorum wait to first dispatch."""
+
+
+class IneffectiveQuorumTimeoutWarning(UserWarning):
+    """Emitted when ``quorum_timeout`` is supplied alongside ``quorum=None`` or ``0``.
+
+    The timeout value is recorded on the proxy but never consulted —
+    no quorum wait runs when the gate is disabled.  Filter this category
+    to ``"error"`` (via :func:`warnings.filterwarnings`) to enforce the
+    previous strict behaviour and turn the warning back into a
+    :class:`ValueError`.
+    """
+
+
 def _restore_proxy(
     discovery: DiscoverySubscriberLike,
     loadbalancer: Factory[LoadBalancerLike] | LoadBalancerLike,
     proxy_id: uuid.UUID,
     lease: int | None,
     lazy: bool,
+    quorum: int | None = DEFAULT_QUORUM,
+    quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
 ) -> WorkerProxy:
     """Reconstruct a :class:`WorkerProxy` from its reduce tuple.
 
     Module-level so the reduce tuple references a stable callable rather
-    than a freshly created closure on every reduction.
+    than a freshly created closure on every reduction.  New parameters
+    are appended with defaults so that older clients whose reduce
+    tuples predate them still unpickle on newer peers within the same
+    major protocol version.
 
     :param discovery:
         Discovery subscriber or factory carried through the reduce tuple.
@@ -133,15 +161,37 @@ def _restore_proxy(
         Lease size, ``None`` for no cap.
     :param lazy:
         Whether to defer worker resolution until first dispatch.
+    :param quorum:
+        Minimum number of workers required before the proxy is ready.
+        Defaults to ``1`` rather than the constructor's ``None`` default,
+        so reduce tuples emitted by clients that predate this parameter
+        preserve their pre-quorum "wait for any worker" semantics.
+    :param quorum_timeout:
+        Seconds to wait for ``quorum`` workers before raising
+        :class:`asyncio.TimeoutError`.  Recorded but never consulted
+        when ``quorum`` is ``None`` or ``0``.  Defaults to ``60`` for
+        back-compat with reduce tuples emitted by clients that
+        predate this parameter.
     :returns:
         A reconstructed :class:`WorkerProxy` with the original id.
     """
-    proxy = WorkerProxy(
-        discovery=discovery,
-        loadbalancer=loadbalancer,
-        lease=lease,
-        lazy=lazy,
-    )
+    if quorum:
+        proxy = WorkerProxy(
+            discovery=discovery,
+            loadbalancer=loadbalancer,
+            lease=lease,
+            quorum=quorum,
+            quorum_timeout=quorum_timeout,
+            lazy=lazy,
+        )
+    else:
+        proxy = WorkerProxy(
+            discovery=discovery,
+            loadbalancer=loadbalancer,
+            lease=lease,
+            quorum=None,
+            lazy=lazy,
+        )
     proxy._id = proxy_id
     return proxy
 
@@ -204,6 +254,19 @@ class WorkerProxy:
         ) as proxy:
             result = await task()
 
+    **Quorum gate:**
+
+    .. code-block:: python
+
+        # Block first dispatch until at least 3 workers are admitted,
+        # giving up after 30 seconds if the quorum is not reached.
+        async with WorkerProxy(
+            discovery=discovery,
+            quorum=3,
+            quorum_timeout=30,
+        ) as proxy:
+            result = await task()
+
     :param pool_uri:
         Pool identifier for discovery-based connection.
     :param tags:
@@ -219,6 +282,34 @@ class WorkerProxy:
     :param lease:
         Maximum number of workers this proxy will admit from discovery.
         Defaults to ``None`` (unbounded).
+    :param quorum:
+        Minimum number of workers that must be discovered before the proxy
+        considers itself ready. Defaults to ``1`` — block until at least
+        one worker is admitted, preserving the pre-quorum implicit-wait
+        behaviour. Pass a larger integer to require more workers, or
+        ``None``/``0`` to disable the gate entirely (``dispatch`` may
+        then raise immediately if no workers have been discovered yet).
+        When ``lazy=True`` (default), the quorum wait is deferred to the
+        first dispatch; with ``lazy=False`` it blocks at context entry.
+    :param quorum_timeout:
+        Seconds to wait for ``quorum`` workers to be discovered before
+        raising :class:`asyncio.TimeoutError`. Only meaningful when
+        ``quorum`` is a positive integer; supplying it with
+        ``quorum=None`` or ``quorum=0`` records the value but never
+        consults it, accompanied by an
+        :class:`IneffectiveQuorumTimeoutWarning`. Defaults to ``60``;
+        pass ``None`` to wait indefinitely.
+
+    :raises ValueError:
+        If ``quorum`` is negative, ``lease`` is non-positive, ``quorum``
+        exceeds ``lease``, ``quorum`` exceeds the compatible worker
+        count when constructed with a static ``workers`` list, or
+        ``quorum_timeout`` is non-positive or supplied without a
+        positive ``quorum``.
+    :raises asyncio.TimeoutError:
+        Raised at context entry (``lazy=False``) or first
+        :meth:`dispatch` (``lazy=True``) if ``quorum`` workers are not
+        admitted within ``quorum_timeout`` seconds.
 
     .. caution::
 
@@ -250,7 +341,9 @@ class WorkerProxy:
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
         lease: int | None = None,
-        lazy: bool = True,
+        quorum: int | None = DEFAULT_QUORUM,
+        quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        lazy: bool = DEFAULT_LAZY,
     ): ...
 
     @overload
@@ -263,7 +356,9 @@ class WorkerProxy:
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
         lease: int | None = None,
-        lazy: bool = True,
+        quorum: int | None = DEFAULT_QUORUM,
+        quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        lazy: bool = DEFAULT_LAZY,
     ): ...
 
     @overload
@@ -276,7 +371,9 @@ class WorkerProxy:
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
         lease: int | None = None,
-        lazy: bool = True,
+        quorum: int | None = DEFAULT_QUORUM,
+        quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        lazy: bool = DEFAULT_LAZY,
     ): ...
 
     def __init__(
@@ -292,7 +389,9 @@ class WorkerProxy:
         ) = RoundRobinLoadBalancer,
         credentials: WorkerCredentials | None | UndefinedType = Undefined,
         lease: int | None = None,
-        lazy: bool = True,
+        quorum: int | None = DEFAULT_QUORUM,
+        quorum_timeout: float | None | UndefinedType = Undefined,
+        lazy: bool = DEFAULT_LAZY,
     ):
         if not (pool_uri or discovery or workers):
             raise ValueError(
@@ -300,15 +399,40 @@ class WorkerProxy:
                 "sequence of workers"
             )
 
+        if quorum is not None and quorum < 0:
+            raise ValueError("Quorum must be a non-negative integer")
+
         if lease is not None and lease < 1:
             raise ValueError("Lease must be a positive, non-zero integer")
 
+        if quorum is not None and lease is not None and quorum > lease:
+            raise ValueError(
+                f"Quorum ({quorum}) cannot exceed lease ({lease}) — "
+                "the quorum would never be satisfied"
+            )
+
+        if quorum_timeout is Undefined:
+            quorum_timeout = DEFAULT_QUORUM_TIMEOUT
+        elif not quorum:
+            warnings.warn(
+                "'quorum_timeout' has no effect when 'quorum' is None or 0; "
+                "the value is recorded but never consulted",
+                IneffectiveQuorumTimeoutWarning,
+                stacklevel=2,
+            )
+
+        if quorum_timeout is not None and quorum_timeout <= 0:
+            raise ValueError("Quorum timeout must be positive")
+
         self._id: uuid.UUID = uuid.uuid4()
         self._started = False
+        self._start_failure: BaseException | None = None
         self._lazy = lazy
         self._start_lock = asyncio.Lock() if lazy else None
         self._loadbalancer = loadbalancer
         self._lease = lease
+        self._quorum = quorum
+        self._quorum_timeout = quorum_timeout
         self._proxy_token: Token[WorkerProxy | None] | None = None
 
         if isinstance(loadbalancer, (ContextManager, AsyncContextManager)):
@@ -356,6 +480,13 @@ class WorkerProxy:
                 self._discovery = discovery
             case (None, None, workers) if workers is not None:
                 compatible_workers = [w for w in workers if compatible(w)]
+                if quorum is not None and quorum > len(compatible_workers):
+                    raise ValueError(
+                        f"Quorum ({quorum}) cannot exceed compatible worker "
+                        f"count ({len(compatible_workers)} of {len(workers)} "
+                        "after security/version filtering) — "
+                        "the quorum would never be satisfied"
+                    )
                 self._discovery = ReducibleAsyncIterator(
                     [
                         DiscoveryEvent("worker-added", metadata=w)
@@ -388,10 +519,11 @@ class WorkerProxy:
     def __wool_reduce__(self) -> tuple[Callable[..., WorkerProxy], tuple[Any, ...]]:
         """Return constructor args for unpickling via Wool's pickler.
 
-        Creates a new WorkerProxy instance with the same discovery stream
-        and load balancer type, then sets the preserved proxy ID on the
-        new object.  Credentials are NOT serialized — the restored proxy
-        resolves them from the active credential context.
+        The reduce tuple carries ``discovery``, ``loadbalancer``, the
+        proxy id, ``lease``, ``lazy``, ``quorum``, and
+        ``quorum_timeout``.  Credentials are NOT serialized — the
+        restored proxy resolves them from the active credential
+        context.
 
         WorkerProxy is guarded against vanilla pickling (see
         :meth:`__reduce_ex__`); this method is invoked only by Wool's own
@@ -424,6 +556,8 @@ class WorkerProxy:
                 self._id,
                 self._lease,
                 self._lazy,
+                self._quorum,
+                self._quorum_timeout,
             ),
         )
 
@@ -465,6 +599,16 @@ class WorkerProxy:
         return self._lazy
 
     @property
+    def quorum(self) -> int | None:
+        """Configured minimum worker count, or ``None``/``0`` for no gate."""
+        return self._quorum
+
+    @property
+    def quorum_timeout(self) -> float | None:
+        """Seconds to wait for ``quorum`` workers; ``None`` waits indefinitely."""
+        return self._quorum_timeout
+
+    @property
     def workers(self) -> list[WorkerMetadata]:
         """A list of the currently discovered worker gRPC stubs."""
         if self._loadbalancer_context:
@@ -492,37 +636,94 @@ class WorkerProxy:
         self._proxy_token = wool.__proxy__.set(self)
         if self._lazy:
             return
-        await self.start()
+        try:
+            await self.start()
+        except BaseException:
+            wool.__proxy__.reset(self._proxy_token)
+            self._proxy_token = None
+            raise
 
     async def start(self) -> None:
         """Start the proxy by initiating discovery and load balancing.
 
         Subscribes to worker discovery, initializes the load-balancer
-        context, and launches the worker sentinel task.
+        context, and launches the worker sentinel task.  Acquired
+        resources are unwound in reverse order if any setup step
+        (including the quorum wait) raises.
 
         :raises RuntimeError:
             If the proxy has already been started.
+        :raises asyncio.TimeoutError:
+            If the quorum wait does not complete within
+            ``quorum_timeout``.
         """
         if self._started:
             raise RuntimeError("Proxy already started")
 
-        (
-            self._loadbalancer_service,
-            self._loadbalancer_context_manager,
-        ) = await self._enter_context(self._loadbalancer)
-        if not isinstance(self._loadbalancer_service, LoadBalancerLike):
-            raise ValueError
+        async with AsyncExitStack() as stack:
+            (
+                self._loadbalancer_service,
+                self._loadbalancer_context_manager,
+            ) = await self._enter_context(self._loadbalancer)
+            if not isinstance(self._loadbalancer_service, LoadBalancerLike):
+                raise ValueError
+            stack.push_async_callback(
+                self._exit_context,
+                self._loadbalancer_context_manager,
+                None,
+                None,
+                None,
+            )
 
-        (
-            self._discovery_stream,
-            self._discovery_context_manager,
-        ) = await self._enter_context(self._discovery)
-        if not isinstance(self._discovery_stream, DiscoverySubscriberLike):
-            raise ValueError
+            (
+                self._discovery_stream,
+                self._discovery_context_manager,
+            ) = await self._enter_context(self._discovery)
+            if not isinstance(self._discovery_stream, DiscoverySubscriberLike):
+                raise ValueError
+            stack.push_async_callback(
+                self._exit_context,
+                self._discovery_context_manager,
+                None,
+                None,
+                None,
+            )
 
-        self._loadbalancer_context = LoadBalancerContext()
-        self._sentinel_task = asyncio.create_task(self._worker_sentinel())
+            self._loadbalancer_context = LoadBalancerContext()
+            self._workers_changed = asyncio.Event()
+            self._sentinel_task = asyncio.create_task(self._worker_sentinel())
+            stack.push_async_callback(self._teardown_sentinel)
+
+            if self._quorum:
+                await asyncio.wait_for(self._await_workers(), self._quorum_timeout)
+
+            stack.pop_all()
+
         self._started = True
+
+    async def _teardown_sentinel(self) -> None:
+        """Cancel the sentinel task and null all partial-init attributes.
+
+        Idempotent rollback callback used by :meth:`start`'s
+        :class:`AsyncExitStack` and reused by :meth:`stop`.  Cancels
+        ``_sentinel_task`` (if any), awaits its termination swallowing
+        ``CancelledError``, and resets every attribute populated by
+        :meth:`start` to ``None`` so a failed start leaves no stale
+        references.
+        """
+        if self._sentinel_task:
+            self._sentinel_task.cancel()
+            try:
+                await self._sentinel_task
+            except asyncio.CancelledError:
+                pass
+            self._sentinel_task = None
+        self._loadbalancer_context = None
+        self._loadbalancer_service = None
+        self._loadbalancer_context_manager = None
+        self._discovery_stream = None
+        self._discovery_context_manager = None
+        self._workers_changed = None
 
     async def exit(self, *args) -> None:
         """Exit the proxy context.
@@ -547,37 +748,51 @@ class WorkerProxy:
     async def stop(self, *args) -> None:
         """Stop the proxy, terminating discovery and clearing connections.
 
+        Teardown runs in reverse-acquisition order: sentinel first
+        (so it stops reading from the discovery stream), then
+        discovery, then load balancer.  All three are guaranteed to
+        run via :class:`AsyncExitStack` even if an earlier teardown
+        raises.
+
         :raises RuntimeError:
             If the proxy was not started first.
         """
         if not self._started:
             raise RuntimeError("Proxy not started - call start() first")
 
-        await self._exit_context(self._discovery_context_manager, *args)
-        await self._exit_context(self._loadbalancer_context_manager, *args)
-
-        if self._sentinel_task:
-            self._sentinel_task.cancel()
-            try:
-                await self._sentinel_task
-            except asyncio.CancelledError:
-                pass
-            self._sentinel_task = None
-        self._loadbalancer_context = None
+        async with AsyncExitStack() as stack:
+            stack.push_async_callback(
+                self._exit_context,
+                self._loadbalancer_context_manager,
+                *args,
+            )
+            stack.push_async_callback(
+                self._exit_context,
+                self._discovery_context_manager,
+                *args,
+            )
+            stack.push_async_callback(self._teardown_sentinel)
         self._started = False
 
     async def dispatch(
         self, task: Task, *, timeout: float | None = None
     ) -> AsyncGenerator:
-        """Dispatches a task to an available worker in the pool.
+        """Dispatch a task to an available worker.
 
-        This method selects a worker using a round-robin strategy. If no
-        workers are available within the timeout period, it raises an
-        exception. When ``lazy=True``, the proxy is started automatically
-        on first dispatch.
+        Selects a worker via the configured load balancer.  When
+        ``lazy=True``, the proxy is started on first dispatch — which
+        runs the quorum wait.  Subsequent dispatches do not re-check
+        quorum; the load balancer surfaces "no workers available"
+        directly if the worker set later drains.
+
+        A failed first dispatch (e.g., quorum timeout) is cached on
+        the proxy: every subsequent dispatch re-raises the same
+        exception immediately rather than re-running ``start()`` and
+        paying another ``quorum_timeout`` per attempt.  Construct a
+        new proxy to retry.
 
         :param task:
-            The :class:`Task` object to be dispatched.
+            The :class:`Task` to dispatch.
         :param timeout:
             Timeout in seconds for getting a worker.
         :returns:
@@ -585,17 +800,24 @@ class WorkerProxy:
         :raises RuntimeError:
             If the proxy is not started and ``lazy`` is ``False``.
         :raises asyncio.TimeoutError:
-            If no worker is available within the timeout period.
+            If no worker is available within ``timeout``, or if the
+            quorum wait fires during a lazy first dispatch.
         """
         if not self._started:
             if not self._lazy:
                 raise RuntimeError("Proxy not started - call start() first")
+            if self._start_failure is not None:
+                raise self._start_failure
             assert self._start_lock is not None
             async with self._start_lock:
+                if self._start_failure is not None:
+                    raise self._start_failure
                 if not self._started:
-                    await self.start()
-
-        await asyncio.wait_for(self._await_workers(), 60)
+                    try:
+                        await self.start()
+                    except BaseException as exc:
+                        self._start_failure = exc
+                        raise
 
         assert isinstance(self._loadbalancer_service, LoadBalancerLike)
         assert self._loadbalancer_context
@@ -673,11 +895,30 @@ class WorkerProxy:
         return version_filter
 
     async def _await_workers(self):
-        while not self._loadbalancer_context or not self._loadbalancer_context.workers:
-            await asyncio.sleep(0)
+        """Block until at least ``quorum`` workers are admitted.
+
+        Waits on the workers-changed event set by
+        :meth:`_worker_sentinel` after each add or drop, re-checking
+        the worker count after each wakeup.  The caller is expected
+        to gate this call on ``self._quorum`` being a positive
+        integer; calling with ``quorum`` of ``None`` or ``0`` will
+        loop forever.
+        """
+        assert self._quorum is not None and self._quorum > 0
+        assert self._workers_changed is not None
+        while True:
+            if (
+                self._loadbalancer_context
+                and len(self._loadbalancer_context.workers) >= self._quorum
+            ):
+                return
+            await self._workers_changed.wait()
+            self._workers_changed.clear()
 
     async def _worker_sentinel(self):
-        assert self._loadbalancer_context
+        assert self._loadbalancer_context is not None
+        assert self._discovery_stream is not None
+        assert self._workers_changed is not None
         client_credentials = (
             self._credentials.client_credentials()
             if self._credentials is not None
@@ -699,9 +940,11 @@ class WorkerProxy:
                     )
                     if event.type == "worker-added":
                         self._loadbalancer_context.add_worker(event.metadata, connection)
+                        self._workers_changed.set()
                     elif event.metadata in self._loadbalancer_context.workers:
                         self._loadbalancer_context.update_worker(
                             event.metadata, connection
                         )
                 case "worker-dropped":
                     self._loadbalancer_context.remove_worker(event.metadata)
+                    self._workers_changed.set()

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -118,6 +118,11 @@ class LazyMode(Enum):
     EAGER = auto()
 
 
+class QuorumMode(Enum):
+    DEFAULT = auto()
+    ABOVE_DEFAULT = auto()
+
+
 def _sync_accept_hook(ctx):
     """Sync backpressure hook that accepts all tasks."""
     return False
@@ -149,6 +154,7 @@ class Scenario:
     ctx_var_1: ContextVarPattern | None = None
     ctx_var_2: ContextVarPattern | None = None
     ctx_var_3: ContextVarPattern | None = None
+    quorum: QuorumMode | None = None
 
     def __or__(self, other: Scenario) -> Scenario:
         """Merge two partial scenarios. Right side wins on ``None`` fields.
@@ -169,7 +175,7 @@ class Scenario:
 
     @property
     def is_complete(self) -> bool:
-        """True when all 13 dimensions are set."""
+        """True when all 14 dimensions are set."""
         return all(getattr(self, f.name) is not None for f in fields(self))
 
     def __str__(self) -> str:
@@ -315,16 +321,22 @@ async def build_pool_from_scenario(scenario, credentials_map):
         case _:
             bp_hook = None
 
+    match scenario.quorum:
+        case QuorumMode.ABOVE_DEFAULT:
+            quorum = 2
+        case _:
+            quorum = 1
+
     try:
         try:
             if scenario.pool_mode is PoolMode.DURABLE:
                 async with _durable_pool_context(
-                    lb, creds, options, lazy, backpressure=bp_hook
+                    lb, creds, options, lazy, quorum, backpressure=bp_hook
                 ) as pool:
                     yield pool
             elif scenario.pool_mode is PoolMode.DURABLE_SHARED:
                 async with _durable_shared_pool_context(
-                    lb, creds, options, lazy, backpressure=bp_hook
+                    lb, creds, options, lazy, quorum, backpressure=bp_hook
                 ) as pool:
                     yield pool
             elif scenario.pool_mode is PoolMode.DURABLE_JOINED:
@@ -334,6 +346,7 @@ async def build_pool_from_scenario(scenario, credentials_map):
                     creds,
                     options,
                     lazy,
+                    quorum,
                     backpressure=bp_hook,
                 ) as pool:
                     yield pool
@@ -345,6 +358,7 @@ async def build_pool_from_scenario(scenario, credentials_map):
                         LocalWorker, options=options, backpressure=bp_hook
                     ),
                     "lazy": lazy,
+                    "quorum": quorum,
                 }
                 match scenario.pool_mode:
                     case PoolMode.DEFAULT:
@@ -392,7 +406,7 @@ async def build_pool_from_scenario(scenario, credentials_map):
 
 
 @asynccontextmanager
-async def _durable_pool_context(lb, creds, options, lazy, *, backpressure=None):
+async def _durable_pool_context(lb, creds, options, lazy, quorum, *, backpressure=None):
     """Manually start a worker, register it, then create a DURABLE pool.
 
     DURABLE pools don't spawn workers — they only discover external
@@ -418,6 +432,7 @@ async def _durable_pool_context(lb, creds, options, lazy, *, backpressure=None):
                         loadbalancer=lb,
                         credentials=creds,
                         lazy=lazy,
+                        quorum=quorum,
                     )
                     async with pool:
                         yield pool
@@ -428,7 +443,9 @@ async def _durable_pool_context(lb, creds, options, lazy, *, backpressure=None):
 
 
 @asynccontextmanager
-async def _durable_shared_pool_context(lb, creds, options, lazy, *, backpressure=None):
+async def _durable_shared_pool_context(
+    lb, creds, options, lazy, quorum, *, backpressure=None
+):
     """Create two pools sharing the same LocalDiscovery subscriber.
 
     Exercises ``SubscriberMeta`` singleton caching and
@@ -454,12 +471,14 @@ async def _durable_shared_pool_context(lb, creds, options, lazy, *, backpressure
                         loadbalancer=lb,
                         credentials=creds,
                         lazy=lazy,
+                        quorum=quorum,
                     )
                     pool_b = WorkerPool(
                         discovery=shared,
                         loadbalancer=lb,
                         credentials=creds,
                         lazy=lazy,
+                        quorum=quorum,
                     )
                     async with pool_a:
                         async with pool_b:
@@ -510,7 +529,7 @@ def _resolve_joiner(namespace, factory):
 
 @asynccontextmanager
 async def _durable_joined_pool_context(
-    discovery_factory, lb, creds, options, lazy, *, backpressure=None
+    discovery_factory, lb, creds, options, lazy, quorum, *, backpressure=None
 ):
     """Create a DURABLE pool that joins an externally owned namespace.
 
@@ -537,6 +556,7 @@ async def _durable_joined_pool_context(
                         loadbalancer=lb,
                         credentials=creds,
                         lazy=lazy,
+                        quorum=quorum,
                     )
                     async with pool:
                         yield pool
@@ -930,6 +950,9 @@ def _pairwise_filter(row):
     - D11/D12/D13 (ctx_var_1/2/3): DOWNSTREAM_OVERWRITE,
       DOWNSTREAM_RESET, UPSTREAM_RESET only valid with NESTED_* shapes;
       PER_YIELD only valid with ASYNC_GEN_* shapes
+    - D14 (quorum) ABOVE_DEFAULT (quorum=2) requires PoolMode.EPHEMERAL —
+      every other pool mode in the builder produces only one worker, so
+      quorum=2 would block forever.
     """
     if len(row) > 2:
         pool_mode = row[1]
@@ -983,6 +1006,11 @@ def _pairwise_filter(row):
                 and pattern is not ContextVarPattern.NONE
             ):
                 return False
+    if len(row) > 13:
+        quorum = row[13]
+        pool_mode = row[1]
+        if quorum is QuorumMode.ABOVE_DEFAULT and pool_mode is not PoolMode.EPHEMERAL:
+            return False
     return True
 
 
@@ -1001,6 +1029,7 @@ PAIRWISE_SCENARIOS = [
         ctx_var_1=row[10],
         ctx_var_2=row[11],
         ctx_var_3=row[12],
+        quorum=row[13],
     )
     for row in AllPairs(
         [
@@ -1017,6 +1046,7 @@ PAIRWISE_SCENARIOS = [
             list(ContextVarPattern),
             list(ContextVarPattern),
             list(ContextVarPattern),
+            list(QuorumMode),
         ],
         filter_func=_pairwise_filter,
     )
@@ -1097,6 +1127,13 @@ def scenarios_strategy(draw):
     ctx_var_2 = _draw_ctx_var_pattern(draw)
     ctx_var_3 = _draw_ctx_var_pattern(draw)
 
+    if pool_mode is PoolMode.EPHEMERAL:
+        quorum = draw(st.sampled_from(QuorumMode))
+    else:
+        quorum = draw(
+            st.sampled_from([m for m in QuorumMode if m is not QuorumMode.ABOVE_DEFAULT])
+        )
+
     return Scenario(
         shape=shape,
         pool_mode=pool_mode,
@@ -1111,6 +1148,7 @@ def scenarios_strategy(draw):
         ctx_var_1=ctx_var_1,
         ctx_var_2=ctx_var_2,
         ctx_var_3=ctx_var_3,
+        quorum=quorum,
     )
 
 

--- a/wool/tests/integration/test_context_var_propagation.py
+++ b/wool/tests/integration/test_context_var_propagation.py
@@ -30,6 +30,7 @@ from .conftest import DiscoveryFactory
 from .conftest import LazyMode
 from .conftest import LbFactory
 from .conftest import PoolMode
+from .conftest import QuorumMode
 from .conftest import RoutineBinding
 from .conftest import RoutineShape
 from .conftest import Scenario
@@ -58,6 +59,7 @@ def _default_scenario(
         ctx_var_1=ContextVarPattern.NONE,
         ctx_var_2=ContextVarPattern.NONE,
         ctx_var_3=ContextVarPattern.NONE,
+        quorum=QuorumMode.DEFAULT,
     )
 
 

--- a/wool/tests/integration/test_integration.py
+++ b/wool/tests/integration/test_integration.py
@@ -17,6 +17,7 @@ from .conftest import DiscoveryFactory
 from .conftest import LazyMode
 from .conftest import LbFactory
 from .conftest import PoolMode
+from .conftest import QuorumMode
 from .conftest import RoutineBinding
 from .conftest import RoutineShape
 from .conftest import Scenario
@@ -87,6 +88,7 @@ async def test_dispatch_pairwise(scenario, credentials_map, retry_grpc_internal)
         ContextVarPattern.NONE,
         ContextVarPattern.NONE,
         ContextVarPattern.NONE,
+        QuorumMode.DEFAULT,
     )
 )
 @example(
@@ -104,6 +106,7 @@ async def test_dispatch_pairwise(scenario, credentials_map, retry_grpc_internal)
         ContextVarPattern.NONE,
         ContextVarPattern.NONE,
         ContextVarPattern.NONE,
+        QuorumMode.DEFAULT,
     )
 )
 @example(
@@ -121,6 +124,7 @@ async def test_dispatch_pairwise(scenario, credentials_map, retry_grpc_internal)
         ContextVarPattern.NONE,
         ContextVarPattern.NONE,
         ContextVarPattern.NONE,
+        QuorumMode.DEFAULT,
     )
 )
 @given(scenario=scenarios_strategy())

--- a/wool/tests/integration/test_pool_composition.py
+++ b/wool/tests/integration/test_pool_composition.py
@@ -19,6 +19,7 @@ from .conftest import DiscoveryFactory
 from .conftest import LazyMode
 from .conftest import LbFactory
 from .conftest import PoolMode
+from .conftest import QuorumMode
 from .conftest import RoutineBinding
 from .conftest import RoutineShape
 from .conftest import Scenario
@@ -62,6 +63,7 @@ class TestPoolComposition:
                 ctx_var_1=ContextVarPattern.NONE,
                 ctx_var_2=ContextVarPattern.NONE,
                 ctx_var_3=ContextVarPattern.NONE,
+                quorum=QuorumMode.DEFAULT,
             )
 
             # Act
@@ -104,6 +106,7 @@ class TestPoolComposition:
                 ctx_var_1=ContextVarPattern.NONE,
                 ctx_var_2=ContextVarPattern.NONE,
                 ctx_var_3=ContextVarPattern.NONE,
+                quorum=QuorumMode.DEFAULT,
             )
 
             # Act
@@ -146,6 +149,7 @@ class TestPoolComposition:
                 ctx_var_1=ContextVarPattern.NONE,
                 ctx_var_2=ContextVarPattern.NONE,
                 ctx_var_3=ContextVarPattern.NONE,
+                quorum=QuorumMode.DEFAULT,
             )
 
             # Act
@@ -188,6 +192,7 @@ class TestPoolComposition:
                 ctx_var_1=ContextVarPattern.NONE,
                 ctx_var_2=ContextVarPattern.NONE,
                 ctx_var_3=ContextVarPattern.NONE,
+                quorum=QuorumMode.DEFAULT,
             )
 
             # Act
@@ -232,6 +237,7 @@ class TestPoolComposition:
                 ctx_var_1=ContextVarPattern.NONE,
                 ctx_var_2=ContextVarPattern.NONE,
                 ctx_var_3=ContextVarPattern.NONE,
+                quorum=QuorumMode.DEFAULT,
             )
 
             # Act
@@ -274,6 +280,7 @@ class TestPoolComposition:
                 ctx_var_1=ContextVarPattern.NONE,
                 ctx_var_2=ContextVarPattern.NONE,
                 ctx_var_3=ContextVarPattern.NONE,
+                quorum=QuorumMode.DEFAULT,
             )
 
             # Act
@@ -317,6 +324,7 @@ class TestPoolComposition:
                 ctx_var_1=ContextVarPattern.NONE,
                 ctx_var_2=ContextVarPattern.NONE,
                 ctx_var_3=ContextVarPattern.NONE,
+                quorum=QuorumMode.DEFAULT,
             )
 
             # Act
@@ -359,6 +367,7 @@ class TestPoolComposition:
                 ctx_var_1=ContextVarPattern.NONE,
                 ctx_var_2=ContextVarPattern.NONE,
                 ctx_var_3=ContextVarPattern.NONE,
+                quorum=QuorumMode.DEFAULT,
             )
 
             # Act
@@ -404,6 +413,7 @@ class TestPoolComposition:
                 ctx_var_1=ContextVarPattern.NONE,
                 ctx_var_2=ContextVarPattern.NONE,
                 ctx_var_3=ContextVarPattern.NONE,
+                quorum=QuorumMode.DEFAULT,
             )
 
             # Act
@@ -447,6 +457,7 @@ class TestPoolComposition:
                 ctx_var_1=ContextVarPattern.NONE,
                 ctx_var_2=ContextVarPattern.NONE,
                 ctx_var_3=ContextVarPattern.NONE,
+                quorum=QuorumMode.DEFAULT,
             )
 
             # Act
@@ -490,6 +501,7 @@ class TestPoolComposition:
                 ctx_var_1=ContextVarPattern.NONE,
                 ctx_var_2=ContextVarPattern.NONE,
                 ctx_var_3=ContextVarPattern.NONE,
+                quorum=QuorumMode.DEFAULT,
             )
 
             # Act

--- a/wool/tests/integration/test_scenario.py
+++ b/wool/tests/integration/test_scenario.py
@@ -9,6 +9,7 @@ from .conftest import DiscoveryFactory
 from .conftest import LazyMode
 from .conftest import LbFactory
 from .conftest import PoolMode
+from .conftest import QuorumMode
 from .conftest import RoutineBinding
 from .conftest import RoutineShape
 from .conftest import Scenario
@@ -106,7 +107,7 @@ class TestScenario:
         """Test that a fully populated scenario reports complete.
 
         Given:
-            A scenario with all 13 dimensions set.
+            A scenario with all 14 dimensions set.
         When:
             ``is_complete`` is checked.
         Then:
@@ -127,6 +128,7 @@ class TestScenario:
             ctx_var_1=ContextVarPattern.NONE,
             ctx_var_2=ContextVarPattern.NONE,
             ctx_var_3=ContextVarPattern.NONE,
+            quorum=QuorumMode.DEFAULT,
         )
 
         # Act & assert
@@ -172,7 +174,7 @@ class TestScenario:
         result = str(scenario)
 
         # Assert
-        assert result == "COROUTINE-DEFAULT-_-_-_-_-_-_-_-_-_-_-_"
+        assert result == "COROUTINE-DEFAULT-_-_-_-_-_-_-_-_-_-_-_-_"
 
     def test___str___with_empty_scenario(self):
         """Test string representation when no dimensions are set.
@@ -192,7 +194,7 @@ class TestScenario:
         result = str(scenario)
 
         # Assert
-        assert result == "-".join(["_"] * 13)
+        assert result == "-".join(["_"] * 14)
 
     def test___str___with_all_fields_set(self):
         """Test string representation when every dimension is set.
@@ -221,6 +223,7 @@ class TestScenario:
             ctx_var_1=ContextVarPattern.ROUND_TRIP,
             ctx_var_2=ContextVarPattern.LOCAL_RESET,
             ctx_var_3=ContextVarPattern.PER_YIELD,
+            quorum=QuorumMode.DEFAULT,
         )
 
         # Act
@@ -229,5 +232,5 @@ class TestScenario:
         # Assert
         assert result == (
             "COROUTINE-DEFAULT-LOCAL_DIRECT-CLASS_REF-INSECURE-DEFAULT-"
-            "NONE-MODULE_FUNCTION-EAGER-NONE-ROUND_TRIP-LOCAL_RESET-PER_YIELD"
+            "NONE-MODULE_FUNCTION-EAGER-NONE-ROUND_TRIP-LOCAL_RESET-PER_YIELD-DEFAULT"
         )

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -25,6 +25,7 @@ from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.worker.local import LocalWorker
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.pool import WorkerPool
+from wool.runtime.worker.proxy import IneffectiveQuorumTimeoutWarning
 
 
 def _make_worker_metadata(*tags: str) -> WorkerMetadata:
@@ -1996,7 +1997,7 @@ class TestWorkerPool:
         """Test zero lease with discovery-only pool is rejected.
 
         Given:
-            A discovery service and lease of 0 with no spawn
+            A discovery service and lease of 0
         When:
             WorkerPool is instantiated
         Then:
@@ -2069,7 +2070,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
     ):
-        """Test ephemeral mode forwards lease to WorkerProxy.
+        """Test ephemeral mode forwards spawn + lease to WorkerProxy.
 
         Given:
             A WorkerPool with spawn=2 and lease=4 without discovery
@@ -2135,7 +2136,7 @@ class TestWorkerPool:
         mock_worker_proxy,
         mock_local_worker,
     ):
-        """Test no lease forwards lease=None to WorkerProxy.
+        """Test ephemeral pool with no lease forwards lease=None.
 
         Given:
             A WorkerPool with plain int spawn and no lease
@@ -2233,3 +2234,490 @@ class TestWorkerPool:
             match="Lease must be non-negative",
         ):
             WorkerPool(spawn=1, lease=lease)
+
+    # ------------------------------------------------------------------
+    # Quorum tests
+    # ------------------------------------------------------------------
+
+    def test___init___with_quorum(self):
+        """Test instantiation with spawn and quorum.
+
+        Given:
+            A spawn of 4 and quorum of 2
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should create the pool successfully
+        """
+        # Act
+        pool = WorkerPool(spawn=4, quorum=2)
+
+        # Assert
+        assert isinstance(pool, WorkerPool)
+
+    def test___init___with_zero_quorum(self):
+        """Test zero quorum is accepted.
+
+        Given:
+            A spawn of 4 and quorum of 0
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should create the pool successfully
+        """
+        # Act
+        pool = WorkerPool(spawn=4, quorum=0)
+
+        # Assert
+        assert isinstance(pool, WorkerPool)
+
+    def test___init___with_quorum_timeout_without_quorum_warns(self):
+        """Test quorum_timeout supplied without a positive quorum emits a warning.
+
+        Given:
+            spawn=2, quorum=None, and quorum_timeout=30
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should emit an IneffectiveQuorumTimeoutWarning; users
+            who want strict behaviour can elevate the category to error
+            via warnings.filterwarnings
+        """
+        # Act & assert
+        with pytest.warns(
+            IneffectiveQuorumTimeoutWarning,
+            match="'quorum_timeout' has no effect when 'quorum' is None or 0",
+        ):
+            WorkerPool(spawn=2, quorum=None, quorum_timeout=30)
+
+    @pytest.mark.asyncio
+    async def test___aenter___with_negative_quorum_raises(
+        self, mock_shared_memory, mock_local_worker
+    ):
+        """Test negative quorum is rejected at context entry.
+
+        Given:
+            A spawn of 4 and quorum of -1
+        When:
+            The WorkerPool context is entered
+        Then:
+            It should raise ValueError from the underlying WorkerProxy
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="Quorum must be a non-negative integer"):
+            async with WorkerPool(spawn=4, quorum=-1):
+                pass
+
+    def test___init___with_quorum_exceeding_capacity(self):
+        """Test quorum exceeding pool capacity is rejected.
+
+        Given:
+            A spawn of 2, lease of 2, and quorum of 5
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should raise ValueError
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match=r"Quorum.*cannot exceed pool capacity"):
+            WorkerPool(spawn=2, lease=2, quorum=5)
+
+    def test___init___with_quorum_equal_to_capacity(self):
+        """Test quorum equal to pool capacity is accepted.
+
+        Given:
+            A spawn of 4, lease of 3, and quorum of 7
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should create the pool successfully
+        """
+        # Act
+        pool = WorkerPool(spawn=4, lease=3, quorum=7)
+
+        # Assert
+        assert isinstance(pool, WorkerPool)
+
+    def test___init___with_quorum_satisfied_by_spawn_alone(self):
+        """Test quorum satisfiable by spawn alone with lease=0 is accepted.
+
+        Given:
+            A spawn of 4, lease of 0, and quorum of 3
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should create the pool successfully
+        """
+        # Act
+        pool = WorkerPool(spawn=4, lease=0, quorum=3)
+
+        # Assert
+        assert isinstance(pool, WorkerPool)
+
+    @pytest.mark.asyncio
+    async def test___aenter___with_quorum_exceeding_lease_discovery_only(
+        self, mock_discovery_service_for_pool
+    ):
+        """Test quorum exceeding lease in discovery-only pool is rejected.
+
+        Given:
+            A discovery service, lease of 2, and quorum of 3
+        When:
+            The WorkerPool context is entered
+        Then:
+            It should raise ValueError from the underlying WorkerProxy
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match=r"Quorum.*cannot exceed lease"):
+            async with WorkerPool(
+                discovery=mock_discovery_service_for_pool, lease=2, quorum=3
+            ):
+                pass
+
+    def test___init___ephemeral_rejects_quorum_above_capacity(self):
+        """Test ephemeral pool rejects quorum exceeding spawn + lease.
+
+        Given:
+            A spawn of 2, lease of 2, no discovery, and quorum of 10
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should raise ValueError, since ephemeral capacity is
+            bounded by spawn + lease
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match=r"Quorum.*cannot exceed pool capacity"):
+            WorkerPool(spawn=2, lease=2, quorum=10)
+
+    def test___init___with_unbounded_lease_and_quorum_above_spawn(self):
+        """Test unbounded lease accepts quorum exceeding spawn.
+
+        Given:
+            A spawn of 2, no lease (unbounded), and quorum of 10
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should create the pool successfully (the quorum
+            reachability check is deferred to runtime via
+            quorum_timeout)
+        """
+        # Act
+        pool = WorkerPool(spawn=2, quorum=10)
+        assert isinstance(pool, WorkerPool)
+
+    def test___init___hybrid_mode_rejects_quorum_above_capacity(
+        self, mocker: MockerFixture
+    ):
+        """Test hybrid pool rejects quorum exceeding spawn + lease.
+
+        Given:
+            A discovery service with spawn=2, lease=2, and quorum=10
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should raise ValueError, since hybrid capacity is
+            spawn + lease
+        """
+        # Arrange
+        mock_discovery = mocker.MagicMock()
+
+        # Act & assert
+        with pytest.raises(ValueError, match=r"Quorum.*cannot exceed pool capacity"):
+            WorkerPool(spawn=2, discovery=mock_discovery, lease=2, quorum=10)
+
+    @pytest.mark.asyncio
+    async def test___aenter___with_non_positive_quorum_timeout_raises(
+        self, mock_shared_memory, mock_local_worker
+    ):
+        """Test non-positive quorum_timeout is rejected at context entry.
+
+        Given:
+            A spawn of 2, quorum of 1, and quorum_timeout of 0
+        When:
+            The WorkerPool context is entered
+        Then:
+            It should raise ValueError from the underlying WorkerProxy
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="Quorum timeout must be positive"):
+            async with WorkerPool(spawn=2, quorum=1, quorum_timeout=0):
+                pass
+
+    def test___init___default_mode_with_quorum_above_cpu_count(self):
+        """Test default-mode pool rejects quorum exceeding resolved capacity.
+
+        Given:
+            A default-mode pool (no spawn, no discovery) with a quorum
+            exceeding os.cpu_count()
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should raise ValueError matching "Quorum cannot exceed
+            pool capacity"
+        """
+        import os
+
+        # Arrange — pick a quorum guaranteed to exceed any plausible CPU count
+        cpu_count = os.cpu_count() or 1
+        excessive_quorum = cpu_count + 100
+
+        # Act & assert
+        with pytest.raises(ValueError, match=r"Quorum.*cannot exceed pool capacity"):
+            WorkerPool(lease=0, quorum=excessive_quorum)
+
+    @pytest.mark.asyncio
+    async def test___aenter___forwards_quorum(
+        self,
+        mocker: MockerFixture,
+        mock_shared_memory,
+        mock_worker_proxy,
+        mock_local_worker,
+    ):
+        """Test quorum is forwarded to WorkerProxy.
+
+        Given:
+            A WorkerPool with spawn=2 and quorum=2
+        When:
+            The pool context is entered
+        Then:
+            It should pass quorum=2 to WorkerProxy
+        """
+        # Arrange
+        import wool.runtime.worker.pool as wp
+
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+
+        # Act
+        async with WorkerPool(spawn=2, quorum=2):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["quorum"] == 2
+
+    @pytest.mark.asyncio
+    async def test___aenter___forwards_default_quorum(
+        self,
+        mocker: MockerFixture,
+        mock_shared_memory,
+        mock_worker_proxy,
+        mock_local_worker,
+    ):
+        """Test default quorum is forwarded to WorkerProxy.
+
+        Given:
+            A WorkerPool with spawn=2 and no explicit quorum
+        When:
+            The pool context is entered
+        Then:
+            It should pass quorum=1 to WorkerProxy (preserves
+            pre-quorum implicit-wait semantics)
+        """
+        # Arrange
+        import wool.runtime.worker.pool as wp
+
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+
+        # Act
+        async with WorkerPool(spawn=2):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["quorum"] == 1
+
+    @pytest.mark.asyncio
+    async def test___aenter___forwards_quorum_none(
+        self,
+        mocker: MockerFixture,
+        mock_shared_memory,
+        mock_worker_proxy,
+        mock_local_worker,
+    ):
+        """Test explicit quorum=None forwards quorum=None to WorkerProxy.
+
+        Given:
+            A WorkerPool with spawn=2 and explicit quorum=None
+        When:
+            The pool context is entered
+        Then:
+            It should pass quorum=None to WorkerProxy without
+            forwarding quorum_timeout
+        """
+        # Arrange
+        import wool.runtime.worker.pool as wp
+
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+
+        # Act
+        async with WorkerPool(spawn=2, quorum=None):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["quorum"] is None
+        assert "quorum_timeout" not in proxy_kwargs
+
+    @pytest.mark.asyncio
+    async def test___aenter___forwards_quorum_zero(
+        self,
+        mocker: MockerFixture,
+        mock_shared_memory,
+        mock_worker_proxy,
+        mock_local_worker,
+    ):
+        """Test quorum=0 normalizes to quorum=None when forwarded to WorkerProxy.
+
+        Given:
+            A WorkerPool with spawn=2 and quorum=0
+        When:
+            The pool context is entered
+        Then:
+            It should pass quorum=None to WorkerProxy without forwarding
+            quorum_timeout — quorum=0 is documented as equivalent to
+            None and normalized at the boundary to satisfy WorkerProxy's
+            typed overload contract
+        """
+        # Arrange
+        import wool.runtime.worker.pool as wp
+
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+
+        # Act
+        async with WorkerPool(spawn=2, quorum=0):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["quorum"] is None
+        assert "quorum_timeout" not in proxy_kwargs
+
+    @pytest.mark.asyncio
+    async def test___aenter___durable_mode_forwards_quorum(
+        self,
+        mocker: MockerFixture,
+        mock_worker_proxy,
+        mock_discovery_service_for_pool,
+    ):
+        """Test durable mode forwards quorum to WorkerProxy.
+
+        Given:
+            A WorkerPool with discovery and quorum=3
+        When:
+            The pool context is entered
+        Then:
+            It should pass quorum=3 to WorkerProxy
+        """
+        # Arrange
+        import wool.runtime.worker.pool as wp
+
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+        discovery_service = mock_discovery_service_for_pool
+
+        # Act
+        async with WorkerPool(discovery=discovery_service, quorum=3):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["quorum"] == 3
+
+    @pytest.mark.asyncio
+    async def test___aenter___hybrid_mode_forwards_quorum(
+        self,
+        mocker: MockerFixture,
+        mock_shared_memory,
+        mock_worker_proxy,
+        mock_local_worker,
+        mock_discovery_service_for_pool,
+    ):
+        """Test hybrid mode forwards quorum to WorkerProxy.
+
+        Given:
+            A WorkerPool with spawn=2, discovery, and quorum=3
+        When:
+            The pool context is entered
+        Then:
+            It should pass quorum=3 to WorkerProxy
+        """
+        # Arrange
+        import wool.runtime.worker.pool as wp
+
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+        discovery_service = mock_discovery_service_for_pool
+
+        # Act
+        async with WorkerPool(spawn=2, discovery=discovery_service, quorum=3):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["quorum"] == 3
+
+    @given(quorum=st.integers(min_value=-100, max_value=-1))
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @pytest.mark.asyncio
+    async def test___aenter___rejects_negative_quorum_pbt(
+        self, quorum, mock_shared_memory, mock_local_worker
+    ):
+        """Test negative quorum values are rejected at context entry.
+
+        Given:
+            Any negative quorum value
+        When:
+            The WorkerPool context is entered
+        Then:
+            It should raise ValueError from the underlying WorkerProxy
+        """
+        # Act & assert
+        with pytest.raises(
+            ValueError,
+            match="Quorum must be a non-negative integer",
+        ):
+            async with WorkerPool(spawn=1, quorum=quorum):
+                pass
+
+    @given(
+        spawn=st.integers(min_value=1, max_value=20),
+        lease=st.integers(min_value=0, max_value=20),
+        quorum=st.integers(min_value=0, max_value=40),
+    )
+    def test___init___accepts_quorum_within_capacity_pbt(self, spawn, lease, quorum):
+        """Test any quorum within the pool capacity is accepted.
+
+        Given:
+            Any spawn in [1, 20], lease in [0, 20], and quorum in
+            [0, spawn + lease]
+        When:
+            WorkerPool is instantiated
+        Then:
+            It should create the pool successfully
+        """
+        # Hypothesis explores the full grid; skip combinations that the
+        # validator legitimately rejects (quorum > spawn + lease).
+        if quorum > spawn + lease:
+            return
+
+        # Act
+        pool = WorkerPool(spawn=spawn, lease=lease, quorum=quorum)
+
+        # Assert
+        assert isinstance(pool, WorkerPool)

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -494,7 +494,7 @@ class TestWorkerProxy:
         ]
 
         # Act
-        proxy = WorkerProxy(workers=workers)
+        proxy = WorkerProxy(workers=workers, quorum=None)
 
         # Assert
         assert isinstance(proxy, WorkerProxy)
@@ -677,7 +677,7 @@ class TestWorkerProxy:
             It should have lazy set to False.
         """
         # Act
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
 
         # Assert
         assert proxy.lazy is False
@@ -694,7 +694,7 @@ class TestWorkerProxy:
             It starts and stops correctly
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
         entered = False
         exited = False
 
@@ -750,7 +750,7 @@ class TestWorkerProxy:
             It should set the started flag to True
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
 
         # Act
         await proxy.start()
@@ -792,7 +792,7 @@ class TestWorkerProxy:
             It should set started to True.
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
 
         # Act
         await proxy.enter()
@@ -851,7 +851,7 @@ class TestWorkerProxy:
             It should clear workers and reset the started flag to False.
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
         await proxy.start()
 
         # Act
@@ -875,7 +875,7 @@ class TestWorkerProxy:
             It should raise RuntimeError
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
         await proxy.start()
 
         # Act & assert
@@ -894,7 +894,7 @@ class TestWorkerProxy:
             It should raise RuntimeError.
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
 
         # Act & assert
         with pytest.raises(RuntimeError, match="Proxy not started"):
@@ -931,7 +931,7 @@ class TestWorkerProxy:
             It should stop the proxy and set started to False.
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service)
+        proxy = WorkerProxy(discovery=mock_discovery_service, quorum=0)
         await proxy.enter()
         await proxy.start()
         assert proxy.started
@@ -956,7 +956,7 @@ class TestWorkerProxy:
             It should automatically start the proxy
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
 
         # Act & assert
         async with proxy as p:
@@ -976,7 +976,7 @@ class TestWorkerProxy:
             It should automatically stop the proxy
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
 
         # Act
         async with proxy:
@@ -1018,7 +1018,7 @@ class TestWorkerProxy:
 
         cm = SyncCM()
         proxy = WorkerProxy(
-            discovery=mock_discovery_service, loadbalancer=cm, lazy=False
+            discovery=mock_discovery_service, loadbalancer=cm, lazy=False, quorum=0
         )
 
         # Act
@@ -1065,7 +1065,7 @@ class TestWorkerProxy:
 
         cm = AsyncCM()
         proxy = WorkerProxy(
-            discovery=mock_discovery_service, loadbalancer=cm, lazy=False
+            discovery=mock_discovery_service, loadbalancer=cm, lazy=False, quorum=0
         )
 
         # Act
@@ -1102,7 +1102,10 @@ class TestWorkerProxy:
             return mock_lb
 
         proxy = WorkerProxy(
-            discovery=mock_discovery_service, loadbalancer=make_lb(), lazy=False
+            discovery=mock_discovery_service,
+            loadbalancer=make_lb(),
+            lazy=False,
+            quorum=0,
         )
 
         # Act
@@ -1726,6 +1729,529 @@ class TestWorkerProxy:
         assert len(restored.workers) == 2
         await restored.stop()
 
+    # ------------------------------------------------------------------
+    # Quorum tests
+    # ------------------------------------------------------------------
+
+    def test___init___with_negative_quorum_raises(self, mock_discovery_service):
+        """Test negative quorum is rejected.
+
+        Given:
+            A discovery service and quorum of -1
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should raise ValueError
+        """
+        # Act & assert
+        with pytest.raises(
+            ValueError,
+            match="Quorum must be a non-negative integer",
+        ):
+            WorkerProxy(discovery=mock_discovery_service, quorum=-1)
+
+    def test___init___with_zero_quorum_accepted(self, mock_discovery_service):
+        """Test zero quorum is accepted.
+
+        Given:
+            A discovery service and quorum of 0
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should create the proxy successfully
+        """
+        # Act
+        proxy = WorkerProxy(discovery=mock_discovery_service, quorum=0)
+
+        # Assert
+        assert isinstance(proxy, WorkerProxy)
+
+    def test___init___with_positive_quorum_accepted(self, mock_discovery_service):
+        """Test positive quorum is accepted.
+
+        Given:
+            A discovery service and quorum of 3
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should create the proxy successfully
+        """
+        # Act
+        proxy = WorkerProxy(discovery=mock_discovery_service, quorum=3)
+
+        # Assert
+        assert isinstance(proxy, WorkerProxy)
+
+    def test___init___with_quorum_exceeding_lease_raises(self, mock_discovery_service):
+        """Test quorum exceeding lease is rejected.
+
+        Given:
+            A discovery service with lease=2 and quorum=3
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should raise ValueError
+        """
+        # Act & assert
+        with pytest.raises(
+            ValueError,
+            match=r"Quorum.*cannot exceed lease",
+        ):
+            WorkerProxy(discovery=mock_discovery_service, lease=2, quorum=3)
+
+    def test___init___with_quorum_equal_to_lease_accepted(self, mock_discovery_service):
+        """Test quorum equal to lease is accepted.
+
+        Given:
+            A discovery service with lease=3 and quorum=3
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should create the proxy successfully
+        """
+        # Act
+        proxy = WorkerProxy(discovery=mock_discovery_service, lease=3, quorum=3)
+
+        # Assert
+        assert isinstance(proxy, WorkerProxy)
+
+    def test___init___with_quorum_and_no_lease_accepted(self, mock_discovery_service):
+        """Test quorum without lease is accepted.
+
+        Given:
+            A discovery service and quorum of 5 with no lease
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should create the proxy successfully
+        """
+        # Act
+        proxy = WorkerProxy(discovery=mock_discovery_service, quorum=5)
+
+        # Assert
+        assert isinstance(proxy, WorkerProxy)
+
+    def test___init___with_non_positive_quorum_timeout_raises(
+        self, mock_discovery_service
+    ):
+        """Test non-positive quorum_timeout is rejected.
+
+        Given:
+            A discovery service, quorum=1, and quorum_timeout=0
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should raise ValueError
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="Quorum timeout must be positive"):
+            WorkerProxy(discovery=mock_discovery_service, quorum=1, quorum_timeout=0)
+
+    def test___init___with_quorum_timeout_without_quorum_warns(
+        self, mock_discovery_service
+    ):
+        """Test quorum_timeout supplied without a positive quorum emits a warning.
+
+        Given:
+            A discovery service, quorum=None, and quorum_timeout=30
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should emit an IneffectiveQuorumTimeoutWarning; users
+            who want strict behaviour can elevate the category to error
+            via warnings.filterwarnings
+        """
+        # Act & assert
+        with pytest.warns(
+            wp.IneffectiveQuorumTimeoutWarning,
+            match="'quorum_timeout' has no effect when 'quorum' is None or 0",
+        ):
+            WorkerProxy(discovery=mock_discovery_service, quorum=None, quorum_timeout=30)
+
+    def test_quorum_and_quorum_timeout_properties(self, mock_discovery_service):
+        """Test the quorum and quorum_timeout properties expose configured values.
+
+        Given:
+            A WorkerProxy constructed with quorum=3 and quorum_timeout=15
+        When:
+            The quorum and quorum_timeout properties are read
+        Then:
+            They should return the configured values
+        """
+        # Arrange
+        proxy = WorkerProxy(
+            discovery=mock_discovery_service, quorum=3, quorum_timeout=15
+        )
+
+        # Act & assert
+        assert proxy.quorum == 3
+        assert proxy.quorum_timeout == 15
+
+    def test___init___with_static_workers_quorum_exceeds_raises(self):
+        """Test quorum exceeding the static workers list is rejected.
+
+        Given:
+            A static workers list of length 2 and quorum of 5
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should raise ValueError, since the static list cannot
+            grow to satisfy the quorum
+        """
+        # Arrange
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"10.0.0.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+            )
+            for i in range(2)
+        ]
+
+        # Act & assert
+        with pytest.raises(
+            ValueError, match=r"Quorum.*cannot exceed compatible worker count"
+        ):
+            WorkerProxy(workers=workers, quorum=5)
+
+    def test___init___with_static_workers_unparseable_version_filtered(self):
+        """Test workers with unparseable versions are filtered out of quorum count.
+
+        Given:
+            A static workers list of length 2 where one worker has an
+            unparseable version, and quorum=2
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should raise ValueError reporting "1 of 2" — the
+            unparseable-version worker is rejected by the version filter
+        """
+        # Arrange
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address="10.0.0.1:50051",
+                pid=1000,
+                version=protocol.__version__,
+            ),
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address="10.0.0.2:50051",
+                pid=1001,
+                version="not-a-semver",
+            ),
+        ]
+
+        # Act & assert
+        with pytest.raises(
+            ValueError,
+            match=r"compatible worker count \(1 of 2",
+        ):
+            WorkerProxy(workers=workers, quorum=2)
+
+    @given(
+        lease=st.integers(min_value=1, max_value=100),
+        quorum=st.integers(min_value=0, max_value=100),
+    )
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test___init___accepts_valid_quorum_within_lease_pbt(
+        self, mock_discovery_service, lease, quorum
+    ):
+        """Test any quorum within the lease cap is accepted.
+
+        Given:
+            Any lease in [1, 100] and quorum in [0, lease]
+        When:
+            WorkerProxy is instantiated
+        Then:
+            It should create the proxy successfully
+        """
+        # Hypothesis explores the full grid; skip combinations that the
+        # validator legitimately rejects (quorum > lease).
+        if quorum > lease:
+            return
+
+        # Act
+        proxy = WorkerProxy(discovery=mock_discovery_service, lease=lease, quorum=quorum)
+
+        # Assert
+        assert isinstance(proxy, WorkerProxy)
+
+    @pytest.mark.asyncio
+    async def test_dispatch_with_zero_quorum_skips_worker_wait(
+        self,
+        mocker: MockerFixture,
+        mock_proxy_session,
+    ):
+        """Test dispatch does not wait for workers when quorum is 0.
+
+        Given:
+            A started WorkerProxy with quorum=0 and no workers
+        When:
+            dispatch is called
+        Then:
+            It should proceed without waiting for workers
+        """
+
+        # Arrange
+        class EmptyDiscovery:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                # Block forever — no workers will appear
+                await asyncio.Event().wait()
+                raise StopAsyncIteration
+
+        class StubLoadBalancer:
+            def __init__(self):
+                self.dispatched = False
+
+            async def dispatch(self, task, *, context, timeout=None):
+                self.dispatched = True
+
+        stub_lb = StubLoadBalancer()
+        proxy = WorkerProxy(
+            discovery=EmptyDiscovery(),
+            loadbalancer=stub_lb,
+            quorum=0,
+        )
+        await proxy.start()
+
+        mock_task = mocker.MagicMock(spec=Task)
+
+        # Act — should not block waiting for workers
+        await asyncio.wait_for(proxy.dispatch(mock_task), timeout=2.0)
+
+        # Assert
+        assert stub_lb.dispatched
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_waits_for_quorum_workers(
+        self,
+        mocker: MockerFixture,
+        mock_proxy_session,
+    ):
+        """Test dispatch blocks until quorum workers are discovered.
+
+        Given:
+            A started WorkerProxy with quorum=2 and a gated
+            discovery stream
+        When:
+            dispatch is called and workers are added one at a time
+        Then:
+            It should block until 2 workers are discovered
+        """
+        # Arrange
+        gate = asyncio.Event()
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+            )
+            for i in range(2)
+        ]
+        call_count = 0
+
+        class GatedDiscovery:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                nonlocal call_count
+                await gate.wait()
+                gate.clear()
+                if call_count < len(workers):
+                    event = DiscoveryEvent("worker-added", metadata=workers[call_count])
+                    call_count += 1
+                    return event
+                await asyncio.Event().wait()
+                raise StopAsyncIteration
+
+        class StubLoadBalancer:
+            def __init__(self):
+                self.dispatched = False
+
+            async def dispatch(self, task, *, context, timeout=None):
+                self.dispatched = True
+
+        stub_lb = StubLoadBalancer()
+        proxy = WorkerProxy(
+            discovery=GatedDiscovery(),
+            loadbalancer=stub_lb,
+            quorum=2,
+        )
+        mock_task = mocker.MagicMock(spec=Task)
+
+        # Act — launch dispatch; lazy start triggers quorum wait
+        dispatch_task = asyncio.create_task(proxy.dispatch(mock_task))
+        await asyncio.sleep(0)
+
+        # Release first worker — still below quorum
+        gate.set()
+        await asyncio.sleep(0.05)
+        assert not dispatch_task.done()
+
+        # Release second worker — quorum met
+        gate.set()
+        await asyncio.wait_for(dispatch_task, timeout=2.0)
+
+        # Assert
+        assert stub_lb.dispatched
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test___aenter___blocks_until_quorum_for_non_lazy_proxy(
+        self,
+        mocker: MockerFixture,
+        mock_proxy_session,
+    ):
+        """Test non-lazy entry blocks until quorum workers are discovered.
+
+        Given:
+            A non-lazy WorkerProxy with quorum=2 and a gated discovery
+            stream that yields workers one at a time
+        When:
+            The proxy is entered as an async context manager
+        Then:
+            __aenter__ should block until 2 workers are discovered
+        """
+        # Arrange
+        gate = asyncio.Event()
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+            )
+            for i in range(2)
+        ]
+        call_count = 0
+
+        class GatedDiscovery:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                nonlocal call_count
+                await gate.wait()
+                gate.clear()
+                if call_count < len(workers):
+                    event = DiscoveryEvent("worker-added", metadata=workers[call_count])
+                    call_count += 1
+                    return event
+                await asyncio.Event().wait()
+                raise StopAsyncIteration
+
+        proxy = WorkerProxy(discovery=GatedDiscovery(), quorum=2, lazy=False)
+
+        # Act — launch __aenter__; it must block on quorum at start
+        enter_task = asyncio.create_task(proxy.__aenter__())
+        await asyncio.sleep(0)
+
+        # Release first worker — still below quorum
+        gate.set()
+        await asyncio.sleep(0.05)
+        assert not enter_task.done()
+
+        # Release second worker — quorum met
+        gate.set()
+        await asyncio.wait_for(enter_task, timeout=2.0)
+
+        # Assert
+        assert proxy.started
+        assert len(proxy.workers) == 2
+
+        # Cleanup
+        await proxy.__aexit__(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_cloudpickle_serialization_preserves_quorum(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test pickle round-trip preserves quorum behavior.
+
+        Given:
+            A non-lazy WorkerProxy with quorum=2 and a discovery
+            stream with 3 worker-added events
+        When:
+            The proxy is pickled, unpickled, started, and processes
+            the discovery events
+        Then:
+            It should require 2 workers before dispatch unblocks,
+            proving the quorum survived the round-trip
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+            )
+            for i in range(3)
+        ]
+        events = [DiscoveryEvent("worker-added", metadata=w) for w in workers]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(
+            discovery=discovery,
+            loadbalancer=wp.RoundRobinLoadBalancer,
+            quorum=2,
+            lazy=False,
+        )
+
+        # Act — pickle round-trip, then start the restored proxy
+        restored = cloudpickle.loads(wool.__serializer__.dumps(proxy))
+        await restored.start()
+        await _drain_discovery(restored, expect=3)
+
+        # Assert — quorum survived the round-trip
+        assert len(restored.workers) >= 2
+        await restored.stop()
+
+    def test__restore_proxy_with_5_arg_legacy_tuple_defaults_quorum(
+        self, mock_discovery_service
+    ):
+        """Test legacy 5-arg reduce tuples restore with default quorum.
+
+        Given:
+            A 5-element reduce tuple (discovery, loadbalancer, proxy_id,
+            lease, lazy) emitted by a peer that predates the quorum
+            parameter
+        When:
+            wp._restore_proxy is invoked with only 5 positional arguments
+        Then:
+            The restored proxy applies the constructor default quorum=1,
+            preserving cross-version unpickle compatibility within the
+            same major protocol version
+        """
+        # Arrange
+        proxy_id = uuid.uuid4()
+
+        # Act — invoke the restore helper as an older peer's reduce tuple would
+        restored = wp._restore_proxy(
+            mock_discovery_service,
+            wp.RoundRobinLoadBalancer,
+            proxy_id,
+            None,
+            True,
+        )
+
+        # Assert
+        assert isinstance(restored, WorkerProxy)
+        assert restored.id == proxy_id
+        assert restored._quorum == 1
+
     def test_cloudpickle_serialization_with_lazy_false(self, mock_discovery_service):
         """Test pickle round-trip with explicit lazy=False.
 
@@ -1847,12 +2373,93 @@ class TestWorkerProxy:
             It should raise RuntimeError
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
 
         # Act & assert
         with pytest.raises(RuntimeError, match="Proxy not started"):
             async for _ in await proxy.dispatch(mock_wool_task):
                 pass
+
+    @pytest.mark.asyncio
+    async def test_stop_raises_runtime_error_when_not_started(
+        self, mock_discovery_service
+    ):
+        """Test stop() on a never-started proxy raises RuntimeError.
+
+        Given:
+            A WorkerProxy that has never been started
+        When:
+            stop() is awaited directly
+        Then:
+            It should raise RuntimeError matching "Proxy not started"
+        """
+        # Arrange
+        proxy = WorkerProxy(discovery=mock_discovery_service)
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="Proxy not started"):
+            await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_enter_resets_proxy_token_on_start_failure(
+        self, mock_discovery_service
+    ):
+        """Test the contextvar is reset when start() raises in enter().
+
+        Given:
+            A non-lazy proxy with an unsatisfiable quorum and a tiny
+            quorum_timeout
+        When:
+            The proxy is used as an async context manager, causing
+            start() to raise asyncio.TimeoutError at context entry
+        Then:
+            The contextvar wool.__proxy__ should be None after the
+            failed entry — the token set in enter() must be reset
+        """
+        # Arrange
+        proxy = WorkerProxy(
+            discovery=mock_discovery_service,
+            lazy=False,
+            quorum=2,
+            quorum_timeout=0.01,
+        )
+
+        # Act & assert
+        with pytest.raises(asyncio.TimeoutError):
+            async with proxy:
+                pass
+        assert wool.__proxy__.get() is None
+
+    @pytest.mark.asyncio
+    async def test_dispatch_caches_start_failure(
+        self, mock_discovery_service, mock_wool_task
+    ):
+        """Test failed start() is cached; subsequent dispatches fail-fast.
+
+        Given:
+            A lazy proxy whose first dispatch will fail with
+            asyncio.TimeoutError due to an unsatisfiable quorum
+        When:
+            Two dispatches are attempted in sequence
+        Then:
+            The first raises asyncio.TimeoutError and caches it; the
+            second re-raises the same exception instance immediately
+        """
+        # Arrange
+        proxy = WorkerProxy(
+            discovery=mock_discovery_service,
+            quorum=2,
+            quorum_timeout=0.01,
+        )
+
+        # Act
+        with pytest.raises(asyncio.TimeoutError) as first_excinfo:
+            await proxy.dispatch(mock_wool_task)
+        with pytest.raises(asyncio.TimeoutError) as second_excinfo:
+            await proxy.dispatch(mock_wool_task)
+
+        # Assert — both dispatches raise the same cached exception
+        assert first_excinfo.value is second_excinfo.value
 
     @pytest.mark.asyncio
     async def test_dispatch_with_lazy_auto_start(
@@ -2068,23 +2675,23 @@ class TestWorkerProxy:
         assert results == ["test_result"]
 
     @pytest.mark.asyncio
-    async def test_dispatch_spins_until_worker_discovered(
+    async def test_dispatch_blocks_on_quorum_until_worker_discovered(
         self,
         mocker: MockerFixture,
         mock_proxy_session,
     ):
-        """Test dispatch spins when no workers are available yet.
+        """Test dispatch blocks at start when quorum is unmet.
 
         Given:
-            A started WorkerProxy whose discovery stream is gated
+            A WorkerProxy with quorum=1 whose discovery stream is gated
             behind an asyncio.Event, so no workers exist initially.
         When:
-            dispatch() is called before any workers are available,
-            then the gate is opened to emit a worker-added event.
+            dispatch() is called before any workers are available, then
+            the gate is opened to emit a worker-added event.
         Then:
-            dispatch() spins in the await-workers loop until the
-            sentinel processes the event and adds the worker,
-            then completes normally.
+            dispatch() blocks inside the lazy start() quorum wait until
+            the sentinel processes the event and admits the worker, then
+            completes normally.
         """
         # Arrange — gated discovery that blocks until signaled
         gate = asyncio.Event()
@@ -2112,19 +2719,15 @@ class TestWorkerProxy:
                 self.dispatched = True
 
         stub_lb = StubLoadBalancer()
-        proxy = WorkerProxy(discovery=GatedDiscovery(), loadbalancer=stub_lb)
-        await proxy.start()
-
-        # Verify no workers before the gate opens
-        assert proxy.workers == []
-
+        proxy = WorkerProxy(discovery=GatedDiscovery(), loadbalancer=stub_lb, quorum=1)
         mock_task = mocker.MagicMock(spec=Task)
 
-        # Act — launch dispatch in background; it spins waiting for workers
+        # Act — launch dispatch in background; it blocks in start() awaiting quorum
         dispatch_task = asyncio.create_task(proxy.dispatch(mock_task))
-        await asyncio.sleep(0)  # yield so dispatch enters the spin loop
+        await asyncio.sleep(0)  # yield so dispatch enters the quorum wait
+        assert not dispatch_task.done()
 
-        # Open the gate — sentinel receives the event and adds the worker
+        # Open the gate — sentinel receives the event and admits the worker
         gate.set()
         await dispatch_task
 
@@ -2166,7 +2769,7 @@ class TestWorkerProxy:
             ),
         ]
 
-        proxy = WorkerProxy(workers=workers, lazy=False)
+        proxy = WorkerProxy(workers=workers, lazy=False, quorum=0)
 
         # Act & assert
         async with proxy as p:
@@ -2175,6 +2778,40 @@ class TestWorkerProxy:
 
         # After exit, proxy should be stopped
         assert not proxy.started
+
+    @pytest.mark.asyncio
+    async def test_proxy_with_static_workers_list_satisfies_quorum(
+        self, mocker: MockerFixture
+    ):
+        """Test static workers satisfy a positive quorum at entry.
+
+        Given:
+            A non-lazy WorkerProxy configured with three static workers
+            and quorum=2
+        When:
+            The proxy is entered as an async context manager
+        Then:
+            __aenter__ should succeed without timing out, with at least
+            two workers admitted
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+                tags=frozenset(["test"]),
+                extra=MappingProxyType({}),
+            )
+            for i in range(3)
+        ]
+
+        # Act & assert
+        async with WorkerProxy(workers=workers, quorum=2, lazy=False) as proxy:
+            assert proxy.started
+            assert len(proxy.workers) >= 2
 
     @pytest.mark.asyncio
     async def test_proxy_with_pool_uri(self):
@@ -2188,7 +2825,7 @@ class TestWorkerProxy:
             It starts and stops correctly
         """
         # Arrange
-        proxy = WorkerProxy("test://pool", lazy=False)
+        proxy = WorkerProxy("test://pool", lazy=False, quorum=0)
 
         # Act & assert
         async with proxy as p:
@@ -2223,7 +2860,7 @@ class TestWorkerProxy:
         await mock_discovery_service.start()
         mock_discovery_service.inject_worker_added(metadata)
 
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
 
         # Act
         async with proxy:
@@ -2320,6 +2957,7 @@ class TestWorkerProxy:
             discovery=discovery_service,
             loadbalancer=wp.RoundRobinLoadBalancer,
             lazy=False,
+            quorum=0,
         )
 
         # Act & assert
@@ -2351,7 +2989,7 @@ class TestWorkerProxy:
         """
         # Arrange - Use real objects instead of mocks for cloudpickle test
         discovery_service = LocalDiscovery("test-pool").subscriber
-        proxy = WorkerProxy(discovery=discovery_service, lazy=False)
+        proxy = WorkerProxy(discovery=discovery_service, lazy=False, quorum=0)
 
         # Act & assert
         async with proxy:
@@ -2381,7 +3019,7 @@ class TestWorkerProxy:
             proxy in an unstarted state and preserved ID
         """
         # Arrange - Use real objects - this creates a LocalDiscovery internally
-        proxy = WorkerProxy("pool-1", lazy=False)
+        proxy = WorkerProxy("pool-1", lazy=False, quorum=0)
 
         # Act & assert
         async with proxy:
@@ -3127,7 +3765,7 @@ class TestWorkerProxy:
         ]
 
         # Act
-        proxy = WorkerProxy(workers=workers)
+        proxy = WorkerProxy(workers=workers, quorum=None)
 
         # Assert
         assert isinstance(proxy, WorkerProxy)


### PR DESCRIPTION
## Summary

Add a `quorum: int | None = 1` parameter to `WorkerProxy` and `WorkerPool` that gates dispatch on a minimum number of workers being admitted, and a sibling `quorum_timeout: float | None = 60` controlling how long to wait. The default `quorum=1` preserves the pre-PR implicit-wait semantics (every `dispatch()` used to block up to 60s for the first worker); pass `quorum=None` or `quorum=0` to disable the gate entirely.

Beyond the user-facing parameter, the proxy's start/stop/dispatch lifecycle is hardened: `start()` uses `AsyncExitStack` to atomically unwind partial setup on failure; `stop()` follows the same pattern with guaranteed teardown ordering (sentinel → discovery → loadbalancer); `enter()` resets the `wool.__proxy__` contextvar token if `start()` raises; `_teardown_sentinel` nulls every attribute populated by `start()` so a failed proxy leaves no stale references; and lazy first-dispatch failures are cached so subsequent dispatches fail-fast instead of paying `quorum_timeout` again. The cloudpickle round-trip carries `quorum` and `quorum_timeout` through `__wool_reduce__`; older reduce tuples without these fields restore via `_restore_proxy` defaults of `(1, 60)`, preserving pre-quorum semantics for cross-version peers.

Closes #144

## Proposed changes

### Quorum parameters on `WorkerProxy`

Add `quorum: int | None = 1` and `quorum_timeout: float | None = 60` across the six `__init__` overloads (three shapes — pool URI, discovery, static workers — × two quorum-or-not variants). The no-quorum overloads expose only `quorum: None`; the with-quorum overloads expose `quorum: int = 1` and `quorum_timeout`. The runtime accepts `quorum_timeout` as `Undefined` internally to distinguish user-supplied from default. Validate at construction: `quorum < 0` raises; `quorum > lease` raises; for static `workers=[...]`, `quorum > len(compatible_workers)` raises with the pre-filter count in the message (e.g., `"1 of 2 after security/version filtering"`); `quorum_timeout <= 0` raises; `quorum_timeout` supplied with `quorum in (None, 0)` raises.

### Lifecycle hardening on `WorkerProxy`

Rewrite `start()` with `contextlib.AsyncExitStack` so partial setup is unwound atomically on failure (loadbalancer entered → discovery entered → sentinel started → quorum wait; reverse order on rollback). Rewrite `stop()` with the same pattern so all three teardowns run even if one raises. Wrap `start()` in `try/except` inside `enter()` so the `_proxy_token` contextvar is reset on failure — Python doesn't invoke `__aexit__` when `__aenter__` raises. Extend `_teardown_sentinel` (the unified rollback callback) to null `_loadbalancer_context`, `_loadbalancer_service`, `_loadbalancer_context_manager`, `_discovery_stream`, `_discovery_context_manager`, and `_workers_changed` so a failed proxy carries no stale references.

`_await_workers` becomes a pure waiter on a new `_workers_changed: asyncio.Event` set by the sentinel after each `worker-added` or `worker-dropped`; `start()` is the sole gate (`if self._quorum: ...`). `dispatch()` no longer runs an unconditional 60s wait — lazy first-dispatch invokes `start()` under `_start_lock`, and if `start()` raises, the exception is cached on `_start_failure` so subsequent dispatches re-raise the same exception immediately without re-running `start()` (preventing N concurrent dispatchers from each paying `quorum_timeout`).

### Cloudpickle round-trip

`__wool_reduce__` carries `_quorum` and `_quorum_timeout` in the reduce tuple. `_restore_proxy` accepts both with back-compat defaults of `quorum=1, quorum_timeout=60` so pre-quorum reduce tuples emitted by older peers restore with the prior implicit-wait behaviour. The restoration uses typed two-branch narrowing — pass literal `None` in the no-quorum path, pass both values in the quorum path — so pyright matches `WorkerProxy`'s typed overloads cleanly.

### Quorum parameters on `WorkerPool`

Add `quorum: int | None = 1` and `quorum_timeout: float | None = 60` across ten `__init__` overloads (five pool shapes — spawn-only, discovery-only, hybrid, plus two deprecated `size=` variants — × two quorum-or-not variants). The pool's `_make_proxy` helper forwards both to the underlying `WorkerProxy` across all four runtime modes (spawn-only, discovery-only, hybrid, default). The helper uses typed two-branch narrowing — `quorum=0` and `quorum=None` are normalized to literal `None` at the boundary (the docstring documents them as equivalent), and `quorum_timeout` is dropped for the no-quorum branch.

Pool-side validation is limited to what only the pool can see: `quorum > pool capacity` (where capacity is `spawn`, `spawn + lease`, or `lease` depending on mode — extracted as the `_validate_quorum` static helper to avoid triplication across mode arms), `lease == 0` for discovery-only, and `quorum_timeout` supplied with `quorum in (None, 0)`. All remaining quorum/quorum_timeout validation is delegated to `WorkerProxy.__init__` and surfaces at `__aenter__` time when `_make_proxy` constructs the proxy.

### Existing test adjustments

- `test___init___with_zero_lease_and_spawn` and `test___init___with_zero_lease_discovery_only` pass `quorum=0` alongside `lease=0` since the new validation rejects `quorum > lease`.
- The Hypothesis strategy in `test___init___accepts_valid_spawn_and_lease` narrows `lease >= 1` to stay above the default quorum.
- Pool tests that previously asserted construction-time `ValueError` for `quorum < 0`, discovery-only `quorum > lease`, non-positive `quorum_timeout`, and negative-quorum Hypothesis are converted to async `async with WorkerPool(...):` tests asserting `__aenter__`-time `ValueError`, reflecting the pool's delegation to `WorkerProxy`.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerProxy` | A discovery service and quorum of -1 | `WorkerProxy` is instantiated | Raise `ValueError` | Negative quorum rejection |
| 2 | `TestWorkerProxy` | A discovery service and quorum of 0 | `WorkerProxy` is instantiated | Create the proxy successfully | Zero quorum acceptance |
| 3 | `TestWorkerProxy` | A discovery service and quorum of 3 | `WorkerProxy` is instantiated | Create the proxy successfully | Positive quorum acceptance |
| 4 | `TestWorkerProxy` | A discovery service with lease=2 and quorum=3 | `WorkerProxy` is instantiated | Raise `ValueError` | Quorum-exceeds-lease rejection |
| 5 | `TestWorkerProxy` | A discovery service with lease=3 and quorum=3 | `WorkerProxy` is instantiated | Create the proxy successfully | Quorum equal to lease acceptance |
| 6 | `TestWorkerProxy` | A discovery service and quorum of 5 with no lease | `WorkerProxy` is instantiated | Create the proxy successfully | Quorum without lease acceptance |
| 7 | `TestWorkerProxy` | A discovery service, quorum=1, quorum_timeout=0 | `WorkerProxy` is instantiated | Raise `ValueError` | Non-positive quorum_timeout rejection |
| 8 | `TestWorkerProxy` | A discovery service, quorum=None, explicit quorum_timeout | `WorkerProxy` is instantiated | Raise `ValueError` | quorum_timeout-without-quorum rejection |
| 9 | `TestWorkerProxy` | A WorkerProxy constructed with quorum=3 and quorum_timeout=15 | `quorum` / `quorum_timeout` properties are read | Return the configured values | Property exposure |
| 10 | `TestWorkerProxy` | A static workers list of length 2 and quorum=5 | `WorkerProxy` is instantiated | Raise `ValueError` matching "compatible worker count" | Static-workers quorum rejection |
| 11 | `TestWorkerProxy` | A static workers list where one worker has an unparseable version, quorum=2 | `WorkerProxy` is instantiated | Raise `ValueError` reporting "1 of 2" after version filtering | Version-filter rejects unparseable |
| 12 | `TestWorkerProxy` | Any lease in [1, 100] and quorum in [0, lease] (Hypothesis) | `WorkerProxy` is instantiated | Create the proxy successfully | Property-based quorum acceptance |
| 13 | `TestWorkerProxy` | A started proxy with quorum=0 and no workers | `dispatch` is called | Proceed without waiting for workers | Zero-quorum dispatch bypass |
| 14 | `TestWorkerProxy` | A started proxy with quorum=2 and a gated discovery stream | `dispatch` is called and workers are added one at a time | Block until 2 workers are discovered | Quorum-gated dispatch blocking |
| 15 | `TestWorkerProxy` | A non-lazy proxy with quorum=2 and unsatisfiable workers | The proxy is entered as `async with` | Raise `asyncio.TimeoutError` at context entry | Non-lazy quorum timeout |
| 16 | `TestWorkerProxy` | A WorkerProxy never started | `stop()` is awaited directly | Raise `RuntimeError` matching "Proxy not started" | Stop-without-start guard |
| 17 | `TestWorkerProxy` | A non-lazy proxy with unsatisfiable quorum and a tiny quorum_timeout | The proxy is used as `async with` (context entry raises) | `wool.__proxy__.get()` returns `None` after the failure | Token reset on start failure |
| 18 | `TestWorkerProxy` | A lazy proxy with unsatisfiable quorum | Two `dispatch()` calls are awaited in sequence | Both raise the same cached `asyncio.TimeoutError` instance | Cached start-failure short-circuit |
| 19 | `TestWorkerProxy` | A non-lazy proxy with quorum=2 pickled and restored | The restored proxy starts and discovers 3 workers | Quorum survives the round-trip | Cloudpickle serialization |
| 20 | `TestWorkerProxy` | A legacy 5-element reduce tuple (no quorum / quorum_timeout) | `_restore_proxy` reconstructs the proxy | Defaults `quorum=1`, `quorum_timeout=60` preserve pre-quorum implicit-wait | Reduce-tuple back-compat |
| 21 | `TestWorkerPool` | A spawn of 4 and quorum of 2 | `WorkerPool` is instantiated | Create the pool successfully | Pool quorum acceptance |
| 22 | `TestWorkerPool` | A spawn of 4 and quorum of 0 | `WorkerPool` is instantiated | Create the pool successfully | Pool zero quorum acceptance |
| 23 | `TestWorkerPool` | A pool with spawn=2, quorum=None, and explicit quorum_timeout | `WorkerPool` is instantiated | Raise `ValueError` | Pool quorum_timeout-without-quorum rejection |
| 24 | `TestWorkerPool` | A spawn of 4 and quorum of -1 | `async with WorkerPool(...)` is entered | Raise `ValueError` from the underlying `WorkerProxy` | Pool negative quorum rejection (delegated) |
| 25 | `TestWorkerPool` | A spawn of 2 and quorum of 5 (no lease) | `WorkerPool` is instantiated | Raise `ValueError` matching "cannot exceed pool capacity" | Pool quorum-exceeds-capacity rejection |
| 26 | `TestWorkerPool` | A pool with spawn=4, lease=3, quorum=7, and discovery | `WorkerPool` is instantiated | Create the pool successfully | Pool quorum equal to capacity acceptance |
| 27 | `TestWorkerPool` | Spawn=4 and quorum=3 (no discovery, no lease) | `WorkerPool` is instantiated | Create the pool successfully | Quorum satisfied by spawn alone |
| 28 | `TestWorkerPool` | A pool with discovery, lease=2, quorum=3 | `async with WorkerPool(...)` is entered | Raise `ValueError` matching "cannot exceed lease" | Discovery-only quorum-exceeds-lease (delegated) |
| 29 | `TestWorkerPool` | A spawn of 2 with no discovery and quorum=10 | `WorkerPool` is instantiated | Raise `ValueError` matching "cannot exceed pool capacity" | Ephemeral rejects quorum > spawn+lease |
| 30 | `TestWorkerPool` | Spawn=2 and quorum=10 with no lease (unbounded) | `WorkerPool` is instantiated | Create the pool successfully (reachability deferred to runtime) | Unbounded lease accepts quorum > spawn |
| 31 | `TestWorkerPool` | A pool with spawn=2, discovery, lease=2, quorum=10 | `WorkerPool` is instantiated | Raise `ValueError` matching "cannot exceed pool capacity" | Hybrid rejects quorum > spawn+lease |
| 32 | `TestWorkerPool` | A pool with spawn=2, quorum=1, quorum_timeout=0 | `async with WorkerPool(...)` is entered | Raise `ValueError` from the underlying `WorkerProxy` | Non-positive quorum_timeout (delegated) |
| 33 | `TestWorkerPool` | A default-mode pool with quorum exceeding `os.cpu_count()` | `WorkerPool` is instantiated | Raise `ValueError` matching "cannot exceed pool capacity" | Default mode quorum-exceeds-capacity |
| 34 | `TestWorkerPool` | A pool with spawn=2 and quorum=2 entered as context manager | `WorkerProxy` is constructed internally | Pass `quorum=2` to `WorkerProxy` | Quorum forwarding (explicit) |
| 35 | `TestWorkerPool` | A pool with spawn=2 and no explicit quorum entered as context manager | `WorkerProxy` is constructed internally | Pass `quorum=1` to `WorkerProxy` | Quorum forwarding (default) |
| 36 | `TestWorkerPool` | A pool with spawn=2 and explicit `quorum=None` entered as context manager | `WorkerProxy` is constructed internally | Pass `quorum=None` to `WorkerProxy` without `quorum_timeout` | _make_proxy no-quorum branch |
| 37 | `TestWorkerPool` | A pool with spawn=2 and `quorum=0` entered as context manager | `WorkerProxy` is constructed internally | Pass `quorum=None` (normalized) to `WorkerProxy` without `quorum_timeout` | _make_proxy zero-quorum normalization |
| 38 | `TestWorkerPool` | A pool with discovery and quorum=3 entered as context manager | `WorkerProxy` is constructed internally | Pass `quorum=3` to `WorkerProxy` | Durable mode quorum forwarding |
| 39 | `TestWorkerPool` | A pool with spawn=2, discovery, and quorum=3 entered as context manager | `WorkerProxy` is constructed internally | Pass `quorum=3` to `WorkerProxy` | Hybrid mode quorum forwarding |
| 40 | `TestWorkerPool` | Any negative quorum value (Hypothesis) | `async with WorkerPool(...)` is entered | Raise `ValueError` from the underlying `WorkerProxy` | Property-based negative rejection (delegated) |
| 41 | `TestWorkerPool` | Any spawn in [1, 20], lease in [0, 20], quorum in [0, spawn+lease] (Hypothesis) | `WorkerPool` is instantiated | Create the pool successfully | Property-based capacity acceptance |
| 42 | Integration | Pairwise scenarios across discovery × loadbalancer × proxy × quorum dimensions | Pool is run end-to-end | Scenario completes per expected outcome | Quorum dimension in integration scenario matrix |