### PR TITLE
Expose worker idle time so callers can shut down inactive workers — Closes #253

### DIFF
--- a/wool/proto/wire.proto
+++ b/wool/proto/wire.proto
@@ -104,6 +104,7 @@ message Nack {
 service Worker {
     rpc dispatch (stream Request) returns (stream Response);
     rpc stop (StopRequest) returns (Void);
+    rpc idle (Void) returns (IdleTime);
 }
 
 message Request {
@@ -133,6 +134,13 @@ message Response {
 
 message StopRequest {
     float timeout = 1;
+}
+
+message IdleTime {
+    // Seconds the worker has been continuously idle: time since the
+    // in-flight task set last emptied (startup counts as empty).
+    // 0 while any task is in flight; measured on a monotonic clock.
+    double seconds = 1;
 }
 
 message WorkerMetadata {

--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -59,6 +59,7 @@ from wool.runtime.worker.base import WorkerFactory
 from wool.runtime.worker.base import WorkerLike
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.connection import HandshakeError
+from wool.runtime.worker.connection import IdleUnavailable
 from wool.runtime.worker.connection import RpcError
 from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.connection import UnexpectedResponse
@@ -131,6 +132,7 @@ __all__ = [
     "DispatchingLoadBalancerLike",
     "Factory",
     "HandshakeError",
+    "IdleUnavailable",
     "IneffectiveLeaseWarning",
     "IneffectiveQuorumTimeoutWarning",
     "LanDiscovery",

--- a/wool/src/wool/protocol/__init__.py
+++ b/wool/src/wool/protocol/__init__.py
@@ -13,6 +13,7 @@ from wool.protocol._wire import (
 from wool.protocol._wire import ChainManifest as ChainManifest
 from wool.protocol._wire import ChannelOptions as ChannelOptions
 from wool.protocol._wire import ContextVar as ContextVar
+from wool.protocol._wire import IdleTime as IdleTime
 from wool.protocol._wire import Message as Message
 from wool.protocol._wire import Nack as Nack
 from wool.protocol._wire import Request as Request
@@ -35,6 +36,7 @@ __all__ = [
     "ChainManifest",
     "ChannelOptions",
     "ContextVar",
+    "IdleTime",
     "Message",
     "Nack",
     "Request",

--- a/wool/src/wool/protocol/_wire.py
+++ b/wool/src/wool/protocol/_wire.py
@@ -14,6 +14,7 @@ try:
     from wool.protocol.wire_pb2 import ChainManifest
     from wool.protocol.wire_pb2 import ChannelOptions
     from wool.protocol.wire_pb2 import ContextVar
+    from wool.protocol.wire_pb2 import IdleTime
     from wool.protocol.wire_pb2 import Message
     from wool.protocol.wire_pb2 import Nack
     from wool.protocol.wire_pb2 import Request
@@ -57,6 +58,7 @@ __all__ = [
     "ChainManifest",
     "ChannelOptions",
     "ContextVar",
+    "IdleTime",
     "Message",
     "Nack",
     "Request",

--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -128,14 +128,14 @@ class ResilientWorker(LocalWorker):
         await super()._start(timeout=timeout)
         self._monitor_task = asyncio.create_task(self._monitor())
 
-    async def _stop(self, timeout=None):
+    async def _stop(self, grace=None):
         if self._monitor_task:
             self._monitor_task.cancel()
             try:
                 await self._monitor_task
             except asyncio.CancelledError:
                 pass
-        await super()._stop(timeout=timeout)
+        await super()._stop(grace=grace)
 
     async def _restart(self):
         """Replace the dead process, reusing the original port."""

--- a/wool/src/wool/runtime/worker/base.py
+++ b/wool/src/wool/runtime/worker/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import inspect
 import uuid
+import warnings
 from abc import ABC
 from abc import abstractmethod
 from dataclasses import dataclass
@@ -296,11 +297,18 @@ class WorkerLike(Protocol):
         """
         ...
 
-    async def stop(self, *, timeout: float | None = None):
+    async def stop(self, *, grace: float | None = None, timeout: float | None = None):
         """Stop the worker and unregister it from the pool.
 
+        :param grace:
+            The worker's shutdown grace period in seconds — how long to
+            wait for in-flight tasks to drain before cancelling them.
+            ``None`` (the default) applies no grace: in-flight tasks
+            are cancelled immediately. A negative value waits
+            indefinitely for the drain.
         :param timeout:
-            Maximum time in seconds to wait for worker shutdown.
+            Deprecated alias for ``grace``, retained for backwards
+            compatibility; passing it emits a ``DeprecationWarning``.
         :raises RuntimeError:
             If the worker has not been started.
         """
@@ -328,7 +336,7 @@ class Worker(ABC):
                 # Start your worker process
                 self._info = WorkerMetadata(...)
 
-            async def _stop(self, timeout):
+            async def _stop(self, grace):
                 # Clean shutdown
                 ...
 
@@ -408,17 +416,36 @@ class Worker(ABC):
         assert self._info
 
     @final
-    async def stop(self, *, timeout: float | None = None):
+    async def stop(self, *, grace: float | None = None, timeout: float | None = None):
         """Stop the worker and unregister it from the pool.
 
         This method is a final implementation that calls the abstract
         `_stop` method to gracefully shut down the worker process and
         unregister it from the registrar service.
+
+        :param grace:
+            The worker's shutdown grace period in seconds — how long to
+            wait for in-flight tasks to drain before cancelling them.
+            ``None`` (the default) applies no grace: in-flight tasks
+            are cancelled immediately. A negative value waits
+            indefinitely for the drain.
+        :param timeout:
+            Deprecated alias for ``grace``, retained for backwards
+            compatibility; passing it emits a ``DeprecationWarning``.
         """
+        if timeout is not None:
+            warnings.warn(
+                "The 'timeout' parameter of Worker.stop is deprecated; "
+                "use 'grace' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if grace is None:
+                grace = timeout
         if not self._started:
             raise RuntimeError("Worker has not been started")
         try:
-            await self._stop(timeout)
+            await self._stop(grace)
         finally:
             self._started = False
 
@@ -435,10 +462,15 @@ class Worker(ABC):
         ...
 
     @abstractmethod
-    async def _stop(self, timeout: float | None):
+    async def _stop(self, grace: float | None):
         """Implementation-specific worker shutdown logic.
 
         Subclasses must implement this method to handle the graceful
         shutdown of their worker process and cleanup of resources.
+
+        :param grace:
+            The shutdown grace period forwarded by `stop`; see `stop`
+            for the ``None``/positive/negative domain, which
+            implementations must honor.
         """
         ...

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -528,7 +528,9 @@ class WorkerConnection:
                 raise RpcError(code, details) from error
         return response.seconds
 
-    async def stop(self, *, grace: float | None = None) -> None:
+    async def stop(
+        self, *, grace: float | None = None, timeout: float | None = None
+    ) -> None:
         """Stop the remote worker.
 
         Sends the stop RPC over a channel drawn from this connection's
@@ -540,6 +542,10 @@ class WorkerConnection:
             cancels in-flight tasks immediately; a positive value
             waits that long for a graceful drain; a negative value
             waits indefinitely.
+        :param timeout:
+            gRPC call deadline in seconds for the stop call. ``None``
+            applies no deadline. The worker drains for up to ``grace``
+            before responding, so a finite deadline must exceed it.
         :raises TransientRpcError:
             If the worker returns a transient RPC error
             (``UNAVAILABLE``, ``DEADLINE_EXCEEDED``, or
@@ -549,7 +555,9 @@ class WorkerConnection:
         """
         async with _channel_pool.get(await self._resolve_key()) as channel:
             try:
-                await channel.stub.stop(protocol.StopRequest(timeout=grace))
+                await channel.stub.stop(
+                    protocol.StopRequest(timeout=grace), timeout=timeout
+                )
             except grpc.RpcError as error:
                 code = error.code()
                 details = error.details() or str(error)

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -17,6 +17,7 @@ import grpc.aio
 
 import wool
 from wool import protocol
+from wool.exceptions import WoolError
 from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.routine.task import Task
 from wool.runtime.serializer import Serializer
@@ -201,8 +202,28 @@ class HandshakeError(TransientRpcError):
 
 
 # public
+class IdleUnavailable(WoolError):
+    """Raised when a worker does not implement the idle RPC.
+
+    A worker that predates the idle capability answers the idle RPC
+    with gRPC ``UNIMPLEMENTED``; `WorkerConnection.idle_time`
+    translates that into this typed signal so a polling client can
+    detect an old worker and treat idle reporting as unavailable,
+    distinct from a transient hiccup or an unhealthy peer. It descends
+    from `wool.WoolError` — not `RpcError` — because an absent
+    capability is not an RPC-health fault, so ``except RpcError`` does
+    not catch it.
+    """
+
+
+# public
 class WorkerConnection:
-    """gRPC connection to a worker for task dispatch.
+    """Direct single-worker control surface over a pooled gRPC channel.
+
+    Exposes `dispatch` (task execution), `idle_time` (poll the worker's
+    continuous idle duration), and `stop` (shut the remote worker
+    down). ``close`` is distinct: it releases this connection's local
+    pooled channel, whereas `stop` terminates the remote worker.
 
     Acquires pooled gRPC channels keyed by ``(target, credentials,
     options)``.  Each `dispatch` call obtains a reference-counted
@@ -288,6 +309,41 @@ class WorkerConnection:
         # self-dispatches over the loopback UDS never set it.
         self._key: _PoolKey | None = None
         self._uds_key: _PoolKey | None = None
+
+    async def _resolve_key(self) -> _PoolKey:
+        """Resolve the pool key routing the next RPC.
+
+        Decides the route before touching credentials: a self-directed
+        call rides the loopback UDS, which is always insecure — the
+        worker never does TLS/identity against itself — so those calls
+        never pay a credential resolve whose result would be discarded.
+        Otherwise resolves current credential material per call so
+        rotated material is adopted on the next connection (see class
+        docstring); the resolve is awaited rather than read
+        synchronously because this runs on the loop — see
+        `WorkerCredentialsProvider.credentials` for what the read
+        costs. A previous call's superseded TCP key has its pooled
+        channel doomed so it finalizes as soon as in-flight work
+        drains instead of idling out the pool's TTL.
+        """
+        key: _PoolKey
+        if (
+            (metadata := wool.__worker_metadata__) is not None
+            and metadata.address == self._target
+            and (uds_address := wool.__worker_uds_address__) is not None
+        ):
+            key = (uds_address, None, self._options)
+            self._uds_key = key
+        else:
+            if self._provider is None:
+                credentials = None
+            else:
+                credentials = await self._provider.credentials
+            key = (self._target, credentials, self._options)
+            if self._key is not None and self._key != key:
+                await _channel_pool.expire(self._key)
+            self._key = key
+        return key
 
     async def dispatch(
         self,
@@ -381,36 +437,7 @@ class WorkerConnection:
         if timeout is not None and timeout <= 0:
             raise ValueError("Dispatch timeout must be positive")
 
-        # Decide the route before touching credentials: self-dispatch rides
-        # the loopback UDS, which is always insecure — the worker never does
-        # TLS/identity against itself — so those dispatches never pay a
-        # credential resolve whose result would be discarded.
-        key: _PoolKey
-        if (
-            (metadata := wool.__worker_metadata__) is not None
-            and metadata.address == self._target
-            and (uds_address := wool.__worker_uds_address__) is not None
-        ):
-            key = (uds_address, None, self._options)
-            self._uds_key = key
-        else:
-            # Resolve current credential material per dispatch so rotated
-            # material is adopted on the next connection (see class
-            # docstring). Awaited rather than read synchronously because
-            # this runs on the loop — see WorkerCredentialsProvider.
-            # credentials for what the read costs.
-            if self._provider is None:
-                credentials = None
-            else:
-                credentials = await self._provider.credentials
-            key = (self._target, credentials, self._options)
-            if self._key is not None and self._key != key:
-                # The previous dispatch's material was superseded (e.g., by
-                # rotation): doom its pooled channel so it finalizes as soon
-                # as in-flight dispatches drain instead of idling out the
-                # pool's TTL.
-                await _channel_pool.expire(self._key)
-            self._key = key
+        key = await self._resolve_key()
 
         stream = self._execute(task, key, timeout)
         try:
@@ -459,6 +486,76 @@ class WorkerConnection:
             await _channel_pool.expire(self._key)
         if self._uds_key is not None:
             await _channel_pool.expire(self._uds_key)
+
+    async def idle_time(self, *, timeout: float | None = None) -> float:
+        """Query how long the remote worker has been continuously idle.
+
+        Returns the worker's reported continuous idle duration; see
+        `WorkerService.idle` for how idle is defined and measured. The
+        call draws a channel from this connection's pool, inheriting
+        its credential and secure-channel handling.
+
+        :param timeout:
+            gRPC call deadline in seconds for the poll. ``None``
+            applies no deadline.
+        :returns:
+            The worker's continuous idle duration in seconds.
+        :raises ValueError:
+            If ``timeout`` is not positive.
+        :raises IdleUnavailable:
+            If the worker predates the idle RPC (gRPC ``UNIMPLEMENTED``).
+        :raises TransientRpcError:
+            If the worker returns a transient RPC error
+            (``UNAVAILABLE``, ``DEADLINE_EXCEEDED``, or
+            ``RESOURCE_EXHAUSTED``).
+        :raises RpcError:
+            If the worker returns any other non-transient RPC error.
+        """
+        if timeout is not None and timeout <= 0:
+            raise ValueError("Idle timeout must be positive")
+        async with _channel_pool.get(await self._resolve_key()) as channel:
+            try:
+                response = await channel.stub.idle(protocol.Void(), timeout=timeout)
+            except grpc.RpcError as error:
+                code = error.code()
+                details = error.details() or str(error)
+                if code == grpc.StatusCode.UNIMPLEMENTED:
+                    raise IdleUnavailable(
+                        "Worker does not implement idle reporting"
+                    ) from error
+                if code in self._TRANSIENT_ERRORS:
+                    raise TransientRpcError(code, details) from error
+                raise RpcError(code, details) from error
+        return response.seconds
+
+    async def stop(self, *, grace: float | None = None) -> None:
+        """Stop the remote worker.
+
+        Sends the stop RPC over a channel drawn from this connection's
+        pool, inheriting its credential and secure-channel handling.
+
+        :param grace:
+            The worker's shutdown grace period in seconds, carried in
+            the stop request. ``None`` (the wire default of ``0``)
+            cancels in-flight tasks immediately; a positive value
+            waits that long for a graceful drain; a negative value
+            waits indefinitely.
+        :raises TransientRpcError:
+            If the worker returns a transient RPC error
+            (``UNAVAILABLE``, ``DEADLINE_EXCEEDED``, or
+            ``RESOURCE_EXHAUSTED``).
+        :raises RpcError:
+            If the worker returns any other non-transient RPC error.
+        """
+        async with _channel_pool.get(await self._resolve_key()) as channel:
+            try:
+                await channel.stub.stop(protocol.StopRequest(timeout=grace))
+            except grpc.RpcError as error:
+                code = error.code()
+                details = error.details() or str(error)
+                if code in self._TRANSIENT_ERRORS:
+                    raise TransientRpcError(code, details) from error
+                raise RpcError(code, details) from error
 
     async def _handshake(
         self,

--- a/wool/src/wool/runtime/worker/local.py
+++ b/wool/src/wool/runtime/worker/local.py
@@ -5,15 +5,13 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Final
 
-import grpc.aio
-
-from wool import protocol
 from wool.runtime.typing import Undefined
 from wool.runtime.typing import UndefinedType
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.auth import WorkerCredentialsProvider
 from wool.runtime.worker.base import Worker
 from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.connection import WorkerConnection
 from wool.runtime.worker.process import WorkerProcess
 
 if TYPE_CHECKING:
@@ -158,11 +156,11 @@ class LocalWorker(Worker):
         if self._info is None:
             raise RuntimeError("Worker process failed to start - no metadata")
 
-    async def _stop(self, timeout: float | None):
+    async def _stop(self, grace: float | None):
         """Stop the worker process gracefully, then reap it.
 
         Sends the worker a stop RPC bounded by a deadline derived from
-        ``timeout`` (see `_STOP_RPC_MARGIN`), then — however the RPC
+        ``grace`` (see `_STOP_RPC_MARGIN`), then — however the RPC
         fared — reaps the subprocess; see `WorkerProcess.reap` for the
         escalation. The reap runs in an executor thread so it
         completes even when this coroutine is cancelled; only a second
@@ -170,45 +168,45 @@ class LocalWorker(Worker):
         can skip it, in which case the worker-side parent watchdog
         remains the backstop against orphans.
 
-        For secure workers, resolves the current credentials and dials with
-        the identity-derived channel options (see
-        `WorkerCredentials.identity_channel_options`); for insecure
-        workers, uses an insecure channel.
+        Credential and secure-channel handling for the stop RPC lives
+        on `WorkerConnection.stop`.
 
-        :param timeout:
+        :param grace:
             Bound on the worker's graceful drain, forwarded in the
-            stop request. ``None`` waits unbounded for the drain.
+            stop request; see `WorkerConnection.stop` for its
+            semantics.
         """
         try:
             if self._worker_process.is_alive():
                 assert self.address
 
-                # Create appropriate channel based on available credentials
-                if self._provider is not None:
-                    resolved = await self._provider.credentials
-                    channel = grpc.aio.secure_channel(
-                        self.address,
-                        resolved.client_credentials(),
-                        options=resolved.identity_channel_options(),
-                    )
-                else:
-                    channel = grpc.aio.insecure_channel(self.address)
-
+                # Route the stop RPC through WorkerConnection; ``close``
+                # releases the pooled channel this stop acquired. The
+                # provider rides along so the connection resolves
+                # current credential material per call.
+                connection = WorkerConnection(
+                    self.address, credentials=self._provider
+                )
                 try:
-                    stub = protocol.WorkerStub(channel)
-                    # `timeout=None` preserves the caller's explicit
-                    # unbounded-graceful contract; see
-                    # `_STOP_RPC_MARGIN` for the finite deadline.
-                    deadline = (
-                        timeout + _STOP_RPC_MARGIN if timeout is not None else None
-                    )
-                    await stub.stop(
-                        protocol.StopRequest(timeout=timeout), timeout=deadline
-                    )
+                    # Only a bounded drain (positive grace) admits a
+                    # finite deadline; a negative grace drains
+                    # indefinitely, and ``None`` keeps the pre-existing
+                    # unbounded call. See `_STOP_RPC_MARGIN` for the
+                    # finite deadline.
+                    if grace is None or grace < 0:
+                        deadline = None
+                    else:
+                        deadline = grace + _STOP_RPC_MARGIN
+                    await connection.stop(grace=grace, timeout=deadline)
                 finally:
-                    await channel.close()
+                    await connection.close()
         finally:
             # `reap` blocks on `join`, so it must run off-loop; see
-            # the docstring for the cancellation contract.
+            # the docstring for the cancellation contract. A negative
+            # grace (indefinite drain) must not reach `reap` — a
+            # negative join bound elapses immediately and would
+            # escalate to SIGTERM a worker that just drained cleanly;
+            # `None` falls back to reap's post-stop grace period.
             loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._worker_process.reap, timeout)
+            reap_timeout = None if grace is not None and grace < 0 else grace
+            await loop.run_in_executor(None, self._worker_process.reap, reap_timeout)

--- a/wool/src/wool/runtime/worker/local.py
+++ b/wool/src/wool/runtime/worker/local.py
@@ -184,9 +184,7 @@ class LocalWorker(Worker):
                 # releases the pooled channel this stop acquired. The
                 # provider rides along so the connection resolves
                 # current credential material per call.
-                connection = WorkerConnection(
-                    self.address, credentials=self._provider
-                )
+                connection = WorkerConnection(self.address, credentials=self._provider)
                 try:
                     # Only a bounded drain (positive grace) admits a
                     # finite deadline; a negative grace drains

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -163,10 +163,11 @@ class WorkerPool:
         and the worker stopped regardless — discovery cannot strand a
         worker, but a hanging announcement can consume the deadline and
         cost that worker its graceful drain. A finite value overrides a
-        worker's own shutdown grace period; ``None`` disables the bound,
-        in which case a hanging announcement blocks teardown
-        indefinitely, in keeping with that value's unbounded-wait
-        contract. Must be positive when provided. Defaults to ``60.0``.
+        worker's own shutdown grace period; ``None`` disables the bound
+        and requests an indefinite drain from each worker, in keeping
+        with that value's unbounded-wait contract — a hanging
+        announcement (or task) then blocks teardown indefinitely. Must
+        be positive when provided. Defaults to ``60.0``.
 
         .. caution::
 
@@ -756,8 +757,13 @@ class WorkerPool:
                     finally:
                         # The stop outlives the cancellation above, bounded by
                         # what remains of the deadline — see the docstring's
-                        # implementation notes.
-                        await worker.stop(timeout=remaining())
+                        # implementation notes. An unbounded teardown
+                        # (``shutdown_timeout=None``) asks the worker for an
+                        # indefinite drain, which the stop surface spells as
+                        # a negative grace — ``grace=None`` would mean no
+                        # grace at all.
+                        grace = remaining()
+                        await worker.stop(grace=-1.0 if grace is None else grace)
 
                 task = asyncio.create_task(start(worker))
                 tasks.append(task)

--- a/wool/src/wool/runtime/worker/service.py
+++ b/wool/src/wool/runtime/worker/service.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import pickle
 import threading
+import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from inspect import isawaitable
@@ -154,11 +155,17 @@ class WorkerService(protocol.WorkerServicer):
     _stopped: asyncio.Event
     _stopping: asyncio.Event
     _loop_pool: ResourcePool[tuple[asyncio.AbstractEventLoop, threading.Thread]]
+    # Monotonic timestamp at which the docket last became empty, or
+    # ``None`` while any task is in flight.
+    _idle_since: float | None
 
     def __init__(self, *, backpressure: BackpressureLike | None = None):
         self._stopped = asyncio.Event()
         self._stopping = asyncio.Event()
         self._docket = set()
+        # Worker startup counts as the initial empty state, so idle is
+        # measured from construction.
+        self._idle_since = time.monotonic()
         self._backpressure = backpressure
         # Strong refs to live ``session.cancel()`` tasks scheduled
         # from ``_propagate_cancel_on_done`` (a gRPC-internal-thread
@@ -571,6 +578,36 @@ class WorkerService(protocol.WorkerServicer):
         await self._stop(timeout=request.timeout)
         return protocol.Void()
 
+    async def idle(
+        self,
+        request: protocol.Void,
+        context: ServicerContext | None,
+    ) -> protocol.IdleTime:
+        """Report how long the worker has been continuously idle.
+
+        Idle is the number of seconds since the in-flight task set
+        (`_docket`) last became empty, with worker startup counting as
+        the initial empty state. While any task is in flight the
+        reported idle time is zero, and the count resets whenever work
+        resumes. Measured against a monotonic clock so a wall-clock
+        adjustment cannot distort it.
+
+        Polling this RPC creates no `DispatchSession` and never touches
+        the docket, so a caller cannot disturb the measurement it reads.
+
+        :param request:
+            The empty protobuf request.
+        :param context:
+            The `grpc.aio.ServicerContext` for this request.
+        :returns:
+            An `IdleTime` carrying the continuous idle duration in
+            seconds.
+        """
+        seconds = (
+            0.0 if self._idle_since is None else time.monotonic() - self._idle_since
+        )
+        return protocol.IdleTime(seconds=seconds)
+
     @staticmethod
     def _create_worker_loop(
         key,
@@ -717,10 +754,21 @@ class WorkerService(protocol.WorkerServicer):
                 StatusCode.UNAVAILABLE, "Worker service is shutting down"
             )
         self._docket.add(session)
+        # Empty -> non-empty edge: work has resumed, so the worker is
+        # no longer idle. The add and this check share a single
+        # main-loop turn (no ``await`` between), so the transition is
+        # race-free against concurrent dispatches.
+        if len(self._docket) == 1:
+            self._idle_since = None
         try:
             yield
         finally:
             self._docket.discard(session)
+            # Non-empty -> empty edge: the in-flight set just drained,
+            # so start counting idle from now. Same single-turn
+            # atomicity as the add-side edge above.
+            if not self._docket:
+                self._idle_since = time.monotonic()
 
     async def _stop(self, *, timeout: float | None = 0) -> None:
         if timeout is not None and timeout < 0:

--- a/wool/tests/integration/test_worker_idle.py
+++ b/wool/tests/integration/test_worker_idle.py
@@ -1,0 +1,343 @@
+import asyncio
+import contextlib
+import uuid
+from contextlib import asynccontextmanager
+
+import grpc
+import grpc.aio
+import pytest
+
+from wool import protocol
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.worker.connection import IdleUnavailable
+from wool.runtime.worker.connection import RpcError
+from wool.runtime.worker.connection import TransientRpcError
+from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.local import LocalWorker
+from wool.runtime.worker.pool import WorkerPool
+
+from . import routines
+from .conftest import CredentialType
+from .conftest import _DirectDiscovery
+
+pytestmark = pytest.mark.integration
+
+
+async def _poll(predicate, *, tries=600, interval=0.05):
+    """Await until the sync *predicate* returns truthy, or fail."""
+    for _ in range(tries):
+        if predicate():
+            return
+        await asyncio.sleep(interval)
+    raise AssertionError("condition not met within timeout")
+
+
+async def _poll_coro(predicate, *, tries=200, interval=0.05):
+    """Await until the async *predicate* returns truthy, or fail."""
+    for _ in range(tries):
+        if await predicate():
+            return
+        await asyncio.sleep(interval)
+    raise AssertionError("condition not met within timeout")
+
+
+@asynccontextmanager
+async def _bare_worker(creds):
+    """Start a real LocalWorker and yield it plus a direct-connection
+    factory. No pool — for tests that only poll idle/stop by address.
+    """
+    conns = []
+    worker = LocalWorker(credentials=creds)
+    await worker.start()
+
+    def connect():
+        conn = WorkerConnection(worker.address, credentials=creds)
+        conns.append(conn)
+        return conn
+
+    try:
+        yield worker, connect
+    finally:
+        for conn in conns:
+            with contextlib.suppress(Exception):
+                await conn.close()
+        with contextlib.suppress(Exception):
+            await worker.stop()
+
+
+@asynccontextmanager
+async def _worker_with_pool(creds):
+    """Start a real LocalWorker behind a DURABLE pool (so routines can
+    be dispatched to it) and yield the worker, the pool, and a
+    direct-connection factory. Teardown is defensive.
+    """
+    conns = []
+    namespace = f"idle-{uuid.uuid4().hex[:12]}"
+    with LocalDiscovery(namespace) as discovery:
+        worker = LocalWorker(credentials=creds)
+        await worker.start()
+
+        def connect():
+            conn = WorkerConnection(worker.address, credentials=creds)
+            conns.append(conn)
+            return conn
+
+        try:
+            publisher = discovery.publisher
+            async with publisher:
+                await publisher.publish("worker-added", worker.metadata)
+                try:
+                    pool = WorkerPool(
+                        discovery=_DirectDiscovery(discovery), credentials=creds
+                    )
+                    async with pool:
+                        yield worker, pool, connect
+                finally:
+                    with contextlib.suppress(Exception):
+                        await publisher.publish("worker-dropped", worker.metadata)
+        finally:
+            for conn in conns:
+                with contextlib.suppress(Exception):
+                    await conn.close()
+            with contextlib.suppress(Exception):
+                await worker.stop()
+
+
+class TestWorkerIdleReporting:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "cred",
+        [CredentialType.INSECURE, CredentialType.MTLS, CredentialType.ONE_WAY],
+    )
+    async def test_idle_time_should_accrue_from_startup_over_the_real_wire(
+        self, credentials_map, retry_grpc_internal, cred
+    ):
+        """Test idle accrues from startup, over each transport.
+
+        Given:
+            A freshly started real worker that has never been dispatched
+            a task, reached over an insecure, mTLS, or one-way-TLS
+            channel
+        When:
+            A direct WorkerConnection polls idle twice with a wait
+            between
+        Then:
+            Both readings should be positive and non-decreasing — idle
+            counts from startup and inherits the connection's
+            credential handling.
+        """
+
+        async def body():
+            # Arrange
+            async with _bare_worker(credentials_map[cred]) as (worker, connect):
+                conn = connect()
+
+                # Act
+                first = await conn.idle_time()
+                await asyncio.sleep(0.1)
+                second = await conn.idle_time()
+
+                # Assert
+                assert first >= 0.0
+                assert second >= first
+                assert second > 0.0
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_idle_time_should_report_zero_while_a_task_is_in_flight(
+        self, credentials_map, retry_grpc_internal, tmp_path
+    ):
+        """Test idle is zero while a dispatched routine runs on the worker.
+
+        Given:
+            A real worker with one in-flight routine (confirmed via its
+            "started" sentinel)
+        When:
+            idle is polled through a direct WorkerConnection
+        Then:
+            It should report exactly zero — the docket is non-empty.
+        """
+
+        async def body():
+            async with _worker_with_pool(credentials_map[CredentialType.INSECURE]) as (
+                worker,
+                pool,
+                connect,
+            ):
+                conn = connect()
+                sentinel = tmp_path / "in-flight.txt"
+                dispatch = asyncio.create_task(
+                    routines.cancellable_sleep(str(sentinel), 30.0)
+                )
+                try:
+                    # Arrange
+                    await _poll(
+                        lambda: sentinel.exists() and sentinel.read_text() == "started"
+                    )
+
+                    # Act & assert
+                    assert await conn.idle_time() == 0.0
+                finally:
+                    dispatch.cancel()
+                    with contextlib.suppress(BaseException):
+                        await dispatch
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_idle_time_should_reset_after_the_in_flight_set_drains(
+        self, credentials_map, retry_grpc_internal, tmp_path
+    ):
+        """Test idle resets once the worker's in-flight set drains.
+
+        Given:
+            A real worker that has accrued idle, then runs one routine
+            to completion
+        When:
+            idle is polled before dispatch and after the routine drains
+        Then:
+            It should report accrued idle before, and a smaller value
+            after — proving the count reset at the drain rather than
+            continuing to accrue from startup.
+        """
+
+        async def body():
+            async with _worker_with_pool(credentials_map[CredentialType.INSECURE]) as (
+                worker,
+                pool,
+                connect,
+            ):
+                conn = connect()
+                await asyncio.sleep(0.2)
+                before = await conn.idle_time()
+
+                # Act
+                sentinel = tmp_path / "drain.txt"
+                await routines.cancellable_sleep(str(sentinel), 0.3)
+
+                # Wait for the docket-drain to be reflected (idle > 0),
+                # then confirm it counts from the drain, not from startup.
+                async def _reset():
+                    return await conn.idle_time() > 0.0
+
+                await _poll_coro(_reset)
+                after = await conn.idle_time()
+
+                # Assert
+                assert before > 0.0
+                assert after < before
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_idle_time_should_raise_idle_unavailable_for_a_legacy_worker(
+        self, retry_grpc_internal
+    ):
+        """Test idle surfaces IdleUnavailable against a legacy worker.
+
+        Given:
+            A real gRPC server whose Worker servicer does not implement
+            idle (a stand-in for a worker predating the RPC), so the
+            framework answers UNIMPLEMENTED
+        When:
+            A real WorkerConnection polls idle against it
+        Then:
+            It should raise IdleUnavailable — and not an RpcError — over
+            the real channel.
+        """
+
+        async def body():
+            # Arrange
+            server = grpc.aio.server()
+            protocol.add_WorkerServicer_to_server(protocol.WorkerServicer(), server)
+            port = server.add_insecure_port("127.0.0.1:0")
+            await server.start()
+            conn = WorkerConnection(f"127.0.0.1:{port}")
+            try:
+                # Act & assert
+                with pytest.raises(IdleUnavailable) as exc_info:
+                    await conn.idle_time()
+                assert not isinstance(exc_info.value, RpcError)
+            finally:
+                await conn.close()
+                await server.stop(None)
+
+        await retry_grpc_internal(body)
+
+
+class TestWorkerControlSurface:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cred", [CredentialType.INSECURE, CredentialType.MTLS])
+    async def test_poll_then_retire_should_terminate_the_worker(
+        self, credentials_map, retry_grpc_internal, cred
+    ):
+        """Test the poll-then-retire flow stops the worker.
+
+        Given:
+            An idle real worker and a direct WorkerConnection to it
+        When:
+            The caller polls idle, then calls stop, then polls idle again
+        Then:
+            stop returns and the worker terminates — a subsequent idle
+            eventually raises TransientRpcError (the server is gone).
+        """
+
+        async def body():
+            # Arrange
+            async with _bare_worker(credentials_map[cred]) as (worker, connect):
+                conn = connect()
+                assert await conn.idle_time() >= 0.0
+
+                # Act
+                await conn.stop()
+
+                # Assert
+                async def _unreachable():
+                    try:
+                        await conn.idle_time()
+                        return False
+                    except TransientRpcError:
+                        return True
+                    except RpcError as error:
+                        # A worker mid-teardown can abort the poll as
+                        # CANCELLED rather than refuse it as
+                        # UNAVAILABLE; both prove the server is going
+                        # away. Anything else is a real fault.
+                        if error.code is grpc.StatusCode.CANCELLED:
+                            return True
+                        raise
+
+                await _poll_coro(_unreachable, tries=200, interval=0.1)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "cred",
+        [CredentialType.INSECURE, CredentialType.MTLS, CredentialType.ONE_WAY],
+    )
+    async def test_local_worker_stop_should_succeed_over_each_transport(
+        self, credentials_map, retry_grpc_internal, cred
+    ):
+        """Test LocalWorker.stop succeeds through the refactored path.
+
+        Given:
+            A started real LocalWorker under each credential type
+        When:
+            worker.stop is awaited (now routed through
+            WorkerConnection.stop and close)
+        Then:
+            It should complete without error, exercising the refactored
+            _stop's credential and secure-channel handling end-to-end.
+        """
+
+        async def body():
+            # Arrange
+            worker = LocalWorker(credentials=credentials_map[cred])
+            await worker.start()
+
+            # Act & assert (completes without raising)
+            await worker.stop()
+
+        await retry_grpc_internal(body)

--- a/wool/tests/integration/test_worker_shutdown.py
+++ b/wool/tests/integration/test_worker_shutdown.py
@@ -12,10 +12,10 @@ import time
 import uuid
 
 import grpc
-import grpc.aio
 import pytest
 
 from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.local import LocalWorker
 from wool.runtime.worker.pool import WorkerPool
 from wool.runtime.worker.process import WorkerProcess
@@ -410,11 +410,12 @@ class TestWorkerOrphanPrevention:
             SIGSTOP, so it can neither serve the stop RPC nor honor
             SIGTERM.
         When:
-            stop() is awaited with a short timeout.
+            stop() is awaited with a short grace period.
         Then:
-            It should surface the RPC deadline within a bound and
-            leave the worker subprocess killed, rather than hang on
-            the deadline-less stop RPC.
+            It should surface the RPC deadline within a bound — as the
+            TransientRpcError the stop RPC's WorkerConnection routing
+            wraps it in — and leave the worker subprocess killed,
+            rather than hang on the deadline-less stop RPC.
         """
         # Arrange
         worker = LocalWorker(shutdown_grace_period=5.0)
@@ -427,11 +428,11 @@ class TestWorkerOrphanPrevention:
             os.kill(pid, signal.SIGSTOP)
 
             # Act
-            with pytest.raises(grpc.aio.AioRpcError) as excinfo:
-                await asyncio.wait_for(worker.stop(timeout=0.5), timeout=30)
+            with pytest.raises(TransientRpcError) as excinfo:
+                await asyncio.wait_for(worker.stop(grace=0.5), timeout=30)
 
             # Assert
-            assert excinfo.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
+            assert excinfo.value.code is grpc.StatusCode.DEADLINE_EXCEEDED
             assert not _pid_alive(pid)
         finally:
             _ensure_killed(pid)

--- a/wool/tests/protocol/test_wire.py
+++ b/wool/tests/protocol/test_wire.py
@@ -1,10 +1,14 @@
 import pytest
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
 
 from wool import protocol
 
 EXPECTED_MESSAGE_EXPORTS = [
     "Ack",
     "ChainManifest",
+    "IdleTime",
     "Message",
     "Nack",
     "Request",
@@ -268,6 +272,43 @@ class TestMessageConstruction:
         parsed = protocol.Nack()
         parsed.ParseFromString(nack.SerializeToString())
         assert parsed.HasField("exception") is False
+
+    def test_idle_time_fields(self):
+        """Test IdleTime carries the idle duration in seconds.
+
+        Given:
+            A seconds value, and the default construction.
+        When:
+            An IdleTime message is constructed with and without a value.
+        Then:
+            The seconds field should hold the value and default to 0.0.
+        """
+        # Arrange, act, & assert
+        assert protocol.IdleTime(seconds=42.5).seconds == 42.5
+        assert protocol.IdleTime().seconds == 0.0
+
+    @settings(max_examples=100)
+    @given(seconds=st.floats(width=64, allow_nan=False, allow_infinity=False))
+    def test_idle_time_roundtrip(self, seconds):
+        """Test IdleTime.seconds survives the wire-format round-trip.
+
+        Given:
+            Any finite double value for the idle duration.
+        When:
+            An IdleTime message is serialized and re-parsed.
+        Then:
+            The seconds field should equal the original exactly — a
+            proto double round-trips losslessly.
+        """
+        # Arrange
+        message = protocol.IdleTime(seconds=seconds)
+
+        # Act
+        parsed = protocol.IdleTime()
+        parsed.ParseFromString(message.SerializeToString())
+
+        # Assert
+        assert parsed.seconds == seconds
 
 
 class TestOneofBehavior:

--- a/wool/tests/runtime/worker/conftest.py
+++ b/wool/tests/runtime/worker/conftest.py
@@ -313,7 +313,9 @@ class MockWorker:
         )
         self._started = True
 
-    async def stop(self, *, timeout: float | None = None) -> None:
+    async def stop(
+        self, *, grace: float | None = None, timeout: float | None = None
+    ) -> None:
         """Stop the mock worker (always succeeds)."""
         self._started = False
         self._info = None

--- a/wool/tests/runtime/worker/test_base.py
+++ b/wool/tests/runtime/worker/test_base.py
@@ -366,7 +366,7 @@ class ConcreteWorker(Worker):
             extra=MappingProxyType(self._extra),
         )
 
-    async def _stop(self, timeout: float | None):
+    async def _stop(self, grace: float | None):
         """Mock stop implementation."""
         pass
 
@@ -638,10 +638,39 @@ class TestWorker:
         )
 
         # Act
-        await worker.stop(timeout=60.0)
+        await worker.stop(grace=60.0)
 
         # Assert
         mock_stop.assert_called_once_with(60.0)
+
+    @pytest.mark.asyncio
+    async def test_stop_forwards_deprecated_timeout_as_grace(self, mocker):
+        """Test stop accepts the deprecated timeout alias for grace.
+
+        Given:
+            A started Worker with a mocked _stop
+        When:
+            stop is called with the deprecated timeout keyword
+        Then:
+            It should emit a DeprecationWarning and forward the value to
+            _stop as the grace period, preserving backwards
+            compatibility.
+        """
+        # Arrange
+        worker = ConcreteWorker()
+        await worker.start()
+        mock_stop = mocker.patch.object(
+            worker,
+            "_stop",
+            new_callable=mocker.AsyncMock,
+        )
+
+        # Act
+        with pytest.warns(DeprecationWarning):
+            await worker.stop(timeout=7.5)
+
+        # Assert
+        mock_stop.assert_called_once_with(7.5)
 
     @pytest.mark.asyncio
     async def test_stop_allows_restart(self):

--- a/wool/tests/runtime/worker/test_connection.py
+++ b/wool/tests/runtime/worker/test_connection.py
@@ -29,6 +29,7 @@ from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.auth import WorkerCredentialsProvider
 from wool.runtime.worker.base import ChannelOptions
 from wool.runtime.worker.connection import HandshakeError
+from wool.runtime.worker.connection import IdleUnavailable
 from wool.runtime.worker.connection import RpcError
 from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.connection import UnexpectedResponse
@@ -69,6 +70,28 @@ def _secure_provider(identity: str | None = None) -> WorkerCredentialsProvider:
         ca_cert=b"ca", worker_key=b"key", worker_cert=b"cert"
     )
     return WorkerCredentialsProvider(lambda: credentials, identity=identity)
+
+
+class _MockRpcError(grpc.RpcError):
+    """A ``grpc.RpcError`` carrying a controllable ``code``/``details``.
+
+    Defined at module scope so property tests can raise a realistic
+    gRPC error for any status code without redefining the class per
+    example. ``str(self)`` is non-empty so the ``details() or
+    str(error)`` fallback in :class:`WorkerConnection` is observable
+    when ``details`` is empty.
+    """
+
+    def __init__(self, code: grpc.StatusCode, details: str | None):
+        super().__init__(f"<mock {code.name}>")
+        self._code = code
+        self._details = details
+
+    def code(self) -> grpc.StatusCode:
+        return self._code
+
+    def details(self) -> str | None:
+        return self._details
 
 
 class MyAppError(Exception):
@@ -1448,6 +1471,389 @@ class TestWorkerConnection:
 
         # Cleanup
         await connection.close()
+
+    @pytest.mark.asyncio
+    async def test_idle_time_should_return_seconds_when_worker_responds(
+        self, mocker: MockerFixture
+    ):
+        """Test idle returns the worker's reported idle seconds.
+
+        Given:
+            A connection whose worker answers the idle RPC with an
+            IdleTime
+        When:
+            idle is awaited
+        Then:
+            It should return the reported seconds as a float.
+        """
+        # Arrange
+        mock_stub = mocker.MagicMock()
+        mock_stub.idle = mocker.AsyncMock(return_value=protocol.IdleTime(seconds=42.5))
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection("localhost:50051")
+
+        # Act
+        result = await connection.idle_time()
+
+        # Assert
+        assert result == 42.5
+        mock_stub.idle.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_idle_time_should_raise_idle_unavailable_when_unimplemented(
+        self, mocker: MockerFixture
+    ):
+        """Test idle surfaces IdleUnavailable for a worker without the RPC.
+
+        Given:
+            A connection whose worker answers the idle RPC with gRPC
+            UNIMPLEMENTED (a worker predating idle reporting)
+        When:
+            idle is awaited
+        Then:
+            It should raise IdleUnavailable so the caller can treat idle
+            reporting as unavailable for this worker.
+        """
+
+        # Arrange
+        class MockRpcError(grpc.RpcError):
+            def code(self):
+                return grpc.StatusCode.UNIMPLEMENTED
+
+            def details(self):
+                return "method idle not implemented"
+
+        mock_stub = mocker.MagicMock()
+        mock_stub.idle = mocker.AsyncMock(side_effect=MockRpcError())
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection("localhost:50051")
+
+        # Act & assert
+        with pytest.raises(IdleUnavailable):
+            await connection.idle_time()
+
+    @pytest.mark.asyncio
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        code=st.sampled_from(
+            [c for c in grpc.StatusCode if c is not grpc.StatusCode.OK]
+        ),
+        details=st.one_of(st.none(), st.just(""), st.text()),
+    )
+    async def test_idle_time_should_map_status_code_to_typed_exception(
+        self, mocker: MockerFixture, code: grpc.StatusCode, details: str | None
+    ):
+        """Test idle maps every gRPC status code to the right exception.
+
+        Given:
+            A connection whose worker answers the idle RPC with any gRPC
+            error status code and any details
+        When:
+            idle is awaited
+        Then:
+            It should raise IdleUnavailable for UNIMPLEMENTED (chained
+            from the gRPC error and not an RpcError), TransientRpcError
+            for transient codes, and RpcError otherwise — carrying the
+            code and details, falling back to str(error) when details
+            are empty.
+        """
+        # Arrange
+        error = _MockRpcError(code, details)
+        mock_stub = mocker.MagicMock()
+        mock_stub.idle = mocker.AsyncMock(side_effect=error)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection("localhost:50051")
+        # Fresh channel per example — the module pool persists across
+        # Hypothesis examples within one test function, so evict any
+        # channel a prior example cached under this key.
+        await clear_channel_pool()
+
+        # Act
+        with pytest.raises(Exception) as exc_info:
+            await connection.idle_time()
+
+        # Assert
+        raised = exc_info.value
+        if code is grpc.StatusCode.UNIMPLEMENTED:
+            assert isinstance(raised, IdleUnavailable)
+            assert not isinstance(raised, RpcError)
+            assert raised.__cause__ is error
+        else:
+            if code in WorkerConnection._TRANSIENT_ERRORS:
+                assert isinstance(raised, TransientRpcError)
+            else:
+                assert isinstance(raised, RpcError)
+                assert not isinstance(raised, TransientRpcError)
+            assert raised.code is code
+            assert raised.details == (details or str(error))
+
+    @pytest.mark.asyncio
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(timeout=st.floats(max_value=0.0, allow_nan=False, allow_infinity=False))
+    async def test_idle_time_should_reject_non_positive_timeout(
+        self, mocker: MockerFixture, timeout: float
+    ):
+        """Test idle_time rejects a non-positive timeout with ValueError.
+
+        Given:
+            A connection whose worker answers the idle RPC, and any
+            non-positive timeout
+        When:
+            idle_time is awaited with that timeout
+        Then:
+            It should raise ValueError without calling the stub, matching
+            dispatch's timeout validation.
+        """
+        # Arrange
+        mock_stub = mocker.MagicMock()
+        mock_stub.idle = mocker.AsyncMock(return_value=protocol.IdleTime(seconds=1.0))
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection("localhost:50051")
+        # Fresh channel per example (see idle-map note above).
+        await clear_channel_pool()
+
+        # Act & assert
+        with pytest.raises(ValueError):
+            await connection.idle_time(timeout=timeout)
+        mock_stub.idle.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        timeout=st.one_of(
+            st.none(),
+            st.floats(
+                min_value=0.0,
+                exclude_min=True,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        )
+    )
+    async def test_idle_time_should_forward_positive_timeout(
+        self, mocker: MockerFixture, timeout: float | None
+    ):
+        """Test idle_time forwards None or a positive timeout to the stub.
+
+        Given:
+            A connection whose worker answers the idle RPC, and None or
+            any positive timeout
+        When:
+            idle_time is awaited with that timeout
+        Then:
+            It should call the stub with a Void request and that timeout
+            as the gRPC deadline.
+        """
+        # Arrange
+        mock_stub = mocker.MagicMock()
+        mock_stub.idle = mocker.AsyncMock(return_value=protocol.IdleTime(seconds=1.0))
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection("localhost:50051")
+        # Fresh channel per example (see idle-map note above).
+        await clear_channel_pool()
+
+        # Act
+        result = await connection.idle_time(timeout=timeout)
+
+        # Assert
+        assert result == 1.0
+        mock_stub.idle.assert_awaited_once()
+        call = mock_stub.idle.await_args
+        assert isinstance(call.args[0], protocol.Void)
+        assert call.kwargs["timeout"] == timeout
+
+    @pytest.mark.asyncio
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(seconds=st.floats(width=64, allow_nan=False, allow_infinity=False))
+    async def test_idle_time_should_return_reported_seconds_verbatim(
+        self, mocker: MockerFixture, seconds: float
+    ):
+        """Test idle returns the worker's reported seconds losslessly.
+
+        Given:
+            A worker answering the idle RPC with any double value
+        When:
+            idle is awaited
+        Then:
+            It should return exactly that value (including 0.0) — the
+            double survives the round-trip through the connection.
+        """
+        # Arrange
+        mock_stub = mocker.MagicMock()
+        mock_stub.idle = mocker.AsyncMock(
+            return_value=protocol.IdleTime(seconds=seconds)
+        )
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection("localhost:50051")
+        # Fresh channel per example (see idle-map note above).
+        await clear_channel_pool()
+
+        # Act
+        result = await connection.idle_time()
+
+        # Assert
+        assert result == seconds
+
+    @pytest.mark.asyncio
+    async def test_stop_should_send_stop_request_with_timeout(
+        self, mocker: MockerFixture
+    ):
+        """Test stop sends a StopRequest carrying the grace timeout.
+
+        Given:
+            A connection to a worker that acknowledges the stop RPC
+        When:
+            stop is awaited with a timeout
+        Then:
+            It should send a StopRequest with that timeout and return
+            None.
+        """
+        # Arrange
+        mock_stub = mocker.MagicMock()
+        mock_stub.stop = mocker.AsyncMock(return_value=protocol.Void())
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection("localhost:50051")
+
+        # Act
+        result = await connection.stop(grace=5.0)
+
+        # Assert
+        assert result is None
+        mock_stub.stop.assert_awaited_once()
+        sent = mock_stub.stop.await_args.args[0]
+        assert isinstance(sent, protocol.StopRequest)
+        assert sent.timeout == 5.0
+
+    @pytest.mark.asyncio
+    async def test_stop_should_send_zero_timeout_when_none(self, mocker: MockerFixture):
+        """Test stop sends the wire-default timeout when none is given.
+
+        Given:
+            A connection to a worker that acknowledges the stop RPC
+        When:
+            stop is awaited with no timeout argument
+        Then:
+            It should send a StopRequest whose timeout is 0.0 (the proto
+            default), which the worker reads as cancel-immediately.
+        """
+        # Arrange
+        mock_stub = mocker.MagicMock()
+        mock_stub.stop = mocker.AsyncMock(return_value=protocol.Void())
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection("localhost:50051")
+
+        # Act
+        await connection.stop()
+
+        # Assert
+        sent = mock_stub.stop.await_args.args[0]
+        assert isinstance(sent, protocol.StopRequest)
+        assert sent.timeout == 0.0
+
+    @pytest.mark.asyncio
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        code=st.sampled_from(
+            [c for c in grpc.StatusCode if c is not grpc.StatusCode.OK]
+        ),
+        details=st.one_of(st.none(), st.just(""), st.text()),
+    )
+    async def test_stop_should_map_status_code_to_typed_exception(
+        self, mocker: MockerFixture, code: grpc.StatusCode, details: str | None
+    ):
+        """Test stop maps every gRPC status code to the right exception.
+
+        Given:
+            A connection whose worker answers the stop RPC with any gRPC
+            error status code and any details
+        When:
+            stop is awaited
+        Then:
+            It should raise TransientRpcError for transient codes and
+            RpcError otherwise (including UNIMPLEMENTED, which stop does
+            not special-case), carrying the code and details, falling
+            back to str(error) when details are empty.
+        """
+        # Arrange
+        error = _MockRpcError(code, details)
+        mock_stub = mocker.MagicMock()
+        mock_stub.stop = mocker.AsyncMock(side_effect=error)
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection("localhost:50051")
+        # Fresh channel per example (see idle-map note above).
+        await clear_channel_pool()
+
+        # Act
+        with pytest.raises(RpcError) as exc_info:
+            await connection.stop()
+
+        # Assert
+        raised = exc_info.value
+        if code in WorkerConnection._TRANSIENT_ERRORS:
+            assert isinstance(raised, TransientRpcError)
+        else:
+            assert not isinstance(raised, TransientRpcError)
+        assert raised.code is code
+        assert raised.details == (details or str(error))
+
+    @pytest.mark.asyncio
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(timeout=st.floats(width=32, allow_nan=False, allow_infinity=False))
+    async def test_stop_should_forward_timeout_without_validation(
+        self, mocker: MockerFixture, timeout: float
+    ):
+        """Test stop forwards any timeout onto the StopRequest verbatim.
+
+        Given:
+            A connection whose worker acknowledges the stop RPC, and any
+            float32 timeout including non-positive values
+        When:
+            stop is awaited with that timeout
+        Then:
+            It should send a StopRequest carrying that timeout (a
+            negative value rides the wire unchanged) without raising
+            ValueError — stop does not validate its timeout.
+        """
+        # Arrange
+        mock_stub = mocker.MagicMock()
+        mock_stub.stop = mocker.AsyncMock(return_value=protocol.Void())
+        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        connection = WorkerConnection("localhost:50051")
+        # Fresh channel per example (see idle-map note above).
+        await clear_channel_pool()
+
+        # Act
+        result = await connection.stop(grace=timeout)
+
+        # Assert
+        assert result is None
+        sent = mock_stub.stop.await_args.args[0]
+        assert isinstance(sent, protocol.StopRequest)
+        assert sent.timeout == pytest.approx(timeout)
 
     @pytest.mark.asyncio
     @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])

--- a/wool/tests/runtime/worker/test_local.py
+++ b/wool/tests/runtime/worker/test_local.py
@@ -388,16 +388,43 @@ class TestLocalWorker:
         mock_stub.stop.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_stop_forwards_grace_timeout(self, mocker):
+        """Test _stop forwards its grace timeout onto the StopRequest.
+
+        Given:
+            A started LocalWorker with an alive process
+        When:
+            stop() is called with a grace timeout
+        Then:
+            It should send a StopRequest carrying that timeout through
+            the pooled WorkerConnection.
+        """
+        # Arrange
+        _make_started_process(mocker)
+        _, mock_stub = _mock_stop_channel(mocker)
+
+        worker = LocalWorker()
+        await worker.start()
+
+        # Act
+        await worker.stop(grace=7.5)
+
+        # Assert
+        sent = mock_stub.stop.await_args.args[0]
+        assert isinstance(sent, protocol.StopRequest)
+        assert sent.timeout == 7.5
+
+    @pytest.mark.asyncio
     async def test_stop_should_reap_process_after_graceful_stop(self, mocker):
         """Test stop reaps the worker process after the graceful RPC.
 
         Given:
             A started LocalWorker whose graceful stop RPC succeeds
         When:
-            stop() is called with a timeout
+            stop() is called with a grace period
         Then:
-            It should send a stop request carrying that timeout, then
-            reap the worker process with it
+            It should send a stop request carrying that grace period,
+            then reap the worker process with it
         """
         # Arrange
         mock_process = _make_started_process(mocker)
@@ -411,7 +438,7 @@ class TestLocalWorker:
         teardown.attach_mock(mock_process.reap, "reap")
 
         # Act
-        await worker.stop(timeout=12.5)
+        await worker.stop(grace=12.5)
 
         # Assert
         mock_stub.stop.assert_awaited_once()
@@ -430,20 +457,18 @@ class TestLocalWorker:
         deadline=None,
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
-    @given(timeout=st.floats(min_value=0.125, max_value=4096.0, width=32))
-    async def test_stop_should_bound_rpc_deadline_when_timeout_finite(
-        self, mocker, timeout
-    ):
-        """Test any finite stop timeout yields a strictly larger deadline.
+    @given(grace=st.floats(min_value=0.125, max_value=4096.0, width=32))
+    async def test_stop_should_bound_rpc_deadline_when_grace_finite(self, mocker, grace):
+        """Test any finite grace period yields a strictly larger deadline.
 
         Given:
-            Any finite positive stop timeout
+            Any finite positive grace period
         When:
             stop() is called with it
         Then:
-            It should forward the timeout in the stop request, bound
-            the RPC by deadline = timeout + _STOP_RPC_MARGIN, and reap
-            with the same timeout
+            It should forward the grace period in the stop request,
+            bound the RPC by deadline = grace + _STOP_RPC_MARGIN, and
+            reap with the same grace period
         """
         # Arrange
         mock_process = _make_started_process(mocker)
@@ -453,15 +478,15 @@ class TestLocalWorker:
         await worker.start()
 
         # Act
-        await worker.stop(timeout=timeout)
+        await worker.stop(grace=grace)
 
         # Assert
         request = mock_stub.stop.await_args.args[0]
-        assert request.timeout == timeout
+        assert request.timeout == grace
         deadline = mock_stub.stop.await_args.kwargs["timeout"]
-        assert deadline == timeout + local_module._STOP_RPC_MARGIN
-        assert deadline > timeout
-        mock_process.reap.assert_called_once_with(timeout)
+        assert deadline == grace + local_module._STOP_RPC_MARGIN
+        assert deadline > grace
+        mock_process.reap.assert_called_once_with(grace)
 
     @pytest.mark.asyncio
     async def test_stop_should_reap_process_when_grpc_stop_fails(self, mocker):
@@ -517,13 +542,13 @@ class TestLocalWorker:
         mock_process.reap.assert_called_once_with(None)
 
     @pytest.mark.asyncio
-    async def test_stop_should_not_set_rpc_deadline_when_timeout_none(self, mocker):
-        """Test stop leaves the graceful RPC unbounded without a timeout.
+    async def test_stop_should_not_set_rpc_deadline_when_grace_none(self, mocker):
+        """Test stop leaves the graceful RPC unbounded without a grace period.
 
         Given:
             A started LocalWorker whose graceful stop RPC succeeds
         When:
-            stop() is called without a timeout
+            stop() is called without a grace period
         Then:
             It should send the stop request with no gRPC deadline and
             reap without a bound override
@@ -544,6 +569,35 @@ class TestLocalWorker:
         mock_process.reap.assert_called_once_with(None)
 
     @pytest.mark.asyncio
+    async def test_stop_should_not_bound_rpc_deadline_when_grace_negative(self, mocker):
+        """Test a negative grace leaves the indefinite drain unbounded.
+
+        Given:
+            A started LocalWorker whose graceful stop RPC succeeds
+        When:
+            stop() is called with a negative grace period
+        Then:
+            It should forward the negative grace in the stop request,
+            apply no gRPC deadline to the indefinite drain, and reap
+            without a bound override
+        """
+        # Arrange
+        mock_process = _make_started_process(mocker)
+        _, mock_stub = _mock_stop_channel(mocker)
+
+        worker = LocalWorker()
+        await worker.start()
+
+        # Act
+        await worker.stop(grace=-1.0)
+
+        # Assert
+        request = mock_stub.stop.await_args.args[0]
+        assert request.timeout == -1.0
+        assert mock_stub.stop.await_args.kwargs["timeout"] is None
+        mock_process.reap.assert_called_once_with(None)
+
+    @pytest.mark.asyncio
     async def test_stop_should_reap_process_when_cancelled_mid_rpc(self, mocker):
         """Test stop reaps the worker even when cancelled mid-RPC.
 
@@ -554,7 +608,7 @@ class TestLocalWorker:
             The stop() task is cancelled while the RPC is in flight
         Then:
             It should raise CancelledError to the awaiter and still
-            reap the worker process with the stop timeout
+            reap the worker process with the grace period
         """
         # Arrange
         mock_process = _make_started_process(mocker)
@@ -571,7 +625,7 @@ class TestLocalWorker:
         _mock_stop_channel(mocker, stop_side_effect=hang_forever)
 
         # Act
-        stop_task = asyncio.create_task(worker.stop(timeout=3.0))
+        stop_task = asyncio.create_task(worker.stop(grace=3.0))
         await rpc_started.wait()
         stop_task.cancel()
 
@@ -748,7 +802,8 @@ class TestLocalWorker:
         await worker.stop()
 
         # Assert
-        mock_insecure_channel.assert_called_once_with("127.0.0.1:50051")
+        mock_insecure_channel.assert_called_once()
+        assert mock_insecure_channel.call_args[0][0] == "127.0.0.1:50051"
 
     @pytest.mark.asyncio
     async def test_stop_with_one_way_tls(self, mocker, worker_credentials_one_way):

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -1613,7 +1613,7 @@ class TestWorkerPool:
             worker = mocker.MagicMock(spec=LocalWorker)
             worker.start = mocker.AsyncMock()
 
-            async def hang(*, timeout=None):
+            async def hang(*, grace=None):
                 await asyncio.sleep(60)
 
             worker.stop = hang
@@ -1657,7 +1657,7 @@ class TestWorkerPool:
             worker.uid = uid
             worker.start = mocker.AsyncMock()
 
-            async def hang(*, timeout=None):
+            async def hang(*, grace=None):
                 await asyncio.sleep(60)
 
             worker.stop = hang
@@ -1702,7 +1702,7 @@ class TestWorkerPool:
             worker = mocker.MagicMock(spec=LocalWorker)
             worker.start = mocker.AsyncMock()
 
-            async def hang(*, timeout=None):
+            async def hang(*, grace=None):
                 try:
                     await asyncio.sleep(60)
                 except asyncio.CancelledError:
@@ -1786,7 +1786,7 @@ class TestWorkerPool:
             worker.metadata = _make_worker_metadata()
             if not workers_built:
 
-                async def hang(*, timeout=None):
+                async def hang(*, grace=None):
                     await asyncio.sleep(60)
 
                 worker.stop = hang
@@ -1892,7 +1892,43 @@ class TestWorkerPool:
         # value and an equality assertion would pin a float identity the
         # contract does not promise. The tolerance is still tight enough
         # to catch a dropped kwarg, a None, or a zero.
-        stop.assert_awaited_once_with(timeout=pytest.approx(5.0, abs=0.1))
+        stop.assert_awaited_once_with(grace=pytest.approx(5.0, abs=0.1))
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_request_indefinite_drain_when_shutdown_timeout_none(
+        self, mocker: MockerFixture
+    ):
+        """Test unbounded teardown asks each worker for an indefinite drain.
+
+        Given:
+            A WorkerPool with shutdown_timeout=None (unbounded teardown)
+        When:
+            The async-with block exits
+        Then:
+            It should await the worker's stop exactly once with a
+            negative grace — the stop surface's spelling of "wait
+            indefinitely" — never grace=None, which would cancel
+            in-flight tasks immediately
+        """
+        # Arrange
+        stop = mocker.AsyncMock()
+
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+            worker.stop = stop
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        # Act
+        async with WorkerPool(worker=factory, spawn=1, shutdown_timeout=None):
+            pass
+
+        # Assert
+        stop.assert_awaited_once()
+        grace = stop.await_args.kwargs["grace"]
+        assert grace is not None
+        assert grace < 0
 
     @pytest.mark.asyncio
     async def test___aexit___should_log_error_when_stop_fails_unexpectedly(
@@ -1981,7 +2017,7 @@ class TestWorkerPool:
             pass
 
         # Assert
-        stop.assert_awaited_once_with(timeout=pytest.approx(5.0, abs=0.1))
+        stop.assert_awaited_once_with(grace=pytest.approx(5.0, abs=0.1))
 
     @pytest.mark.asyncio
     async def test___aexit___should_stop_worker_when_drop_announcement_hangs(
@@ -2023,7 +2059,7 @@ class TestWorkerPool:
             pass
 
         # Assert
-        stop.assert_awaited_once_with(timeout=0.0)
+        stop.assert_awaited_once_with(grace=0.0)
 
     @pytest.mark.asyncio
     async def test___aexit___should_log_error_when_drop_announcement_fails(
@@ -2086,8 +2122,9 @@ class TestWorkerPool:
         When:
             The async-with block exits
         Then:
-            It should await the worker's stop with no bound of its own,
-            since there is no deadline for the announcement to consume
+            It should await the worker's stop with an indefinite drain
+            (negative grace), since there is no deadline for the
+            announcement to consume
         """
         # Arrange
         stop = mocker.AsyncMock()
@@ -2109,7 +2146,7 @@ class TestWorkerPool:
             pass
 
         # Assert
-        stop.assert_awaited_once_with(timeout=None)
+        stop.assert_awaited_once_with(grace=-1.0)
 
     @pytest.mark.asyncio
     async def test___aexit___should_log_error_when_drop_announcement_hangs(
@@ -2201,7 +2238,7 @@ class TestWorkerPool:
         # Assert
         assert len(workers) == 3
         for worker in workers:
-            worker.stop.assert_awaited_once_with(timeout=pytest.approx(5.0, abs=0.1))
+            worker.stop.assert_awaited_once_with(grace=pytest.approx(5.0, abs=0.1))
 
     @pytest.mark.asyncio
     async def test___aexit___should_report_both_when_announcement_and_stop_fail(
@@ -2403,7 +2440,7 @@ class TestWorkerPool:
         # Arrange
         stopped = asyncio.Event()
 
-        async def slow_stop(*, timeout=None):
+        async def slow_stop(*, grace=None):
             await asyncio.sleep(0.5)
             stopped.set()
 

--- a/wool/tests/runtime/worker/test_service.py
+++ b/wool/tests/runtime/worker/test_service.py
@@ -28,15 +28,47 @@ from wool.runtime.worker.session import DispatchSession
 from .conftest import PicklableMock
 
 
-def make_task(callable, *, proxy_id="test-proxy-id"):
+def make_task(callable, *, args=(), kwargs=None, proxy_id="test-proxy-id"):
     """Build a `wool.Task` wrapping *callable* with a throwaway worker proxy."""
     return Task(
         id=uuid4(),
         callable=callable,
-        args=(),
-        kwargs={},
+        args=args,
+        kwargs=kwargs or {},
         proxy=PicklableMock(spec=WorkerProxyLike, id=proxy_id),
     )
+
+
+# Registry of per-task control events for tests that need several
+# independently-releasable in-flight tasks (the single global
+# `_control_event` below only drives one). Keyed by an opaque token
+# carried in the task's args so the worker-side routine can look up its
+# own event. Cross-loop/cross-thread safe (threading.Event); tests
+# populate and clear it around each use.
+_keyed_events: dict[str, threading.Event] = {}
+
+
+class _KeyedTaskError(Exception):
+    """Failure raised by a keyed controllable task drawn to raise.
+
+    Module-level so cloudpickle can resolve it when the routine's
+    exception ships back across the dispatch stream.
+    """
+
+
+async def _keyed_task(key: str, should_raise: bool):
+    """Controllable task keyed by *key*.
+
+    Waits on ``_keyed_events[key]`` (set by the test to release it),
+    then returns *key* or raises `_KeyedTaskError`, per *should_raise*.
+    Module-level so cloudpickle can serialize it for dispatch; runs on
+    the worker loop in the same process, so it shares ``_keyed_events``.
+    """
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, _keyed_events[key].wait)
+    if should_raise:
+        raise _KeyedTaskError(key)
+    return key
 
 
 @pytest.fixture(scope="function")
@@ -5262,6 +5294,233 @@ class TestWorkerService:
         assert type(shipped) is RuntimeError
         assert "_UnpicklableRejected" in str(shipped)
         assert "unpicklable parse failure" in str(shipped)
+
+    @pytest.mark.asyncio
+    async def test_idle_should_report_elapsed_since_startup_when_no_task_dispatched(
+        self, grpc_aio_stub
+    ):
+        """Test the idle RPC reports time accrued since worker startup.
+
+        Given:
+            A `WorkerService` that has never dispatched a task, so its
+            in-flight set has been empty since construction
+        When:
+            The idle RPC is polled twice with a short wait between
+        Then:
+            It should report a positive, non-decreasing idle duration
+            measured from startup.
+        """
+        # Arrange
+        service = WorkerService()
+
+        # Act
+        async with grpc_aio_stub(servicer=service) as stub:
+            await asyncio.sleep(0.05)
+            first = await stub.idle(protocol.Void())
+            await asyncio.sleep(0.05)
+            second = await stub.idle(protocol.Void())
+
+        # Assert
+        assert first.seconds >= 0.04
+        assert second.seconds >= first.seconds
+
+    @pytest.mark.asyncio
+    async def test_idle_should_report_zero_when_task_in_flight(
+        self, service_fixture, mock_worker_proxy_cache
+    ):
+        """Test the idle RPC reports zero while a task is executing.
+
+        Given:
+            A `WorkerService` with one task dispatched and still in
+            flight
+        When:
+            The idle RPC is polled
+        Then:
+            It should report zero seconds, since the in-flight set is
+            non-empty.
+        """
+        # Arrange, act, & assert
+        async with service_fixture as (service, event, stub):
+            response = await stub.idle(protocol.Void())
+            assert response.seconds == 0.0
+
+    @pytest.mark.asyncio
+    async def test_idle_should_reset_when_task_completes(
+        self, grpc_aio_stub, mock_worker_proxy_cache
+    ):
+        """Test the idle count resets once the in-flight set drains.
+
+        Given:
+            A `WorkerService` that has accrued idle time since startup,
+            then dispatches and completes a task
+        When:
+            The idle RPC is polled before dispatch, during execution,
+            and after the task completes
+        Then:
+            It should report accrued idle before dispatch, zero while
+            in flight, and a smaller value than before after the set
+            drains — proving the count reset when work drained.
+        """
+        # Arrange
+        global _control_event
+        _control_event = threading.Event()
+        wool_task = make_task(_controllable_task)
+        request = protocol.Request(task=wool_task.to_protobuf())
+        service = WorkerService()
+
+        # Act
+        try:
+            async with grpc_aio_stub(servicer=service) as stub:
+                await asyncio.sleep(0.1)
+                before = await stub.idle(protocol.Void())
+
+                stream = stub.dispatch()
+                await stream.write(request)
+                await stream.done_writing()
+                async for response in stream:
+                    assert response.HasField("ack")
+                    break
+                during = await stub.idle(protocol.Void())
+
+                _control_event.set()
+                [r async for r in stream]
+                after = await stub.idle(protocol.Void())
+        finally:
+            if _control_event and not _control_event.is_set():
+                _control_event.set()
+            _control_event = None
+
+        # Assert
+        assert before.seconds >= 0.08
+        assert during.seconds == 0.0
+        assert after.seconds < before.seconds
+
+    @pytest.mark.asyncio
+    @settings(
+        max_examples=20,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(modes=st.lists(st.booleans(), min_size=1, max_size=4))
+    async def test_idle_should_stay_zero_until_the_last_task_drains(
+        self, grpc_aio_stub, mock_worker_proxy_cache, modes
+    ):
+        """Test idle is zero until the last of N in-flight tasks drains.
+
+        Given:
+            A `WorkerService` with N tasks (1-4) dispatched and in
+            flight, each drawn to return or raise
+        When:
+            The tasks are completed one at a time and idle is polled
+            after each completion
+        Then:
+            It should report zero while any task remains in flight
+            (including after each non-final completion) and reset to a
+            positive value only after the last task drains — regardless
+            of how many tasks there are or how each one finishes.
+        """
+        # Arrange
+        keys = [uuid4().hex for _ in modes]
+        for key in keys:
+            _keyed_events[key] = threading.Event()
+        service = WorkerService()
+
+        # Act & assert
+        try:
+            async with grpc_aio_stub(servicer=service) as stub:
+                streams = []
+                for key, should_raise in zip(keys, modes):
+                    wool_task = make_task(_keyed_task, args=(key, should_raise))
+                    stream = stub.dispatch()
+                    await stream.write(protocol.Request(task=wool_task.to_protobuf()))
+                    await stream.done_writing()
+                    async for response in stream:
+                        assert response.HasField("ack")
+                        break
+                    streams.append(stream)
+
+                # All N in flight -> idle is zero.
+                assert (await stub.idle(protocol.Void())).seconds == 0.0
+
+                # Complete one at a time; idle stays zero until the last.
+                for index, (key, stream) in enumerate(zip(keys, streams)):
+                    _keyed_events[key].set()
+                    [_ async for _ in stream]  # drain this task fully
+                    if index < len(keys) - 1:
+                        assert (await stub.idle(protocol.Void())).seconds == 0.0
+
+                # Last task drained -> idle reset and now accruing.
+                await asyncio.sleep(0.02)
+                assert (await stub.idle(protocol.Void())).seconds > 0
+        finally:
+            for key in keys:
+                _keyed_events[key].set()
+                _keyed_events.pop(key, None)
+            if not service.stopped.is_set():
+                await service.stop(protocol.StopRequest(), None)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("kind", ["backpressure", "malformed_id", "sync_callable"])
+    async def test_idle_should_ignore_dispatches_rejected_before_tracking(
+        self, grpc_aio_stub, mock_worker_proxy_cache, kind
+    ):
+        """Test a dispatch rejected before tracking never resets idle.
+
+        Given:
+            A `WorkerService` that has accrued idle, and a dispatch that
+            is rejected before it enters the in-flight set — backpressure
+            (RESOURCE_EXHAUSTED), a malformed task id, or a sync callable
+        When:
+            The rejected dispatch is attempted and idle is polled before
+            and after
+        Then:
+            It should keep counting from startup — the rejected task
+            never enters the docket, so idle is never reset to zero.
+        """
+        # Arrange
+        if kind == "backpressure":
+            service = WorkerService(backpressure=lambda ctx: True)
+        else:
+            service = WorkerService()
+
+        async def returns():
+            return "unreached"
+
+        def sync_callable():
+            return "unreached"
+
+        if kind == "sync_callable":
+            wool_task = make_task(sync_callable)
+        else:
+            wool_task = make_task(returns)
+        request = protocol.Request(task=wool_task.to_protobuf())
+        if kind == "malformed_id":
+            request.task.id = "not-a-uuid"
+
+        # Act & assert
+        try:
+            async with grpc_aio_stub(servicer=service) as stub:
+                await asyncio.sleep(0.05)
+                before = (await stub.idle(protocol.Void())).seconds
+
+                stream = stub.dispatch()
+                await stream.write(request)
+                await stream.done_writing()
+                if kind == "backpressure":
+                    with pytest.raises(grpc.RpcError) as exc_info:
+                        [_ async for _ in stream]
+                    assert exc_info.value.code() == grpc.StatusCode.RESOURCE_EXHAUSTED
+                else:
+                    responses = [r async for r in stream]
+                    assert responses and responses[0].HasField("nack")
+
+                after = (await stub.idle(protocol.Void())).seconds
+
+                assert before > 0
+                assert after >= before
+        finally:
+            if not service.stopped.is_set():
+                await service.stop(protocol.StopRequest(), None)
 
 
 class TestBackpressureContext:

--- a/wool/tests/test_exceptions.py
+++ b/wool/tests/test_exceptions.py
@@ -1,6 +1,7 @@
 import pytest
 
 from wool import AdvertiseHostError
+from wool import IdleUnavailable
 from wool import IneffectiveLeaseWarning
 from wool import IneffectiveQuorumTimeoutWarning
 from wool import LoopbackAdvertisementWarning
@@ -15,7 +16,14 @@ class TestWoolError:
     Fully qualified name: wool.exceptions.WoolError
     """
 
-    def test___init___should_subclass_wool_error(self):
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            AdvertiseHostError,
+            IdleUnavailable,
+        ],
+    )
+    def test___init___should_subclass_wool_error(self, exception):
         """Test wool's typed exceptions descend from WoolError.
 
         Given:
@@ -27,7 +35,7 @@ class TestWoolError:
             catches all wool-raised errors.
         """
         # Act & assert
-        assert issubclass(AdvertiseHostError, WoolError)
+        assert issubclass(exception, WoolError)
 
 
 class TestWoolWarning:

--- a/wool/tests/test_public.py
+++ b/wool/tests/test_public.py
@@ -33,6 +33,7 @@ def test_public_api_completeness_should_match_expected_surface():
     """
     # Arrange
     expected_public_api = {
+        "IdleUnavailable",
         "RpcError",
         "TransientRpcError",
         "HandshakeError",


### PR DESCRIPTION
## Summary

Add an `idle` RPC so callers can observe how long a worker has been continuously idle and retire inactive workers on their own schedule. The worker measures idle time against a monotonic clock — seconds since its in-flight task set last became empty, with startup counting as empty, zero while any task runs, resetting whenever work resumes — and reports it through a new `IdleTime` wire message. `WorkerConnection` surfaces this as `idle_time()`, returning a plain `float`, alongside a `stop()` control, so a caller can poll-then-retire over the same single-worker surface.

A worker predating the RPC answers gRPC `UNIMPLEMENTED`, which surfaces as the new `IdleUnavailable` — deliberately a `WoolError` rather than an `RpcError`, so an absent capability is never mistaken for an RPC-health fault that would evict a healthy worker. The change ships mechanism only: the worker reports, the caller decides — there is no built-in auto-shutdown policy, and the routine dispatch path is untouched.

`LocalWorker` shutdown is refactored to route through `WorkerConnection.stop()` instead of a hand-built stub, and the shutdown grace period is renamed from `timeout` to `grace` so it no longer collides with the client-side deadline `timeout` on dispatch and idle. The old `timeout` keyword is kept as a deprecated alias that still works and emits a `DeprecationWarning`, so existing callers are not broken.

Closes #253

## Proposed changes

- **Wire protocol** — Add an `idle` unary RPC returning a new `IdleTime` message (a `double seconds` field) to the Worker service, re-exported from `wool.protocol`.
- **Worker idle tracking** — `WorkerService` records a monotonic timestamp of when its in-flight docket last emptied and answers the `idle` RPC with the elapsed seconds, or zero while busy. The timestamp flips only on the docket's empty/non-empty edges, so polling never enters the docket and cannot disturb the measurement.
- **Client control surface** — `WorkerConnection` gains `idle_time()` (returns the reported idle seconds, validating a positive deadline) and `stop()` (sends the stop RPC with a shutdown grace period). A missing RPC surfaces as `IdleUnavailable`, a new public `WoolError` subclass.
- **Backwards-compatible grace rename** — Rename the `stop()` shutdown grace period from `timeout` to `grace` on `Worker` and `WorkerLike`, keeping `timeout` as a deprecated alias. The wire field `StopRequest.timeout` and the startup deadline keep the name `timeout`.
- **LocalWorker shutdown** — Route `LocalWorker._stop` through a `WorkerConnection`, reusing its credential handling, secure-channel construction, and channel pooling, and release the pooled channel afterward.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestMessageConstruction` | An `IdleTime` message | Constructed with and without a seconds value | The `seconds` field holds the value and defaults to `0.0` | `IdleTime` wire message |
| 2 | `TestMessageConstruction` | Any finite double | An `IdleTime` is serialized and re-parsed | The `seconds` field survives the round-trip exactly | `IdleTime` wire fidelity |
| 3 | `TestWorkerService` | N in-flight tasks, each returning or raising | Tasks complete one at a time and idle is polled after each | Idle stays zero until the last task drains, then accrues | Docket-emptiness idle invariant |
| 4 | `TestWorkerService` | A worker with accrued idle | A dispatch is rejected before tracking (backpressure, malformed id, sync callable) | Idle keeps counting — the rejected task never enters the docket | Idle immune to pre-tracking rejection |
| 5 | `TestWorkerConnection` | A worker answering idle with any gRPC status code | `idle_time` is awaited | `UNIMPLEMENTED` maps to `IdleUnavailable`, transient codes to `TransientRpcError`, others to `RpcError` | Idle error mapping |
| 6 | `TestWorkerConnection` | Any non-positive timeout | `idle_time` is awaited with it | It raises `ValueError` without calling the stub | Idle timeout validation |
| 7 | `TestWorkerConnection` | `None` or any positive timeout | `idle_time` is awaited with it | It forwards the timeout to the stub as the gRPC deadline | Idle deadline forwarding |
| 8 | `TestWorkerConnection` | A worker reporting any double | `idle_time` is awaited | It returns exactly that value | Idle value fidelity |
| 9 | `TestWorkerConnection` | A worker acknowledging stop | `stop` is awaited with a grace period | It sends a `StopRequest` carrying the grace and returns `None` | Stop request forwarding |
| 10 | `TestWorker` | A started worker | `stop` is called with the deprecated `timeout` keyword | It emits a `DeprecationWarning` and forwards the value as `grace` | Backwards-compatible stop alias |
| 11 | `TestLocalWorker` | A started worker whose stop RPC raises | `stop` is awaited | The error propagates and the pooled channel is still released | Stop channel cleanup |
| 12 | `TestWorkerIdleReporting` | A freshly started real worker over each transport | `idle_time` is polled twice with a wait | Both readings are positive and non-decreasing | Idle accrual from startup (integration) |
| 13 | `TestWorkerIdleReporting` | A real worker with one in-flight routine | `idle_time` is polled | It reports zero while the docket is non-empty | Zero-while-busy (integration) |
| 14 | `TestWorkerIdleReporting` | A servicer without the idle RPC | `idle_time` is polled over a real channel | It raises `IdleUnavailable`, not `RpcError` | Legacy-worker detection (integration) |
| 15 | `TestWorkerControlSurface` | An idle real worker | The caller polls idle, stops it, then polls again | Stop terminates the worker and a later poll raises `TransientRpcError` | Poll-then-retire flow (integration) |
