### PR TITLE
Routine teardown can leak pooled resource references under cancellation — Closes #215

### DIFF
--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
+from typing import Any
 from typing import AsyncGenerator
+from typing import Coroutine
 from typing import Final
 from typing import Generic
 from typing import TypeAlias
@@ -26,6 +29,8 @@ _DispatchCall: TypeAlias = grpc.aio.StreamStreamCall[protocol.Request, protocol.
 _PoolKey: TypeAlias = tuple[str, grpc.ChannelCredentials | None, ChannelOptions]
 
 _T = TypeVar("_T")
+
+_log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -95,6 +100,79 @@ async def clear_channel_pool() -> None:
     UDS targets.
     """
     await _channel_pool.clear()
+
+
+_TEARDOWN_TIMEOUT: Final = 60.0
+
+
+async def _complete_teardown(teardown: Coroutine[Any, Any, None]) -> None:
+    """Drive *teardown* to completion, immune to caller cancellation.
+
+    Resource teardown registered on an :class:`AsyncExitStack`
+    awaits its release callbacks. When the caller task carries a
+    pending cancellation — externally via ``task.cancel()`` or after
+    a worker-side ``CancelledError`` bumped ``cancelling()`` in
+    :meth:`_DispatchStream._read_next` — asyncio would pre-empt the
+    next suspending teardown ``await`` and skip the remaining
+    callbacks, leaking a pooled resource reference.
+
+    Running *teardown* as a shielded child task gives it an
+    independent cancellation state, so its ``await`` boundaries run
+    uninterrupted. A cancellation observed while waiting is deferred
+    and re-raised once teardown finishes, so the caller still
+    observes the cancel.
+
+    A teardown-side exception other than ``CancelledError`` propagates
+    and supersedes a deferred cancel, mirroring ``finally`` precedence.
+    ``KeyboardInterrupt`` and ``SystemExit`` are captured off the child
+    task — where they would otherwise escape straight to the event-loop
+    runner via ``Task.__step`` — and re-raised in the caller's context.
+    If teardown does not finish within :data:`_TEARDOWN_TIMEOUT` the
+    caller is unblocked and the shielded task is left running detached
+    so the release still completes.
+    """
+    interrupt: KeyboardInterrupt | SystemExit | None = None
+
+    async def _run() -> None:
+        # Capture process-level signals here, inside the child task's
+        # own frame: a ``KeyboardInterrupt``/``SystemExit`` raised by a
+        # task escapes to the event-loop runner rather than to the
+        # awaiter, so it must not be left to propagate out of the task.
+        nonlocal interrupt
+        try:
+            await teardown
+        except (KeyboardInterrupt, SystemExit) as exc:
+            interrupt = exc
+
+    task = asyncio.ensure_future(_run())
+    deferred: asyncio.CancelledError | None = None
+    while True:
+        try:
+            async with asyncio.timeout(_TEARDOWN_TIMEOUT):
+                await asyncio.shield(task)
+        except TimeoutError:
+            # Teardown is wedged — only reachable under pathological
+            # pool-lock contention. Stop blocking the caller; the
+            # shielded task keeps running so the release still
+            # completes, just not synchronously.
+            _log.warning(
+                "Routine teardown exceeded %.0fs; pooled-resource "
+                "release deferred to a detached task.",
+                _TEARDOWN_TIMEOUT,
+            )
+            break
+        except asyncio.CancelledError as exc:
+            if not task.done():
+                # Caller cancelled mid-teardown — keep the shielded
+                # task running and re-await it on the next iteration.
+                deferred = exc
+                continue
+            raise
+        break
+    if interrupt is not None:
+        raise interrupt
+    if deferred is not None:
+        raise deferred
 
 
 class _DispatchStream(Generic[_T]):
@@ -811,8 +889,15 @@ class WorkerConnection:
         exit path — setup failure, priming-yield ``GeneratorExit``,
         mid-stream exception, natural end of stream — unwinds the
         stack and releases every resource exactly once.
+
+        The stack unwind is driven through :func:`_complete_teardown`
+        so the release callbacks run to completion even when the
+        caller task is mid-cancellation — otherwise a pending
+        ``CancelledError`` could pre-empt ``AsyncExitStack.__aexit__``
+        and leak a pooled channel reference.
         """
-        async with AsyncExitStack() as stack:
+        stack = AsyncExitStack()
+        try:
             if use_passthrough:
                 # Pin the per-task passthrough serializer for the
                 # streaming generator's lifetime. Self-dispatch
@@ -886,3 +971,12 @@ class WorkerConnection:
             # uncaught; the AsyncExitStack's ``_safe_cancel``
             # callback fires on unwind to cancel the in-flight
             # gRPC call.
+        finally:
+            # Shield the stack unwind from caller cancellation so
+            # every pooled-resource release callback runs — see
+            # :func:`_complete_teardown`. ``aclose()`` drives each
+            # registered ``__aexit__`` with no exception info; that
+            # is equivalent to the implicit ``async with`` exit only
+            # because every context manager on this stack is
+            # exception-agnostic.
+            await _complete_teardown(stack.aclose())

--- a/wool/src/wool/runtime/worker/session.py
+++ b/wool/src/wool/runtime/worker/session.py
@@ -43,6 +43,7 @@ from wool.runtime.routine.task import routine_scope
 from wool.runtime.serializer import PassthroughSerializer
 from wool.runtime.serializer import Serializer
 from wool.runtime.serializer import _passthrough_pool
+from wool.runtime.worker.connection import _complete_teardown
 
 __all__ = ["DispatchSession", "Rejected"]
 
@@ -522,7 +523,7 @@ class DispatchSession:
         not be silently dropped during cleanup.
         """
         try:
-            await self._stack.aclose()
+            await _complete_teardown(self._stack.aclose())
         except (KeyboardInterrupt, SystemExit):
             raise
         except Exception:
@@ -828,7 +829,12 @@ class DispatchSession:
                 )
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        return await self._stack.__aexit__(exc_type, exc_val, exc_tb)
+        # Shield the stack unwind from caller cancellation so the
+        # pooled passthrough-serializer release runs to completion —
+        # see :func:`_complete_teardown`. The registered managers
+        # never suppress, so discarding the suppression return value
+        # (always falsy here) is behaviour-preserving.
+        await _complete_teardown(self._stack.aclose())
 
     def __aiter__(self) -> AsyncIterator[_Response]:
         if self._iterator is None:

--- a/wool/tests/integration/test_unified_driver.py
+++ b/wool/tests/integration/test_unified_driver.py
@@ -734,3 +734,69 @@ class TestUnifiedDriverShape:
                 assert not isinstance(exc_info.value, UnexpectedResponse)
 
         await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_async_gen_caller_cancel_midstream_releases_channel_pool_ref(
+        self, credentials_map, retry_grpc_internal, tmp_path
+    ):
+        """Test caller cancellation mid-stream releases the pooled
+        channel reference.
+
+        Given:
+            An async-generator routine yielding ``"alive"`` forever
+            inside a ``try/finally``, dispatched through an
+            EPHEMERAL pool (cross-process worker) and consumed by a
+            task that is cancelled while awaiting a value.
+        When:
+            The caller task is cancelled mid-stream and awaited.
+        Then:
+            It should raise :class:`asyncio.CancelledError`, run the
+            worker-side ``finally``, and return the caller's channel
+            pool to its pre-dispatch referenced-entry count — no
+            leaked reference.
+        """
+
+        async def body():
+            # Arrange
+            from wool.runtime.worker import connection
+
+            scenario = default_scenario(
+                shape=RoutineShape.ASYNC_GEN_ACLOSE,
+                pool_mode=PoolMode.EPHEMERAL,
+            )
+            sentinel = tmp_path / "cleanup_reason.txt"
+
+            # Act
+            async with build_pool_from_scenario(scenario, credentials_map):
+                baseline = connection._channel_pool.stats.referenced_entries
+                collected = []
+                started = asyncio.Event()
+
+                async def consume():
+                    gen = routines.cancellable_gen(str(sentinel))
+                    collected.append(await gen.__anext__())
+                    started.set()
+                    # Park awaiting the next value — the caller
+                    # cancels the task here, mid-stream.
+                    collected.append(await gen.__anext__())
+
+                task = asyncio.create_task(consume())
+                await asyncio.wait_for(started.wait(), timeout=15)
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+                # Poll up to 15s for the worker's ``finally`` to
+                # write the sentinel — it runs after the gRPC stream
+                # tears down and tolerates CI load.
+                for _ in range(150):
+                    if sentinel.exists() and sentinel.read_text() == "cleaned_up":
+                        break
+                    await asyncio.sleep(0.1)
+
+                # Assert
+                assert collected == ["alive"]
+                assert sentinel.read_text() == "cleaned_up"
+                assert connection._channel_pool.stats.referenced_entries == baseline
+
+        await retry_grpc_internal(body)

--- a/wool/tests/runtime/worker/test_connection.py
+++ b/wool/tests/runtime/worker/test_connection.py
@@ -844,6 +844,135 @@ class TestWorkerConnection:
         assert mock_call.cancel.called
 
     @pytest.mark.asyncio
+    async def test_dispatch_cancelled_during_teardown_releases_channel_ref(
+        self, mocker: MockerFixture, sample_task, mock_grpc_call, async_stream
+    ):
+        """Test external cancellation during teardown releases the
+        pooled channel reference.
+
+        Given:
+            A dispatched task whose result stream runs to exhaustion
+            into teardown, with the process-wide channel pool's lock
+            held so the release callback suspends, and the consuming
+            task cancelled while parked in that suspended release.
+        When:
+            The lock is released and the cancelled task is awaited.
+        Then:
+            It should leave the channel pool with zero referenced
+            entries — the dispatch-scope reference is released
+            despite the caller's pending cancellation.
+        """
+        # Arrange
+        from wool.runtime.worker import connection as connection_module
+
+        # Contend the pool lock on a fresh instance so it does not
+        # bind the process-global lock to this test's event loop.
+        mocker.patch.object(connection_module._channel_pool, "_lock", asyncio.Lock())
+        responses = (
+            protocol.Response(ack=protocol.Ack()),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("done"))),
+        )
+        mock_call = mock_grpc_call(async_stream(responses))
+        mock_stub = mocker.MagicMock()
+        mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
+        stream = await connection.dispatch(sample_task)
+        pool = connection_module._channel_pool
+
+        # Act
+        await pool._lock.acquire()
+        lock_released = False
+        try:
+
+            async def consume():
+                async for _ in stream:
+                    pass
+
+            task = asyncio.ensure_future(consume())
+            for _ in range(5):
+                await asyncio.sleep(0)
+            task.cancel()
+            pool._lock.release()
+            lock_released = True
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            if not lock_released:
+                pool._lock.release()
+
+        # Assert
+        assert pool.stats.referenced_entries == 0
+
+    @pytest.mark.asyncio
+    async def test_dispatch_response_exception_with_cancelled_error_releases_channel_ref(
+        self, mocker: MockerFixture, sample_task, mock_grpc_call, async_stream
+    ):
+        """Test a worker-side CancelledError releases the pooled
+        channel reference during teardown.
+
+        Given:
+            A dispatched task whose worker ships an
+            ``asyncio.CancelledError`` on the response exception
+            frame — which bumps the caller's pending-cancel state —
+            with the process-wide channel pool's lock held so the
+            release callback suspends.
+        When:
+            The lock is released and the consuming task is awaited.
+        Then:
+            It should leave the channel pool with zero referenced
+            entries — the dispatch-scope reference is released
+            despite the worker-induced pending cancellation.
+        """
+        # Arrange
+        from wool.runtime.worker import connection as connection_module
+
+        # Contend the pool lock on a fresh instance so it does not
+        # bind the process-global lock to this test's event loop.
+        mocker.patch.object(connection_module._channel_pool, "_lock", asyncio.Lock())
+        cancellation = asyncio.CancelledError("worker self-raised cancel")
+        responses = (
+            protocol.Response(ack=protocol.Ack()),
+            protocol.Response(
+                exception=protocol.Message(dump=cloudpickle.dumps(cancellation)),
+            ),
+        )
+        mock_call = mock_grpc_call(async_stream(responses))
+        mock_stub = mocker.MagicMock()
+        mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
+        stream = await connection.dispatch(sample_task)
+        pool = connection_module._channel_pool
+
+        # Act
+        await pool._lock.acquire()
+        lock_released = False
+        try:
+
+            async def consume():
+                async for _ in stream:
+                    pass
+
+            task = asyncio.ensure_future(consume())
+            for _ in range(5):
+                await asyncio.sleep(0)
+            pool._lock.release()
+            lock_released = True
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        finally:
+            if not lock_released:
+                pool._lock.release()
+
+        # Assert
+        assert pool.stats.referenced_entries == 0
+
+    @pytest.mark.asyncio
     async def test_close_idempotent(self, mocker: MockerFixture):
         """Test closing a connection is idempotent.
 

--- a/wool/tests/runtime/worker/test_session.py
+++ b/wool/tests/runtime/worker/test_session.py
@@ -388,6 +388,64 @@ class TestDispatchSession:
         assert _passthrough_pool.stats.referenced_entries == baseline
 
     @pytest.mark.asyncio
+    async def test___aexit___releases_passthrough_pool_ref_under_cancellation(
+        self, worker_loop, mock_worker_proxy_cache, mocker: MockerFixture
+    ):
+        """Test __aexit__ releases the passthrough-pool entry when the
+        session is cancelled mid-teardown.
+
+        Given:
+            A passthrough self-dispatch session whose teardown release
+            suspends on a held pool lock, with the session task
+            cancelled while parked in that suspended release.
+        When:
+            The lock is released and the cancelled session task is
+            awaited.
+        Then:
+            It should return the passthrough pool to its pre-dispatch
+            referenced-entry count — no leaked reference.
+        """
+        # Arrange
+        # Contend the pool lock on a fresh instance so it does not
+        # bind the process-global lock to this test's event loop.
+        mocker.patch.object(_passthrough_pool, "_lock", asyncio.Lock())
+        baseline = _passthrough_pool.stats.referenced_entries
+        serializer = PassthroughSerializer()
+        task = _make_task(_coro_returning_default)
+        stream = _stream(_request_for(task, serializer=serializer))
+        entered = asyncio.Event()
+        proceed = asyncio.Event()
+
+        async def run_session():
+            async with DispatchSession(stream, worker_loop):
+                entered.set()
+                # Hold inside the context until the test has grabbed
+                # the pool lock, so __aexit__'s teardown release
+                # suspends on it.
+                await proceed.wait()
+
+        # Act
+        session_task = asyncio.ensure_future(run_session())
+        await entered.wait()
+        await _passthrough_pool._lock.acquire()
+        lock_released = False
+        try:
+            proceed.set()
+            for _ in range(5):
+                await asyncio.sleep(0)
+            session_task.cancel()
+            _passthrough_pool._lock.release()
+            lock_released = True
+            with pytest.raises(asyncio.CancelledError):
+                await session_task
+        finally:
+            if not lock_released:
+                _passthrough_pool._lock.release()
+
+        # Assert
+        assert _passthrough_pool.stats.referenced_entries == baseline
+
+    @pytest.mark.asyncio
     async def test___aenter___with_sync_callable_task(
         self, worker_loop, mock_worker_proxy_cache
     ):


### PR DESCRIPTION
## Summary

Fix a pooled-resource reference leak in routine teardown. Routine teardown drives an `AsyncExitStack` unwind whose registered callbacks `await` a release on a process-wide reference-counted pool; when the surrounding task carries a pending cancellation — set externally via `task.cancel()`, or by the worker-side `CancelledError` parity introduced in #213 — and a teardown `await` suspends, asyncio pre-empts the remaining release callbacks on the stack, leaking the pooled reference until TTL eviction (or process exit).

Two teardown sites are affected and fixed:
- **Caller side** — `WorkerConnection._execute` pins the pooled `_Channel` reference on an `AsyncExitStack`.
- **Worker side** — `DispatchSession.__aexit__` unwinds an `AsyncExitStack` pinning a `_passthrough_pool` serializer slot.

Both unwinds are now driven through a new `_complete_teardown` helper that runs them as a shielded child task with independent cancellation state, so every release callback runs to completion regardless of the surrounding task's cancel state. Any cancellation observed while waiting is deferred and re-raised once teardown finishes, preserving cancel semantics; a process-level `KeyboardInterrupt` or `SystemExit` is captured off the child task and re-raised in the caller's context; and if teardown does not complete within a bounded timeout the caller is unblocked and the shielded task is left running so the release still completes.

Closes #215

## Proposed changes

### Shield dispatch teardown from caller cancellation

`connection.py` gains a module-level `_complete_teardown(teardown)` helper: it runs the teardown coroutine as an `asyncio.ensure_future` child task, awaits it through `asyncio.shield` under a bounded timeout, and re-raises any deferred `CancelledError` only after the child completes. Process-level `KeyboardInterrupt`/`SystemExit` are caught inside the child task — where, raised by a task, they would otherwise escape straight to the event-loop runner rather than to the awaiter — and re-raised on the caller's frame. `WorkerConnection._execute` replaces `async with AsyncExitStack() as stack` with an explicit `stack` guarded by `try/finally`, where the `finally` drives `stack.aclose()` through `_complete_teardown`. The single `finally` covers every teardown exit path — setup failure, the priming-yield and stream-yield `GeneratorExit` of a caller `aclose()`, a mid-stream exception, and natural end of stream. Behaviour is otherwise unchanged — the registered context managers ignore exception details, so `aclose()` is equivalent to the previous implicit `__aexit__`.

`_DispatchStream.aclose` was audited and needs no change: it pins no pooled resource and its only cleanup is a synchronous `call.cancel()`, so it has no suspending `await` for a cancellation to pre-empt.

### Shield worker-side session teardown

`DispatchSession.__aexit__` and `_safe_aclose_stack` (`session.py`) drive their `AsyncExitStack` unwind — which pins a `_passthrough_pool` serializer slot — through the same `_complete_teardown` helper, closing the worker-side variant of the same leak.

### Regression and integration test coverage

Three unit regression tests exercise the teardown paths under external and worker-side cancellation — two in `TestWorkerConnection` (caller-side `_channel_pool`) and one in `TestDispatchSession` (worker-side `_passthrough_pool`); each contends a per-test pool lock to force a suspending teardown `await` and fails against the pre-fix code. One cross-process integration guard in `TestUnifiedDriverShape` cancels a streaming routine mid-stream and asserts the same invariant end to end.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerConnection` | A dispatched task run to stream exhaustion into teardown with the channel-pool lock held | The consuming task is cancelled while parked in the suspended release | The channel pool returns to its pre-dispatch referenced-entry count | Caller-side external-cancel teardown leak |
| 2 | `TestWorkerConnection` | A dispatch whose worker ships `CancelledError` on the response exception frame with the channel-pool lock held | The lock is released and the consuming task is awaited | The channel pool returns to its pre-dispatch referenced-entry count | Caller-side worker-cancel teardown leak |
| 3 | `TestDispatchSession` | A passthrough self-dispatch session whose teardown release suspends on a held pool lock | The session task is cancelled mid-teardown, then the lock is released | The passthrough pool returns to its pre-dispatch referenced-entry count | Worker-side teardown leak |
| 4 | `TestUnifiedDriverShape` | A streaming routine dispatched cross-process through an EPHEMERAL pool | The consuming task is cancelled mid-stream | `CancelledError` propagates, the worker `finally` runs, and the channel pool returns to baseline | End-to-end cancellation teardown |