### PR TITLE
Add Invariants sections to SDLC skill definitions — Closes #171

### DIFF
--- a/llms/dispatchers/claude/audit.md
+++ b/llms/dispatchers/claude/audit.md
@@ -20,7 +20,8 @@ Spawn a general-purpose subagent with the following brief:
 >
 > 1. Read the project instructions in `CLAUDE.md`.
 > 2. Read and execute the complete workflow defined in `llms/skills/audit.md`.
-> 3. Follow every step faithfully. When a step requires user approval (e.g., remediation decision), surface it to the user and wait for their response.
-> 4. When done, return the full verification report including the pass/fail verdicts and overall compliance status.
+> 3. Follow every step faithfully. Pay special attention to the `## Invariants` section — these are non-negotiable safety constraints. When a step requires user approval (e.g., remediation decision), surface it to the user and wait for their response.
+> 4. The checklist MUST be exhaustive — extract every MUST, MUST NOT, SHALL, SHALL NOT, REQUIRED, and RECOMMENDED statement from the skill definition, including those in the `## Invariants` section. A partial checklist that omits normative requirements is itself a compliance failure.
+> 5. When done, return the full verification report including the pass/fail verdicts and overall compliance status.
 
 When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/commit.md
+++ b/llms/dispatchers/claude/commit.md
@@ -23,7 +23,7 @@ Spawn a general-purpose subagent with the following brief:
 >
 > 1. Read the project instructions in `CLAUDE.md`.
 > 2. Read and execute the complete workflow defined in `llms/skills/commit.md`.
-> 3. Follow every step faithfully. When a step requires user approval (e.g., commit plan approval, final commit review), surface it to the user and wait for their response.
+> 3. Follow every step faithfully. Pay special attention to the `## Invariants` section — these are non-negotiable safety constraints. When a step requires user approval (e.g., commit plan approval, final commit review), surface it to the user and wait for their response.
 > 4. When done, return a structured summary: what was accomplished, key artifacts (commit SHAs, commit messages, branch names), and the next pipeline step prompt from the skill definition.
 
 When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/implement.md
+++ b/llms/dispatchers/claude/implement.md
@@ -21,7 +21,7 @@ Spawn a general-purpose subagent with the following brief:
 >
 > 1. Read the project instructions in `CLAUDE.md`.
 > 2. Read and execute the complete workflow defined in `llms/skills/implement.md`.
-> 3. Follow every step faithfully. When a step requires user approval (e.g., plan approval), surface it to the user and wait for their response.
+> 3. Follow every step faithfully. Pay special attention to the `## Invariants` section — these are non-negotiable safety constraints. When a step requires user approval (e.g., plan approval), surface it to the user and wait for their response.
 > 4. When done, return a structured summary: what was accomplished, key artifacts (branch names, PR URLs, commit SHAs, etc.), and the next pipeline step prompt from the skill definition.
 
 When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/issue.md
+++ b/llms/dispatchers/claude/issue.md
@@ -19,7 +19,7 @@ Spawn a general-purpose subagent with the following brief:
 >
 > 1. Read the project instructions in `CLAUDE.md`.
 > 2. Read and execute the complete workflow defined in `llms/skills/issue.md`.
-> 3. Follow every step faithfully. When a step requires user approval (e.g., draft approval, label approval), surface it to the user and wait for their response.
+> 3. Follow every step faithfully. Pay special attention to the `## Invariants` section — these are non-negotiable safety constraints. When a step requires user approval (e.g., draft approval, label approval), surface it to the user and wait for their response.
 > 4. When done, return a structured summary: what was accomplished, key artifacts (issue URL, issue number, labels applied), and the next pipeline step prompt from the skill definition.
 
 When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/pr.md
+++ b/llms/dispatchers/claude/pr.md
@@ -19,7 +19,7 @@ Spawn a general-purpose subagent with the following brief:
 >
 > 1. Read the project instructions in `CLAUDE.md`.
 > 2. Read and execute the complete workflow defined in `llms/skills/pr.md`.
-> 3. Follow every step faithfully. When a step requires user approval (e.g., PR description approval), surface it to the user and wait for their response.
+> 3. Follow every step faithfully. Pay special attention to the `## Invariants` section — these are non-negotiable safety constraints. When a step requires user approval (e.g., PR description approval), surface it to the user and wait for their response.
 > 4. When done, return a structured summary: what was accomplished, key artifacts (PR URL, PR number, branch name), and the next pipeline step prompt from the skill definition.
 
 When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/review.md
