### PR TITLE
Restrict pickling of Wool types to Wool's internal pickler — Closes #192

### DIFF
--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -20,11 +20,12 @@ from wool.runtime.loadbalancer.base import LoadBalancerLike
 from wool.runtime.loadbalancer.base import NoWorkersAvailable
 from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
 from wool.runtime.resourcepool import ResourcePool
-from wool.runtime.routine.task import Serializer
 from wool.runtime.routine.task import Task
 from wool.runtime.routine.task import TaskException
 from wool.runtime.routine.task import current_task
 from wool.runtime.routine.wrapper import routine
+from wool.runtime.serializer import CloudpickleSerializer
+from wool.runtime.serializer import Serializer
 from wool.runtime.typing import Factory
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import Worker
@@ -48,6 +49,8 @@ try:
     __version__ = version("wool")
 except PackageNotFoundError:
     __version__ = "unknown"
+
+__serializer__: Final[Serializer] = CloudpickleSerializer()
 
 __proxy__: Final[ContextVar[WorkerProxy | None]] = ContextVar("__proxy__", default=None)
 
@@ -77,11 +80,12 @@ __all__ = [
     "NoWorkersAvailable",
     "RoundRobinLoadBalancer",
     # Routines
-    "Serializer",
     "Task",
     "TaskException",
     "current_task",
     "routine",
+    # Serialization
+    "Serializer",
     # Backpressure
     "BackpressureContext",
     "BackpressureLike",

--- a/wool/src/wool/runtime/routine/task.py
+++ b/wool/src/wool/runtime/routine/task.py
@@ -4,7 +4,6 @@ import asyncio
 import functools
 import logging
 import traceback
-import weakref
 from collections.abc import Callable
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -12,7 +11,6 @@ from dataclasses import dataclass
 from inspect import isasyncgenfunction
 from inspect import iscoroutinefunction
 from types import TracebackType
-from typing import Any
 from typing import AsyncGenerator
 from typing import ContextManager
 from typing import Coroutine
@@ -27,13 +25,14 @@ from typing import cast
 from typing import overload
 from typing import runtime_checkable
 from uuid import UUID
-from uuid import uuid4
 
 import cloudpickle
 
 import wool
 from wool import protocol
 from wool.runtime.context import RuntimeContext
+from wool.runtime.serializer import PassthroughSerializer
+from wool.runtime.serializer import Serializer
 
 Args = Tuple
 Kwargs = Dict
@@ -42,86 +41,18 @@ Routine: TypeAlias = Coroutine | AsyncGenerator
 W = TypeVar("W", bound=Routine)
 
 
-# public
-@runtime_checkable
-class Serializer(Protocol):
-    """Protocol for pluggable serialization of Task payload fields."""
-
-    def dumps(self, obj: Any) -> bytes: ...
-
-    def loads(self, data: bytes) -> Any: ...
-
-
-class _PassthroughKey:
-    """Weak-referenceable key for the passthrough store."""
-
-    __slots__ = ("__weakref__", "token")
-
-    def __init__(self, token: UUID | None = None):
-        self.token = token if token is not None else uuid4()
-
-    def __hash__(self):
-        return hash(self.token)
-
-    def __eq__(self, other):
-        if not isinstance(other, _PassthroughKey):
-            return super().__eq__(other)
-        return self.token == other.token
-
-
-class PassthroughSerializer:
-    """In-process serializer that avoids pickling entirely.
-
-    Each instance acts as a scope guard for one dispatch.
-    ``dumps`` creates a weakly-referenceable key, stores the object
-    in a module-level :class:`~weakref.WeakKeyDictionary`, and
-    retains a strong reference to the key on ``self``.  When the
-    serializer goes out of scope the keys are garbage-collected and
-    the weak-dict entries are removed automatically.
-
-    ``loads`` is static — it reconstructs the key from the bytes
-    token in the protobuf message and pops the entry from the store.
-
-    All instances hash and compare equal so that
-    ``_pickle_serializer``'s LRU cache hits on every call.
-    """
-
-    def __init__(self):
-        self._keys: list[_PassthroughKey] = []
-
-    def __hash__(self):
-        return hash(PassthroughSerializer)
-
-    def __eq__(self, other):
-        # Required by _pickle_serializer's lru_cache: all instances
-        # share the same hash, so __eq__ must confirm the match for
-        # the cache to hit instead of treating each instance as a
-        # separate key.
-        return isinstance(other, PassthroughSerializer)
-
-    def __reduce__(self):
-        return (PassthroughSerializer, ())
-
-    def dumps(self, obj: Any) -> bytes:
-        key = _PassthroughKey()
-        self._keys.append(key)
-        _passthrough_store[key] = obj
-        return key.token.bytes
-
-    @staticmethod
-    def loads(data: bytes) -> Any:
-        key = _PassthroughKey(UUID(bytes=data))
-        return _passthrough_store.pop(key)
-
-
-_passthrough_store: weakref.WeakKeyDictionary[_PassthroughKey, Any] = (
-    weakref.WeakKeyDictionary()
-)
-
-
 @functools.lru_cache(maxsize=8)
-def _pickle_serializer(s: Serializer) -> bytes:
-    return cloudpickle.dumps(s)
+def _pickle_serializer(serializer: Serializer) -> bytes:
+    """Pickle a :class:`Serializer` instance for transport on the wire.
+
+    Cached via :func:`functools.lru_cache` keyed on the serializer
+    instance.  :class:`PassthroughSerializer` and
+    :class:`CloudpickleSerializer` deliberately collapse all instances to
+    one cache slot via ``__hash__`` and ``__eq__``; user implementations
+    that hash uniquely will fill the cache one entry per instance and
+    evict in LRU order.
+    """
+    return wool.__serializer__.dumps(serializer)
 
 
 @functools.lru_cache(maxsize=8)
@@ -300,8 +231,13 @@ class Task(Generic[W]):
     def from_protobuf(cls, task: protocol.Task) -> Task:
         """Deserialize a Task from a protobuf message.
 
-        .. note::
-            The payload's serializer is unpickled and cached for subsequent calls.
+        When the protobuf carries a ``serializer`` field, it is unpickled
+        and cached for subsequent calls; the resulting :class:`Serializer`
+        deserializes the payload fields.  When the field is unset (the
+        default emitted by :meth:`to_protobuf` for the no-serializer case),
+        :func:`cloudpickle.loads` is used directly — payloads produced by
+        :class:`~wool.runtime.serializer.CloudpickleSerializer` are
+        standard reduce tuples that stock unpickling executes natively.
 
         :param task:
             A protobuf ``Task`` message.
@@ -338,26 +274,24 @@ class Task(Generic[W]):
     def to_protobuf(self, serializer: Serializer | None = None) -> protocol.Task:
         """Serialize this Task to a protobuf message.
 
-        The serializer itself is pickled via :func:`_pickle_serializer`
-        which uses an LRU cache keyed on the serializer instance.
-        :class:`PassthroughSerializer` instances all hash and compare
-        equal, so repeated calls hit the cache and avoid redundant
-        pickling.
-
         :param serializer:
-            Optional serializer for the callable and its arguments. When ``None`` (the
-            default), ``cloudpickle`` is used and the protobuf ``serializer`` field is
-            left unset. When provided, the serializer is pickled into the ``serializer``
-            field so that :meth:`from_protobuf` can use it on the receiving side.
-
-            .. note::
-                If specified, the serializer is pickled and cached for subsequent calls.
+            Optional serializer for the callable and its arguments.  When
+            ``None`` (the default), :data:`wool.__serializer__` is used
+            and the protobuf ``serializer`` field is left unset.  When
+            provided, the serializer is pickled into the ``serializer``
+            field so that :meth:`from_protobuf` can use it on the
+            receiving side.  The proxy is always pickled with
+            :data:`wool.__serializer__` unless ``serializer`` is a
+            :class:`PassthroughSerializer`, in which case the proxy uses
+            the same serializer as the rest of the payload.
         :returns:
             A protobuf ``Task`` message.
         """
-        dumps = serializer.dumps if serializer is not None else cloudpickle.dumps
+        dumps = serializer.dumps if serializer is not None else wool.__serializer__.dumps
         proxy_dumps = (
-            dumps if isinstance(serializer, PassthroughSerializer) else cloudpickle.dumps
+            dumps
+            if isinstance(serializer, PassthroughSerializer)
+            else wool.__serializer__.dumps
         )
         task_msg = protocol.Task(
             version=protocol.__version__,

--- a/wool/src/wool/runtime/serializer.py
+++ b/wool/src/wool/runtime/serializer.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import io
+import weakref
+from typing import Any
+from typing import Protocol
+from typing import runtime_checkable
+from uuid import UUID
+from uuid import uuid4
+
+import cloudpickle
+
+
+# public
+@runtime_checkable
+class Serializer(Protocol):
+    """Protocol for pluggable serialization of dispatch payloads.
+
+    Implementations must be hashable.  Wool caches the pickled form of each
+    serializer instance via :func:`functools.lru_cache`.  A class that
+    overrides ``__eq__`` without supplying a compatible ``__hash__``
+    (which Python silently sets to ``None``) fails ``isinstance(obj,
+    Serializer)`` because the runtime-checkable protocol consults
+    ``hasattr``, and ``hasattr(obj, "__hash__")`` returns ``False`` when
+    ``__hash__`` is ``None``.  An instance that bypasses both static
+    type checking and the ``isinstance`` gate would trip the cache with
+    a :exc:`TypeError` on first dispatch.
+    """
+
+    def __hash__(self) -> int: ...
+
+    def dumps(self, obj: Any) -> bytes:
+        """Serialize *obj* to bytes for transport across a worker boundary.
+
+        :param obj:
+            The object to serialize.  Implementations decide which payloads
+            are supported.
+        :returns:
+            The serialized representation of *obj*.
+        """
+        ...
+
+    def loads(self, data: bytes) -> Any:
+        """Deserialize *data* produced by a matching :meth:`dumps` call.
+
+        :param data:
+            Bytes previously produced by :meth:`dumps`.
+        :returns:
+            The reconstructed object.
+        """
+        ...
+
+
+class _WoolPickler(cloudpickle.Pickler):
+    """Cloudpickle-based pickler that honors the ``__wool_reduce__`` protocol.
+
+    For objects whose type defines ``__wool_reduce__``, the method's return
+    value (a standard ``(callable, args)`` reduce tuple) is used in place of
+    the standard reduction protocol.  All other objects are handled exactly
+    as :class:`cloudpickle.Pickler` would handle them.
+
+    The override fires before ``__reduce_ex__``, so a type that pairs
+    ``__wool_reduce__`` with a ``__reduce_ex__`` guard (raising
+    :exc:`TypeError`) can be guarded against vanilla pickling while still
+    serializing correctly through this pickler.
+    """
+
+    def reducer_override(self, obj: Any) -> Any:
+        if hasattr(type(obj), "__wool_reduce__"):
+            return obj.__wool_reduce__()
+        return super().reducer_override(obj)
+
+
+class CloudpickleSerializer:
+    """Default :class:`Serializer` implementation.
+
+    Used by :class:`~wool.runtime.routine.task.Task.to_protobuf` when the
+    caller does not provide an explicit serializer.  Semantically the
+    contract is cloudpickle's: callables and arguments must be
+    cloudpickle-picklable.  The fact that ``dumps`` routes through Wool's
+    internal pickler — and therefore respects the ``__wool_reduce__``
+    protocol on guarded Wool types — is an implementation detail.
+    """
+
+    def __hash__(self) -> int:
+        """Return a constant hash so all instances share an LRU-cache slot."""
+        return hash(CloudpickleSerializer)
+
+    def __eq__(self, other: object) -> bool:
+        """Return True for any other CloudpickleSerializer; instances are interchangeable."""
+        return isinstance(other, CloudpickleSerializer)
+
+    def dumps(self, obj: Any) -> bytes:
+        """Serialize *obj* via Wool's internal pickler.
+
+        Honors the ``__wool_reduce__`` protocol on guarded Wool types and
+        otherwise reduces via cloudpickle.
+        """
+        buffer = io.BytesIO()
+        _WoolPickler(buffer).dump(obj)
+        return buffer.getvalue()
+
+    def loads(self, data: bytes) -> Any:
+        """Deserialize *data* via :func:`cloudpickle.loads`."""
+        return cloudpickle.loads(data)
+
+
+class _PassthroughKey:
+    """Weak-referenceable key for the passthrough store."""
+
+    __slots__ = ("__weakref__", "token")
+
+    def __init__(self, token: UUID | None = None) -> None:
+        self.token = token if token is not None else uuid4()
+
+    def __hash__(self) -> int:
+        return hash(self.token)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, _PassthroughKey):
+            return super().__eq__(other)
+        return self.token == other.token
+
+
+# Weak keys let the owning PassthroughSerializer's `_keys` list act as the
+# lifetime anchor: when the serializer goes out of scope, its keys are
+# garbage-collected and the corresponding entries here are removed
+# automatically without any explicit cleanup.
+_passthrough_store: weakref.WeakKeyDictionary[_PassthroughKey, Any] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+class PassthroughSerializer:
+    """In-process serializer that avoids pickling entirely.
+
+    Each instance acts as a scope guard for one dispatch.
+    ``dumps`` creates a weakly-referenceable key, stores the object
+    in a module-level :class:`~weakref.WeakKeyDictionary`, and
+    retains a strong reference to the key on ``self``.  When the
+    serializer goes out of scope the keys are garbage-collected and
+    the weak-dict entries are removed automatically.
+
+    ``loads`` is static — it reconstructs the key from the bytes
+    token in the protobuf message and pops the entry from the store.
+
+    All instances hash and compare equal so the LRU cache that pickles
+    serializer instances for transport hits on every call.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty list of strong key references for this dispatch scope."""
+        self._keys: list[_PassthroughKey] = []
+
+    def __hash__(self) -> int:
+        """Return a constant hash so all instances share an LRU-cache slot."""
+        return hash(PassthroughSerializer)
+
+    def __eq__(self, other: object) -> bool:
+        """Return True for any other PassthroughSerializer; instances are interchangeable."""
+        return isinstance(other, PassthroughSerializer)
+
+    def __reduce__(self) -> tuple[type[PassthroughSerializer], tuple[()]]:
+        """Reduce to a fresh instance; the per-scope key list does not survive transport."""
+        return (PassthroughSerializer, ())
+
+    def dumps(self, obj: Any) -> bytes:
+        """Stash *obj* in the module store and return its weak-key token."""
+        key = _PassthroughKey()
+        self._keys.append(key)
+        _passthrough_store[key] = obj
+        return key.token.bytes
+
+    @staticmethod
+    def loads(data: bytes) -> Any:
+        """Pop and return the object stashed under the token in *data*."""
+        key = _PassthroughKey(UUID(bytes=data))
+        return _passthrough_store.pop(key)

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -15,8 +15,8 @@ import grpc.aio
 import wool
 from wool import protocol
 from wool.runtime.resourcepool import ResourcePool
-from wool.runtime.routine.task import PassthroughSerializer
 from wool.runtime.routine.task import Task
+from wool.runtime.serializer import PassthroughSerializer
 from wool.runtime.worker.base import ChannelOptions
 
 _DispatchCall: TypeAlias = grpc.aio.StreamStreamCall[protocol.Request, protocol.Response]
@@ -203,8 +203,9 @@ class _DispatchStream(Generic[_T]):
             raise RuntimeError("anext(): asynchronous generator is already running")
         self._running = True
         try:
-            dump = cloudpickle.dumps(value)
-            request = protocol.Request(send=protocol.Message(dump=dump))
+            request = protocol.Request(
+                send=protocol.Message(dump=wool.__serializer__.dumps(value))
+            )
             await self._call.write(request)
             result = await self._read_next()
             self._step += 1
@@ -246,8 +247,9 @@ class _DispatchStream(Generic[_T]):
             else:  # pragma: no cover
                 exc = typ()
 
-            dump = cloudpickle.dumps(exc)
-            request = protocol.Request(throw=protocol.Message(dump=dump))
+            request = protocol.Request(
+                throw=protocol.Message(dump=wool.__serializer__.dumps(exc))
+            )
             await self._call.write(request)
             result = await self._read_next()
             self._step += 1
@@ -382,7 +384,7 @@ class WorkerConnection:
            When dispatching to the current worker process (self-dispatch),
            a :class:`PassthroughSerializer` is used so the four payload
            fields (callable, args, kwargs, proxy) are stored in-process
-           instead of being cloudpickled.  The request still travels
+           instead of being serialized.  The request still travels
            through gRPC so the full streaming protocol is preserved.
 
         :param task:

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -76,8 +76,8 @@ class WorkerProcess(Process):
     :param backpressure:
         Optional admission control hook. See
         :class:`~wool.runtime.worker.service.BackpressureLike`.
-        Serialized with ``cloudpickle`` for transfer to the
-        subprocess.
+        Serialized via :data:`wool.__serializer__` for transfer to
+        the subprocess.
     :param args:
         Additional args for :class:`multiprocessing.Process`.
     :param kwargs:
@@ -128,7 +128,7 @@ class WorkerProcess(Process):
         self._extra = extra if extra is not None else {}
         self._metadata = None
         self._backpressure = (
-            cloudpickle.dumps(backpressure) if backpressure is not None else None
+            wool.__serializer__.dumps(backpressure) if backpressure is not None else None
         )
         self._get_metadata, self._set_metadata = Pipe(duplex=False)
 

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -4,6 +4,7 @@ import asyncio
 import uuid
 import warnings
 from typing import TYPE_CHECKING
+from typing import Any
 from typing import AsyncContextManager
 from typing import AsyncGenerator
 from typing import AsyncIterator
@@ -11,7 +12,9 @@ from typing import Awaitable
 from typing import Callable
 from typing import ContextManager
 from typing import Generic
+from typing import NoReturn
 from typing import Sequence
+from typing import SupportsIndex
 from typing import TypeAlias
 from typing import TypeVar
 from typing import overload
@@ -105,6 +108,42 @@ class ReducibleAsyncIterator(Generic[T]):
 
 
 WorkerUri: TypeAlias = str
+
+
+def _restore_proxy(
+    discovery: DiscoverySubscriberLike,
+    loadbalancer: Factory[LoadBalancerLike] | LoadBalancerLike,
+    proxy_id: uuid.UUID,
+    lease: int | None,
+    lazy: bool,
+) -> WorkerProxy:
+    """Reconstruct a :class:`WorkerProxy` from its reduce tuple.
+
+    Module-level so the reduce tuple references a stable callable rather
+    than a freshly created closure on every reduction.
+
+    :param discovery:
+        Discovery subscriber or factory carried through the reduce tuple.
+    :param loadbalancer:
+        Load balancer instance or factory carried through the reduce tuple.
+    :param proxy_id:
+        Original proxy id, restored after construction so the receiving
+        side observes the same identity.
+    :param lease:
+        Lease size, ``None`` for no cap.
+    :param lazy:
+        Whether to defer worker resolution until first dispatch.
+    :returns:
+        A reconstructed :class:`WorkerProxy` with the original id.
+    """
+    proxy = WorkerProxy(
+        discovery=discovery,
+        loadbalancer=loadbalancer,
+        lease=lease,
+        lazy=lazy,
+    )
+    proxy._id = proxy_id
+    return proxy
 
 
 class WorkerProxy:
@@ -346,13 +385,17 @@ class WorkerProxy:
     def __eq__(self, value: object) -> bool:
         return isinstance(value, WorkerProxy) and hash(self) == hash(value)
 
-    def __reduce__(self) -> tuple:
-        """Return constructor args for unpickling with proxy ID preserved.
+    def __wool_reduce__(self) -> tuple[Callable[..., WorkerProxy], tuple[Any, ...]]:
+        """Return constructor args for unpickling via Wool's pickler.
 
         Creates a new WorkerProxy instance with the same discovery stream
         and load balancer type, then sets the preserved proxy ID on the
         new object.  Credentials are NOT serialized — the restored proxy
         resolves them from the active credential context.
+
+        WorkerProxy is guarded against vanilla pickling (see
+        :meth:`__reduce_ex__`); this method is invoked only by Wool's own
+        pickler.
 
         :returns:
             Tuple of (callable, args) for unpickling.
@@ -373,16 +416,6 @@ class WorkerProxy:
                     f"{name}=my_cm())."
                 )
 
-        def _restore_proxy(discovery, loadbalancer, proxy_id, lease, lazy):
-            proxy = WorkerProxy(
-                discovery=discovery,
-                loadbalancer=loadbalancer,
-                lease=lease,
-                lazy=lazy,
-            )
-            proxy._id = proxy_id
-            return proxy
-
         return (
             _restore_proxy,
             (
@@ -392,6 +425,31 @@ class WorkerProxy:
                 self._lease,
                 self._lazy,
             ),
+        )
+
+    def __reduce_ex__(self, _protocol: SupportsIndex) -> NoReturn:
+        """Reject vanilla pickling.
+
+        WorkerProxy carries credentials that are resolved from the active
+        credential context at construction and intentionally not
+        transported across process boundaries.  Allowing vanilla
+        :func:`pickle.dumps` or :func:`cloudpickle.dumps` would silently
+        produce payloads that deserialize into nonsense outside the
+        dispatch path.  Wool's own pickler consults ``reducer_override``
+        (and therefore ``__wool_reduce__``) before ``__reduce_ex__``, so
+        this guard is invisible to Wool's own serialization.
+
+        :func:`copy.copy` and :func:`copy.deepcopy` also route through
+        ``__reduce_ex__`` and are rejected for the same reason — a
+        runtime-bound proxy has no meaningful copy semantics.
+
+        :raises TypeError:
+            Always.
+        """
+        raise TypeError(
+            "WorkerProxy cannot be pickled via vanilla pickle/cloudpickle; "
+            "it is serialized automatically when dispatched through Wool's "
+            "runtime."
         )
 
     @property

--- a/wool/src/wool/runtime/worker/service.py
+++ b/wool/src/wool/runtime/worker/service.py
@@ -230,13 +230,13 @@ class WorkerService(protocol.WorkerServicer):
             try:
                 if isasyncgen(task):
                     async for result in task:
-                        result = protocol.Message(dump=cloudpickle.dumps(result))
+                        result = protocol.Message(dump=wool.__serializer__.dumps(result))
                         yield protocol.Response(result=result)
                 elif isinstance(task, asyncio.Task):
-                    result = protocol.Message(dump=cloudpickle.dumps(await task))
+                    result = protocol.Message(dump=wool.__serializer__.dumps(await task))
                     yield protocol.Response(result=result)
             except (Exception, asyncio.CancelledError) as e:
-                exception = protocol.Message(dump=cloudpickle.dumps(e))
+                exception = protocol.Message(dump=wool.__serializer__.dumps(e))
                 yield protocol.Response(exception=exception)
 
     async def stop(
@@ -485,7 +485,7 @@ class WorkerService(protocol.WorkerServicer):
             The incoming bidirectional request stream.
         :yields:
             The :class:`asyncio.Task` or async generator for the
-            wool task.
+            Wool task.
 
         """
         if iscoroutinefunction(work_task.callable):

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -703,7 +703,7 @@ def _pairwise_filter(row):
     - D3 must be a LOCAL_* variant when D2 is DURABLE_JOINED
       (LanDiscovery does not support namespacing)
     - D4 must not be ASYNC_CM (pre-called async CM instances are not
-      picklable inside WorkerProxy.__reduce__; documented limitation,
+      picklable inside WorkerProxy.__wool_reduce__; documented limitation,
       see #61)
     - D8 must be MODULE_FUNCTION or INSTANCE_METHOD when D1 is ASEND,
       ATHROW, or ACLOSE (no classmethod/staticmethod routines defined
@@ -813,7 +813,7 @@ def scenarios_strategy(draw):
         discovery = draw(st.sampled_from(DiscoveryFactory))
 
     # ASYNC_CM lb excluded: pre-called CM instances are not picklable
-    # inside WorkerProxy.__reduce__ (documented limitation, see #61)
+    # inside WorkerProxy.__wool_reduce__ (documented limitation, see #61)
     lb = draw(st.sampled_from([f for f in LbFactory if f is not LbFactory.ASYNC_CM]))
     credential = draw(st.sampled_from(CredentialType))
     options = draw(st.sampled_from(WorkerOptionsKind))

--- a/wool/tests/runtime/routine/test_task.py
+++ b/wool/tests/runtime/routine/test_task.py
@@ -13,13 +13,13 @@ from hypothesis import strategies as st
 from wool import protocol
 from wool.runtime.context import RuntimeContext
 from wool.runtime.context import dispatch_timeout
-from wool.runtime.routine.task import PassthroughSerializer
-from wool.runtime.routine.task import Serializer
 from wool.runtime.routine.task import Task
 from wool.runtime.routine.task import TaskException
 from wool.runtime.routine.task import WorkerProxyLike
 from wool.runtime.routine.task import current_task
 from wool.runtime.routine.task import do_dispatch
+from wool.runtime.serializer import PassthroughSerializer
+from wool.runtime.serializer import Serializer
 
 
 class _PicklableProxy:
@@ -33,6 +33,29 @@ class _PicklableProxy:
             yield "result"
 
         return _stream()
+
+
+def _restore_picklable_proxy(proxy_id):
+    """Reconstruct a _PicklableProxy with the supplied id."""
+    proxy = _PicklableProxy()
+    proxy.id = proxy_id
+    return proxy
+
+
+class _GuardedProxy(_PicklableProxy):
+    """Proxy test double that adopts the Wool pickling protocol.
+
+    Defines __wool_reduce__ for serialization through Wool's pickler and
+    a __reduce_ex__ guard that raises TypeError to model a guarded type.
+    Reconstruction returns a plain _PicklableProxy with the original id
+    preserved, mirroring the production WorkerProxy reduce contract.
+    """
+
+    def __wool_reduce__(self):
+        return (_restore_picklable_proxy, (self.id,))
+
+    def __reduce_ex__(self, *_):
+        raise TypeError("_GuardedProxy cannot be pickled via vanilla pickle/cloudpickle")
 
 
 class TestWorkerProxyLike:
@@ -1490,6 +1513,139 @@ class TestTask:
         # Assert
         assert not task_msg.HasField("serializer")
 
+    def test_to_protobuf_without_serializer_with_guarded_proxy(
+        self, sample_async_callable
+    ):
+        """Test the default Serializer respects __wool_reduce__ on the proxy.
+
+        Given:
+            A Task whose proxy adopts the Wool pickling protocol.
+        When:
+            to_protobuf() is called without an explicit serializer.
+        Then:
+            It should serialize the proxy via wool.__serializer__ — the
+            default fallback honors __wool_reduce__ instead of tripping
+            the __reduce_ex__ guard.
+        """
+        # Arrange
+        proxy = _GuardedProxy()
+        task = Task(
+            id=uuid4(),
+            callable=sample_async_callable,
+            args=(),
+            kwargs={},
+            proxy=proxy,
+        )
+
+        # Act
+        task_msg = task.to_protobuf()
+
+        # Assert
+        assert task_msg.proxy
+        assert task_msg.proxy_id == str(proxy.id)
+
+    def test_to_protobuf_with_custom_serializer_with_guarded_proxy(
+        self, sample_async_callable
+    ):
+        """Test custom Serializer routes the proxy through wool.__serializer__.
+
+        Given:
+            A Task whose proxy is a guarded type and a user-supplied
+            Serializer that is not PassthroughSerializer; the user
+            serializer counts dumps invocations so the test can verify
+            its participation in payload-field serialization.
+        When:
+            to_protobuf(serializer=...) is called.
+        Then:
+            It should pickle the user serializer into the protobuf
+            serializer field, route the four payload fields (callable,
+            args, kwargs) through the user serializer, and route the
+            proxy field through wool.__serializer__ so the proxy bytes
+            are decodable via cloudpickle.loads even though the user
+            serializer would otherwise mishandle guarded types.
+        """
+
+        # Arrange
+        class _RecordingSerializer:
+            """User serializer that records dumps invocations."""
+
+            def __init__(self):
+                self.dumps_calls = []
+
+            def __hash__(self):
+                return hash(_RecordingSerializer)
+
+            def __eq__(self, other):
+                return isinstance(other, _RecordingSerializer)
+
+            def __reduce__(self):
+                return (_RecordingSerializer, ())
+
+            def dumps(self, obj):
+                self.dumps_calls.append(obj)
+                return cloudpickle.dumps(obj)
+
+            def loads(self, data):
+                return cloudpickle.loads(data)
+
+        proxy = _GuardedProxy()
+        task = Task(
+            id=uuid4(),
+            callable=sample_async_callable,
+            args=(),
+            kwargs={},
+            proxy=proxy,
+        )
+        user_serializer = _RecordingSerializer()
+
+        # Act — must not raise even though the user serializer would
+        task_msg = task.to_protobuf(serializer=user_serializer)
+
+        # Assert — proxy bytes round-trip via stock cloudpickle.loads
+        assert task_msg.proxy
+        restored_proxy = cloudpickle.loads(task_msg.proxy)
+        assert isinstance(restored_proxy, _PicklableProxy)
+        # Assert — protobuf carries the user serializer
+        assert task_msg.HasField("serializer")
+        # Assert — user serializer received callable/args/kwargs but not the proxy
+        assert sample_async_callable in user_serializer.dumps_calls
+        assert () in user_serializer.dumps_calls
+        assert {} in user_serializer.dumps_calls
+        assert proxy not in user_serializer.dumps_calls
+
+    def test_from_protobuf_without_serializer_with_guarded_proxy(
+        self, sample_async_callable
+    ):
+        """Test the to_protobuf / from_protobuf round-trip with no explicit serializer.
+
+        Given:
+            A Task whose proxy is a guarded type.
+        When:
+            The Task is serialized via to_protobuf() and deserialized via
+            from_protobuf(), both with the default fallback (no explicit
+            Serializer).
+        Then:
+            The restored Task's proxy and proxy_id should match the
+            original.
+        """
+        # Arrange
+        proxy = _GuardedProxy()
+        original = Task(
+            id=uuid4(),
+            callable=sample_async_callable,
+            args=(),
+            kwargs={},
+            proxy=proxy,
+        )
+
+        # Act
+        restored = Task.from_protobuf(original.to_protobuf())
+
+        # Assert
+        assert restored.id == original.id
+        assert isinstance(restored.proxy, _PicklableProxy)
+        assert restored.proxy.id == proxy.id
+
     def test_to_protobuf_with_serializer(self, sample_async_callable, picklable_proxy):
         """Test to_protobuf with serializer sets the serializer field.
 
@@ -1628,11 +1784,11 @@ class TestPassthroughSerializer:
         """Test dumps returns a 16-byte token.
 
         Given:
-            An arbitrary Python object
+            An arbitrary Python object.
         When:
-            ``dumps`` is called
+            ``dumps`` is called.
         Then:
-            It should return a 16-byte bytes token
+            It should return a 16-byte bytes token.
         """
         # Arrange
         serializer = PassthroughSerializer()
@@ -1649,11 +1805,11 @@ class TestPassthroughSerializer:
         """Test dumps returns unique tokens for distinct objects.
 
         Given:
-            Two distinct Python objects
+            Two distinct Python objects.
         When:
-            ``dumps`` is called on each
+            ``dumps`` is called on each.
         Then:
-            It should return different tokens for each object
+            It should return different tokens for each object.
         """
         # Arrange
         serializer = PassthroughSerializer()
@@ -1671,12 +1827,12 @@ class TestPassthroughSerializer:
         """Test loads retrieves the original object by identity.
 
         Given:
-            An arbitrary Python object stored via ``dumps``
+            An arbitrary Python object stored via ``dumps``.
         When:
-            ``loads`` is called with the returned token
+            ``loads`` is called with the returned token.
         Then:
             It should return the exact same object (identity, not
-            equality)
+            equality).
         """
         # Arrange
         serializer = PassthroughSerializer()
@@ -1693,12 +1849,12 @@ class TestPassthroughSerializer:
         """Test loads consumes the stored entry.
 
         Given:
-            An object serialized via ``dumps``
+            An object serialized via ``dumps``.
         When:
-            ``loads`` is called twice with the same data
+            ``loads`` is called twice with the same data.
         Then:
             It should raise ``KeyError`` on the second call because
-            the entry was consumed
+            the entry was consumed.
         """
         # Arrange
         serializer = PassthroughSerializer()
@@ -1711,31 +1867,74 @@ class TestPassthroughSerializer:
         with pytest.raises(KeyError):
             serializer.loads(data)
 
-    def test_isinstance_with_serializer_protocol(self):
+    def test___instancecheck___with_serializer_protocol(self):
         """Test PassthroughSerializer satisfies the Serializer protocol.
 
         Given:
-            A PassthroughSerializer instance
+            A PassthroughSerializer instance.
         When:
-            Checked against the Serializer protocol via isinstance
+            isinstance is evaluated against the runtime-checkable
+            Serializer protocol.
         Then:
-            It should be recognized as a Serializer
+            It should return True.
         """
-        # Arrange & act
+        # Arrange, act, & assert
+        assert isinstance(PassthroughSerializer(), Serializer)
+
+    def test_hash_and_equality_contract(self):
+        """Test all PassthroughSerializer instances are interchangeable.
+
+        Given:
+            Two distinct PassthroughSerializer instances and an arbitrary
+            object of a different type.
+        When:
+            Their hashes and equality are evaluated.
+        Then:
+            The two PassthroughSerializer instances should compare equal,
+            share a hash (so the LRU cache deduplicates them), and not
+            compare equal to the other-type object.
+        """
+        # Arrange
+        first = PassthroughSerializer()
+        second = PassthroughSerializer()
+
+        # Act & assert
+        assert first == second
+        assert hash(first) == hash(second)
+        assert first != object()
+
+    def test_dumps_with_guarded_proxy(self):
+        """Test PassthroughSerializer stores guarded objects by identity.
+
+        Given:
+            A PassthroughSerializer instance and a proxy that adopts the
+            Wool pickling protocol (__wool_reduce__ + __reduce_ex__ guard).
+        When:
+            The serializer dumps and loads the proxy.
+        Then:
+            It should return the exact same object (identity), bypassing
+            __wool_reduce__ and __reduce_ex__ entirely — passthrough
+            never invokes pickle on the payload.
+        """
+        # Arrange
         serializer = PassthroughSerializer()
+        proxy = _GuardedProxy()
+
+        # Act
+        restored = serializer.loads(serializer.dumps(proxy))
 
         # Assert
-        assert isinstance(serializer, Serializer)
+        assert restored is proxy
 
     def test_cloudpickle_roundtrip(self):
         """Test PassthroughSerializer survives cloudpickle serialization.
 
         Given:
-            A PassthroughSerializer instance
+            A PassthroughSerializer instance.
         When:
-            Serialized and deserialized via cloudpickle
+            Serialized and deserialized via cloudpickle.
         Then:
-            It should produce a functional PassthroughSerializer
+            It should produce a functional PassthroughSerializer.
         """
         # Arrange
         original = PassthroughSerializer()

--- a/wool/tests/runtime/test_serializer.py
+++ b/wool/tests/runtime/test_serializer.py
@@ -1,0 +1,276 @@
+import pickle
+
+import cloudpickle
+import pytest
+from hypothesis import HealthCheck
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
+
+from wool.runtime.serializer import CloudpickleSerializer
+from wool.runtime.serializer import Serializer
+
+_GUARD_MESSAGE = "instances of this type must be pickled via wool.runtime.serializer"
+
+
+class _GuardedType:
+    """Test double for a type that adopts the Wool pickling protocol."""
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __eq__(self, other):
+        return isinstance(other, _GuardedType) and self.payload == other.payload
+
+    def __hash__(self):
+        return hash(("_GuardedType", self.payload))
+
+    def __wool_reduce__(self):
+        return (_GuardedType, (self.payload,))
+
+    def __reduce_ex__(self, *_):
+        raise TypeError(_GUARD_MESSAGE)
+
+
+class _Unguarded:
+    """Test double for a plain type that does not adopt the Wool pickling protocol."""
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __eq__(self, other):
+        return isinstance(other, _Unguarded) and self.payload == other.payload
+
+    def __hash__(self):
+        return hash(("_Unguarded", self.payload))
+
+
+def _arbitrary_payloads():
+    """Recursive Hypothesis strategy covering nested cloudpickle-picklable values."""
+    primitives = st.one_of(
+        st.none(),
+        st.booleans(),
+        st.text(),
+        st.integers(),
+        st.binary(),
+        st.floats(allow_nan=False),
+    )
+    return st.recursive(
+        primitives,
+        lambda children: st.one_of(
+            st.lists(children),
+            st.tuples(children, children),
+            st.dictionaries(st.text(), children),
+        ),
+        max_leaves=20,
+    )
+
+
+class TestCloudpickleSerializer:
+    def test_dumps_with_guarded_type(self):
+        """Test CloudpickleSerializer.dumps round-trips a guarded type.
+
+        Given:
+            A CloudpickleSerializer instance and a _GuardedType payload.
+        When:
+            The serializer dumps and loads the payload.
+        Then:
+            It should round-trip to an equal instance.
+        """
+        # Arrange
+        serializer = CloudpickleSerializer()
+        instance = _GuardedType("hello")
+
+        # Act
+        restored = serializer.loads(serializer.dumps(instance))
+
+        # Assert
+        assert restored == instance
+
+    def test_dumps_with_lambda(self):
+        """Test the serializer preserves cloudpickle's lambda-pickling behavior.
+
+        Given:
+            A lambda — picklable by cloudpickle but not by stdlib pickle.
+        When:
+            The serializer dumps and loads the lambda.
+        Then:
+            It should round-trip to a callable that returns the same value
+            (regression guard against accidentally bypassing cloudpickle).
+        """
+        # Arrange
+        serializer = CloudpickleSerializer()
+        lam = lambda x: x * 2  # noqa: E731
+
+        # Act
+        restored = serializer.loads(serializer.dumps(lam))
+
+        # Assert
+        assert restored(21) == 42
+
+    def test_dumps_with_guarded_type_via_vanilla_pickle(self):
+        """Test vanilla pickle and cloudpickle paths fail for guarded types.
+
+        Given:
+            A _GuardedType instance.
+        When:
+            pickle.dumps and cloudpickle.dumps are called on the instance.
+        Then:
+            Both should raise TypeError from the __reduce_ex__ guard.
+        """
+        # Arrange
+        instance = _GuardedType("hello")
+
+        # Act & assert
+        with pytest.raises(TypeError, match=_GUARD_MESSAGE):
+            pickle.dumps(instance)
+        with pytest.raises(TypeError, match=_GUARD_MESSAGE):
+            cloudpickle.dumps(instance)
+
+    @given(payload=_arbitrary_payloads())
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    def test_dumps_round_trips_arbitrary_payloads(self, payload):
+        """Test the serializer round-trips arbitrary cloudpickle-picklable payloads.
+
+        Given:
+            Any nested combination of None, bool, text, int, float, bytes,
+            list, tuple, or dict.
+        When:
+            The payload is serialized and deserialized.
+        Then:
+            It should equal the original.
+        """
+        # Arrange
+        serializer = CloudpickleSerializer()
+
+        # Act
+        restored = serializer.loads(serializer.dumps(payload))
+
+        # Assert
+        assert restored == payload
+
+    def test_hash_and_equality_contract(self):
+        """Test all CloudpickleSerializer instances are interchangeable.
+
+        Given:
+            Two distinct CloudpickleSerializer instances and an arbitrary
+            object of a different type.
+        When:
+            Their hashes and equality are evaluated.
+        Then:
+            The two CloudpickleSerializer instances should compare equal,
+            share a hash (so the LRU cache deduplicates them), and not
+            compare equal to the other-type object.
+        """
+        # Arrange
+        first = CloudpickleSerializer()
+        second = CloudpickleSerializer()
+
+        # Act & assert
+        assert first == second
+        assert hash(first) == hash(second)
+        assert first != object()
+
+    def test___instancecheck___with_serializer_protocol(self):
+        """Test CloudpickleSerializer satisfies the Serializer protocol.
+
+        Given:
+            A CloudpickleSerializer instance.
+        When:
+            isinstance is evaluated against the runtime-checkable Serializer
+            protocol.
+        Then:
+            It should return True.
+        """
+        # Arrange, act, & assert
+        assert isinstance(CloudpickleSerializer(), Serializer)
+
+    def test_dumps_with_unguarded_type(self):
+        """Test the serializer delegates to cloudpickle for unguarded types.
+
+        Given:
+            A CloudpickleSerializer and an instance of a class defined
+            inside the test method — a payload that requires cloudpickle's
+            non-default reduction (stdlib pickle alone cannot resolve a
+            local class by qualified name).
+        When:
+            The serializer dumps the instance.
+        Then:
+            The bytes should round-trip via cloudpickle.loads to an equal
+            value, which only succeeds if the pickler delegated to
+            cloudpickle's special-case handling rather than returning
+            NotImplemented directly.
+        """
+
+        # Arrange
+        class _LocalUnguarded:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __eq__(self, other):
+                return (
+                    isinstance(other, _LocalUnguarded) and self.payload == other.payload
+                )
+
+            def __hash__(self):
+                return hash(("_LocalUnguarded", self.payload))
+
+        serializer = CloudpickleSerializer()
+        instance = _LocalUnguarded("hello")
+
+        # Act
+        restored = cloudpickle.loads(serializer.dumps(instance))
+
+        # Assert
+        assert restored == instance
+
+    def test_dumps_with_instance_attribute_named___wool_reduce__(self):
+        """Test an instance attribute named __wool_reduce__ does not opt in.
+
+        Given:
+            An unguarded instance with an instance attribute named
+            __wool_reduce__ that raises if invoked.
+        When:
+            The serializer dumps the instance.
+        Then:
+            It should not invoke the instance attribute (protocol opt-in is
+            class-level, not instance-level), so dump must succeed without
+            raising.
+        """
+
+        # Arrange
+        def _raise():
+            raise RuntimeError("instance attribute must not be invoked")
+
+        serializer = CloudpickleSerializer()
+        instance = _Unguarded("hello")
+        setattr(instance, "__wool_reduce__", _raise)
+
+        # Act — must not raise
+        serializer.dumps(instance)
+
+    def test_dumps_with_raising___wool_reduce__(self):
+        """Test an exception inside __wool_reduce__ propagates from dumps.
+
+        Given:
+            A guarded type whose __wool_reduce__ raises ValueError.
+        When:
+            The serializer dumps an instance.
+        Then:
+            It should propagate the original ValueError.
+        """
+
+        # Arrange
+        class _Failing:
+            def __wool_reduce__(self):
+                raise ValueError("boom")
+
+        serializer = CloudpickleSerializer()
+
+        # Act & assert
+        with pytest.raises(ValueError, match="boom"):
+            serializer.dumps(_Failing())

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -6,6 +6,8 @@ to avoid network overhead and ensure deterministic behavior.
 """
 
 import asyncio
+import copy
+import pickle
 import uuid
 import warnings
 from types import MappingProxyType
@@ -19,6 +21,7 @@ from hypothesis import strategies as st
 from packaging.version import Version
 from pytest_mock import MockerFixture
 
+import wool
 import wool.runtime.worker.proxy as wp
 from wool import protocol
 from wool.runtime.discovery.base import DiscoveryEvent
@@ -1714,7 +1717,7 @@ class TestWorkerProxy:
         )
 
         # Act — pickle round-trip, then start the restored proxy
-        pickled_data = cloudpickle.dumps(proxy)
+        pickled_data = wool.__serializer__.dumps(proxy)
         restored = cloudpickle.loads(pickled_data)
         await restored.start()
         await _drain_discovery(restored, expect=2)
@@ -1741,7 +1744,7 @@ class TestWorkerProxy:
         )
 
         # Act
