### PR TITLE
Drain pending tasks before stopping the worker loop — Closes #202

### DIFF
--- a/wool/src/wool/runtime/worker/service.py
+++ b/wool/src/wool/runtime/worker/service.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from inspect import isawaitable
 from typing import AsyncIterator
 from typing import Awaitable
+from typing import Final
 from typing import Protocol
 from typing import runtime_checkable
 
@@ -28,6 +29,13 @@ from wool.runtime.worker.session import DispatchSession
 from wool.runtime.worker.session import Rejected
 
 _log = logging.getLogger(__name__)
+
+_DRAIN_TIMEOUT: Final[float] = 5.0
+"""Wall-clock timeout in seconds for the multi-generation task drain
+in :meth:`WorkerService._destroy_worker_loop`. Generous enough for a
+normal chain of ``finally``-scheduled cleanup tasks to unwind, short
+enough not to stall worker-loop teardown; past this timeout the drain
+gives up, with the daemon-thread reap as the backstop."""
 
 
 def _safely_serialize_exception(
@@ -726,11 +734,20 @@ class WorkerService(protocol.WorkerServicer):
     ) -> None:
         """Schedule worker-loop shutdown and optionally join the thread.
 
-        Cancels all pending tasks on the worker loop and signals the
-        loop to stop. The loop is closed by the worker thread itself
-        (see :meth:`_create_worker_loop`'s ``_run_then_close`` target),
-        not from this caller's thread — eliminating the close-while-
-        running race.
+        Drains successive generations of pending tasks on the
+        worker loop, then signals the loop to stop. A cancelled
+        task's ``finally`` clause can schedule a second generation
+        of tasks (e.g. follow-up cleanup, fire-and-forget logging,
+        further cancellations, etc.); the drain cancels and awaits
+        successive generations until none remain or
+        :data:`_DRAIN_TIMEOUT` elapses, so the loop closes without
+        leaking ``Task was destroyed but it is pending!`` warnings.
+        If a routine schedules cleanup-of-cleanup past the budget,
+        the drain stops anyway and the daemon-thread reap remains
+        the backstop. The loop is closed by the worker
+        thread itself (see :meth:`_create_worker_loop`'s
+        ``_run_then_close`` target), not from this caller's thread —
+        eliminating the close-while-running race.
 
         Joins the worker thread for up to :attr:`_stop_timeout`
         seconds (set by :meth:`_stop` from the StopRequest's
@@ -748,11 +765,36 @@ class WorkerService(protocol.WorkerServicer):
 
         async def _shutdown():
             current = asyncio.current_task()
-            tasks = [t for t in asyncio.all_tasks() if t is not current and not t.done()]
-            for task in tasks:
-                task.cancel()
-            await asyncio.gather(*tasks, return_exceptions=True)
-            loop.stop()
+            deadline = loop.time() + _DRAIN_TIMEOUT
+            leaked: list[asyncio.Task] = []
+            try:
+                while True:
+                    pending = [
+                        task for task in asyncio.all_tasks() if task is not current
+                    ]
+                    if not pending:
+                        break
+                    for task in pending:
+                        task.cancel()
+                    remaining = deadline - loop.time()
+                    if remaining <= 0:
+                        leaked = pending
+                        break
+                    try:
+                        await asyncio.wait_for(
+                            asyncio.gather(*pending, return_exceptions=True),
+                            timeout=remaining,
+                        )
+                    except TimeoutError:
+                        leaked = pending
+                        break
+                if leaked:
+                    _log.warning(
+                        f"Worker-loop teardown drain timed out after "
+                        f"{_DRAIN_TIMEOUT}s; {len(leaked)} task(s) still pending."
+                    )
+            finally:
+                loop.stop()
 
         try:
             loop.call_soon_threadsafe(lambda: loop.create_task(_shutdown()))

--- a/wool/tests/integration/routines.py
+++ b/wool/tests/integration/routines.py
@@ -439,6 +439,64 @@ async def self_cancel_coroutine():
 
 
 @wool.routine
+async def add_then_schedule_cleanup(a: int, b: int, sentinel_path: str) -> int:
+    """Coroutine that returns the sum and schedules an orphaned cleanup
+    task on the worker loop from its ``finally`` clause.
+
+    Models the fire-and-forget cleanup pattern behind issue #202: a
+    routine whose ``finally`` schedules further work on the worker
+    loop. The scheduled task (:func:`_drain_probe_first_gen`) outlives
+    the dispatch and is left for worker-loop teardown to drain.
+
+    :param a:
+        First addend.
+    :param b:
+        Second addend.
+    :param sentinel_path:
+        Filesystem path threaded through the cleanup chain; the
+        deepest generation writes to it so the caller can verify the
+        teardown drain reached every generation.
+    :returns:
+        The sum ``a + b``.
+    """
+    try:
+        return a + b
+    finally:
+        asyncio.get_running_loop().create_task(_drain_probe_first_gen(sentinel_path))
+
+
+async def _drain_probe_first_gen(sentinel_path: str) -> None:
+    """First-generation orphan task scheduled by
+    :func:`add_then_schedule_cleanup`.
+
+    Awaits indefinitely until worker-loop teardown cancels it, then
+    schedules the second generation from its own ``finally`` clause —
+    the generation a single-pass shutdown drain never observes.
+    """
+    try:
+        await asyncio.Event().wait()
+    finally:
+        asyncio.get_running_loop().create_task(_drain_probe_second_gen(sentinel_path))
+
+
+async def _drain_probe_second_gen(sentinel_path: str) -> None:
+    """Second-generation orphan task scheduled by
+    :func:`_drain_probe_first_gen`.
+
+    Writes ``"drained"`` to *sentinel_path* from its ``finally``
+    clause. The file appears only if the worker-loop teardown drain
+    cancels and awaits this generation; a single-pass drain leaves it
+    pending and unstarted, so the absence of the file flags the
+    issue #202 regression.
+    """
+    try:
+        await asyncio.Event().wait()
+    finally:
+        with open(sentinel_path, "w") as f:
+            f.write("drained")
+
+
+@wool.routine
 @context_pattern_aware
 async def nested_add(a: int, b: int) -> int:
     """Coroutine that dispatches to ``add``, triggering nested dispatch."""

--- a/wool/tests/integration/test_worker_shutdown.py
+++ b/wool/tests/integration/test_worker_shutdown.py
@@ -1,0 +1,42 @@
+"""Integration tests for worker-loop teardown task draining."""
+
+import pytest
+
+from . import routines
+from .conftest import build_pool_from_scenario
+from .conftest import default_scenario
+
+
+@pytest.mark.integration
+class TestWorkerLoopDrain:
+    @pytest.mark.asyncio
+    async def test_graceful_shutdown_drains_second_generation_cleanup_tasks(
+        self, tmp_path, credentials_map, retry_grpc_internal
+    ):
+        """Test that worker-loop teardown drains every generation of
+        pending cleanup tasks.
+
+        Given:
+            A routine whose finally clause schedules an orphaned cleanup
+            task that, when cancelled during teardown, schedules a
+            further cleanup task.
+        When:
+            A worker pool is dispatched the routine and then torn down.
+        Then:
+            It should drain every generation, so the deepest cleanup
+            task runs its finally clause and writes its sentinel file.
+        """
+        # Arrange
+        sentinel = tmp_path / "drain-sentinel.txt"
+        scenario = default_scenario()
+
+        # Act
+        async def body():
+            async with build_pool_from_scenario(scenario, credentials_map):
+                result = await routines.add_then_schedule_cleanup(1, 2, str(sentinel))
+                assert result == 3
+
+        await retry_grpc_internal(body)
+
+        # Assert
+        assert sentinel.read_text() == "drained"

--- a/wool/tests/runtime/worker/test_service.py
+++ b/wool/tests/runtime/worker/test_service.py
@@ -104,6 +104,56 @@ _stop_cancellation_observed: threading.Event | None = None
 # suspended in its long sleep.
 _stop_routine_started: threading.Event | None = None
 
+# Cross-loop side-channel for the issue #202 worker-loop drain test
+# (``test_stop_with_orphaned_cleanup_chain``). The second-generation
+# cleanup task runs on the worker loop and sets this
+# :class:`threading.Event`; the test asserts on it from the main loop.
+# The probe routine schedules a two-generation cleanup chain whose
+# second generation is observed only when worker-loop teardown drains
+# every generation, not just the first.
+_drain_cleanup_observed: threading.Event | None = None
+
+
+async def _drain_probe_routine():
+    """Routine that schedules an orphaned cleanup chain on the worker
+    loop from its ``finally`` clause.
+
+    Models the issue #202 teardown scenario: the ``finally`` schedules
+    a first-generation cleanup task that, once cancelled by worker-loop
+    teardown, schedules a second generation. A single-pass drain never
+    observes that second generation.
+    """
+    try:
+        return "drain-probe-done"
+    finally:
+        asyncio.get_running_loop().create_task(_drain_probe_first_gen())
+
+
+async def _drain_probe_first_gen():
+    """First-generation orphan scheduled by :func:`_drain_probe_routine`.
+
+    Awaits indefinitely until worker-loop teardown cancels it, then
+    schedules the second generation from its own ``finally`` clause.
+    """
+    try:
+        await asyncio.Event().wait()
+    finally:
+        asyncio.get_running_loop().create_task(_drain_probe_second_gen())
+
+
+async def _drain_probe_second_gen():
+    """Second-generation orphan scheduled by :func:`_drain_probe_first_gen`.
+
+    Sets :data:`_drain_cleanup_observed` from its ``finally`` clause.
+    The event is set only when worker-loop teardown drains every
+    generation, not just the first.
+    """
+    try:
+        await asyncio.Event().wait()
+    finally:
+        if _drain_cleanup_observed is not None:
+            _drain_cleanup_observed.set()
+
 
 class _AttributeRejectingRoutineError(Exception):
     """Module-level exception class for the A4 regression test.