+++ b/llms/dispatchers/claude/review.md
@@ -21,7 +21,7 @@ Spawn a general-purpose subagent with the following brief:
 >
 > 1. Read the project instructions in `CLAUDE.md`.
 > 2. Read and execute the complete workflow defined in `llms/skills/review.md`.
-> 3. Follow every step faithfully. When a step requires user approval (e.g., review findings approval), surface it to the user and wait for their response.
+> 3. Follow every step faithfully. Pay special attention to the `## Invariants` section — these are non-negotiable safety constraints. When a step requires user approval (e.g., review findings approval), surface it to the user and wait for their response.
 > 4. When done, return a structured summary: what was accomplished, key artifacts (review event posted, findings count, PR number), and the next pipeline step prompt from the skill definition.
 
 When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/dispatchers/claude/test.md
+++ b/llms/dispatchers/claude/test.md
@@ -20,7 +20,7 @@ Spawn a general-purpose subagent with the following brief:
 >
 > 1. Read the project instructions in `CLAUDE.md`.
 > 2. Read and execute the complete workflow defined in `llms/skills/test.md`.
-> 3. Follow every step faithfully. When a step requires user approval (e.g., test plan approval), surface it to the user and wait for their response.
+> 3. Follow every step faithfully. Pay special attention to the `## Invariants` section — these are non-negotiable safety constraints. When a step requires user approval (e.g., test plan approval), surface it to the user and wait for their response.
 > 4. When done, return a structured summary: what was accomplished, key artifacts (test files created or modified, test results), and the next pipeline step prompt from the skill definition.
 
 When the subagent returns, relay its summary to the user verbatim. Do not repeat work or add commentary.

--- a/llms/skills/audit.md
+++ b/llms/skills/audit.md
@@ -18,6 +18,12 @@ Spawn a fresh subagent to evaluate whether a skill's requirements were met durin
 
 This skill is a **cross-cutting quality gate** invoked at the end of every SDLC pipeline stage: `/issue` → audit → `/implement` → audit → `/test` → audit → `/commit` → audit → `/pr` → audit → `/review` → audit.
 
+## Invariants
+
+- MUST extract checklist items from every normative requirement (MUST, SHALL, REQUIRED, RECOMMENDED) in the skill definition -- not a subset.
+- MUST NOT report a COMPLIANT verdict when any requirement has a FAIL verdict.
+- MUST present remediation descriptions for every FAIL item before proceeding.
+
 ## Arguments
 
 ```
@@ -29,7 +35,7 @@ This skill is a **cross-cutting quality gate** invoked at the end of every SDLC 
 
 ## Workflow
 
-### TL;DR
+### Checklist
 
 1. Resolve the skill definition
 2. Compile the action summary

--- a/llms/skills/commit.md
+++ b/llms/skills/commit.md
@@ -21,9 +21,17 @@ This skill transforms a messy working tree into a clean sequence of atomic, well
 
 This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr`. This skill is the **fourth** stage. The implement, test, and commit steps are iterative — they can be invoked multiple times for a given issue.
 
+## Invariants
+
+- MUST create a staging branch before making any commits -- never commit directly to the working branch.
+- MUST NOT merge the staging branch back without explicit user approval.
+- MUST verify staged diff with `git diff --cached` before every commit.
+- MUST NOT include untracked files without asking the user first.
+- MUST check whether the current repo is a fork via `gh repo view --json isFork,parent` and resolve the target repo before any git operations.
+
 ## Workflow
 
-### TL;DR
+### Checklist
 
 1. Verify git state
 2. Create a staging branch
@@ -39,9 +47,12 @@ This skill is part of the development workflow pipeline: `/issue` → `/implemen
 ```bash
 git status
 git diff HEAD
+gh repo view --json isFork,parent
 ```
 
 If the working tree is clean (nothing to commit), tell the user and stop.
+
+If `isFork` is `true`, note the upstream repo — this context is useful for ensuring commit footers and branch references align with the upstream issue tracker. No `--repo` flags are needed for commit operations (they are local), but awareness of the fork relationship prevents mistakes in commit messages that reference issues or PRs.
 
 Untracked files SHOULD be checked for new source files, config files, etc. The user MUST be asked before including untracked files unless their inclusion is obvious. Build artifacts, cache directories, and anything in .gitignore MUST be ignored.
 

--- a/llms/skills/implement.md
+++ b/llms/skills/implement.md
@@ -19,13 +19,21 @@ Fetch a GitHub issue, create a branch, gather codebase context, and enter plan m
 
 This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr`. This skill is the **second** stage. The implement, test, and commit steps are iterative — they can be invoked multiple times for a given issue to address PR feedback or refine the implementation.
 