-        restored = cloudpickle.loads(cloudpickle.dumps(proxy))
+        restored = cloudpickle.loads(wool.__serializer__.dumps(proxy))
 
         # Assert
         assert restored.lazy is False
@@ -1763,7 +1766,7 @@ class TestWorkerProxy:
         )
 
         # Act
-        restored = cloudpickle.loads(cloudpickle.dumps(proxy))
+        restored = cloudpickle.loads(wool.__serializer__.dumps(proxy))
 
         # Assert
         assert restored.lazy is True
@@ -2325,7 +2328,7 @@ class TestWorkerProxy:
             assert proxy.started is True
 
             # Pickle from within the started proxy context
-            pickled_data = cloudpickle.dumps(proxy)
+            pickled_data = wool.__serializer__.dumps(proxy)
             unpickled_proxy = cloudpickle.loads(pickled_data)
 
             # Unpickled proxy should be unstarted regardless of source state
@@ -2356,7 +2359,7 @@ class TestWorkerProxy:
             assert proxy.started is True
 
             # Pickle from within the started proxy context
-            pickled_data = cloudpickle.dumps(proxy)
+            pickled_data = wool.__serializer__.dumps(proxy)
             unpickled_proxy = cloudpickle.loads(pickled_data)
 
             # Unpickled proxy should be unstarted regardless of source state