@@ -2181,6 +2231,53 @@ class TestWorkerService:
             stop_result = await asyncio.wait_for(stop_task, 5)
             assert isinstance(stop_result, protocol.Void)
             assert service.stopped.is_set()
+
+    @pytest.mark.asyncio
+    async def test_stop_with_orphaned_cleanup_chain(
+        self, grpc_aio_stub, grpc_servicer, mock_worker_proxy_cache
+    ):
+        """Test :class:`WorkerService` stop drains every generation of
+        orphaned worker-loop tasks.
+
+        Given:
+            A dispatched routine whose finally clause schedules an
+            orphaned cleanup task that, when cancelled during teardown,
+            schedules a further cleanup task
+        When:
+            The stop RPC tears down the worker loop
+        Then:
+            It should drain every generation, so the second-generation
+            cleanup task runs its finally clause
+        """
+        global _drain_cleanup_observed
+
+        # Arrange
+        _drain_cleanup_observed = threading.Event()
+        try:
+            mock_proxy = PicklableMock(spec=WorkerProxyLike, id="test-proxy-id")
+            wool_task = Task(
+                id=uuid4(),
+                callable=_drain_probe_routine,
+                args=(),
+                kwargs={},
+                proxy=mock_proxy,
+            )
+            request = protocol.Request(task=wool_task.to_protobuf())
+
+            # Act
+            async with grpc_aio_stub() as stub:
+                stream = stub.dispatch()
+                await stream.write(request)
+                await stream.done_writing()
+                ack, response = [r async for r in stream]
+                assert ack.HasField("ack")
+                assert response.HasField("result")
+                await asyncio.wait_for(stub.stop(protocol.StopRequest(timeout=10)), 5)
+
+            # Assert
+            assert _drain_cleanup_observed.wait(timeout=5)
+        finally:
+            _drain_cleanup_observed = None
 
     @pytest.mark.asyncio
     async def test_dispatch_async_generator_task(

--- a/wool/tests/runtime/worker/test_service.py
+++ b/wool/tests/runtime/worker/test_service.py
@@ -84,6 +84,18 @@ async def _controllable_task():
 # CancelledError; the test asserts on it from the main loop.
 _a1_cancellation_observed: threading.Event | None = None
 
+# Side-channel for the A1 regression test to confirm the worker
+# routine is actually running before the test cancels the stream.
+# The dispatch ``ack`` only confirms the handler reached its
+# ``yield ack`` — the worker task is scheduled lazily on the
+# handler's first ``async for`` iteration. Cancelling before the
+# routine starts races :meth:`DispatchSession._schedule_worker`,
+# which short-circuits on ``_cancelled`` and never dispatches the
+# routine, leaving nothing for the cancellation to interrupt. The
+# routine sets this event as its first statement; the test waits
+# for it before cancelling.
+_a1_routine_started: threading.Event | None = None
+
 # Cross-loop side-channel for the stop+cancel regression tests
 # (``test_stop_and_cancel`` and ``test_stop_and_cancel_streaming_routine``).
 # The routine on the worker loop signals via this :class:`threading.Event`
@@ -198,10 +210,14 @@ async def _a1_long_routine():
     """Module-level routine for the A1 regression test.
 
     Defined at module level so cloudpickle can serialize the
-    callable for dispatch. Sleeps long enough that the test will
-    have given up; signals the global event if interrupted by
-    :class:`asyncio.CancelledError`.
+    callable for dispatch. Signals :data:`_a1_routine_started` as
+    its first statement so the test can wait for the routine to be
+    running before cancelling. Sleeps long enough that the test
+    will have given up; signals :data:`_a1_cancellation_observed`
+    if interrupted by :class:`asyncio.CancelledError`.
     """
+    if _a1_routine_started is not None:
+        _a1_routine_started.set()
     try:
         await asyncio.sleep(30)
     except asyncio.CancelledError:
@@ -2019,8 +2035,9 @@ class TestWorkerService:
             out because :meth:`cancel` left the worker driver
             task running.
         """
-        global _a1_cancellation_observed
+        global _a1_cancellation_observed, _a1_routine_started
         _a1_cancellation_observed = threading.Event()
+        _a1_routine_started = threading.Event()
         try:
             mock_proxy = PicklableMock(spec=WorkerProxyLike, id="test-proxy-id")
             wool_task = Task(
@@ -2038,6 +2055,27 @@ class TestWorkerService:
                 await stream.write(request)
                 ack = await anext(aiter(stream))
                 assert ack.HasField("ack")
+
+                # Barrier: wait until the worker routine is actually
+                # running before cancelling. The ``ack`` only
+                # confirms the dispatch handler reached its
+                # ``yield ack``; the worker task is scheduled lazily
+                # on the handler's first ``async for`` iteration.
+                # Cancelling before the routine starts races
+                # :meth:`DispatchSession._schedule_worker`, which
+                # short-circuits on ``_cancelled`` and never
+                # dispatches the routine — leaving nothing for the
+                # cancellation to interrupt and failing this test
+                # spuriously. Off-loop wait, mirroring
+                # ``_stop_routine_started``.
+                loop = asyncio.get_running_loop()
+                started = await loop.run_in_executor(
+                    None, _a1_routine_started.wait, 10.0
+                )
+                assert started, (
+                    "Worker routine did not start within 10s — "
+                    "cannot test cancellation propagation"
+                )
 
                 # Client-side cancel — simulates a caller that
                 # has given up (network drop, deadline, explicit
@@ -2066,7 +2104,6 @@ class TestWorkerService:
                 # absorb that variability while still failing fast
                 # if the chain is actually broken (regression would
                 # see the routine sleep the full 30s).
-                loop = asyncio.get_running_loop()
                 observed = await loop.run_in_executor(
                     None, _a1_cancellation_observed.wait, 10.0
                 )
@@ -2082,6 +2119,7 @@ class TestWorkerService:
             )
         finally:
             _a1_cancellation_observed = None
+            _a1_routine_started = None
 
     @pytest.mark.asyncio
     async def test_stop_timeout_then_cancel(


### PR DESCRIPTION
## Summary

`WorkerService._destroy_worker_loop` scheduled a single `asyncio.gather` over a one-time snapshot of pending worker-loop tasks before calling `loop.stop()`. A cancelled task whose `finally` clause scheduled new work — a follow-up cleanup, fire-and-forget logging, a further cancellation — produced a second generation of tasks the gather never observed. Those tasks were still pending when the worker thread closed the loop, surfacing `Task was destroyed but it is pending!` during graceful shutdown.

Replace the snapshot gather with a bounded drain loop that re-scans `asyncio.all_tasks()` and cancels successive generations until none remain or the new `_DRAIN_TIMEOUT` budget elapses. The budget caps the wait so a routine scheduling cleanup-of-cleanup cannot block teardown indefinitely; the daemon-thread reap remains the backstop.

Closes #202

## Proposed changes

### Bounded multi-generation drain in `_destroy_worker_loop`

The `_shutdown` coroutine drains in a loop: each iteration re-scans `asyncio.all_tasks()`, cancels every pending task, and awaits that generation, so a generation scheduled by a prior generation's `finally` clause is picked up on the next pass. The loop exits as soon as no pending tasks remain. Each generation's `gather` is bounded by `asyncio.wait_for` against the time left in a new module-level `_DRAIN_TIMEOUT` (5.0s) budget, so the budget is a true wall-clock cap — a routine that ignores cancellation cannot wedge the drain. `loop.stop()` runs from a `finally`, so worker-loop teardown completes even if `_shutdown` is interrupted; if the budget is exhausted with tasks still pending, a `logging.warning` records the abandoned count.

`_DRAIN_TIMEOUT` is a module constant rather than a constructor parameter — worker-loop teardown is internal hygiene, not a caller-facing knob, and it is independent of the `stop` RPC's `timeout` (which bounds the caller-thread join, not the worker-loop drain).

### Regression coverage

A standalone integration test dispatches a routine whose `finally` schedules a three-generation orphaned cleanup chain to a real subprocess worker; the deepest generation writes a sentinel file. An in-process unit test drives the same chain through the `Dispatch` and `Stop` gRPC surface, observing the deepest generation via a cross-loop `Event`. Both assert the deepest generation runs — which holds only when teardown drains every generation, not a single snapshot. Verified by reverting the fix: both tests fail against the pre-fix single-gather code.

### Pre-existing test flake fix

`test_dispatch_client_cancellation_propagates_to_routine` (added by #201) cancelled the dispatch stream as soon as it received the ack, racing the lazy worker-routine scheduling. Under CPU contention the cancel could land before the routine was scheduled, so `DispatchSession._schedule_worker` short-circuited on `_cancelled` and never dispatched the routine — failing the test spuriously. This surfaced as an intermittent Python 3.11 CI failure on this PR; reproduced on Linux/3.11 under load and confirmed to fail on the untouched base too, so it is pre-existing and not introduced here. Fixed by adding a worker-start barrier mirroring the existing `_stop_routine_started` pattern; verified at 80/80 passes under the load that previously failed.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerLoopDrain` | A routine whose finally clause schedules a cleanup task that, on cancellation, schedules a further cleanup task | A subprocess-worker pool is dispatched the routine and torn down | The deepest-generation cleanup task runs and writes its sentinel file | End-to-end multi-generation drain via the `Stop` RPC and `WorkerPool` teardown |
| 2 | `TestWorkerService` | A `WorkerService` dispatched a routine whose finally clause schedules a multi-generation cleanup chain on the worker loop | The `Stop` RPC tears down the worker loop | The deepest cleanup generation runs before the loop closes and stop completes cleanly | Bounded drain loop in `_destroy_worker_loop` |

_`test_dispatch_client_cancellation_propagates_to_routine` in `tests/runtime/worker/test_service.py` was also **modified** (a worker-start barrier added), not new coverage — see "Pre-existing test flake fix" above._