+## Invariants
+
+- MUST enter plan mode and receive user approval before writing any code.
+- MUST NOT create or modify files outside the scope of the approved plan.
+- MUST check for an existing PR and address unresolved review comments on re-invocation before planning new work.
+- MUST NOT proceed to the next pipeline step autonomously -- always prompt the user.
+- MUST use the knowledge graph (`llms/skills/understand-chat.md`) for context gathering when `.understand-anything/knowledge-graph.json` exists.
+
 ## Arguments
 
 An issue number MUST be provided as the sole argument (e.g., `/implement 103`).
 
 ## Workflow
 
-### TL;DR
+### Checklist
 
 1. Resolve target repository
 2. Fetch the issue

--- a/llms/skills/issue.md
+++ b/llms/skills/issue.md
@@ -17,9 +17,16 @@ Create a well-structured GitHub issue, either from a prepared `.issue.md` file o
 
 This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr`. This skill is the **first** stage. The implement, test, and commit steps are iterative — they can be invoked multiple times for a given issue.
 
+## Invariants
+
+- MUST NOT push the issue to GitHub until the user explicitly approves the draft.
+- MUST use a heredoc for the `gh issue create` body to avoid shell escaping issues.
+- MUST NOT add the `--assignee` flag -- issues are not auto-assigned at creation.
+- MUST use the knowledge graph (`llms/skills/understand-chat.md`) for context gathering when `.understand-anything/knowledge-graph.json` exists.
+
 ## Workflow
 
-### TL;DR
+### Checklist
 
 1. Determine the source
 2. Resolve target repository

--- a/llms/skills/pr.md
+++ b/llms/skills/pr.md
@@ -17,13 +17,23 @@ Review committed source and test changes on a branch and create a draft pull req
 
 This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr`. This skill is the **fifth** (final) stage. After review feedback is received, the user re-enters the loop at the implement skill to address comments, then optionally re-runs the test and commit skills before re-running the PR skill to update the description.
 
+## Invariants
+
+- MUST always create the PR as a draft -- never mark it ready for review automatically.
+- MUST NOT create the PR until the user explicitly approves the description.
+- MUST match the PR title exactly to the issue title with ` — Closes #<number>` appended.
+- MUST use a heredoc for the `gh pr create` body to avoid shell escaping issues.
+- MUST structure the PR description according to the project's PR template if one exists, otherwise the built-in format defined in this document.
+- MUST assign the PR to the current user upon creation via `gh pr edit <number> --add-assignee @me`.
+- MUST use the knowledge graph (`llms/skills/understand-chat.md`) for context gathering when `.understand-anything/knowledge-graph.json` exists.
+
 ## Arguments
 
 An issue number MUST be provided as the sole argument (e.g., `/pr 103`). The issue number is used to identify the branch (`<number>-<kebab-case-summary>`) and to link the PR via `Closes #<number>`.
 
 ## Workflow
 
-### TL;DR
+### Checklist
 
 1. Resolve target repository
 2. Identify the issue and branch
@@ -181,6 +191,14 @@ gh pr edit <pr-number> --repo <target> --body "$(cat <<'EOF'
 <updated body>
 EOF
 )"
+```
+
+The `--repo <target>` flag MUST be included when the target repo differs from the current repo.
+
+After the PR is created (or updated), assign it to the current user:
+
+```bash
+gh pr edit <number> --repo <target> --add-assignee @me
 ```
 
 The `--repo <target>` flag MUST be included when the target repo differs from the current repo.

--- a/llms/skills/review.md
+++ b/llms/skills/review.md
@@ -19,13 +19,21 @@ Fetch a pull request, analyze its diff against project guides and source context
 
 This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr` → `/review`. This skill is the **sixth** stage, invoked after the PR has been created and is ready for review.
 
