### PR TITLE
Guard `wool.__proxy__` against concurrent clobbering — Closes #230, #256

### DIFF
--- a/wool/src/wool/runtime/context/exceptions.py
+++ b/wool/src/wool/runtime/context/exceptions.py
@@ -141,8 +141,8 @@ _KIND_MESSAGES: dict[str, str] = {
         "wool.to_thread to offload work onto a fresh, detached chain."
     ),
     "task": (
-        "wool.ContextVar accessed by task {current_task!r} but chain "
-        "{chain_id} is owned by task {owning_task!r}; a Wool chain cannot "
+        "wool.ContextVar accessed by task {current_task} but chain "
+        "{chain_id} is owned by task {owning_task}; a Wool chain cannot "
         "be entered by two tasks at once. Each task must run on "
         "its own chain — create child tasks the ordinary way (the task "
         "factory forks a fresh chain per task), or pass a fresh "
@@ -198,17 +198,21 @@ class ChainContention(WoolError):
     :param current_thread:
         Offending thread identity, when *kind* is ``"thread"``.
     :param owning_task:
-        Owner task, when *kind* is ``"task"``.
+        Owner task, when *kind* is ``"task"``; after a cross-process hop
+        the task's ``repr`` string instead (see `__reduce__`).
     :param current_task:
-        Offending task, when *kind* is ``"task"``.
+        Offending task, when *kind* is ``"task"``; after a cross-process
+        hop the task's ``repr`` string instead (see `__reduce__`).
     """
 
     chain_id: UUID
     kind: Literal["thread", "task", "create_task"]
     owning_thread: int | None
     current_thread: int | None
-    owning_task: asyncio.Future[Any] | None
-    current_task: asyncio.Future[Any] | None
+    # Post-wire ``str`` form documented on the ``owning_task`` /
+    # ``current_task`` params (see ``__reduce__``).
+    owning_task: asyncio.Future[Any] | str | None
+    current_task: asyncio.Future[Any] | str | None
 
     def __init__(
         self,
@@ -217,8 +221,8 @@ class ChainContention(WoolError):
         kind: Literal["thread", "task", "create_task"],
         owning_thread: int | None = None,
         current_thread: int | None = None,
-        owning_task: asyncio.Future[Any] | None = None,
-        current_task: asyncio.Future[Any] | None = None,
+        owning_task: asyncio.Future[Any] | str | None = None,
+        current_task: asyncio.Future[Any] | str | None = None,
     ) -> None:
         # Validate ``kind`` explicitly so an unknown value raises a
         # typed ``ValueError`` from a known origin rather than a bare
@@ -255,9 +259,19 @@ class ChainContention(WoolError):
         # ``serializer.dumps`` path, but the type-preserving fallback
         # rebuilds via ``cls(*exc.args)``, which our keyword-only
         # constructor rejects. ``__reduce__`` returning the structured
-        # kwargs as a ``(cls, (), state)`` triple keeps both paths
-        # intact: the structured fields ride the wire, and the message
-        # is re-composed by ``__init__`` on the receiver.
+        # kwargs keeps both paths intact: the structured fields ride the
+        # wire and the message is re-composed by ``__init__`` on the
+        # receiver.
+        #
+        # ``owning_task``/``current_task`` hold live ``asyncio.Task``
+        # objects, which are unpicklable — left as-is a ``kind="task"``
+        # contention fails the primary ``dumps`` *and* the
+        # ``cls(*exc.args)`` fallback, demoting to a plain
+        # ``RuntimeError`` across the wire (wool-labs/wool#256). Substitute
+        # their ``repr`` so the structured identity rides the wire as
+        # diagnostic text; the message templates render a live ``Task``
+        # and its ``repr`` identically, so the reconstructed message is
+        # unchanged.
         return (
             _reconstruct_chain_contention,
             (
@@ -265,8 +279,8 @@ class ChainContention(WoolError):
                 self.kind,
                 self.owning_thread,
                 self.current_thread,
-                self.owning_task,
-                self.current_task,
+                repr(self.owning_task) if self.owning_task is not None else None,
+                repr(self.current_task) if self.current_task is not None else None,
             ),
         )
 
@@ -276,8 +290,8 @@ def _reconstruct_chain_contention(
     kind: Literal["thread", "task", "create_task"],
     owning_thread: int | None,
     current_thread: int | None,
-    owning_task: asyncio.Future[Any] | None,
-    current_task: asyncio.Future[Any] | None,
+    owning_task: asyncio.Future[Any] | str | None,
+    current_task: asyncio.Future[Any] | str | None,
 ) -> ChainContention:
     """Module-level constructor for `ChainContention.__reduce__`."""
     return ChainContention(

--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -252,6 +252,10 @@ Worker subprocesses can dispatch tasks to other workers. Each subprocess is conf
 
 Proxies on worker subprocesses are lazy by default — the `WorkerPool` propagates its `lazy` flag to every `WorkerProxy` it constructs, and each task serializes the proxy (including the flag) so that workers receiving the task inherit the same laziness setting. A lazy proxy defers discovery subscription and worker-sentinel task setup until its first `dispatch()` call, so workers that never invoke nested routines pay no startup cost.
 
+### Concurrent-entry guard
+
+`wool.__proxy__` — the active proxy a nested `@wool.routine` reads to dispatch — is a plain `contextvars.ContextVar`, so it is invisible to the [chain-contention guard](../context/README.md#the-chain-contention-guard). To stop two tasks that share one `contextvars.Context` from silently clobbering each other's proxy (last-write-wins, so both dispatch through the wrong proxy), `WorkerProxy.__aenter__` arms a guarded marker (`WorkerProxy._armed`, a `wool.ContextVar`) before binding the proxy, so a contended second entry fails loud instead of corrupting the first task's dispatch — see `WorkerProxy.__aenter__` for the precise contract. A consequence is that entering a proxy with `async with` arms the chain, even when the routine sets no `wool.ContextVar` of its own. Only the `async with` path arms: the worker pool binds `wool.__proxy__` through `enter()` directly, which deliberately leaves the chain unarmed.
+
 ## Connections
 
 `WorkerProxy` is the client-side bridge between routines and workers. It manages discovery, connection pooling, and load-balanced dispatch.

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -11,6 +11,7 @@ from typing import AsyncGenerator
 from typing import AsyncIterator
 from typing import Awaitable
 from typing import Callable
+from typing import ClassVar
 from typing import ContextManager
 from typing import Final
 from typing import Generic
@@ -26,6 +27,7 @@ from packaging.version import Version
 
 import wool
 from wool.exceptions import WoolWarning
+from wool.runtime.context.var import ContextVar
 from wool.runtime.discovery.base import DiscoveryEvent
 from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.local import LocalDiscovery
@@ -333,6 +335,16 @@ class WorkerProxy:
     )
     _credentials: WorkerCredentials | None
 
+    # ``wool.__proxy__`` is a plain ``contextvars.ContextVar``, invisible to
+    # the chain-contention guard; this ``wool.ContextVar`` is the guarded
+    # marker whose arming brings proxy entry under the guard. The value is an
+    # inert arming sentinel — only ``set`` is consulted (it arms the chain),
+    # so the ``bool`` payload and ``default`` are never read. ``__aenter__``
+    # owns the contention contract.
+    _armed: ClassVar[ContextVar[bool]] = ContextVar(
+        "_armed", namespace="wool", default=False
+    )
+
     @overload
     def __init__(
         self,
@@ -435,6 +447,7 @@ class WorkerProxy:
         self._quorum = quorum
         self._quorum_timeout = quorum_timeout
         self._proxy_token: Token[WorkerProxy | None] | None = None
+        self._exit_stack: AsyncExitStack | None = None
 
         if isinstance(loadbalancer, (ContextManager, AsyncContextManager)):
             warnings.warn(
@@ -503,13 +516,31 @@ class WorkerProxy:
         self._loadbalancer_context: LoadBalancerContext | None = None
 
     async def __aenter__(self):
-        """Enters the proxy context and sets it as the active proxy."""
-        await self.enter()
+        """Enter the proxy context and set it as the active proxy.
+
+        Arm `_armed` *before* binding the proxy, so a second task
+        entering a proxy in a `contextvars.Context` it does not own
+        raises `wool.ChainContention` at this point rather than silently
+        clobbering `wool.__proxy__`. The arming and its reset are
+        registered on an `~contextlib.AsyncExitStack` (the same idiom
+        `start` uses) so the marker is unwound if `enter` raises and
+        reset on `__aexit__` — never leaked.
+        """
+        async with AsyncExitStack() as stack:
+            token = self._armed.set(True)
+            stack.callback(self._armed.reset, token)
+            await self.enter()
+            self._exit_stack = stack.pop_all()
         return self
 
     async def __aexit__(self, *args):
-        """Exits the proxy context and resets the active proxy."""
-        await self.exit(*args)
+        """Exit the proxy context and reset the active proxy."""
+        try:
+            await self.exit(*args)
+        finally:
+            if self._exit_stack is not None:
+                await self._exit_stack.aclose()
+                self._exit_stack = None
 
     def __hash__(self) -> int:
         return hash(str(self.id))

--- a/wool/tests/integration/routines.py
+++ b/wool/tests/integration/routines.py
@@ -10,6 +10,7 @@ Routines are organized by dimension:
 """
 
 import asyncio
+import contextvars
 import functools
 import inspect
 from enum import Enum
@@ -1108,3 +1109,99 @@ async def read_var_off_thread_via_wool_to_thread(value: str) -> str:
     """
     TENANT_ID.set(value)
     return await wool.to_thread(TENANT_ID.get)
+
+
+async def _drive_proxy_collision_on_worker() -> wool.ChainContention:
+    """Drive two tasks sharing one fresh context into a proxy collision.
+
+    Runs inside a dispatched routine, whose own chain is already armed
+    and owned by the routine task. A FRESH `contextvars.Context` is used
+    — not `contextvars.copy_context` — so it starts unarmed and is shared
+    (not forked) by the two child tasks: the first child enters a proxy
+    in it and owns it, and the second child's entry into that context it
+    does not own raises `wool.ChainContention` with kind ``"task"``. The
+    events serialize the interleave so the first always enters first and
+    stays live until the second has contended. The proxies are lazy, so
+    entry incurs no discovery or worker startup.
+    """
+    wool.install_task_factory()
+    loop = asyncio.get_running_loop()
+    shared = contextvars.Context()
+    armed = asyncio.Event()
+    first_can_finish = asyncio.Event()
+
+    async def first() -> None:
+        async with wool.WorkerProxy("proxy-collision-pool", lazy=True):
+            armed.set()
+            await first_can_finish.wait()
+
+    async def second():
+        await armed.wait()
+        try:
+            async with wool.WorkerProxy("proxy-collision-pool", lazy=True):
+                return None
+        except wool.ChainContention as exc:
+            return exc
+        finally:
+            first_can_finish.set()
+
+    first_task = loop.create_task(first(), context=shared)
+    second_task = loop.create_task(second(), context=shared)
+    observed, _ = await asyncio.gather(second_task, first_task)
+    assert isinstance(observed, wool.ChainContention)
+    return observed
+
+
+@wool.routine
+async def report_proxy_collision_in_shared_context() -> str:
+    """Trigger a worker-side proxy collision and return its contention kind.
+
+    Drives two tasks sharing one fresh context into a `wool.WorkerProxy`
+    collision on the worker, catches the resulting `wool.ChainContention`,
+    and returns its ``kind`` (``"task"``) as a plain string — proving the
+    guard fired on the worker without relying on the exception crossing
+    the wire.
+    """
+    return (await _drive_proxy_collision_on_worker()).kind
+
+
+@wool.routine
+async def raise_proxy_collision_in_shared_context() -> None:
+    """Trigger a worker-side proxy collision and re-raise it to the caller.
+
+    Lets the worker-side `wool.ChainContention` propagate through the
+    routine-exception back-propagation channel so the caller observes it
+    directly (relies on the contention being wire-safe).
+    """
+    raise await _drive_proxy_collision_on_worker()
+
+
+@wool.routine
+async def stream_proxy_collision_in_shared_context():
+    """Stream a worker-side proxy collision: yield ``"ready"``, then its kind.
+
+    Async-generator variant of
+    `report_proxy_collision_in_shared_context`: yields ``"ready"`` first,
+    then drives the worker-side collision and yields its contention
+    ``kind`` (``"task"``) — exercising the async-generator dispatch
+    driver.
+    """
+    yield "ready"
+    yield (await _drive_proxy_collision_on_worker()).kind
+
+
+@wool.routine
+async def enter_proxies_in_separate_tasks_on_worker() -> str:
+    """Enter two proxies in separate forked tasks on the worker (no collision).
+
+    Each ``asyncio.gather`` child forks a fresh, child-owned chain via
+    the task factory, so concurrent proxy entries inside a dispatched
+    routine never contend. Returns ``"ok"``.
+    """
+
+    async def use_proxy() -> None:
+        async with wool.WorkerProxy("proxy-collision-pool", lazy=True):
+            await asyncio.sleep(0)
+
+    await asyncio.gather(use_proxy(), use_proxy())
+    return "ok"

--- a/wool/tests/integration/test_context_var_propagation.py
+++ b/wool/tests/integration/test_context_var_propagation.py
@@ -2006,30 +2006,32 @@ class TestCopyContextWidthAcrossWorkers:
         """Test copy_context enumerates 1+N wool variables after a dispatch.
 
         Given:
-            A caller with an unarmed context and a routine that
-            counts wool-owned ``contextvars.ContextVar``s visible in a
-            worker-side ``contextvars.copy_context()``
+            A caller that has entered a pool — which arms its context — and
+            a routine that counts wool-owned `contextvars.ContextVar`s
+            visible in a worker-side `contextvars.copy_context`.
         When:
-            The caller arms its context by binding two
-            ``wool.ContextVar``s and dispatches the counting routine
+            The caller binds two more `wool.ContextVar`s and dispatches the
+            counting routine.
         Then:
-            The unarmed caller's own copy_context should enumerate
-            zero wool variables, and the worker — running with two
-            bound variables forward-propagated — should report
-            ``1 + 2`` (the context variable plus one backing
-            variable per bound var).
+            The caller's own copy_context should enumerate exactly two wool
+            variables — the chain variable plus one arming backing marker —
+            confirming that entering a proxy arms the context; and the
+            worker — running with the propagated marker plus the two user
+            variables — should report ``1 + 3`` (the chain variable plus
+            one backing per bound var).
         """
 
         # Arrange, act, & assert
         async def body():
             scenario = default_scenario()
             async with build_pool_from_scenario(scenario, credentials_map):
-                # Unarmed: no wool-owned variables in a copy.
-                unarmed = [
-                    var
+                # Entering the pool arms the context, so the caller carries
+                # the chain variable plus one arming backing marker.
+                armed = sorted(
+                    var.name
                     for var in contextvars.copy_context()
                     if var.name.startswith("__wool")
-                ]
+                )
 
                 tenant_token = routines.TENANT_ID.set("width-tenant")
                 region_token = routines.REGION.set("width-region")
@@ -2038,10 +2040,11 @@ class TestCopyContextWidthAcrossWorkers:
                 finally:
                     routines.REGION.reset(region_token)
                     routines.TENANT_ID.reset(tenant_token)
-            assert unarmed == []
-            # 1 context variable + 2 backing variables for the two
-            # bound wool.ContextVars propagated to the worker.
-            assert worker_count == 3
+            assert len(armed) == 2
+            assert "__wool_chain__" in armed
+            # 1 chain variable + 3 backing variables: the arming marker plus
+            # the two bound wool.ContextVars propagated to the worker.
+            assert worker_count == 4
 
         await retry_grpc_internal(body)
 
@@ -2235,5 +2238,120 @@ class TestChainContentionAcrossDispatch:
 
             # Assert
             assert collected == [caller.id.hex] * 6
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestProxyCollisionAcrossDispatch:
+    @pytest.mark.asyncio
+    async def test_worker_proxy_collision_should_report_task_contention(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a proxy collision inside a dispatched routine fires on the worker.
+
+        Given:
+            A DEFAULT pool running a routine that spawns two tasks sharing
+            one fresh `contextvars.Context` on the worker loop, each
+            entering its own `wool.WorkerProxy`, and catches the second
+            entry's contention.
+        When:
+            The caller dispatches the routine.
+        Then:
+            It should return ``"task"`` — the contention guard fired inside
+            the dispatched routine on the worker, and the kind crossed the
+            wire as a plain string.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                result = await routines.report_proxy_collision_in_shared_context()
+            assert result == "task"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_proxy_collision_should_surface_chain_contention(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a re-raised worker proxy collision reaches the caller intact.
+
+        Given:
+            A DEFAULT pool running a routine that drives a worker-side
+            `wool.WorkerProxy` collision and re-raises the resulting
+            `wool.ChainContention` instead of catching it.
+        When:
+            The caller dispatches the routine.
+        Then:
+            The caller should catch a `wool.ChainContention` with kind
+            ``"task"`` — the cross-task contention survives the
+            worker-to-caller exception channel as itself rather than
+            degrading to a plain `RuntimeError`.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                with pytest.raises(wool.ChainContention) as exc_info:
+                    await routines.raise_proxy_collision_in_shared_context()
+            assert exc_info.value.kind == "task"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_separate_task_proxy_entry_should_not_raise(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test concurrent forked proxy entries inside a routine do not contend.
+
+        Given:
+            A DEFAULT pool running a routine that enters two
+            `wool.WorkerProxy` contexts in separate forked tasks
+            (`asyncio.gather`) on the worker.
+        When:
+            The caller dispatches the routine.
+        Then:
+            It should return ``"ok"`` with no `wool.ChainContention` — the
+            task factory forks a fresh, child-owned chain per task, so
+            legitimate concurrent proxy use on the worker never trips.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                result = await routines.enter_proxies_in_separate_tasks_on_worker()
+            assert result == "ok"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_async_gen_worker_proxy_collision_should_report_contention(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker proxy collision fires under the async-gen driver.
+
+        Given:
+            A DEFAULT pool running an async-generator routine that yields
+            ``"ready"``, then drives a worker-side `wool.WorkerProxy`
+            collision and yields the contention kind.
+        When:
+            The caller iterates the dispatched generator.
+        Then:
+            It should yield ``["ready", "task"]`` — the guard fires
+            identically under the async-generator dispatch driver and the
+            kind streams back over the wire.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                gen = routines.stream_proxy_collision_in_shared_context()
+                collected = [value async for value in gen]
+            assert collected == ["ready", "task"]
 
         await retry_grpc_internal(body)

--- a/wool/tests/runtime/context/test_exceptions.py
+++ b/wool/tests/runtime/context/test_exceptions.py
@@ -1,8 +1,10 @@
+import asyncio
 import pickle
 import warnings
 from uuid import uuid4
 
 import pytest
+from hypothesis import HealthCheck
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
@@ -382,6 +384,62 @@ class TestChainContention:
         assert restored.owning_thread == 12345
         assert restored.current_thread == 67890
         assert str(restored) == str(exc)
+
+    @settings(max_examples=25, suppress_health_check=[HealthCheck.too_slow])
+    @given(
+        chain_id=st.uuids(),
+        with_owning=st.booleans(),
+        with_current=st.booleans(),
+    )
+    def test_chain_contention_should_round_trip_task_kind_carrying_live_tasks(
+        self, chain_id, with_owning, with_current
+    ):
+        """Test a task-kind ChainContention survives the wire carrying live tasks.
+
+        Given:
+            A ChainContention with kind "task" carrying live asyncio.Task
+            objects in any combination of the owning and current fields.
+        When:
+            The exception is pickled and unpickled.
+        Then:
+            It should restore as a ChainContention with kind "task" — not
+            a demoted RuntimeError — with each task field rendered as its
+            repr string and the message unchanged.
+        """
+
+        # Arrange, act, & assert
+        async def roundtrip() -> None:
+            async def idle() -> None:
+                await asyncio.sleep(0)
+
+            owning = asyncio.ensure_future(idle()) if with_owning else None
+            current = asyncio.ensure_future(idle()) if with_current else None
+            try:
+                exc = ChainContention(
+                    chain_id=chain_id,
+                    kind="task",
+                    owning_task=owning,
+                    current_task=current,
+                )
+                expected_message = str(exc)
+                expected_owning = repr(owning) if owning is not None else None
+                expected_current = repr(current) if current is not None else None
+
+                restored = pickle.loads(pickle.dumps(exc))
+
+                assert type(restored) is ChainContention
+                assert restored.kind == "task"
+                assert restored.chain_id == chain_id
+                assert restored.owning_task == expected_owning
+                assert restored.current_task == expected_current
+                assert str(restored) == expected_message
+            finally:
+                live = [t for t in (owning, current) if t is not None]
+                for task in live:
+                    task.cancel()
+                await asyncio.gather(*live, return_exceptions=True)
+
+        asyncio.run(roundtrip())
 
     def test_chain_contention_should_interpolate_chain_id_when_create_task_kind(self):
         """Test the create_task kind interpolates the chain id.

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -6,6 +6,7 @@ to avoid network overhead and ensure deterministic behavior.
 """
 
 import asyncio
+import contextvars
 import copy
 import pickle
 import uuid
@@ -23,6 +24,7 @@ from pytest_mock import MockerFixture
 
 import wool
 import wool.runtime.worker.proxy as wp
+from tests.helpers import _unique
 from wool import protocol
 from wool.runtime.discovery.base import DiscoveryEvent
 from wool.runtime.discovery.local import LocalDiscovery
@@ -2171,8 +2173,258 @@ class TestWorkerProxy:
         assert proxy.started
         assert len(proxy.workers) == 2
 
-        # Cleanup
-        await proxy.__aexit__(None, None, None)
+        # Cleanup. ``__aenter__`` ran inside ``enter_task``'s context, so the
+        # ``_armed`` token it minted cannot be reset from this (different)
+        # context; tear the started proxy down directly instead.
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_enter_should_not_arm_chain_when_called_directly(
+        self, mock_discovery_service
+    ):
+        """Test the direct enter() path does not arm the chain.
+
+        Given:
+            A fresh, unarmed context and a lazy proxy.
+        When:
+            `enter` is called directly (the path the worker pool factory
+            uses) rather than via the async context manager.
+        Then:
+            `wool.__proxy__` should be bound to the proxy, but the chain
+            should remain unarmed — only `__aenter__` arms, so the worker
+            pool path stays unguarded by design.
+        """
+        # Arrange
+        proxy = WorkerProxy(discovery=mock_discovery_service)
+        assert wool.__chain__.get(None) is None
+
+        # Act
+        await proxy.enter()
+        try:
+            # Assert
+            assert wool.__proxy__.get() is proxy
+            assert wool.__chain__.get(None) is None
+        finally:
+            await proxy.exit()
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_arm_chain_for_contention_guard(
+        self, mock_discovery_service
+    ):
+        """Test entering a proxy via the context manager arms the chain.
+
+        Given:
+            A fresh, unarmed context.
+        When:
+            A proxy is entered as an async context manager.
+        Then:
+            The chain should be armed inside the block — this is what
+            brings `wool.__proxy__`'s lifecycle under the contention
+            guard.
+        """
+        # Arrange
+        assert wool.__chain__.get(None) is None
+
+        # Act & assert
+        async with WorkerProxy(discovery=mock_discovery_service):
+            assert wool.__chain__.get(None) is not None
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_preserve_active_proxy_when_second_task_contends(
+        self, mock_discovery_service
+    ):
+        """Test a contended second entry never clobbers the first proxy.
+
+        Given:
+            Two tasks share one context; the first enters `proxy_first`
+            (binding `wool.__proxy__`) and holds it open.
+        When:
+            The second task, sharing that context it does not own, enters
+            its own `proxy_second` and the entry is rejected.
+        Then:
+            It should raise `wool.ChainContention` (kind ``"task"``)
+            before enter() runs, so the first task still observes
+            `wool.__proxy__` as `proxy_first` — the active proxy is never
+            silently clobbered.
+        """
+        # Arrange
+        wool.install_task_factory()
+        loop = asyncio.get_running_loop()
+        shared = contextvars.copy_context()
+        proxy_first = WorkerProxy(discovery=mock_discovery_service)
+        proxy_second = WorkerProxy(discovery=mock_discovery_service)
+        armed = asyncio.Event()
+        first_can_finish = asyncio.Event()
+        observed: dict[str, object] = {}
+
+        async def first() -> None:
+            async with proxy_first:
+                observed["before"] = wool.__proxy__.get()
+                armed.set()
+                await first_can_finish.wait()
+                observed["after"] = wool.__proxy__.get()
+
+        async def second() -> BaseException | None:
+            await armed.wait()
+            try:
+                async with proxy_second:
+                    return None
+            except wool.ChainContention as exc:
+                return exc
+            finally:
+                first_can_finish.set()
+
+        # Act
+        first_task = loop.create_task(first(), context=shared)
+        second_task = loop.create_task(second(), context=shared)
+        contention, _ = await asyncio.gather(second_task, first_task)
+
+        # Assert
+        assert isinstance(contention, wool.ChainContention)
+        assert contention.kind == "task"
+        assert observed["before"] is proxy_first
+        assert observed["after"] is proxy_first
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_raise_when_foreign_task_enters_pre_armed_context(
+        self, mock_discovery_service
+    ):
+        """Test entering a proxy on a pre-armed, foreign-owned context fails.
+
+        Given:
+            A `contextvars.Context` already armed and owned by a first
+            task via a plain `wool.ContextVar` (not a proxy); the first
+            task then enters its own proxy without raising and holds it.
+        When:
+            A second task, sharing that context it does not own, enters a
+            proxy.
+        Then:
+            It should raise `wool.ChainContention` with kind ``"task"`` —
+            the guard keys on chain ownership, not on the proxy having
+            done the arming.
+        """
+        # Arrange
+        wool.install_task_factory()
+        loop = asyncio.get_running_loop()
+        shared = contextvars.copy_context()
+        marker = wool.ContextVar(_unique("prearmed"))
+        armed = asyncio.Event()
+        first_can_finish = asyncio.Event()
+
+        async def first() -> None:
+            marker.set("owned-by-first")
+            async with WorkerProxy(discovery=mock_discovery_service):
+                armed.set()
+                await first_can_finish.wait()
+
+        async def second() -> BaseException | None:
+            await armed.wait()
+            try:
+                async with WorkerProxy(discovery=mock_discovery_service):
+                    return None
+            except wool.ChainContention as exc:
+                return exc
+            finally:
+                first_can_finish.set()
+
+        # Act
+        first_task = loop.create_task(first(), context=shared)
+        second_task = loop.create_task(second(), context=shared)
+        observed, _ = await asyncio.gather(second_task, first_task)
+
+        # Assert
+        assert isinstance(observed, wool.ChainContention)
+        assert observed.kind == "task"
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_bind_inner_then_revert_to_outer_when_nested(
+        self, mock_discovery_service
+    ):
+        """Test nesting two proxies in one task rebinds then reverts.
+
+        Given:
+            One task and two distinct lazy proxies.
+        When:
+            The task enters an outer proxy and, while it is open, enters
+            an inner proxy.
+        Then:
+            Neither entry should raise — a single owner satisfies the
+            guard — and `wool.__proxy__` should be the inner proxy inside
+            the nested block and revert to the outer proxy after it.
+        """
+        # Arrange
+        outer = WorkerProxy(discovery=mock_discovery_service)
+        inner = WorkerProxy(discovery=mock_discovery_service)
+
+        # Act & assert
+        async with outer:
+            assert wool.__proxy__.get() is outer
+            async with inner:
+                assert wool.__proxy__.get() is inner
+            assert wool.__proxy__.get() is outer
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_not_raise_in_forked_child_when_parent_armed(
+        self, mock_discovery_service
+    ):
+        """Test a forked child entering a proxy under an armed parent is fine.
+
+        Given:
+            A parent task whose context is already armed (a bound
+            `wool.ContextVar`), then a child task forked the ordinary way.
+        When:
+            The forked child enters its own proxy.
+        Then:
+            It should not raise — the task factory forks a fresh,
+            child-owned chain, so the child owns the chain it arms (this
+            discriminates from the concurrent-isolation negative, which
+            starts from an unarmed parent).
+        """
+        # Arrange
+        wool.install_task_factory()
+        marker = wool.ContextVar(_unique("parent_armed"))
+        marker.set("parent")
+
+        async def child() -> None:
+            async with WorkerProxy(discovery=mock_discovery_service):
+                await asyncio.sleep(0)
+
+        # Act & assert
+        await asyncio.create_task(child())
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_isolate_distinct_proxies_across_concurrent_tasks(
+        self, mock_discovery_service
+    ):
+        """Test concurrent coroutines each entering their own proxy stay isolated.
+
+        Given:
+            Two coroutines, each entering a distinct proxy, run
+            concurrently as ordinary separate tasks.
+        When:
+            They run via asyncio.gather.
+        Then:
+            Neither should raise and each should observe its own proxy as
+            `wool.__proxy__` — each coroutine task runs in its own context
+            with its own chain, so distinct proxies never collide or cross
+            over (the common concurrent-dispatch case).
+        """
+        # Arrange
+        proxy_a = WorkerProxy(discovery=mock_discovery_service)
+        proxy_b = WorkerProxy(discovery=mock_discovery_service)
+        seen: dict[str, object] = {}
+
+        async def use(proxy: WorkerProxy, key: str) -> None:
+            async with proxy:
+                await asyncio.sleep(0)
+                seen[key] = wool.__proxy__.get()
+
+        # Act
+        await asyncio.gather(use(proxy_a, "a"), use(proxy_b, "b"))
+
+        # Assert
+        assert seen["a"] is proxy_a
+        assert seen["b"] is proxy_b
 
     @pytest.mark.asyncio
     async def test_cloudpickle_serialization_preserves_quorum(


### PR DESCRIPTION
## Summary

`wool.__proxy__` — the active proxy a nested `@wool.routine` reads to choose a dispatch target — is a plain `contextvars.ContextVar`, invisible to the chain-contention guard. Two tasks that share one `contextvars.Context` and each enter a different `WorkerProxy` would clobber each other's binding last-write-wins, silently misrouting dispatch.

Rather than retyping `__proxy__` itself, add a guarded sentinel: `WorkerProxy._armed`, a class-level `wool.ContextVar[bool]` that `WorkerProxy.__aenter__` arms before binding the proxy. Arming brings the proxy's lifecycle under the existing chain-ownership guard, so a second task entering a proxy in a context it does not own fails loud with `wool.ChainContention` instead of corrupting the first task's dispatch. The arming registers on an `AsyncExitStack`, so it unwinds if `enter()` raises and resets on exit. The worker-pool path (`enter()` called directly) stays unarmed by design.

Surfacing the guard across a dispatch exposed a latent wire bug: a `kind="task"` `ChainContention` carries live `asyncio.Task` objects, which are unpicklable, so a worker-raised task contention was demoted to a plain `RuntimeError` over the wire. `ChainContention.__reduce__` now substitutes the tasks' `repr` so the contention survives as itself.

Closes #230, #256.

## Proposed changes

**Guard `wool.__proxy__` against concurrent clobbering (feat)** — Add `WorkerProxy._armed`, a `ClassVar` `wool.ContextVar[bool]` armed in `__aenter__` before `enter()` binds the proxy, via an `AsyncExitStack` that unwinds on entry failure and resets on `__aexit__`. The stored value is an inert arming sentinel — only `set` matters. Document the guard in the worker README and on `__aenter__`.

**Preserve `ChainContention` type across the wire for task contentions (fix)** — `__reduce__` substitutes `repr(...)` for the live `owning_task`/`current_task` objects so a `kind="task"` contention pickles cleanly and reconstructs as a `wool.ChainContention` (not a `RuntimeError`); the rendered message is unchanged because a `Task`'s `str` equals its `repr`. Field types widen to `asyncio.Future[Any] | str | None`.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerProxy` | A lazy proxy and a fresh unarmed context | `enter()` is called directly | `wool.__proxy__` binds but the chain stays unarmed | Worker-pool path stays unguarded |
| 2 | `TestWorkerProxy` | A fresh unarmed context | A proxy is entered with `async with` | The chain is armed inside the block | Entry arms the guard |
| 3 | `TestWorkerProxy` | Two tasks share one context; the first holds an entered proxy | The second enters its own proxy | It raises `wool.ChainContention` kind `"task"` and the first proxy stays bound | No-clobber on collision |
| 4 | `TestWorkerProxy` | A context pre-armed and owned by a first task via a plain `wool.ContextVar` | A foreign task enters a proxy in it | It raises `wool.ChainContention` kind `"task"` | Guard keys on ownership |
| 5 | `TestWorkerProxy` | One task and two distinct proxies | An inner proxy is entered inside an outer one | `wool.__proxy__` binds the inner then reverts to the outer | Same-owner nesting does not contend |
| 6 | `TestWorkerProxy` | A parent task with an armed context | A child forked the ordinary way enters a proxy | It does not raise | Forked child owns its fresh chain |
| 7 | `TestWorkerProxy` | Two coroutines each entering a distinct proxy | They run concurrently via `asyncio.gather` | Neither raises and each observes its own proxy | Concurrent dispatch stays isolated |
| 8 | `TestChainContention` | A `kind="task"` contention carrying live `asyncio.Task` fields | It is pickled and unpickled | It restores as `ChainContention` with the tasks as `repr` strings and an unchanged message | `__reduce__` wire-safety |
| 9 | `TestProxyCollisionAcrossDispatch` | A pool running a routine that drives a worker-side proxy collision | The caller dispatches it | It returns `"task"` | Worker-side guard fires and the kind crosses the wire |
| 10 | `TestProxyCollisionAcrossDispatch` | A routine that re-raises a worker-side collision | The caller dispatches it | The caller catches `wool.ChainContention` kind `"task"` | Contention survives the worker-to-caller channel |
| 11 | `TestProxyCollisionAcrossDispatch` | A routine entering two proxies in separate forked tasks on the worker | The caller dispatches it | It returns `"ok"` with no contention | Forked tasks on the worker never contend |
| 12 | `TestProxyCollisionAcrossDispatch` | An async-generator routine that streams a worker-side collision | The caller iterates it | It yields `["ready", "task"]` | Guard fires under the async-generator driver |
| 13 | `TestCopyContextWidthAcrossWorkers` | A caller that entered a pool and bound two more vars | A counting routine is dispatched | The caller enumerates two wool vars and the worker reports four | Arming width across dispatch |
