### PR TITLE
Recover from a transient first-dispatch quorum timeout instead of latching the proxy permanently — Closes #238

### DIFF
--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -270,7 +270,7 @@ Proxies on worker subprocesses are lazy by default — the `WorkerPool` propagat
 
 | `lazy` | `enter()` / `__aenter__` | `dispatch()` | `exit()` on un-started proxy |
 | ------ | ------------------------ | ------------- | ----------------------------- |
-| `True` | Sets context var only | Calls `start()` on first call, then dispatches | No-op (safe to call) |
+| `True` | Sets context var only | Calls `start()` on first call (retrying on a later call if it failed), then dispatches | No-op (safe to call) |
 | `False` | Sets context var, calls `start()` | Raises `RuntimeError` if not started | Raises `RuntimeError` |
 
 When `lazy=True`, concurrent `dispatch()` calls use a double-checked lock to ensure the proxy starts exactly once. The `lazy` flag is preserved through `cloudpickle` serialization, so proxies sent to worker subprocesses as part of a task retain their laziness setting.

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -228,9 +228,13 @@ class WorkerPool:
         ``quorum=None`` or ``quorum=0`` records the value but never
         consults it, accompanied by an
         `~wool.runtime.worker.proxy.IneffectiveQuorumTimeoutWarning`.
-        Defaults to ``60``; pass ``None`` to wait indefinitely. On
-        timeout the pool instance becomes unusable (single-use
-        semantics); construct a new pool to retry.
+        Defaults to ``60``; pass ``None`` to wait indefinitely.  With
+        ``lazy=False`` the timeout fires at ``__aenter__``; the pool,
+        never having entered, is unusable per its single-use
+        semantics, so construct a new pool to retry.  With
+        ``lazy=True`` (default) the timeout fires on the first
+        `WorkerProxy.dispatch`, which leaves the proxy un-started so a
+        later dispatch retries and recovers once a worker is admitted.
     :param shutdown_timeout:
         Maximum number of seconds to wait for spawned workers to stop
         during pool teardown. The bound applies as a single deadline to

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -428,7 +428,6 @@ class WorkerProxy:
 
         self._id: uuid.UUID = uuid.uuid4()
         self._started = False
-        self._start_failure: BaseException | None = None
         self._lazy = lazy
         self._start_lock = asyncio.Lock() if lazy else None
         self._loadbalancer = loadbalancer
@@ -787,18 +786,18 @@ class WorkerProxy:
         quorum; the load balancer surfaces "no workers available"
         directly if the worker set later drains.
 
-        A failed first dispatch (e.g., quorum timeout) is cached on
-        the proxy: every subsequent dispatch re-raises the same
-        exception immediately rather than re-running ``start()`` and
-        paying another ``quorum_timeout`` per attempt.  Construct a
-        new proxy to retry.
+        A failed first dispatch (e.g., quorum timeout) leaves the
+        proxy un-started: the next dispatch re-runs ``start()`` and
+        retries, re-paying the quorum wait.  This lets a pool recover
+        once a worker is admitted, without constructing a new proxy.
 
         :param task:
             The :class:`Task` to dispatch.
         :param timeout:
             Timeout in seconds for getting a worker.
         :returns:
-            A protobuf result object from the worker.
+            An async generator yielding result objects from the
+            worker.
         :raises RuntimeError:
             If the proxy is not started and ``lazy`` is ``False``.
         :raises asyncio.TimeoutError:
@@ -808,18 +807,10 @@ class WorkerProxy:
         if not self._started:
             if not self._lazy:
                 raise RuntimeError("Proxy not started - call start() first")
-            if self._start_failure is not None:
-                raise self._start_failure
             assert self._start_lock is not None
             async with self._start_lock:
-                if self._start_failure is not None:
-                    raise self._start_failure
                 if not self._started:
-                    try:
-                        await self.start()
-                    except BaseException as exc:
-                        self._start_failure = exc
-                        raise
+                    await self.start()
 
         assert isinstance(self._loadbalancer_service, LoadBalancerLike)
         assert self._loadbalancer_context

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -2431,35 +2431,211 @@ class TestWorkerProxy:
         assert wool.__proxy__.get() is None
 
     @pytest.mark.asyncio
