### PR TITLE
Bound shutdown gather in WorkerPool to prevent teardown hangs — Closes #203

### DIFF
--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import sys
 import uuid
@@ -35,6 +36,8 @@ from wool.runtime.worker.proxy import LoadBalancerLike
 from wool.runtime.worker.proxy import RoundRobinLoadBalancer
 from wool.runtime.worker.proxy import WorkerProxy
 from wool.utilities.noreentry import noreentry
+
+logger = logging.getLogger(__name__)
 
 
 # public
@@ -208,13 +211,24 @@ class WorkerPool:
         Defaults to ``60``; pass ``None`` to wait indefinitely. On
         timeout the pool instance becomes unusable (single-use
         semantics); construct a new pool to retry.
+    :param shutdown_timeout:
+        Maximum number of seconds to wait for spawned workers to stop
+        during pool teardown. The bound applies as a single deadline to
+        the full teardown sequence: each worker's ``stop()`` receives
+        ``shutdown_timeout`` as its per-worker bound, the gather waits
+        for whatever time remains, and publisher cleanup gets whatever
+        is left. When the deadline elapses, abandoned worker UIDs are
+        logged via ``logging.warning`` and teardown proceeds. ``None``
+        disables the bound and restores the legacy unbounded wait.
+        Must be positive when provided. Defaults to ``60.0``.
     :param lazy:
         When ``True`` (default), defer discovery setup and the quorum
         wait to the first :meth:`WorkerProxy.dispatch`.  When ``False``,
         eagerly enter the underlying proxy at ``__aenter__`` time and
         run the quorum wait there.
     :raises ValueError:
-        If configuration is invalid or CPU count unavailable.
+        If configuration is invalid, CPU count unavailable, or
+        ``shutdown_timeout`` is not positive.
     :raises asyncio.TimeoutError:
         If the quorum wait does not complete within ``quorum_timeout``
         — raised by the underlying :class:`WorkerProxy` at context
@@ -243,6 +257,7 @@ class WorkerPool:
         credentials: WorkerCredentials | None = None,
         quorum: int | None = DEFAULT_QUORUM,
         quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        shutdown_timeout: float | None = 60.0,
         lazy: bool = DEFAULT_LAZY,
     ):
         """
@@ -263,6 +278,7 @@ class WorkerPool:
         credentials: WorkerCredentials | None = None,
         quorum: int | None = DEFAULT_QUORUM,
         quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        shutdown_timeout: float | None = 60.0,
         lazy: bool = DEFAULT_LAZY,
     ):
         """