+## Invariants
+
+- MUST NOT post the review until the user explicitly approves the final set of findings.
+- MUST use `REQUEST_CHANGES` as the review event when any blocking findings remain after approval.
+- MUST present every finding to the user with severity, file, line range, and comment text before posting.
+- MUST NOT fabricate guide requirements that do not exist in the project's actual guides.
+- MUST use the knowledge graph (`llms/skills/understand-chat.md`) for context gathering when `.understand-anything/knowledge-graph.json` exists.
+
 ## Arguments
 
 A PR number MUST be provided as the sole argument (e.g., `/review 146`).
 
 ## Workflow
 
-### TL;DR
+### Checklist
 
 1. Resolve target repository
 2. Fetch the PR metadata and diff

--- a/llms/skills/test.md
+++ b/llms/skills/test.md
@@ -18,6 +18,14 @@ Analyze code changes associated with an issue, evaluate existing test coverage, 
 
 This skill is part of the development workflow pipeline: `/issue` → `/implement` → `/test` → `/commit` → `/pr`. This skill is the **third** stage. The implement, test, and commit steps are iterative — they can be invoked multiple times for a given issue.
 
+## Invariants
+
+- MUST NOT create branches -- the test skill operates on an existing branch created by the implement skill.
+- MUST enter plan mode and receive user approval before writing any test files.
+- MUST read existing test files and account for current coverage before planning new tests.
+- MUST NOT write test specifications to disk -- the test plan is an internal planning artifact only.
+- MUST use the knowledge graph (`llms/skills/understand-chat.md`) for context gathering when `.understand-anything/knowledge-graph.json` exists.
+
 ## Arguments
 
 An issue number MUST be provided as the sole argument (e.g., `/test 103`).
@@ -32,7 +40,7 @@ An issue number MUST be provided as the sole argument (e.g., `/test 103`).
 
 ## Workflow
 
-### TL;DR
+### Checklist
 
 1. Resolve issue, PR, and branch
 2. Gather knowledge graph context


### PR DESCRIPTION
## Summary

Add a dedicated `## Invariants` section to each of the 7 SDLC skill definitions containing the 3-5 hardest MUST/MUST NOT constraints for that skill. Update all 7 Claude dispatcher briefs to explicitly reference the Invariants section so subagents treat those constraints as non-negotiable. Rename the `### TL;DR` subsection to `### Checklist` across all skill files for clarity.

Subagents executing SDLC skills sometimes skip critical workflow steps despite the skill definition containing clear normative requirements. The full workflow sections are long enough that safety-critical constraints get lost among procedural steps. Extracting the hardest constraints into a short, prominent section gives subagents a focused reminder of which requirements must never be violated.

Closes #171

## Proposed changes

### Invariants sections in skill definitions

Add an `## Invariants` section to each of the 7 skill files in `llms/skills/` (`audit.md`, `commit.md`, `implement.md`, `issue.md`, `pr.md`, `review.md`, `test.md`). Each section is placed immediately after `## Pipeline Context` and before the next major section (`## Arguments` or `## Workflow`), so it is read early and prominently. The constraints are distilled from existing normative requirements in each skill's workflow -- they are not new rules but a focused restatement of the most safety-critical ones:

- **audit** (3 constraints): Exhaustive checklist extraction, no false COMPLIANT verdicts, remediation before proceeding
- **commit** (4 constraints): Staging branch required, no merge without approval, diff verification, no silent untracked file inclusion
- **implement** (4 constraints): Plan approval before code, scope enforcement, review comment handling on re-invocation, no autonomous pipeline advancement
- **issue** (3 constraints): No push without approval, heredoc for body, no auto-assignment
- **pr** (4 constraints): Always draft, no creation without approval, title matching, heredoc for body
- **review** (4 constraints): No posting without approval, correct review event, full finding presentation, no fabricated guide requirements
- **test** (4 constraints): No branch creation, plan approval before writing, existing coverage analysis, no test spec files on disk

### TL;DR renamed to Checklist

Rename the `### TL;DR` subsection heading to `### Checklist` in all 7 skill files. The new name better describes the content -- a numbered sequence of workflow steps -- and avoids informal tone in a normative document.

### Dispatcher brief updates

Update step 3 of the subagent brief in all 7 Claude dispatcher files (`llms/dispatchers/claude/*.md`) to include the sentence: "Pay special attention to the `## Invariants` section -- these are non-negotiable safety constraints." This is inserted inline in the existing instruction, immediately after "Follow every step faithfully." The invariants remain the single source of truth in the skill definition; the dispatcher simply signals their importance.

## Test cases

N/A