-    async def test_dispatch_caches_start_failure(
-        self, mock_discovery_service, mock_wool_task
+    async def test_dispatch_retries_start_after_failed_quorum(
+        self, mocker: MockerFixture
     ):
-        """Test failed start() is cached; subsequent dispatches fail-fast.
+        """Test a failed first dispatch leaves the proxy retryable.
 
         Given:
-            A lazy proxy whose first dispatch will fail with
-            asyncio.TimeoutError due to an unsatisfiable quorum
+            A lazy proxy with quorum=1 whose first dispatch times out
+            because no worker is available, then a worker appears
         When:
-            Two dispatches are attempted in sequence
+            A second dispatch is attempted after the worker is admitted
         Then:
-            The first raises asyncio.TimeoutError and caches it; the
-            second re-raises the same exception instance immediately
+            The first dispatch raises asyncio.TimeoutError and leaves
+            the proxy un-started; the retried dispatch re-runs start()
+            and dispatches successfully
         """
         # Arrange
-        proxy = WorkerProxy(
-            discovery=mock_discovery_service,
-            quorum=2,
-            quorum_timeout=0.01,
+        worker_available = asyncio.Event()
+        metadata = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.100:50051",
+            pid=1001,
+            version="1.0.0",
         )
 
-        # Act
-        with pytest.raises(asyncio.TimeoutError) as first_excinfo:
-            await proxy.dispatch(mock_wool_task)
-        with pytest.raises(asyncio.TimeoutError) as second_excinfo:
-            await proxy.dispatch(mock_wool_task)
+        class RecoverableDiscovery:
+            def __init__(self):
+                self._emitted = False
 
-        # Assert — both dispatches raise the same cached exception
-        assert first_excinfo.value is second_excinfo.value
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                await worker_available.wait()
+                if not self._emitted:
+                    self._emitted = True
+                    return DiscoveryEvent("worker-added", metadata=metadata)
+                await asyncio.Event().wait()
+                raise StopAsyncIteration
+
+        class StubLoadBalancer:
+            def __init__(self):
+                self.dispatched = False
+
+            async def dispatch(self, task, *, context, timeout=None):
+                self.dispatched = True
+
+        stub_lb = StubLoadBalancer()
+        proxy = WorkerProxy(
+            discovery=RecoverableDiscovery(),
+            loadbalancer=stub_lb,
+            quorum=1,
+            quorum_timeout=0.1,
+        )
+        mock_task = mocker.MagicMock(spec=Task)
+
+        # Act — first dispatch times out because no worker is present
+        with pytest.raises(asyncio.TimeoutError):
+            await proxy.dispatch(mock_task)
+
+        # Assert — the failed start left the proxy un-started and retryable
+        assert not proxy.started
+        assert not stub_lb.dispatched
+
+        # Act — a worker appears and a retried dispatch re-runs start()
+        worker_available.set()
+        await asyncio.wait_for(proxy.dispatch(mock_task), timeout=2.0)
+
+        # Assert — the retry started the proxy and dispatched the task
+        assert proxy.started
+        assert stub_lb.dispatched
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_recovers_concurrent_first_dispatch_after_failed_quorum(
+        self, mocker: MockerFixture
+    ):
+        """Test concurrent first dispatches recover after a failed quorum.
+
+        Given:
+            A lazy proxy with quorum=1 whose first start() times out
+            while several dispatches contend for the start lock, then a
+            worker appears
+        When:
+            Several dispatches are attempted concurrently before the
+            worker is admitted, then one more after it is admitted
+        Then:
+            Every concurrent dispatch raises asyncio.TimeoutError and
+            leaves the proxy un-started, and the later dispatch recovers
+            once the worker is present
+        """
+        # Arrange
+        worker_available = asyncio.Event()
+        metadata = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.101:50051",
+            pid=1002,
+            version="1.0.0",
+        )
+
+        class RecoverableDiscovery:
+            def __init__(self):
+                self._emitted = False
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                await worker_available.wait()
+                if not self._emitted:
+                    self._emitted = True
+                    return DiscoveryEvent("worker-added", metadata=metadata)
+                await asyncio.Event().wait()
+                raise StopAsyncIteration
+
+        class StubLoadBalancer:
+            def __init__(self):
+                self.dispatched = False
+
+            async def dispatch(self, task, *, context, timeout=None):
+                self.dispatched = True
+
+        stub_lb = StubLoadBalancer()
+        proxy = WorkerProxy(
+            discovery=RecoverableDiscovery(),
+            loadbalancer=stub_lb,
+            quorum=1,
+            quorum_timeout=0.1,
+        )
+        mock_task = mocker.MagicMock(spec=Task)
+
+        # Act — three dispatches race the first start() while no worker exists
+        results = await asyncio.gather(
+            proxy.dispatch(mock_task),
+            proxy.dispatch(mock_task),
+            proxy.dispatch(mock_task),
+            return_exceptions=True,
+        )
+
+        # Assert — every contender timed out and the proxy stayed un-started
+        assert all(isinstance(result, asyncio.TimeoutError) for result in results)
+        assert not proxy.started
+        assert not stub_lb.dispatched
+
+        # Act — a worker appears and a retried dispatch recovers
+        worker_available.set()
+        await asyncio.wait_for(proxy.dispatch(mock_task), timeout=2.0)
+
+        # Assert — the retry started the proxy and dispatched the task
+        assert proxy.started
+        assert stub_lb.dispatched
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_propagates_quorum_timeout_out_of_context(
+        self, mocker: MockerFixture, mock_proxy_session
+    ):
+        """Test a lazy first-dispatch failure propagates out of context.
+
+        Given:
+            A lazy proxy entered as an async context manager whose first
+            dispatch times out because no worker is ever discovered
+        When:
+            The dispatch is awaited inside the async with block
+        Then:
+            The asyncio.TimeoutError propagates out of the block and the
+            context exit is a safe no-op leaving the proxy un-started
+        """
+
+        # Arrange
+        class EmptyDiscovery:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                await asyncio.Event().wait()
+                raise StopAsyncIteration
+
+        class StubLoadBalancer:
+            def __init__(self):
+                self.dispatched = False
+
+            async def dispatch(self, task, *, context, timeout=None):
+                self.dispatched = True
+
+        stub_lb = StubLoadBalancer()
+        proxy = WorkerProxy(
+            discovery=EmptyDiscovery(),
+            loadbalancer=stub_lb,
+            quorum=1,
+            quorum_timeout=0.1,
+        )
+        mock_task = mocker.MagicMock(spec=Task)
+
+        # Act & assert — the timeout propagates out of the async with block
+        with pytest.raises(asyncio.TimeoutError):
+            async with proxy:
+                await proxy.dispatch(mock_task)
+
+        # Assert — the exit was a safe no-op; the proxy is un-started
+        assert not proxy.started
+        assert not stub_lb.dispatched
 
     @pytest.mark.asyncio
     async def test_dispatch_with_lazy_auto_start(


### PR DESCRIPTION
## Summary

Fix a bug where a transient quorum miss at first dispatch permanently wedged a `WorkerProxy`. The proxy cached the exception from its first `start()` in `_start_failure` and re-raised it on every subsequent `dispatch()` for the life of the proxy, so a single unlucky cold-start request — one that ran the lazy `start()` before any worker had been admitted — turned an `asyncio.TimeoutError` from the quorum gate into a process-lifetime failure. Because `WorkerPool` builds its proxy once on `__aenter__` and never reconstructs it, the documented "construct a new proxy to retry" escape was unreachable and the only recovery was a process restart.

Remove the start-failure latch so a failed `start()` propagates and leaves the proxy un-started. A subsequent dispatch re-acquires the start lock and re-runs `start()`, which succeeds once a worker has been admitted — no process restart, no new pool. The fail-fast path already self-cleans: `start()`'s `AsyncExitStack` unwinds on the quorum-wait exception, rolling back via `_teardown_sentinel` and leaving `_started` false, so the proxy returns to a clean pre-start state. The start lock still serializes concurrent first-dispatch starts, and the `quorum` / `quorum_timeout` gate is unchanged. The known trade-off is that each retry re-pays a `quorum_timeout` and re-subscribes discovery, which is acceptable for restoring recoverability. Teardown and context-manager-exit behavior are untouched.

Closes #238

## Proposed changes

- **Remove the `_start_failure` latch in `WorkerProxy` (`proxy.py`).** Drop the `_start_failure` attribute, the cached-failure fast-path and locked double-check guards, and the `try`/`except` that latched the exception. The lazy-start block in `dispatch()` now acquires `_start_lock` and calls `await self.start()`, letting a failure propagate.
- **Update the documentation to describe recovery instead of the removed latch.** Rewrite the `dispatch()` recovery paragraph and correct its stale `:returns:` line (an async generator of results, not a protobuf object); rescope the `WorkerPool.quorum_timeout` docstring so "construct a new pool to retry" applies only to the `lazy=False` eager-entry timeout, while the default `lazy=True` first-dispatch timeout recovers on a later dispatch; and note retry-on-failure in the worker README lazy-startup table.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerProxy` | A lazy proxy with `quorum=1` whose first dispatch times out because no worker is available, then a worker appears | A second dispatch is attempted after the worker is admitted | The first dispatch raises `asyncio.TimeoutError` and leaves the proxy un-started, and the retried dispatch re-runs `start()` and dispatches successfully | First-dispatch quorum-timeout recovery |
| 2 | `TestWorkerProxy` | A lazy proxy with `quorum=1` whose first `start()` times out while several dispatches contend for the start lock, then a worker appears | Several dispatches are attempted concurrently before the worker is admitted, then one more after | Every concurrent dispatch raises `asyncio.TimeoutError` and leaves the proxy un-started, and the later dispatch recovers once the worker is present | Concurrent first-dispatch recovery |
| 3 | `TestWorkerProxy` | A lazy proxy entered as an async context manager whose first dispatch times out because no worker is ever discovered | The dispatch is awaited inside the `async with` block | The `asyncio.TimeoutError` propagates out of the block and the context exit is a safe no-op leaving the proxy un-started | Exception propagation out of `async with` |