@@ -285,6 +301,7 @@ class WorkerPool:
         credentials: WorkerCredentials | None = None,
         quorum: int | None = DEFAULT_QUORUM,
         quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        shutdown_timeout: float | None = 60.0,
         lazy: bool = DEFAULT_LAZY,
     ):
         """
@@ -307,6 +324,7 @@ class WorkerPool:
         credentials: WorkerCredentials | None = None,
         quorum: int | None = DEFAULT_QUORUM,
         quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        shutdown_timeout: float | None = 60.0,
         lazy: bool = DEFAULT_LAZY,
     ): ...
 
@@ -325,6 +343,7 @@ class WorkerPool:
         credentials: WorkerCredentials | None = None,
         quorum: int | None = DEFAULT_QUORUM,
         quorum_timeout: float | None = DEFAULT_QUORUM_TIMEOUT,
+        shutdown_timeout: float | None = 60.0,
         lazy: bool = DEFAULT_LAZY,
     ): ...
 
@@ -342,6 +361,7 @@ class WorkerPool:
         credentials: WorkerCredentials | None = None,
         quorum: int | None = DEFAULT_QUORUM,
         quorum_timeout: float | None | UndefinedType = Undefined,
+        shutdown_timeout: float | None = 60.0,
         lazy: bool = DEFAULT_LAZY,
     ):
         self._workers = {}
@@ -380,6 +400,10 @@ class WorkerPool:
                 IneffectiveQuorumTimeoutWarning,
                 stacklevel=2,
             )
+
+        if shutdown_timeout is not None and shutdown_timeout <= 0:
+            raise ValueError("Shutdown timeout must be positive")
+        self._shutdown_timeout = shutdown_timeout
 
         match (spawn, discovery):
             case (spawn, discovery) if spawn is not None and discovery is not None:
@@ -567,7 +591,7 @@ class WorkerPool:
 
             async def stop(worker):
                 await publisher.publish("worker-dropped", worker.metadata)
-                await worker.stop()
+                await worker.stop(timeout=self._shutdown_timeout)
 
             task = asyncio.create_task(start(worker))
             tasks.append(task)
@@ -579,9 +603,55 @@ class WorkerPool:
                 raise ExceptionGroup("worker spawn failures", errors)
             yield [w.metadata for w in self._workers if w.metadata]
         finally:
-            tasks = [asyncio.create_task(stop) for stop in self._workers.values()]
-            await asyncio.gather(*tasks, return_exceptions=True)
-            await self._exit_context(publisher_ctx)
+            loop = asyncio.get_running_loop()
+            deadline = (
+                None
+                if self._shutdown_timeout is None
+                else loop.time() + self._shutdown_timeout
+            )
+
+            def remaining() -> float | None:
+                if deadline is None:
+                    return None
+                return max(0.0, deadline - loop.time())
+
+            if self._workers:
+                worker_by_task = {
+                    asyncio.create_task(coro): worker
+                    for worker, coro in self._workers.items()
+                }
+                done, pending = await asyncio.wait(worker_by_task, timeout=remaining())
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*done, *pending, return_exceptions=True)
+                abandoned_tasks = set(pending)
+                for task in done:
+                    if not task.cancelled() and isinstance(
+                        task.exception(), TimeoutError
+                    ):
+                        abandoned_tasks.add(task)
+                if abandoned_tasks:
+                    abandoned_uids = sorted(
+                        str(worker_by_task[task].uid) for task in abandoned_tasks
+                    )
+                    logger.warning(
+                        "WorkerPool shutdown abandoned %d worker(s) "
+                        "that did not stop within %ss: %s",
+                        len(abandoned_uids),
+                        self._shutdown_timeout,
+                        abandoned_uids,
+                        extra={"abandoned_worker_uids": abandoned_uids},
+                    )
+
+            try:
+                await asyncio.wait_for(
+                    self._exit_context(publisher_ctx), timeout=remaining()
+                )
+            except TimeoutError:
+                logger.warning(
+                    "WorkerPool publisher cleanup did not complete within %ss",
+                    self._shutdown_timeout,
+                )
 
     def _default_worker_factory(self):
         def factory(*tags, credentials=None):

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -6,6 +6,7 @@ subprocess overhead and ensure deterministic behavior.
 """
 
 import asyncio
+import logging
 import time
 import uuid
 from contextlib import contextmanager
@@ -124,6 +125,66 @@ class TestWorkerPool:
         # Act & assert
         with pytest.raises(ValueError, match="Spawn must be non-negative"):
             WorkerPool(spawn=invalid_spawn)