@@ -2386,7 +2389,7 @@ class TestWorkerProxy:
             assert proxy.started is True
 
             # Pickle from within the started proxy context
-            pickled_data = cloudpickle.dumps(proxy)
+            pickled_data = wool.__serializer__.dumps(proxy)
             unpickled_proxy = cloudpickle.loads(pickled_data)
 
             # Unpickled proxy should be unstarted regardless of source state
@@ -2417,7 +2420,7 @@ class TestWorkerProxy:
 
         # Act
         async with proxy:
-            pickled_data = cloudpickle.dumps(proxy)
+            pickled_data = wool.__serializer__.dumps(proxy)
             unpickled_proxy = cloudpickle.loads(pickled_data)
 
         # Assert
@@ -2425,7 +2428,7 @@ class TestWorkerProxy:
         assert unpickled_proxy.id == proxy.id
         assert unpickled_proxy.started is False
         # Verify a second roundtrip still produces a valid proxy
-        repickled = cloudpickle.loads(cloudpickle.dumps(unpickled_proxy))
+        repickled = cloudpickle.loads(wool.__serializer__.dumps(unpickled_proxy))
         assert repickled.id == proxy.id
 
     @pytest.mark.asyncio
@@ -2452,7 +2455,7 @@ class TestWorkerProxy:
         )
 
         async with proxy:
-            pickled_data = cloudpickle.dumps(proxy)
+            pickled_data = wool.__serializer__.dumps(proxy)
 
         # Act — unpickle outside any WorkerCredentials context
         unpickled_proxy = cloudpickle.loads(pickled_data)
@@ -2485,7 +2488,7 @@ class TestWorkerProxy:
         )
 
         async with proxy:
-            pickled_data = cloudpickle.dumps(proxy)
+            pickled_data = wool.__serializer__.dumps(proxy)
 
         # Act — unpickle inside a WorkerCredentials context with
         # static workers so we can observe the security filter
@@ -2549,7 +2552,7 @@ class TestWorkerProxy:
 
         # Act & assert
         with pytest.raises(TypeError, match="loadbalancer"):
-            cloudpickle.dumps(proxy)
+            wool.__serializer__.dumps(proxy)
 
     def test_cloudpickle_serialization_with_async_cm_loadbalancer_raises(
         self, mock_discovery_service
@@ -2581,7 +2584,7 @@ class TestWorkerProxy:
 
         # Act & assert
         with pytest.raises(TypeError, match="loadbalancer"):
-            cloudpickle.dumps(proxy)
+            wool.__serializer__.dumps(proxy)
 
     def test_cloudpickle_serialization_with_sync_cm_discovery_raises(self):
         """Test TypeError when pickling proxy with sync CM discovery.
@@ -2608,7 +2611,7 @@ class TestWorkerProxy:
 
         # Act & assert
         with pytest.raises(TypeError, match="discovery"):
-            cloudpickle.dumps(proxy)
+            wool.__serializer__.dumps(proxy)
 
     def test_cloudpickle_serialization_with_async_cm_discovery_raises(self):
         """Test TypeError when pickling proxy with async CM discovery.
@@ -2635,7 +2638,36 @@ class TestWorkerProxy:
 
         # Act & assert
         with pytest.raises(TypeError, match="discovery"):
+            wool.__serializer__.dumps(proxy)
+
+    def test___reduce_ex___with_vanilla_pickle_and_copy(self, mock_discovery_service):
+        """Test the guard fires for vanilla pickle, cloudpickle, and copy paths.
+
+        Given:
+            A WorkerProxy instance.
+        When:
+            pickle.dumps, cloudpickle.dumps, copy.copy, and copy.deepcopy
+            are called on it directly.
+        Then:
+            Each should raise TypeError pointing at Wool's runtime as the
+            supported serialization path.
+        """
+        # Arrange
+        proxy = WorkerProxy(
+            discovery=mock_discovery_service,
+            loadbalancer=wp.RoundRobinLoadBalancer,
+        )
+        match = "WorkerProxy cannot be pickled"
+
+        # Act & assert
+        with pytest.raises(TypeError, match=match):
+            pickle.dumps(proxy)
+        with pytest.raises(TypeError, match=match):
             cloudpickle.dumps(proxy)
+        with pytest.raises(TypeError, match=match):
+            copy.copy(proxy)
+        with pytest.raises(TypeError, match=match):
+            copy.deepcopy(proxy)
 
     @pytest.mark.asyncio
     async def test_explicit_credentials_parameter_overrides_contextvar(

--- a/wool/tests/test_public.py
+++ b/wool/tests/test_public.py
@@ -40,11 +40,11 @@ def test_public_api_completeness():
         "LoadBalancerLike",
         "NoWorkersAvailable",
         "RoundRobinLoadBalancer",
-        "Serializer",
         "Task",
         "TaskException",
         "current_task",
         "routine",
+        "Serializer",
         "BackpressureContext",
         "BackpressureLike",
         "LocalWorker",
@@ -73,3 +73,31 @@ def test_public_api_completeness():
 
     # Assert
     assert actual_public_api == expected_public_api
+
+
+def test_serializer_singleton_identity():
+    """Test wool.__serializer__ is a stable module-level singleton.
+
+    Given:
+        The wool package.
+    When:
+        wool.__serializer__ is accessed twice.
+    Then:
+        Each access should return the same instance.
+    """
+    # Arrange, act, & assert
+    assert wool.__serializer__ is wool.__serializer__
+
+
+def test_serializer_singleton_with_serializer_protocol():
+    """Test wool.__serializer__ satisfies the wool.Serializer protocol.
+
+    Given:
+        The wool.__serializer__ singleton and the wool.Serializer protocol.
+    When:
+        isinstance is evaluated against the runtime-checkable protocol.
+    Then:
+        It should return True.
+    """
+    # Arrange, act, & assert
+    assert isinstance(wool.__serializer__, wool.Serializer)


### PR DESCRIPTION
## Summary

Introduce a Wool-internal pickling protocol — `__wool_reduce__` for serialization through Wool's own pickler and `__reduce_ex__` to reject vanilla `pickle` and `cloudpickle` — and apply it to `WorkerProxy`. The new `wool.runtime.serializer` module hosts the protocol mechanism, the `Serializer` Protocol (moved from `wool.runtime.routine.task`), the `CloudPickleSerializer` default implementation, and the module-level `DEFAULT_SERIALIZER` singleton consumed by every dispatch site. Wool types that hold runtime-bound dispatch state — initially just `WorkerProxy`, later the `wool.Context` / `wool.ContextVar` / `wool.Token` types from #157 — fail loudly when serialized outside the dispatch path. The receiving side continues to use `cloudpickle.loads` because `__wool_reduce__` returns standard `(callable, args)` reduce tuples.

Other picklable Wool types (`RoundRobinLoadBalancer`, `LocalDiscovery`, `afilter`, `ReducibleAsyncIterator`, `PassthroughSerializer`) implement user-facing protocols whose user implementations must be cloudpickle-picklable. Wool's own implementations of those protocols stay freely picklable to match that contract.

Closes #192.

## Design rationale

**Two categories of picklable Wool types, with only one guarded.** Wool's picklable types split into dispatch-state types (`WorkerProxy` today; `wool.Context` / `wool.ContextVar` / `wool.Token` once #157 lands) and protocol implementations (`RoundRobinLoadBalancer`, `LocalDiscovery`, `afilter`, `PassthroughSerializer`, `ReducibleAsyncIterator`). Dispatch-state types hold runtime-bound state — credentials resolved against the active `CredentialContext`, manifest tokens against the task-keyed store — that is meaningless outside a Wool runtime. Protocol implementations carry no runtime-bound state; user implementations of the same protocols must be cloudpickle-picklable, and Wool's own implementations follow that contract by symmetry. Guarding the protocol implementations would force a divergent rule on Wool's implementations versus user-supplied ones with no corresponding benefit.

**`reducer_override` over `copyreg.dispatch_table`.** The `_WoolPickler` subclass overrides `cloudpickle.Pickler.reducer_override(obj)` and looks for `__wool_reduce__` on the object's type; when absent, the override delegates to `super().reducer_override(obj)` so cloudpickle's special-case handling for lambdas, locally-defined classes, and other dynamic types is preserved. A `copyreg`-style dispatch table was rejected because it requires every picklable type to be registered in a single mapping — coupling the pickler to the set of opt-in types and forcing edits to a central file every time a new type is added. Duck-typing on `__wool_reduce__` keeps the opt-in on the type itself.

**`__reduce_ex__` carries the guard, not `__reduce__`.** Cloudpickle's pickler calls `__reduce_ex__` first, falling back to `__reduce__` if the former returns `NotImplemented`; raising in `__reduce_ex__` short-circuits both paths. Because `reducer_override` is consulted before `__reduce_ex__`, the guard is invisible to `_WoolPickler` — the override fires and serialization proceeds via `__wool_reduce__`. The guard fires for vanilla picklers and stays out of Wool's way. `copy.copy` and `copy.deepcopy` route through `__reduce_ex__` as well, so they are rejected through the same path — a runtime-bound proxy has no meaningful copy semantics.

**`__wool_reduce__` returns the standard reduce-tuple shape.** The unpickling side does not need Wool-specific machinery to reconstruct the object; the standard pickle reconstructor runs the callable with the args as it would for any reduce tuple. This keeps the migration trivial — rename the existing `__reduce__` method — and means there is no `WoolUnpickler`. Cloudpickle ships only a `Pickler`, not an `Unpickler`, for the same reason: serialization is the only side that needs custom logic.

**Default `Serializer` becomes `CloudPickleSerializer`, owned in `wool.runtime.serializer`.** The pre-change fallback at `task.py:358` was bare `cloudpickle.dumps`, which after the migration would fail any time a guarded type appeared in a Task payload. `CloudPickleSerializer` is a `Serializer` Protocol implementation that uses `_WoolPickler` underneath; the module-level `DEFAULT_SERIALIZER` singleton is the canonical instance. Every dispatch site — `task.py`'s default fallback, `worker/connection.py`, `worker/service.py`, `worker/process.py` — imports the same singleton. End-user-facing semantics remain "your callables and args must be cloudpickle-picklable"; the `_WoolPickler` aspect is an implementation detail.

**`Serializer` Protocol requires hashability.** Wool caches the pickled form of each serializer instance via `functools.lru_cache`; an implementation that overrides `__eq__` without supplying a compatible `__hash__` (which Python silently sets to `None`) would trip the cache with a `TypeError` on first dispatch. The Protocol declares `__hash__(self) -> int` so static type checkers catch this. Runtime `isinstance` cannot enforce it (Python's `hasattr` returns True for `__hash__ = None`), so the docstring states the contract explicitly.

**`_WoolPickler` is module-private.** Its only consumer is `CloudPickleSerializer.dumps`. The leading underscore signals that callers should not subclass it directly; the surface they consume is the `Serializer` Protocol, the `CloudPickleSerializer` class, or the `DEFAULT_SERIALIZER` singleton.

## Proposed changes

### `wool.runtime.serializer` (new module)

Houses the serialization surface lifted out of `wool.runtime.routine.task`:

- `Serializer` Protocol — moved verbatim from `task.py` and extended with `__hash__(self) -> int`. Re-exported via `wool.__all__` under a new "Serialization" group.
- `_WoolPickler` — `cloudpickle.Pickler` subclass whose `reducer_override` honors `__wool_reduce__` when present and delegates to `super()` otherwise.
- `CloudPickleSerializer` — `Serializer` implementation. `dumps` wraps `_WoolPickler` over a `BytesIO` buffer; `loads` delegates to `cloudpickle.loads`. All instances hash and compare equal so the `_pickle_serializer` LRU cache collapses them to one slot.
- `DEFAULT_SERIALIZER` — module-level `CloudPickleSerializer` singleton. The canonical default for dispatch-path serialization.
- `_PassthroughKey`, `_passthrough_store`, `PassthroughSerializer` — moved verbatim from `task.py`. Behavior unchanged.

### `WorkerProxy` migration (`wool/runtime/worker/proxy.py`)

Rename `WorkerProxy.__reduce__` to `__wool_reduce__`; preserve its existing body — the loadbalancer/discovery context-manager check, the credential exclusion, the proxy-id preservation. Add `WorkerProxy.__reduce_ex__` raising `TypeError` with a message that names Wool's runtime as the supported serialization path. Hoist the previously-nested `_restore_proxy` helper to module level so the reduce tuple references a stable callable rather than a freshly-created closure on every reduction. The hoist matches the convention established by `_proxy_factory` in `worker/process.py`.

### Dispatch-path routing

`wool/runtime/routine/task.py` — drop the local `_DEFAULT_SERIALIZER` declaration; import `DEFAULT_SERIALIZER` from `wool.runtime.serializer`. The `Task.to_protobuf` `dumps` and `proxy_dumps` fallbacks resolve to `DEFAULT_SERIALIZER.dumps` when no explicit serializer is supplied. `_pickle_serializer` (which serializes the `Serializer` instance itself for the wire) routes through `DEFAULT_SERIALIZER.dumps` for consistency.

`wool/runtime/worker/connection.py`, `worker/service.py`, `worker/process.py` — replace direct `cloudpickle.dumps` calls with `DEFAULT_SERIALIZER.dumps`. The `cloudpickle.loads` calls stay unchanged.

### `wool/__init__.py`

Re-export `Serializer` from the new `wool.runtime.serializer` location. Move it under a new "Serialization" group in `__all__` (was grouped under "Routines"); update `tests/test_public.py`'s expected ordering accordingly.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestCloudPickleSerializer` | A guarded type defining `__wool_reduce__` and a `__reduce_ex__` guard | The serializer dumps and loads the instance | The result equals the original | Guarded-type round-trip |
| 2 | `TestCloudPickleSerializer` | A simple string payload | The serializer dumps and loads it | The result equals the original | Standard payload round-trip |
| 3 | `TestCloudPickleSerializer` | A locally-defined lambda | The serializer dumps and loads it | The restored callable returns the same value | Cloudpickle delegation preserved |
| 4 | `TestCloudPickleSerializer` | A guarded type instance | `pickle.dumps` and `cloudpickle.dumps` are called on it | Both raise `TypeError` from the `__reduce_ex__` guard | Vanilla pickle rejection |
| 5 | `TestCloudPickleSerializer` | Arbitrary text, integer, binary, or list payloads (Hypothesis) | The serializer dumps and loads each | Each round-trips to an equal value | Property-based round-trip |
| 6 | `TestCloudPickleSerializer` | Two distinct serializer instances | Their hashes are computed | The hashes are equal so the LRU cache deduplicates them | Cache compatibility |
| 7 | `TestCloudPickleSerializer` | Two distinct serializer instances | They are compared for equality | They compare equal so the cache treats them as one key | Cache compatibility |
| 8 | `TestCloudPickleSerializer` | A `CloudPickleSerializer` and an arbitrary other object | They are compared for equality | They do not compare equal | Cross-type equality |
| 9 | `TestDefaultSerializer` | The module-level `DEFAULT_SERIALIZER` constant | Its type is inspected | It is a `CloudPickleSerializer` instance | Singleton identity |
| 10 | `TestWorkerProxy` | A `WorkerProxy` instance | `pickle.dumps` and `cloudpickle.dumps` are called on it directly | Both raise `TypeError` naming Wool's runtime as the supported path | Vanilla pickle rejection |
| 11 | `TestTask` | A `Task` whose proxy implements `__wool_reduce__` and the `__reduce_ex__` guard | `to_protobuf` is called with no explicit `Serializer` | `DEFAULT_SERIALIZER` serializes the proxy successfully via `_WoolPickler` | Default Serializer respects guarded types |

Existing `WorkerProxy` pickle round-trip tests in `tests/runtime/worker/test_proxy.py` (~14 sites) were rewired from `cloudpickle.dumps(proxy)` to `DEFAULT_SERIALIZER.dumps(proxy)` so they continue to verify round-trip behavior through the migrated pickler. The previously-existing `TestWoolPickler` tests were removed when `WoolPickler` became private; their behaviors are covered by `TestCloudPickleSerializer` end-to-end.