+
+    def test___init___accepts_positive_shutdown_timeout(self):
+        """Test pool constructs with a positive shutdown_timeout.
+
+        Given:
+            A positive shutdown_timeout value
+        When:
+            WorkerPool is initialized
+        Then:
+            It should construct a valid pool
+        """
+        # Act
+        pool = WorkerPool(spawn=1, shutdown_timeout=5.0)
+
+        # Assert
+        assert isinstance(pool, WorkerPool)
+
+    def test___init___accepts_none_shutdown_timeout(self):
+        """Test pool constructs with shutdown_timeout=None.
+
+        Given:
+            Shutdown_timeout explicitly set to None to opt out of bounding
+        When:
+            WorkerPool is initialized
+        Then:
+            It should construct a valid pool
+        """
+        # Act
+        pool = WorkerPool(spawn=1, shutdown_timeout=None)
+
+        # Assert
+        assert isinstance(pool, WorkerPool)
+
+    def test___init___rejects_zero_shutdown_timeout(self):
+        """Test zero shutdown_timeout raises ValueError.
+
+        Given:
+            A shutdown_timeout of 0
+        When:
+            WorkerPool is initialized
+        Then:
+            It should raise ValueError indicating the timeout must be positive
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="Shutdown timeout must be positive"):
+            WorkerPool(spawn=1, shutdown_timeout=0)
+
+    def test___init___rejects_negative_shutdown_timeout(self):
+        """Test negative shutdown_timeout raises ValueError.
+
+        Given:
+            A negative shutdown_timeout value
+        When:
+            WorkerPool is initialized
+        Then:
+            It should raise ValueError indicating the timeout must be positive
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="Shutdown timeout must be positive"):
+            WorkerPool(spawn=1, shutdown_timeout=-1.0)
 
     def test___init___size_emits_deprecation_warning(self):
         """Test deprecated size parameter emits DeprecationWarning.
@@ -739,6 +800,218 @@ class TestWorkerPool:
         except OSError:
             # Expected - cleanup error propagates as it should
             pass
+
+    @pytest.mark.asyncio
+    async def test___aexit___bounds_teardown_when_worker_stop_hangs(
+        self, mocker: MockerFixture
+    ):
+        """Test pool teardown returns within the configured shutdown bound.
+
+        Given:
+            A WorkerPool whose worker has a stop() that never returns
+        When:
+            The async-with block exits
+        Then:
+            It should complete within a small multiple of shutdown_timeout
+        """
+
+        # Arrange
+        def hanging_factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+
+            async def hang(*, timeout=None):
+                await asyncio.sleep(60)
+
+            worker.stop = hang
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        shutdown_timeout = 0.2
+
+        # Act
+        start = time.monotonic()
+        async with WorkerPool(
+            worker=hanging_factory,
+            spawn=1,
+            shutdown_timeout=shutdown_timeout,
+        ):
+            pass
+        elapsed = time.monotonic() - start
+
+        # Assert
+        assert elapsed < shutdown_timeout * 5
+
+    @pytest.mark.asyncio
+    async def test___aexit___logs_warning_when_workers_abandoned(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test pool logs a warning naming the abandoned worker count.
+
+        Given:
+            A WorkerPool whose worker has a stop() that never returns
+        When:
+            The async-with block exits and the shutdown bound elapses
+        Then:
+            It should emit a logger.warning identifying the abandoned count
+        """
+
+        # Arrange
+        def hanging_factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+
+            async def hang(*, timeout=None):
+                await asyncio.sleep(60)
+
+            worker.stop = hang
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        # Act
+        with caplog.at_level(logging.WARNING, "wool.runtime.worker.pool"):
+            async with WorkerPool(
+                worker=hanging_factory,
+                spawn=1,
+                shutdown_timeout=0.2,
+            ):
+                pass
+
+        # Assert
+        assert any(
+            "abandoned 1 worker" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+
+    @pytest.mark.asyncio
+    async def test___aexit___cancels_pending_stops_after_timeout(
+        self, mocker: MockerFixture
+    ):
+        """Test pending stop coroutines receive CancelledError on timeout.
+
+        Given:
+            A WorkerPool whose worker has a stop() that never returns
+        When:
+            The async-with block exits and the shutdown bound elapses
+        Then:
+            It should cancel the pending stop coroutine
+        """
+        # Arrange
+        cancelled = asyncio.Event()
+
+        def hanging_factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+
+            async def hang(*, timeout=None):
+                try:
+                    await asyncio.sleep(60)
+                except asyncio.CancelledError:
+                    cancelled.set()
+                    raise
+
+            worker.stop = hang
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        # Act
+        async with WorkerPool(
+            worker=hanging_factory,
+            spawn=1,
+            shutdown_timeout=0.2,
+        ):
+            pass
+        await asyncio.wait_for(cancelled.wait(), timeout=1.0)
+
+        # Assert
+        assert cancelled.is_set()
+
+    @pytest.mark.asyncio
+    async def test___aexit___completes_normally_when_workers_stop_within_timeout(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test pool teardown emits no warning when workers stop in time.
+
+        Given:
+            A WorkerPool whose workers stop quickly
+        When:
+            The async-with block exits with shutdown_timeout configured
+        Then:
+            It should complete without an abandonment warning
+        """
+
+        # Arrange
+        def fast_factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+            worker.stop = mocker.AsyncMock()
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        # Act
+        with caplog.at_level(logging.WARNING, "wool.runtime.worker.pool"):
+            async with WorkerPool(
+                worker=fast_factory,
+                spawn=2,
+                shutdown_timeout=1.0,
+            ):
+                pass
+
+        # Assert
+        assert not any(
+            "abandoned" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+
+    @pytest.mark.asyncio
+    async def test___aexit___does_not_block_other_cleanup_when_one_worker_hangs(
+        self, mocker: MockerFixture
+    ):
+        """Test fast worker still stops when a sibling worker's stop hangs.
+
+        Given:
+            A WorkerPool with one hanging worker and one fast worker
+        When:
+            The async-with block exits and the shutdown bound elapses
+        Then:
+            It should call stop on the fast worker and complete within bound
+        """
+        # Arrange
+        fast_stop = mocker.AsyncMock()
+        workers_built: list = []
+
+        def mixed_factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+            worker.metadata = _make_worker_metadata()
+            if not workers_built:
+
+                async def hang(*, timeout=None):
+                    await asyncio.sleep(60)
+
+                worker.stop = hang
+            else:
+                worker.stop = fast_stop
+            workers_built.append(worker)
+            return worker
+
+        shutdown_timeout = 0.2
+
+        # Act
+        start = time.monotonic()
+        async with WorkerPool(
+            worker=mixed_factory,
+            spawn=2,
+            shutdown_timeout=shutdown_timeout,
+        ):
+            pass
+        elapsed = time.monotonic() - start
+
+        # Assert
+        fast_stop.assert_awaited_once()
+        assert elapsed < shutdown_timeout * 5
 
     @pytest.mark.asyncio
     async def test___aenter___default_case_covers_shared_memory_creation(


### PR DESCRIPTION
## Summary

The pool's shutdown gather was unbounded, so a single hung worker.stop() could block __aexit__ indefinitely — most reachably on the quorum-failure cleanup path introduced in #170, where partially-initialized workers are exactly the population most likely to hang on stop. Bound the entire teardown sequence under a single deadline derived from a new shutdown_timeout constructor parameter (default 60.0): each worker's own stop() receives shutdown_timeout as its per-worker bound, the outer asyncio.wait waits for whatever time remains, and publisher cleanup gets whatever is left. Abandoned worker UIDs are surfaced via logger.warning so the signal flows through standard logging pipelines and structured handlers (with extra={"abandoned_worker_uids": [...]}); operators wanting hard-fail can attach a handler that raises. shutdown_timeout=None restores the legacy unbounded behavior for callers that opt out.

Closes #203

## Proposed changes

### Add shutdown_timeout parameter to WorkerPool

- Add the keyword shutdown_timeout: float | None = 60.0 to every __init__ overload and the implementation.
- Validate at construction: raise ValueError("Shutdown timeout must be positive") for non-positive values. None is permitted and disables the bound.
- Document the parameter, the single-deadline semantics, and the validation rule in the class docstring.

### Single-deadline bounded teardown in _worker_context

- Compute a single deadline at the start of the finally block.
- Forward shutdown_timeout into each worker via worker.stop(timeout=shutdown_timeout) — layered defense over the existing protocol kwarg.
- Replace the unbounded asyncio.gather(*tasks, return_exceptions=True) with asyncio.wait(tasks, timeout=remaining()) so the gather honors the deadline.
- Cancel pending stops, drain done and pending via asyncio.gather(*done, *pending, return_exceptions=True) to consume exceptions and let cancellations unwind cleanly, then bound publisher cleanup with asyncio.wait_for(self._exit_context(publisher_ctx), timeout=remaining()).
- Emit a single logger.warning when the deadline elapses — count both pending tasks and done tasks whose worker.stop() returned TimeoutError. The message names the abandoned UIDs; extra={"abandoned_worker_uids": [...]} carries them as structured fields for OTel/logging aggregators.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | \`TestWorkerPool\` | A positive shutdown_timeout value | WorkerPool is initialized | It should construct a valid pool | \`__init__\` accepts positive timeout |
| 2 | \`TestWorkerPool\` | Shutdown_timeout explicitly set to None to opt out of bounding | WorkerPool is initialized | It should construct a valid pool | \`__init__\` accepts None opt-out |
| 3 | \`TestWorkerPool\` | A shutdown_timeout of 0 | WorkerPool is initialized | It should raise ValueError indicating the timeout must be positive | \`__init__\` rejects zero |
| 4 | \`TestWorkerPool\` | A negative shutdown_timeout value | WorkerPool is initialized | It should raise ValueError indicating the timeout must be positive | \`__init__\` rejects negative |
| 5 | \`TestWorkerPool\` | A WorkerPool whose worker has a stop() that never returns | The async-with block exits | It should complete within a small multiple of shutdown_timeout | Bounded teardown |
| 6 | \`TestWorkerPool\` | A WorkerPool whose worker has a stop() that never returns | The async-with block exits and the shutdown bound elapses | It should log a warning identifying the abandoned count | Warning emission |
| 7 | \`TestWorkerPool\` | A WorkerPool whose worker has a stop() that never returns | The async-with block exits and the shutdown bound elapses | It should cancel the pending stop coroutine | Cancellation of pending stops |
| 8 | \`TestWorkerPool\` | A WorkerPool whose workers stop quickly | The async-with block exits with shutdown_timeout configured | It should complete without an abandonment warning | Normal completion path |
| 9 | \`TestWorkerPool\` | A WorkerPool with one hanging worker and one fast worker | The async-with block exits and the shutdown bound elapses | It should call stop on the fast worker and complete within bound | Regression target for the quorum-cleanup path |