### PR TITLE
Force-terminate worker subprocesses on shutdown to prevent orphan accumulation — Closes #260

### DIFF
--- a/wool/src/wool/runtime/resourcepool.py
+++ b/wool/src/wool/runtime/resourcepool.py
@@ -116,12 +116,22 @@ class ResourcePool(Generic[T]):
             The cached object.
         :param reference_count:
             Number of active references to this object.
+        :param timer:
+            Optional TTL timer scheduled when the reference count
+            reaches zero; spawns the cleanup task once the TTL
+            elapses.
+        :param timer_loop:
+            The event loop that owns ``timer``, kept for thread-safe
+            cross-loop cancellation (a `asyncio.TimerHandle` does not
+            expose its loop).
         :param cleanup:
-            Optional cleanup task scheduled when reference count reaches zero.
+            Optional cleanup task created when the TTL timer fires.
         """
 
         obj: Any
         reference_count: int
+        timer: asyncio.TimerHandle | None = None
+        timer_loop: asyncio.AbstractEventLoop | None = None
         cleanup: asyncio.Task | None = None
 
     @dataclass
@@ -134,7 +144,7 @@ class ResourcePool(Generic[T]):
         :param referenced_entries:
             Number of entries currently being referenced (reference_count > 0).
         :param pending_cleanup:
-            Number of cleanup tasks currently pending execution.
+            Number of keys in `ResourcePool.pending_cleanup`.
         """
 
         total_entries: int
@@ -186,28 +196,30 @@ class ResourcePool(Generic[T]):
         :returns:
             :class:`ResourcePool.Stats` containing current statistics.
         """
-        pending_cleanup = sum(
-            1 for c in self.pending_cleanup.values() if c is not None and not c.done()
-        )
         return self.Stats(
             total_entries=len(self._cache),
             referenced_entries=sum(
                 1 for e in self._cache.values() if e.reference_count > 0
             ),
-            pending_cleanup=pending_cleanup,
+            pending_cleanup=len(self.pending_cleanup),
         )
 
     @property
     def pending_cleanup(self):
-        """Dictionary of cache keys with pending cleanup tasks.
+        """
+        Map cache keys to their pending cleanup work.
+
+        A pending entry holds either an unfired TTL timer or a
+        cleanup task that has not finished.
 
         :returns:
-            Dictionary mapping cache keys to their cleanup tasks.
+            Dictionary mapping each such key to its pending TTL timer
+            or cleanup task.
         """
         return {
-            k: v.cleanup
+            k: v.timer if v.timer is not None else v.cleanup
             for k, v in self._cache.items()
-            if v.cleanup is not None and not v.cleanup.done()
+            if v.timer is not None or (v.cleanup is not None and not v.cleanup.done())
         }
 
     def get(self, key: Any) -> Resource[T]:
@@ -238,27 +250,8 @@ class ResourcePool(Generic[T]):
             if key in self._cache:
                 entry = self._cache[key]
                 entry.reference_count += 1
-
-                # Cancel pending cleanup task if it exists
-                if entry.cleanup is not None and not entry.cleanup.done():
-                    current_loop = asyncio.get_running_loop()
-                    task_loop = entry.cleanup.get_loop()
-
-                    if task_loop is current_loop:
-                        # Same event loop - safe to cancel and await
-                        entry.cleanup.cancel()
-                        try:
-                            await entry.cleanup
-                        except asyncio.CancelledError:
-                            pass
-                    else:
-                        # Different event loop - cancel from correct loop, don't await
-                        try:
-                            task_loop.call_soon_threadsafe(entry.cleanup.cancel)
-                        except RuntimeError:
-                            pass
-                    entry.cleanup = None
-
+                self._cancel_timer(entry)
+                await self._cancel_cleanup(entry)
                 return entry.obj
             else:
                 # Cache miss - create new object
@@ -271,12 +264,13 @@ class ResourcePool(Generic[T]):
         Release a reference to the cached object.
 
         Decrements reference count. If count reaches 0, schedules cleanup
-        after TTL expires (if TTL > 0).
+        after TTL expires (if TTL > 0). Releasing a key that is not
+        cached is a silent no-op.
 
         :param key:
             The cache key.
-        :raises KeyError:
-            If key not in cache.
+        :raises ValueError:
+            If the key's reference count is already 0.
         """
         async with self._lock:
             if key not in self._cache:
@@ -290,8 +284,15 @@ class ResourcePool(Generic[T]):
 
             if entry.reference_count <= 0:
                 if self._ttl > 0:
-                    # Schedule cleanup after TTL
-                    entry.cleanup = asyncio.create_task(self._schedule_cleanup(key))
+                    # Defer cleanup with a plain timer rather than a
+                    # task parked on a TTL sleep: an unfired
+                    # TimerHandle is discarded silently at loop close,
+                    # whereas a parked task is destroyed pending —
+                    # and, if never started, its coroutine emits a
+                    # "never awaited" RuntimeWarning.
+                    loop = asyncio.get_running_loop()
+                    entry.timer = loop.call_later(self._ttl, self._expire, key)
+                    entry.timer_loop = loop
                 else:
                     # Immediate cleanup
                     await self._cleanup(key)
@@ -301,6 +302,8 @@ class ResourcePool(Generic[T]):
 
         :param key:
             Specific key to clear (clears all entries if not specified).
+        :raises KeyError:
+            If the given key is not cached.
         """
         async with self._lock:
             # Clean up all entries
@@ -311,27 +314,103 @@ class ResourcePool(Generic[T]):
             for key in keys:
                 await self._cleanup(key)
 
-    async def _schedule_cleanup(self, key: Any) -> None:
+    def _cancel_timer(self, entry: ResourcePool.CacheEntry) -> None:
         """
-        Schedule cleanup after TTL delay.
+        Cancel an entry's pending TTL timer, if any.
 
-        Only cleans up if the reference count is still 0 when TTL expires.
+        Same-loop timers are cancelled directly; timers owned by a
+        different loop are cancelled via that loop's
+        `call_soon_threadsafe`, best-effort — a closed foreign loop
+        can never fire its timers, so a failed cancellation is safe
+        to ignore.
+
+        :param entry:
+            The cache entry whose timer to cancel.
+        """
+        if entry.timer is None or entry.timer_loop is None:
+            return
+        timer, timer_loop = entry.timer, entry.timer_loop
+        entry.timer = None
+        entry.timer_loop = None
+
+        if timer_loop is asyncio.get_running_loop():
+            timer.cancel()
+        else:
+            try:
+                timer_loop.call_soon_threadsafe(timer.cancel)
+            except RuntimeError:
+                pass
+
+    async def _cancel_cleanup(self, entry: ResourcePool.CacheEntry) -> None:
+        """
+        Cancel an entry's in-flight cleanup task, if any.
+
+        A task on the running loop is cancelled and awaited; a task
+        owned by a different loop is cancelled via that loop's
+        `call_soon_threadsafe`, best-effort — a closed foreign loop
+        can never run its tasks, so a failed cancellation is safe to
+        ignore. The current task is left alone: on the expiry path
+        this runs *inside* the entry's own cleanup task
+        (`_finalize`), which must not cancel itself.
+
+        :param entry:
+            The cache entry whose cleanup task to cancel.
+        """
+        cleanup = entry.cleanup
+        entry.cleanup = None
+        if cleanup is None or cleanup.done() or cleanup is asyncio.current_task():
+            return
+
+        if cleanup.get_loop() is asyncio.get_running_loop():
+            cleanup.cancel()
+            try:
+                await cleanup
+            except asyncio.CancelledError:
+                pass
+        else:
+            try:
+                cleanup.get_loop().call_soon_threadsafe(cleanup.cancel)
+            except RuntimeError:
+                pass
+
+    def _expire(self, key: Any) -> None:
+        """
+        Spawn the cleanup task for an expired entry.
+
+        Runs synchronously, as a timer callback, on the loop that
+        scheduled the timer; see `_finalize` for how the spawned task
+        tolerates a concurrent re-acquire.
 
         :param key:
-            The cache key to schedule cleanup for.
+            The cache key whose TTL elapsed.
+        """
+        entry = self._cache.get(key)
+        if entry is None:
+            return
+        entry.timer = None
+        entry.timer_loop = None
+        entry.cleanup = asyncio.get_running_loop().create_task(self._finalize(key))
+
+    async def _finalize(self, key: Any) -> None:
+        """
+        Clean up an expired entry if it is still unreferenced.
+
+        Re-checks the reference count under the lock, so an entry
+        re-acquired between TTL expiry and lock acquisition is left
+        untouched; cancellation by a concurrent re-acquire is
+        likewise tolerated as an expected outcome.
+
+        :param key:
+            The cache key to clean up.
         """
         try:
-            await asyncio.sleep(self._ttl)
-
             async with self._lock:
-                # Double-check conditions - reference might have been re-acquired
                 if key in self._cache:
                     entry = self._cache[key]
                     if entry.reference_count == 0:
                         await self._cleanup(key)
 
         except asyncio.CancelledError:
-            # Cleanup was cancelled due to new reference - this is expected
             pass
 
     async def _cleanup(self, key: Any) -> None:
@@ -346,25 +425,8 @@ class ResourcePool(Generic[T]):
         """
         entry = self._cache[key]
         try:
-            # Cancel cleanup task if running
-            if entry.cleanup is not None and not entry.cleanup.done():
-                current_loop = asyncio.get_running_loop()
-                task_loop = entry.cleanup.get_loop()
-
-                if task_loop is current_loop:
-                    # Same event loop - safe to cancel and await
-                    entry.cleanup.cancel()
-                    try:
-                        await entry.cleanup
-                    except asyncio.CancelledError:
-                        pass
-                else:
-                    # Different event loop (e.g., task created in worker thread)
-                    # Cancel from the correct loop, don't await cross-loop
-                    try:
-                        task_loop.call_soon_threadsafe(entry.cleanup.cancel)
-                    except RuntimeError:
-                        pass
+            self._cancel_timer(entry)
+            await self._cancel_cleanup(entry)
         finally:
             # Evict from the cache *unconditionally*, before and
             # regardless of how the finalizer exits. A finalized
@@ -373,7 +435,7 @@ class ResourcePool(Generic[T]):
             # under a cancelled teardown, which is a ``BaseException``
             # and so escapes ``except Exception`` — the entry must
             # still be removed, or a later ``acquire`` hands back a
-            # torn-down resource (e.g. a closed event loop). The
+            # torn-down resource (e.g., a closed event loop). The
             # inner ``try`` lets the finalizer run for its side
             # effects while the outer ``finally`` guarantees eviction
             # and lets any cancellation propagate.

--- a/wool/src/wool/runtime/worker/local.py
+++ b/wool/src/wool/runtime/worker/local.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Final
 
 import grpc.aio
 
@@ -14,6 +15,14 @@ from wool.runtime.worker.process import WorkerProcess
 
 if TYPE_CHECKING:
     from wool.runtime.worker.service import BackpressureLike
+
+_STOP_RPC_MARGIN: Final[float] = 5.0
+"""Seconds added to a finite stop timeout to form the graceful stop
+RPC's deadline. The worker drains in-flight tasks for up to the full
+stop timeout before responding, so the deadline must exceed it; the
+margin covers transport and response overhead. Without a deadline, a
+wedged worker would hang ``stop()`` forever and the force-terminate
+fallback would never be reached."""
 
 
 # public
@@ -117,14 +126,16 @@ class LocalWorker(Worker):
         return self._worker_process.address
 
     async def _start(self, timeout: float | None):
-        """Start the worker process and register it with the pool.
+        """Start the worker subprocess and adopt its metadata.
 
-        Initializes the registrar service, starts the worker process
-        with its gRPC server, and registers the worker's network
-        address with the registrar for discovery by client sessions.
+        Runs the blocking `WorkerProcess.start` in an executor thread
+        and, once the subprocess reports back over its pipe, adopts
+        the reported metadata as this worker's own.
 
         :param timeout:
             Maximum time in seconds to wait for worker process startup.
+        :raises RuntimeError:
+            If the worker process starts without reporting metadata.
         """
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(
@@ -135,29 +146,52 @@ class LocalWorker(Worker):
             raise RuntimeError("Worker process failed to start - no metadata")
 
     async def _stop(self, timeout: float | None):
-        """Stop the worker process and unregister it from the pool.
+        """Stop the worker process gracefully, then reap it.
 
-        Unregisters the worker from the registrar service, gracefully
-        shuts down the worker process using a gRPC stop request, and cleans
-        up the registrar service. If graceful shutdown fails, the process
-        is forcefully terminated.
+        Sends the worker a stop RPC bounded by a deadline derived from
+        ``timeout`` (see `_STOP_RPC_MARGIN`), then — however the RPC
+        fared — reaps the subprocess; see `WorkerProcess.reap` for the
+        escalation. The reap runs in an executor thread so it
+        completes even when this coroutine is cancelled; only a second
+        cancellation landing while the executor job is still queued
+        can skip it, in which case the worker-side parent watchdog
+        remains the backstop against orphans.
 
-        For workers configured with :class:`WorkerCredentials`, uses
-        the client credentials to establish a secure connection for the
-        stop operation. For insecure workers, uses an insecure channel.
+        For workers configured with `WorkerCredentials`, uses the
+        client credentials to establish a secure connection for the
+        stop operation. For insecure workers, uses an insecure
+        channel.
+
+        :param timeout:
+            Bound on the worker's graceful drain, forwarded in the
+            stop request. ``None`` waits unbounded for the drain.
         """
-        if self._worker_process.is_alive():
-            assert self.address
+        try:
+            if self._worker_process.is_alive():
+                assert self.address
 
-            # Create appropriate channel based on available credentials
-            if self._credentials is not None:
-                credentials = self._credentials.client_credentials()
-                channel = grpc.aio.secure_channel(self.address, credentials)
-            else:
-                channel = grpc.aio.insecure_channel(self.address)
+                # Create appropriate channel based on available credentials
+                if self._credentials is not None:
+                    credentials = self._credentials.client_credentials()
+                    channel = grpc.aio.secure_channel(self.address, credentials)
+                else:
+                    channel = grpc.aio.insecure_channel(self.address)
 
-            try:
-                stub = protocol.WorkerStub(channel)
-                await stub.stop(protocol.StopRequest(timeout=timeout))
-            finally:
-                await channel.close()
+                try:
+                    stub = protocol.WorkerStub(channel)
+                    # `timeout=None` preserves the caller's explicit
+                    # unbounded-graceful contract; see
+                    # `_STOP_RPC_MARGIN` for the finite deadline.
+                    deadline = (
+                        timeout + _STOP_RPC_MARGIN if timeout is not None else None
+                    )
+                    await stub.stop(
+                        protocol.StopRequest(timeout=timeout), timeout=deadline
+                    )
+                finally:
+                    await channel.close()
+        finally:
+            # `reap` blocks on `join`, so it must run off-loop; see
+            # the docstring for the cancellation contract.
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, self._worker_process.reap, timeout)

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -242,9 +242,11 @@ class WorkerPool:
         ``shutdown_timeout`` as its per-worker bound, the gather waits
         for whatever time remains, and publisher cleanup gets whatever
         is left. When the deadline elapses, abandoned worker UIDs are
-        logged via ``logging.warning`` and teardown proceeds. ``None``
-        disables the bound and restores the legacy unbounded wait.
-        Must be positive when provided. Defaults to ``60.0``.
+        logged via ``logging.warning`` and teardown proceeds — an
+        abandoned `LocalWorker` is still reaped off-loop (see
+        `LocalWorker._stop`), which can hold ``__aexit__`` past the
+        deadline by up to the reap escalation. ``None`` disables the
+        bound. Must be positive when provided. Defaults to ``60.0``.
     :param lazy:
         When ``True`` (default), defer discovery setup and the quorum
         wait to the first `WorkerProxy.dispatch`.  When ``False``,
@@ -609,9 +611,10 @@ class WorkerPool:
         bind host (see `~wool.DiscoveryPublisherLike.bind_host`);
         bound factories own their binding. Teardown applies the
         pool's ``shutdown_timeout`` as a single deadline across worker
-        stops and publisher cleanup, logging any workers it abandons,
-        and runs even when publisher validation or worker construction
-        fails, so an entered publisher context is never leaked.
+        stops and publisher cleanup, logging any workers it abandons
+        (see ``shutdown_timeout``), and runs even when publisher
+        validation or worker construction fails, so an entered
+        publisher context is never leaked.
 
         :yields:
             Metadata for the spawned workers.

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -9,6 +9,8 @@ import signal
 import socket
 import sys
 import tempfile
+import threading
+import time
 import uuid
 from contextlib import contextmanager
 from functools import partial
@@ -43,6 +45,10 @@ Process = _ctx.Process
 logger = logging.getLogger(__name__)
 
 _HAS_UDS: Final[bool] = hasattr(socket, "AF_UNIX")
+
+_REAP_GRACE: Final[float] = 5.0
+"""Seconds to wait for a terminated worker process to exit before
+escalating to SIGKILL in `WorkerProcess.reap`."""
 
 
 class WorkerProcess(Process):
@@ -202,12 +208,42 @@ class WorkerProcess(Process):
             assert self._metadata is not None
             self._port = int(self._metadata.address.rsplit(":", 1)[1])
         else:
-            self.terminate()
-            self.join()
+            self.reap(timeout=0)
             raise RuntimeError(
                 f"Worker process failed to start within {timeout} seconds"
             )
         self._get_metadata.close()
+
+    def reap(self, timeout: float | None = None) -> None:
+        """Ensure the worker process has fully terminated.
+
+        Joins the process, escalating to `terminate` (SIGTERM)
+        and then `kill` (SIGKILL) if it does not exit within
+        the given bound, so a worker can never outlive its manager
+        regardless of how graceful shutdown fared. Blocks the calling
+        thread; a no-op if the process was never started.
+
+        :param timeout:
+            Maximum time in seconds to wait for the process to exit
+            on its own before escalating. Defaults to the worker's
+            shutdown grace period, the upper bound on legitimate
+            post-stop work in the subprocess.
+        """
+        if self.pid is None:
+            return
+        self.join(timeout if timeout is not None else self._shutdown_grace_period)
+        if self.is_alive():
+            logger.warning(
+                f"Worker process {self.pid} did not exit gracefully; terminating"
+            )
+            self.terminate()
+            self.join(_REAP_GRACE)
+            if self.is_alive():
+                logger.warning(
+                    f"Worker process {self.pid} survived termination; killing"
+                )
+                self.kill()
+                self.join()
 
     def run(self) -> None:
         """Run the worker process.
@@ -243,9 +279,10 @@ class WorkerProcess(Process):
         """Run the worker's gRPC server for the lifetime of the process.
 
         Creates the gRPC server with the configured channel options,
-        registers the worker service, installs credential and signal-
-        handler context managers, and blocks until a shutdown signal
-        fires.
+        registers the worker service, ties the process's lifetime to
+        its parent via the parent-death watchdog, installs credential
+        and signal-handler context managers, and blocks until a
+        shutdown signal fires.
         """
         creds_ctx = (
             CredentialContext(self._credentials)
@@ -327,6 +364,10 @@ class WorkerProcess(Process):
 
             install_task_factory()
 
+            _parent_watchdog(
+                asyncio.get_running_loop(), service, self._shutdown_grace_period
+            )
+
             with _signal_handlers(service):
                 try:
                     await server.start()
@@ -378,6 +419,49 @@ class WorkerProcess(Process):
         return f"{host}:{port}"
 
 
+def _parent_watchdog(
+    loop: asyncio.AbstractEventLoop,
+    service: WorkerService,
+    grace: float,
+) -> threading.Thread | None:
+    """Tie the worker process's lifetime to its parent process.
+
+    Starts a daemon thread that blocks until the parent process
+    exits — including abrupt deaths such as SIGKILL, which bypass
+    every parent-side teardown path — then initiates the same
+    graceful shutdown as SIGTERM and, if the process is still alive
+    once the grace window elapses, hard-exits via `os._exit`.
+    Without this, a worker whose parent never completes the stop RPC
+    reparents to init and accumulates as an orphan across runs.
+
+    :param loop:
+        The worker's running event loop.
+    :param service:
+        The `WorkerService` to stop when the parent dies.
+    :param grace:
+        Seconds to allow graceful shutdown after parent death before
+        hard-exiting.
+    :returns:
+        The started watchdog thread, or ``None`` when the process
+        was not spawned by `multiprocessing` (e.g., in-process
+        test invocations of `WorkerProcess.run`).
+    """
+    parent = _mp.parent_process()
+    if parent is None:
+        return None
+
+    def watch():
+        parent.join()
+        logger.warning("Parent process exited; shutting down worker")
+        _schedule_stop(loop, service, timeout=0)
+        time.sleep(grace)
+        os._exit(1)
+
+    thread = threading.Thread(target=watch, name="wool-parent-watchdog", daemon=True)
+    thread.start()
+    return thread
+
+
 @contextmanager
 def _signal_handlers(service: WorkerService):
     """Context manager for setting up signal handlers for graceful shutdown.
@@ -402,21 +486,47 @@ def _signal_handlers(service: WorkerService):
 
 
 def _sigterm_handler(loop, service, signum, frame):
-    if loop.is_running():
-        loop.call_soon_threadsafe(
-            lambda: asyncio.create_task(
-                service.stop(protocol.StopRequest(timeout=0), None)
-            )
-        )
+    """Stop the service immediately, cancelling in-flight tasks."""
+    _schedule_stop(loop, service, timeout=0)
 
 
 def _sigint_handler(loop, service, signum, frame):
+    """Stop the service, draining in-flight tasks indefinitely."""
+    _schedule_stop(loop, service, timeout=-1)
+
+
+def _schedule_stop(
+    loop: asyncio.AbstractEventLoop,
+    service: WorkerService,
+    timeout: float,
+) -> None:
+    """Dispatch a graceful service stop onto the worker's event loop.
+
+    Safe to call from any thread, including signal handlers and the
+    parent-death watchdog. A ``timeout`` of ``0`` cancels in-flight
+    tasks immediately; a negative value drains them indefinitely (see
+    `WorkerService.stop`).
+
+    :param loop:
+        The worker's event loop.
+    :param service:
+        The `WorkerService` to stop.
+    :param timeout:
+        Drain bound forwarded in the ``StopRequest``.
+    """
     if loop.is_running():
-        loop.call_soon_threadsafe(
-            lambda: asyncio.create_task(
-                service.stop(protocol.StopRequest(timeout=-1), None)
+        # The loop can close between `is_running` and the dispatch; a
+        # closed loop has nothing left to stop gracefully, so callers'
+        # fallbacks (e.g. the watchdog's hard exit) must survive the
+        # race.
+        try:
+            loop.call_soon_threadsafe(
+                lambda: asyncio.create_task(
+                    service.stop(protocol.StopRequest(timeout=timeout), None)
+                )
             )
-        )
+        except RuntimeError:
+            pass
 
 
 async def _proxy_factory(

--- a/wool/tests/integration/test_worker_shutdown.py
+++ b/wool/tests/integration/test_worker_shutdown.py
@@ -1,10 +1,42 @@
-"""Integration tests for worker-loop teardown task draining."""
+"""Integration tests for worker shutdown, reaping, and orphan prevention."""
 
+import asyncio
+import contextlib
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import grpc
+import grpc.aio
 import pytest
+
+from wool.runtime.worker.local import LocalWorker
+from wool.runtime.worker.pool import WorkerPool
+from wool.runtime.worker.process import WorkerProcess
 
 from . import routines
 from .conftest import build_pool_from_scenario
 from .conftest import default_scenario
+
+_PARENT_SCRIPT = """
+import asyncio
+
+from wool.runtime.worker.local import LocalWorker
+
+
+async def main():
+    worker = LocalWorker(shutdown_grace_period=5.0)
+    await worker.start(timeout=30)
+    assert worker.metadata is not None
+    print(worker.metadata.pid, flush=True)
+    await asyncio.sleep(300)
+
+
+asyncio.run(main())
+"""
 
 
 @pytest.mark.integration
@@ -40,3 +72,222 @@ class TestWorkerLoopDrain:
 
         # Assert
         assert sentinel.read_text() == "drained"
+
+
+@pytest.mark.integration
+class TestWorkerOrphanPrevention:
+    @pytest.mark.asyncio
+    async def test_stop_should_leave_no_live_worker_process(self):
+        """Test stop fully reaps the worker subprocess before returning.
+
+        Given:
+            A started LocalWorker backed by a real subprocess.
+        When:
+            stop() is called.
+        Then:
+            It should return only once the worker subprocess no
+            longer exists.
+        """
+        # Arrange
+        worker = LocalWorker(shutdown_grace_period=30.0)
+        await worker.start(timeout=30)
+        assert worker.metadata is not None
+        pid = worker.metadata.pid
+        assert _pid_alive(pid)
+
+        try:
+            # Act
+            await worker.stop(timeout=30)
+
+            # Assert
+            assert not _pid_alive(pid)
+        finally:
+            _ensure_killed(pid)
+
+    def test_worker_should_exit_when_parent_is_killed(self):
+        """Test a worker never outlives an abruptly killed parent.
+
+        Given:
+            A parent process that started a LocalWorker and holds no
+            teardown path.
+        When:
+            The parent is killed with SIGKILL, bypassing all graceful
+            shutdown.
+        Then:
+            The orphaned worker subprocess should detect parent death
+            and exit within the grace window.
+        """
+        # Arrange
+        helper = subprocess.Popen(
+            [sys.executable, "-c", _PARENT_SCRIPT],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        worker_pid = None
+        try:
+            assert helper.stdout is not None
+            worker_pid = int(helper.stdout.readline().strip())
+            assert _pid_alive(worker_pid)
+
+            # Act
+            helper.kill()
+            helper.wait(timeout=10)
+
+            # Assert
+            deadline = time.monotonic() + 15.0
+            while _pid_alive(worker_pid) and time.monotonic() < deadline:
+                time.sleep(0.1)
+            assert not _pid_alive(worker_pid)
+        finally:
+            if helper.poll() is None:
+                helper.kill()
+                helper.wait(timeout=10)
+            _ensure_killed(worker_pid)
+
+    @pytest.mark.asyncio
+    async def test_pool_exit_should_leave_no_live_worker_processes(self):
+        """Test pool teardown reaps every spawned worker process.
+
+        Given:
+            An ephemeral WorkerPool with two spawned local workers.
+        When:
+            The pool context exits normally.
+        Then:
+            It should leave no worker subprocess alive.
+        """
+        # Arrange
+        before = {child.pid for child in multiprocessing.active_children()}
+        spawned = []
+
+        try:
+            # Act
+            async with WorkerPool("orphan-test", spawn=2):
+                spawned = [
+                    child.pid
+                    for child in multiprocessing.active_children()
+                    if child.pid not in before
+                ]
+                assert len(spawned) == 2
+
+            # Assert
+            for pid in spawned:
+                assert not _pid_alive(pid)
+        finally:
+            for pid in spawned:
+                _ensure_killed(pid)
+
+    @pytest.mark.asyncio
+    async def test_pool_exit_should_tolerate_crashed_worker(self):
+        """Test pool teardown survives a worker that already died.
+
+        Given:
+            An entered single-worker pool whose worker subprocess was
+            killed mid-context.
+        When:
+            The pool context exits.
+        Then:
+            It should complete teardown without raising and leave the
+            worker's corpse reaped.
+        """
+        # Arrange
+        before = {child.pid for child in multiprocessing.active_children()}
+        spawned = []
+
+        try:
+            # Act
+            async with WorkerPool("orphan-test", spawn=1):
+                spawned = [
+                    child.pid
+                    for child in multiprocessing.active_children()
+                    if child.pid not in before
+                ]
+                assert len(spawned) == 1
+                os.kill(spawned[0], signal.SIGKILL)
+                await asyncio.sleep(0.2)
+
+            # Assert
+            assert not _pid_alive(spawned[0])
+        finally:
+            for pid in spawned:
+                _ensure_killed(pid)
+
+    def test_reap_should_terminate_worker_without_stop_rpc(self):
+        """Test reap force-terminates a worker that was never stopped.
+
+        Given:
+            A started real WorkerProcess that never receives a stop
+            RPC.
+        When:
+            reap() is called with a short timeout.
+        Then:
+            It should return with the worker subprocess terminated.
+        """
+        # Arrange
+        process = WorkerProcess(shutdown_grace_period=5.0)
+        process.start(timeout=30)
+        pid = process.pid
+        assert pid is not None
+        assert _pid_alive(pid)
+
+        # Act
+        try:
+            process.reap(timeout=0.5)
+
+            # Assert
+            assert not _pid_alive(pid)
+        finally:
+            _ensure_killed(pid)
+
+    @pytest.mark.asyncio
+    async def test_stop_should_kill_unresponsive_worker(self):
+        """Test stop force-kills a worker that cannot respond.
+
+        Given:
+            A started LocalWorker whose subprocess is suspended with
+            SIGSTOP, so it can neither serve the stop RPC nor honor
+            SIGTERM.
+        When:
+            stop() is awaited with a short timeout.
+        Then:
+            It should surface the RPC deadline within a bound and
+            leave the worker subprocess killed, rather than hang on
+            the deadline-less stop RPC.
+        """
+        # Arrange
+        worker = LocalWorker(shutdown_grace_period=5.0)
+        await worker.start(timeout=30)
+        assert worker.metadata is not None
+        pid = worker.metadata.pid
+        assert _pid_alive(pid)
+
+        try:
+            os.kill(pid, signal.SIGSTOP)
+
+            # Act
+            with pytest.raises(grpc.aio.AioRpcError) as excinfo:
+                await asyncio.wait_for(worker.stop(timeout=0.5), timeout=30)
+
+            # Assert
+            assert excinfo.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
+            assert not _pid_alive(pid)
+        finally:
+            _ensure_killed(pid)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return whether a process with the given pid currently exists."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _ensure_killed(pid: int | None) -> None:
+    """Best-effort SIGKILL so a failing run cannot leak the orphan under test."""
+    if pid is not None and _pid_alive(pid):
+        with contextlib.suppress(OSError):
+            os.kill(pid, signal.SIGKILL)

--- a/wool/tests/runtime/test_resourcepool.py
+++ b/wool/tests/runtime/test_resourcepool.py
@@ -1,36 +1,17 @@
 import asyncio
+import gc
 import time
-from collections import defaultdict
+import warnings
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
-from unittest.mock import patch
 
 import pytest
 from hypothesis import given
 from hypothesis import strategies
 
-import wool.runtime.resourcepool as rp
 from wool.runtime.resourcepool import Resource
 from wool.runtime.resourcepool import ResourcePool
-
-# Global tracking for factory and finalizer calls using function names as keys
-call_tracker = defaultdict(lambda: {"factory_calls": [], "finalizer_calls": []})
-
-
-def reset_call_tracker():
-    """Reset the global call tracker."""
-    call_tracker.clear()
-
-
-def track_factory_call(func_name, key, result):
-    """Track a factory function call."""
-    call_tracker[func_name]["factory_calls"].append({"key": key, "result": result})
-
-
-def track_finalizer_call(func_name, obj):
-    """Track a finalizer function call."""
-    call_tracker[func_name]["finalizer_calls"].append({"obj": obj})
 
 
 @strategies.composite
@@ -55,7 +36,6 @@ def factory_functions(draw):
             obj = Mock()
             obj.name = f"sync-{key}"
             obj.created_by = "sync_simple"
-            track_factory_call("sync_simple", key, obj)
             return obj
 
         return sync_factory
@@ -66,7 +46,6 @@ def factory_functions(draw):
             obj = Mock()
             obj.name = f"async-{key}"
             obj.created_by = "async_simple"
-            track_factory_call("async_simple", key, obj)
             return obj
 
         return async_factory
@@ -74,18 +53,14 @@ def factory_functions(draw):
     elif factory_type == "sync_lambda":
 
         def sync_lambda_factory(key):
-            obj = SimpleNamespace(name=f"lambda-{key}", created_by="sync_lambda")
-            track_factory_call("sync_lambda", key, obj)
-            return obj
+            return SimpleNamespace(name=f"lambda-{key}", created_by="sync_lambda")
 
         return lambda key: sync_lambda_factory(key)
 
     elif factory_type == "async_lambda":
 
         async def async_lambda_factory(key):
-            obj = SimpleNamespace(name=f"async-lambda-{key}", created_by="async_lambda")
-            track_factory_call("async_lambda", key, obj)
-            return obj
+            return SimpleNamespace(name=f"async-lambda-{key}", created_by="async_lambda")
 
         return lambda key: async_lambda_factory(key)
 
@@ -93,13 +68,12 @@ def factory_functions(draw):
 
         class CallableLike:
             def __call__(self, key):
-                self.sync_factory(key)
+                return self.sync_factory(key)
 
             def sync_factory(self, key):
                 obj = Mock()
                 obj.name = f"callable-{key}"
                 obj.created_by = "callable"
-                track_factory_call("callable", key, obj)
                 return obj
 
         return CallableLike()
@@ -117,7 +91,6 @@ def factory_functions(draw):
                 obj = Mock()
                 obj.name = f"awaitable-{self.key}"
                 obj.created_by = "awaitable"
-                track_factory_call("awaitable", self.key, obj)
                 return obj
 
         return AwaitableLike
@@ -144,19 +117,14 @@ def finalizer_functions(draw):
     elif finalizer_type == "sync_simple":
 
         def simple_sync_finalizer(obj):
-            # Simple finalizer that just validates it was called with an object
             assert obj is not None
-            track_finalizer_call("sync_simple", obj)
 
-        # Store the type on the function for easy identification
         return simple_sync_finalizer
 
     elif finalizer_type == "async_simple":
 
         async def simple_async_finalizer(obj):
-            # Simple finalizer that just validates it was called with an object
             assert obj is not None
-            track_finalizer_call("async_simple", obj)
 
         return simple_async_finalizer
 
@@ -164,7 +132,6 @@ def finalizer_functions(draw):
 
         def sync_lambda_finalizer(obj):
             assert obj is not None
-            track_finalizer_call("sync_lambda", obj)
 
         return lambda obj: sync_lambda_finalizer(obj)
 
@@ -172,12 +139,10 @@ def finalizer_functions(draw):
 
         async def async_lambda_finalizer(obj):
             assert obj is not None
-            track_finalizer_call("async_lambda", obj)
 
         return lambda obj: async_lambda_finalizer(obj)
 
 
-# Reusable fixtures for simplified test setup
 @pytest.fixture
 def mock_resource_factory():
     """Create a mock factory with consistent behavior."""
@@ -193,15 +158,63 @@ def mock_finalizer():
 
 
 @pytest.fixture
-def resource_pool_with_ttl(mock_resource_factory, mock_finalizer):
-    """Create a resource pool configured for TTL testing."""
-    return ResourcePool(factory=mock_resource_factory, finalizer=mock_finalizer, ttl=0.1)
-
-
-@pytest.fixture
 def resource_pool_immediate_cleanup(mock_resource_factory, mock_finalizer):
     """Create a resource pool with TTL=0 for immediate cleanup testing."""
     return ResourcePool(factory=mock_resource_factory, finalizer=mock_finalizer, ttl=0)
+
+
+@pytest.fixture
+def expiry_race_pool(mocker):
+    """Build a short-TTL pool whose lock can be parked via a blocker key.
+
+    Returns the pool, its finalizer mock, the list of factory calls,
+    and the event that releases the parked ``blocker`` acquire.
+    """
+    release_blocker = asyncio.Event()
+    factory_calls = []
+
+    async def factory(key):
+        factory_calls.append(key)
+        if key == "blocker":
+            await release_blocker.wait()
+        return f"obj-{key}"
+
+    finalizer = mocker.AsyncMock()
+    pool = ResourcePool(factory=factory, finalizer=finalizer, ttl=0.05)
+    return pool, finalizer, factory_calls, release_blocker
+
+
+async def _queue_behind_fired_cleanup(pool, factory_calls, queued_coroutine):
+    """Race a fired TTL cleanup against an operation queued on the pool lock.
+
+    Caches and releases ``expired`` so its TTL timer arms, parks an
+    acquire of ``blocker`` inside its factory — the factory runs under
+    the pool lock, so the lock stays held — then queues the given
+    operation on the (FIFO) lock and waits for the timer to fire so
+    its cleanup task queues behind that operation. Returns the blocker
+    and queued-operation tasks.
+    """
+    async with pool.get("expired"):
+        pass
+
+    blocker_task = asyncio.create_task(pool.acquire("blocker"))
+
+    async def blocker_parked():
+        while "blocker" not in factory_calls:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(blocker_parked(), timeout=2.0)
+
+    queued_task = asyncio.create_task(queued_coroutine)
+
+    async def cleanup_task_spawned():
+        # The armed timer already counts as pending; wait until the
+        # pending work is the fired timer's cleanup *task*.
+        while not isinstance(pool.pending_cleanup.get("expired"), asyncio.Task):
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(cleanup_task_spawned(), timeout=2.0)
+    return blocker_task, queued_task
 
 
 @pytest.fixture
@@ -243,9 +256,6 @@ class TestResourcePool:
         keys = []
 
         async def setup():
-            # Reset call tracker for this test run
-            reset_call_tracker()
-
             for i in range(draw(strategies.integers(0, max_key_count))):
                 key = f"resource-{i}"
                 keys.append(key)
@@ -283,7 +293,6 @@ class TestResourcePool:
         assert isinstance(resource_acquisition, Resource)
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_should_return_resource_instance")
     async def test_release_should_decrement_reference_counts(self):
         """Test releasing resources decrements reference counts properly.
 
@@ -323,13 +332,10 @@ class TestResourcePool:
         assert pool.stats.referenced_entries == 0
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency(
-        "TestResourcePool::test_release_should_decrement_reference_counts"
-    )
     async def test_release_should_not_affect_existing_resources_when_key_nonexistent(
         self, counting_factory
     ):
-        """Test releasing nonexistent key raises KeyError.
+        """Test releasing a nonexistent key is a silent no-op.
 
         Given:
             A pool with some existing resources
@@ -359,9 +365,6 @@ class TestResourcePool:
         assert pool.stats.referenced_entries == 0
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency(
-        "TestResourcePool::test_release_should_decrement_reference_counts"
-    )
     async def test_release_should_raise_value_error_when_zero_reference_count(self):
         """Test releasing key with zero ref count raises ValueError.
 
@@ -449,27 +452,25 @@ class TestResourcePool:
             assert resource.name == "second"
         assert factory.call_count == 2
 
-    def test_acquire_should_cancel_cross_loop_cleanup_task_threadsafe(self):
-        """Test acquire cancels a foreign-loop cleanup task cross-loop.
+    def test_acquire_should_cancel_cross_loop_timer_threadsafe(self, mocker):
+        """Test acquire cancels a foreign-loop TTL timer cross-loop.
 
         Given:
-            A pool whose cached entry has a pending TTL cleanup task
+            A pool whose cached entry has an unfired TTL timer
             scheduled on one event loop, which has since closed.
         When:
             The same key is re-acquired from a different event loop.
         Then:
-            The cleanup should be cancelled on its own (now-closed) loop
-            via call_soon_threadsafe rather than awaited cross-loop, the
-            resulting RuntimeError should be swallowed, the cached object
-            should be returned, and the pending cleanup should be
-            cleared.
+            The timer should be cancelled on its own (now-closed) loop
+            via call_soon_threadsafe, the resulting RuntimeError
+            should be swallowed, the cached object should be returned,
+            and the pending cleanup should be cleared.
         """
         # Arrange
-        pool = ResourcePool(factory=Mock(return_value="obj"), ttl=60)
+        pool = ResourcePool(factory=mocker.Mock(return_value="obj"), ttl=60)
 
-        # Acquire and release on a dedicated loop so a TTL cleanup task is
-        # scheduled and bound to that loop, then close it. The pending task is
-        # held by reference so it survives until the cross-loop cancel runs.
+        # Acquire and release on a dedicated loop so a TTL timer is
+        # scheduled and bound to that loop, then close it.
         foreign_loop = asyncio.new_event_loop()
 
         async def schedule_cleanup_on_foreign_loop():
@@ -492,29 +493,28 @@ class TestResourcePool:
             acquiring_loop.close()
             del pending_cleanup
 
-    def test_clear_should_cancel_cross_loop_cleanup_task_threadsafe(self):
-        """Test clear cancels a foreign-loop cleanup task cross-loop.
+    def test_clear_should_cancel_cross_loop_timer_threadsafe(self, mocker):
+        """Test clear cancels a foreign-loop TTL timer cross-loop.
 
         Given:
-            A pool whose cached entry has a pending TTL cleanup task
+            A pool whose cached entry has an unfired TTL timer
             scheduled on one event loop, which has since closed.
         When:
             The key is cleared from a different event loop.
         Then:
-            The cleanup should be cancelled on its own (now-closed) loop
-            via call_soon_threadsafe, the resulting RuntimeError should be
-            swallowed, the finalizer should still run, and the entry
-            should be evicted.
+            The timer should be cancelled on its own (now-closed) loop
+            via call_soon_threadsafe, the resulting RuntimeError
+            should be swallowed, the finalizer should still run, and
+            the entry should be evicted.
         """
         # Arrange
-        finalizer = AsyncMock()
+        finalizer = mocker.AsyncMock()
         pool = ResourcePool(
-            factory=Mock(return_value="obj"), finalizer=finalizer, ttl=60
+            factory=mocker.Mock(return_value="obj"), finalizer=finalizer, ttl=60
         )
 
-        # Acquire and release on a dedicated loop so a TTL cleanup task is
-        # scheduled and bound to that loop, then close it. The pending task is
-        # held by reference so it survives until the cross-loop cancel runs.
+        # Acquire and release on a dedicated loop so a TTL timer is
+        # scheduled and bound to that loop, then close it.
         foreign_loop = asyncio.new_event_loop()
 
         async def schedule_cleanup_on_foreign_loop():
@@ -537,8 +537,163 @@ class TestResourcePool:
             clearing_loop.close()
             del pending_cleanup
 
+    def test_release_should_leave_no_pending_task_when_loop_closes_before_ttl(
+        self, mocker
+    ):
+        """Test release defers cleanup without parking a task on the loop.
+
+        Given:
+            A pool with a positive TTL whose resource is released on
+            a dedicated event loop.
+        When:
+            The loop is closed and garbage-collected before the TTL
+            elapses.
+        Then:
+            It should leave no pending task on the loop and emit no
+            RuntimeWarning when the deferred cleanup is collected.
+        """
+        # Arrange
+        loop = asyncio.new_event_loop()
+
+        def create_release_and_drop():
+            pool = ResourcePool(factory=mocker.Mock(return_value="obj"), ttl=60)
+
+            async def acquire_release():
+                async with pool.get("key"):
+                    pass
+
+            loop.run_until_complete(acquire_release())
+
+        # Act
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            create_release_and_drop()
+            pending = asyncio.all_tasks(loop)
+            loop.close()
+            gc.collect()
+
+        # Assert
+        assert pending == set()
+        assert not [w for w in caught if issubclass(w.category, RuntimeWarning)]
+
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_should_return_resource_instance")
+    async def test_acquire_should_cancel_in_flight_cleanup_when_reacquired_after_expiry(
+        self, expiry_race_pool
+    ):
+        """Test acquire cancels a fired cleanup racing on the pool lock.
+
+        Given:
+            A pool whose expired key's TTL timer has fired while the
+            pool lock is held by another key's acquire, so the
+            spawned cleanup task and a queued re-acquire of the
+            expired key both wait on the lock with the re-acquire
+            first
+        When:
+            The lock holder completes and the queued re-acquire runs
+        Then:
+            It should cancel the in-flight cleanup, return the cached
+            object without re-invoking the factory or finalizer, and
+            leave the key without pending cleanup
+        """
+        # Arrange
+        pool, finalizer, factory_calls, release_blocker = expiry_race_pool
+        blocker_task, reacquire_task = await _queue_behind_fired_cleanup(
+            pool, factory_calls, pool.acquire("expired")
+        )
+
+        # Act
+        release_blocker.set()
+        acquired = await reacquire_task
+        await blocker_task
+
+        # Assert
+        assert acquired == "obj-expired"
+        assert factory_calls.count("expired") == 1
+        finalizer.assert_not_awaited()
+        assert "expired" not in pool.pending_cleanup
+        assert pool.stats.total_entries == 2
+
+    @pytest.mark.asyncio
+    async def test_clear_should_cancel_in_flight_cleanup_when_cleared_after_expiry(
+        self, expiry_race_pool
+    ):
+        """Test clear cancels a fired cleanup racing on the pool lock.
+
+        Given:
+            A pool whose expired key's TTL timer has fired while the
+            pool lock is held by another key's acquire, so the
+            spawned cleanup task and a queued clear of the expired
+            key both wait on the lock with the clear first
+        When:
+            The lock holder completes and the queued clear runs
+        Then:
+            It should cancel the in-flight cleanup, still run the
+            finalizer exactly once, and evict the entry
+        """
+        # Arrange
+        pool, finalizer, factory_calls, release_blocker = expiry_race_pool
+        blocker_task, clear_task = await _queue_behind_fired_cleanup(
+            pool, factory_calls, pool.clear("expired")
+        )
+
+        # Act
+        release_blocker.set()
+        await clear_task
+        await blocker_task
+
+        # Assert
+        finalizer.assert_awaited_once_with("obj-expired")
+        assert "expired" not in pool.pending_cleanup
+        assert pool.stats.total_entries == 1
+
+    @pytest.mark.asyncio
+    @given(
+        operations=strategies.lists(
+            strategies.tuples(
+                strategies.sampled_from(["acquire", "release"]),
+                strategies.sampled_from(["a", "b", "c"]),
+            ),
+            max_size=30,
+        )
+    )
+    async def test_release_should_maintain_bookkeeping_invariants(self, operations):
+        """Test acquire and release keep TTL bookkeeping consistent.
+
+        Given:
+            Any interleaved sequence of acquire and release
+            operations over a small key domain, where releases are
+            applied only while a reference is held
+        When:
+            The sequence is applied step by step to a long-TTL pool
+        Then:
+            It should keep total entries equal to the keys ever
+            acquired, referenced entries equal to the keys with live
+            references, and pending cleanup on exactly the keys whose
+            references all released
+        """
+        # Arrange
+        pool = ResourcePool(factory=lambda key: f"obj-{key}", ttl=60)
+        model_refcount = {}
+
+        # Act & assert
+        for operation, key in operations:
+            if operation == "acquire":
+                await pool.acquire(key)
+                model_refcount[key] = model_refcount.get(key, 0) + 1
+            elif model_refcount.get(key, 0) > 0:
+                await pool.release(key)
+                model_refcount[key] -= 1
+
+            stats = pool.stats
+            assert stats.total_entries == len(model_refcount)
+            assert stats.referenced_entries == sum(
+                1 for count in model_refcount.values() if count > 0
+            )
+            assert set(pool.pending_cleanup) == {
+                key for key, count in model_refcount.items() if count == 0
+            }
+
+    @pytest.mark.asyncio
     async def test_clear_should_finalize_all_resources(self):
         """Test clearing the pool calls finalizer on all resources.
 
@@ -577,7 +732,6 @@ class TestResourcePool:
         assert mock_finalizer.call_count == 3
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_should_return_resource_instance")
     async def test_clear_should_remove_specific_resource_when_key_given(
         self, mock_finalizer
     ):
@@ -661,7 +815,6 @@ class TestResourcePool:
         mock_finalizer.assert_not_called()
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_should_return_resource_instance")
     async def test_ttl_cleanup_should_schedule_resource_removal(self):
         """Test TTL-based cleanup schedules and executes properly.
 
@@ -682,38 +835,23 @@ class TestResourcePool:
 
         key = "ttl-test"
 
-        # Create an event to control when the mocked sleep completes
-        sleep_event = asyncio.Event()
-
-        async def mock_sleep(_delay):
-            # Wait for the test to signal that sleep should complete
-            await sleep_event.wait()
-
-        with patch.object(rp.asyncio, "sleep", side_effect=mock_sleep):
-            # Act
-            # Acquire and immediately release
-            async with pool.get(key) as resource:
-                assert resource is mock_resource
-                assert pool.stats.total_entries == 1
-                assert pool.stats.referenced_entries == 1
-
-            # Resource should still be in cache but with cleanup task scheduled
+        # Act
+        # Acquire and immediately release
+        async with pool.get(key) as resource:
+            assert resource is mock_resource
             assert pool.stats.total_entries == 1
-            assert pool.stats.referenced_entries == 0
-            assert pool.stats.pending_cleanup == 1
+            assert pool.stats.referenced_entries == 1
 
-            # At this point, cleanup task is waiting for our mocked sleep
-            # Resource should still be in cache
-            assert pool.stats.total_entries == 1
-            mock_finalizer.assert_not_called()
-
-            # Signal that sleep should complete
-            sleep_event.set()
+        # Resource should still be in cache with cleanup deferred
+        assert pool.stats.total_entries == 1
+        assert pool.stats.referenced_entries == 0
+        assert pool.stats.pending_cleanup == 1
+        mock_finalizer.assert_not_called()
 
         # Assert
         # Wait for cleanup to complete using polling with timeout
         start_time = time.time()
-        while (key in pool.pending_cleanup) and (time.time() - start_time < 0.5):
+        while (key in pool.pending_cleanup) and (time.time() - start_time < 2.0):
             await asyncio.sleep(0.01)
 
         # Resource should now be cleaned up
@@ -721,7 +859,6 @@ class TestResourcePool:
         mock_finalizer.assert_called_once_with(mock_resource)
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_should_return_resource_instance")
     async def test_ttl_cleanup_should_be_cancelled_when_reacquired(self):
         """Test TTL cleanup is cancelled when resource is reacquired.
 
@@ -767,7 +904,6 @@ class TestResourcePool:
         assert pool.stats.referenced_entries == 0
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_should_return_resource_instance")
     async def test_stats_should_return_accurate_counts(self):
         """Test stats method returns accurate cache statistics.
 
@@ -777,14 +913,14 @@ class TestResourcePool:
             Stats property is accessed
         Then:
             Should return accurate counts for entries, references, and pending
-            tasks
+            timers or tasks
         """
         # Arrange
         mock_factory = Mock()
         mock_finalizer = AsyncMock()
         pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=0.1)
 
-        # Start with empty pool
+        # Guard: a fresh pool reports zero across all stats.
         stats = pool.stats
         assert stats.total_entries == 0
         assert stats.referenced_entries == 0
@@ -804,7 +940,6 @@ class TestResourcePool:
                     assert stats.pending_cleanup == 0  # None scheduled yet
 
     @pytest.mark.asyncio
-    @pytest.mark.dependency("TestResourcePool::test_get_should_return_resource_instance")
     async def test_async_context_manager_should_clear_resources(self):
         """Test ResourcePool as async context manager clears all on exit.
 
@@ -834,72 +969,34 @@ class TestResourcePool:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("ttl", [0, 0.1, 1, 1.1, 10, 10.1])
     async def test_ttl_should_schedule_cleanup_based_on_value(self, ttl):
-        """Test specific TTL values with controlled sleep mocking.
+        """Test specific TTL values defer or run cleanup accordingly.
 
         Given:
             A pool with specific TTL value
         When:
             A resource is acquired and released
         Then:
-            Should schedule cleanup based on TTL value
+            It should finalize immediately for TTL 0 and defer
+            cleanup for positive TTLs
         """
         # Arrange
-        sleep_calls = []
-        cleanup_started = asyncio.Event()
-        finalizer_called = asyncio.Event()
+        mock_factory = Mock(return_value=Mock(name="test-obj"))
+        mock_finalizer = Mock()
+        pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=ttl)
 
-        async def mock_sleep(delay):
-            sleep_calls.append(delay)
-            if delay != 0:  # Only signal for non-zero delays (actual TTL sleeps)
-                cleanup_started.set()
-                # Wait briefly to ensure the test can check the finalizer state
-                await finalizer_called.wait()
-            # Don't actually sleep, just record the call
+        # Act
+        async with pool.get("test-key"):
+            pass
 
-        # Act & assert
-        # Patch asyncio.sleep globally to ensure it captures calls from background tasks
-        with patch("asyncio.sleep", side_effect=mock_sleep):
-            mock_factory = Mock(return_value=Mock(name="test-obj"))
-
-            def mock_finalizer_func(obj):
-                finalizer_called.set()
-
-            mock_finalizer = Mock(side_effect=mock_finalizer_func)
-
-            pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=ttl)
-
-            async with pool.get("test-key"):
-                pass
-
-            if ttl == 0:
-                # Filter out our own sleep(0) call
-                filtered_calls = [call for call in sleep_calls if call != 0]
-                assert len(filtered_calls) == 0
-                mock_finalizer.assert_called_once()
-            else:
-                # Wait for the background task to actually call sleep with the TTL value
-                try:
-                    await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
-                    # At this point cleanup task is waiting for finalizer_called
-                    # Finalizer should not have been called yet
-                    mock_finalizer.assert_not_called()
-
-                    # Now allow cleanup to proceed
-                    finalizer_called.set()
-
-                    # Wait a bit for cleanup to complete
-                    await asyncio.sleep(0.1)
-                except asyncio.TimeoutError:
-                    # If timeout, just check that sleep was called with TTL
-                    pass
-
-                # Filter out our own sleep(0) calls and any wait_for internal calls
-                filtered_calls = [
-                    call for call in sleep_calls if call != 0 and call == ttl
-                ]
-                assert len(filtered_calls) > 0, (
-                    f"Expected TTL {ttl} not found in sleep calls: {sleep_calls}"
-                )
+        # Assert
+        if ttl == 0:
+            mock_finalizer.assert_called_once()
+            assert pool.stats.total_entries == 0
+            assert pool.stats.pending_cleanup == 0
+        else:
+            mock_finalizer.assert_not_called()
+            assert pool.stats.total_entries == 1
+            assert pool.stats.pending_cleanup == 1
 
     @pytest.mark.asyncio
     async def test_finalizer_should_catch_exception_and_remove_resource(self):
@@ -1203,8 +1300,6 @@ class TestResource:
         mock_pool = AsyncMock()
         mock_pool.acquire.side_effect = RuntimeError("Acquire failed")
 
-        from wool.runtime.resourcepool import Resource
-
         resource = Resource(pool=mock_pool, key="test-key")
 
         # Act & assert
@@ -1228,8 +1323,6 @@ class TestResource:
         """
         # Arrange
         mock_pool = AsyncMock()
-        from wool.runtime.resourcepool import Resource
-
         resource = Resource(pool=mock_pool, key="test-key")
 
         # Act & assert - manually call __aexit__ without calling __aenter__
@@ -1255,8 +1348,6 @@ class TestResource:
         mock_pool = AsyncMock()
         mock_resource = Mock()
         mock_pool.acquire.return_value = mock_resource
-
-        from wool.runtime.resourcepool import Resource
 
         resource = Resource(pool=mock_pool, key="test-key")
 

--- a/wool/tests/runtime/worker/test_local.py
+++ b/wool/tests/runtime/worker/test_local.py
@@ -1,8 +1,12 @@
+import asyncio
+from types import MappingProxyType
 from uuid import uuid4
 
 import grpc.aio
 import pytest
+from hypothesis import HealthCheck
 from hypothesis import given
+from hypothesis import settings
 from hypothesis import strategies as st
 
 from wool import protocol
@@ -25,6 +29,28 @@ def _make_metadata(address="127.0.0.1:50051", pid=12345, secure=False) -> Worker
         version="1.0.0",
         secure=secure,
     )
+
+
+def _make_started_process(mocker, *, alive=True):
+    """Build a WorkerProcess mock and patch it into local_module."""
+    mock_process = mocker.MagicMock(spec=WorkerProcess)
+    mock_process.address = "127.0.0.1:50051"
+    mock_process.metadata = _make_metadata()
+    mock_process.start.return_value = None
+    mock_process.is_alive.return_value = alive
+    mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
+    return mock_process
+
+
+def _mock_stop_channel(mocker, *, stop_side_effect=None):
+    """Mock the insecure channel and stub behind the graceful stop RPC."""
+    mock_channel = mocker.MagicMock()
+    mock_channel.close = mocker.AsyncMock()
+    mock_stub = mocker.MagicMock()
+    mock_stub.stop = mocker.AsyncMock(side_effect=stop_side_effect)
+    mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
+    mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+    return mock_channel, mock_stub
 
 
 class TestLocalWorker:
@@ -262,10 +288,6 @@ class TestLocalWorker:
             It should use the WorkerMetadata returned by the process
         """
         # Arrange
-        from types import MappingProxyType
-
-        from wool.runtime.worker.metadata import WorkerMetadata
-
         expected_metadata = WorkerMetadata(
             uid=uuid4(),
             address="192.168.1.100:50051",
@@ -352,24 +374,11 @@ class TestLocalWorker:
             It should send gRPC stop request
         """
         # Arrange
-        mock_process = mocker.MagicMock(spec=WorkerProcess)
-        mock_process.address = "127.0.0.1:50051"
-        mock_process.metadata = _make_metadata()
-        mock_process.start.return_value = None
-        mock_process.is_alive.return_value = True
-
-        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
+        _make_started_process(mocker)
+        _, mock_stub = _mock_stop_channel(mocker)
 
         worker = LocalWorker()
         await worker.start()
-
-        mock_channel = mocker.MagicMock()
-        mock_channel.close = mocker.AsyncMock()
-        mock_stub = mocker.MagicMock()
-        mock_stub.stop = mocker.AsyncMock()
-
-        mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
-        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
         # Act
         await worker.stop()
@@ -378,24 +387,121 @@ class TestLocalWorker:
         mock_stub.stop.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_stop_does_nothing_if_process_not_alive(self, mocker):
-        """Test _stop does nothing if worker process is not alive.
+    async def test_stop_should_reap_process_after_graceful_stop(self, mocker):
+        """Test stop reaps the worker process after the graceful RPC.
 
         Given:
-            A started LocalWorker with dead process
+            A started LocalWorker whose graceful stop RPC succeeds
+        When:
+            stop() is called with a timeout
+        Then:
+            It should send a stop request carrying that timeout, then
+            reap the worker process with it
+        """
+        # Arrange
+        mock_process = _make_started_process(mocker)
+        _, mock_stub = _mock_stop_channel(mocker)
+
+        worker = LocalWorker()
+        await worker.start()
+
+        teardown = mocker.MagicMock()
+        teardown.attach_mock(mock_stub.stop, "rpc_stop")
+        teardown.attach_mock(mock_process.reap, "reap")
+
+        # Act
+        await worker.stop(timeout=12.5)
+
+        # Assert
+        mock_stub.stop.assert_awaited_once()
+        request = mock_stub.stop.await_args.args[0]
+        assert request.timeout == 12.5
+        mock_process.reap.assert_called_once_with(12.5)
+        # Reap must follow the graceful request: reap-first would park
+        # in join with no stop ever asked of the worker, then SIGTERM
+        # a healthy process.
+        call_names = [name for name, _, _ in teardown.mock_calls]
+        assert call_names.index("rpc_stop") < call_names.index("reap")
+
+    @pytest.mark.asyncio
+    @settings(
+        max_examples=25,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(timeout=st.floats(min_value=0.125, max_value=4096.0, width=32))
+    async def test_stop_should_bound_rpc_deadline_when_timeout_finite(
+        self, mocker, timeout
+    ):
+        """Test any finite stop timeout yields a strictly larger deadline.
+
+        Given:
+            Any finite positive stop timeout
+        When:
+            stop() is called with it
+        Then:
+            It should forward the timeout in the stop request, bound
+            the RPC by deadline = timeout + _STOP_RPC_MARGIN, and reap
+            with the same timeout
+        """
+        # Arrange
+        mock_process = _make_started_process(mocker)
+        _, mock_stub = _mock_stop_channel(mocker)
+
+        worker = LocalWorker()
+        await worker.start()
+
+        # Act
+        await worker.stop(timeout=timeout)
+
+        # Assert
+        request = mock_stub.stop.await_args.args[0]
+        assert request.timeout == timeout
+        deadline = mock_stub.stop.await_args.kwargs["timeout"]
+        assert deadline == timeout + local_module._STOP_RPC_MARGIN
+        assert deadline > timeout
+        mock_process.reap.assert_called_once_with(timeout)
+
+    @pytest.mark.asyncio
+    async def test_stop_should_reap_process_when_grpc_stop_fails(self, mocker):
+        """Test stop reaps the worker process even if the RPC fails.
+
+        Given:
+            A started LocalWorker whose graceful stop RPC raises
         When:
             stop() is called
         Then:
-            It should not attempt gRPC call
+            It should propagate the error and still reap the process
         """
         # Arrange
-        mock_process = mocker.MagicMock(spec=WorkerProcess)
-        mock_process.address = "127.0.0.1:50051"
-        mock_process.metadata = _make_metadata()
-        mock_process.start.return_value = None
-        mock_process.is_alive.return_value = False
+        mock_process = _make_started_process(mocker)
+        mock_channel, _ = _mock_stop_channel(
+            mocker, stop_side_effect=Exception("gRPC error")
+        )
 
-        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
+        worker = LocalWorker()
+        await worker.start()
+
+        # Act & assert
+        with pytest.raises(Exception, match="gRPC error"):
+            await worker.stop()
+
+        mock_process.reap.assert_called_once_with(None)
+        mock_channel.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_should_reap_process_when_not_alive(self, mocker):
+        """Test stop reaps the worker process even when already dead.
+
+        Given:
+            A started LocalWorker whose process is no longer alive
+        When:
+            stop() is called
+        Then:
+            It should skip the RPC but still reap the process
+        """
+        # Arrange
+        mock_process = _make_started_process(mocker, alive=False)
 
         worker = LocalWorker()
         await worker.start()
@@ -407,43 +513,71 @@ class TestLocalWorker:
 
         # Assert
         mock_channel_fn.assert_not_called()
+        mock_process.reap.assert_called_once_with(None)
 
     @pytest.mark.asyncio
-    async def test_stop_handles_grpc_errors_gracefully(self, mocker):
-        """Test _stop handles gRPC errors without crashing.
+    async def test_stop_should_not_set_rpc_deadline_when_timeout_none(self, mocker):
+        """Test stop leaves the graceful RPC unbounded without a timeout.
 
         Given:
-            A started LocalWorker where gRPC call fails
+            A started LocalWorker whose graceful stop RPC succeeds
         When:
-            stop() is called
+            stop() is called without a timeout
         Then:
-            It should handle the error gracefully
+            It should send the stop request with no gRPC deadline and
+            reap without a bound override
         """
         # Arrange
-        mock_process = mocker.MagicMock(spec=WorkerProcess)
-        mock_process.address = "127.0.0.1:50051"
-        mock_process.metadata = _make_metadata()
-        mock_process.start.return_value = None
-        mock_process.is_alive.return_value = True
-
-        mocker.patch.object(local_module, "WorkerProcess", return_value=mock_process)
+        mock_process = _make_started_process(mocker)
+        _, mock_stub = _mock_stop_channel(mocker)
 
         worker = LocalWorker()
         await worker.start()
 
-        mock_channel = mocker.MagicMock()
-        mock_channel.close = mocker.AsyncMock()
-        mock_stub = mocker.MagicMock()
-        mock_stub.stop = mocker.AsyncMock(side_effect=Exception("gRPC error"))
+        # Act
+        await worker.stop()
 
-        mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
-        mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
+        # Assert
+        mock_stub.stop.assert_awaited_once()
+        assert mock_stub.stop.await_args.kwargs["timeout"] is None
+        mock_process.reap.assert_called_once_with(None)
 
-        # Act & assert
-        with pytest.raises(Exception, match="gRPC error"):
-            await worker.stop()
+    @pytest.mark.asyncio
+    async def test_stop_should_reap_process_when_cancelled_mid_rpc(self, mocker):
+        """Test stop reaps the worker even when cancelled mid-RPC.
 
-    # === NEW CREDENTIAL TESTS ===
+        Given:
+            A started LocalWorker whose graceful stop RPC never
+            completes
+        When:
+            The stop() task is cancelled while the RPC is in flight
+        Then:
+            It should raise CancelledError to the awaiter and still
+            reap the worker process with the stop timeout
+        """
+        # Arrange
+        mock_process = _make_started_process(mocker)
+
+        worker = LocalWorker()
+        await worker.start()
+
+        rpc_started = asyncio.Event()
+
+        async def hang_forever(request, timeout=None):
+            rpc_started.set()
+            await asyncio.Event().wait()
+
+        _mock_stop_channel(mocker, stop_side_effect=hang_forever)
+
+        # Act
+        stop_task = asyncio.create_task(worker.stop(timeout=3.0))
+        await rpc_started.wait()
+        stop_task.cancel()
+
+        # Assert
+        with pytest.raises(asyncio.CancelledError):
+            await stop_task
+        mock_process.reap.assert_called_once_with(3.0)
 
     def test___init___with_worker_credentials(self, worker_credentials):
         """Test LocalWorker with WorkerCredentials.

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -1,4 +1,7 @@
+import asyncio
+import multiprocessing.context
 import signal
+import threading
 import uuid
 from types import MappingProxyType
 
@@ -18,9 +21,55 @@ from wool.runtime.worker.base import ChannelOptions
 from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.process import WorkerProcess
+from wool.runtime.worker.process import _parent_watchdog
 from wool.runtime.worker.process import _sigint_handler
 from wool.runtime.worker.process import _signal_handlers
 from wool.runtime.worker.process import _sigterm_handler
+
+
+def _run_scheduled_callback(scheduled):
+    """Execute the single captured loop callback on a real event loop."""
+    assert len(scheduled) == 1
+
+    async def run():
+        scheduled[0]()
+        # Yield so the task the callback spawned runs to completion.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+
+@pytest.fixture
+def watchdog_env(mocker):
+    """Arrange a watchdog environment with a dead parent and patched exit.
+
+    Patches parent_process to a mock whose join returns immediately
+    (the parent is already dead) and os._exit to set an event instead
+    of killing the test process. Returns the parent mock, the exit
+    mock, and the exited event.
+    """
+    mock_parent = mocker.MagicMock()
+    mock_parent.join.return_value = None
+    mocker.patch.object(process_module._mp, "parent_process", return_value=mock_parent)
+
+    exited = threading.Event()
+    mock_exit = mocker.patch.object(
+        process_module.os, "_exit", side_effect=lambda code: exited.set()
+    )
+    return mock_parent, mock_exit, exited
+
+
+def _join_watchdog(thread, exited):
+    """Wait out a watchdog thread through its patched hard exit.
+
+    Waiting for the exit event before joining guarantees the patched
+    os._exit is not restored while the thread could still reach it —
+    the real os._exit would kill the test process.
+    """
+    assert thread is not None
+    assert exited.wait(timeout=5.0)
+    thread.join(timeout=5.0)
 
 
 def test__sigterm_handler_calls_service_stop_when_loop_is_running(mocker):
@@ -29,27 +78,30 @@ def test__sigterm_handler_calls_service_stop_when_loop_is_running(mocker):
     Given:
         A running event loop and WorkerService
     When:
-        _sigterm_handler is called with SIGTERM
+        _sigterm_handler is called with SIGTERM and the callback it
+        scheduled on the loop executes
     Then:
-        It should schedule service.stop with timeout=0 via call_soon_threadsafe
+        It should await service.stop with a zero-timeout StopRequest
+        and no context
     """
     # Arrange
+    scheduled = []
     mock_loop = mocker.MagicMock()
     mock_loop.is_running.return_value = True
+    mock_loop.call_soon_threadsafe.side_effect = scheduled.append
     mock_service = mocker.MagicMock()
-
-    mock_stop_request = mocker.MagicMock()
-    mocker.patch(
-        "wool.runtime.worker.process.protocol.StopRequest",
-        return_value=mock_stop_request,
-    )
+    mock_service.stop = mocker.AsyncMock()
 
     # Act
     _sigterm_handler(mock_loop, mock_service, signal.SIGTERM, None)
+    _run_scheduled_callback(scheduled)
 
     # Assert
     mock_loop.is_running.assert_called_once()
-    mock_loop.call_soon_threadsafe.assert_called_once()
+    mock_service.stop.assert_awaited_once()
+    request, context = mock_service.stop.await_args.args
+    assert request.timeout == 0
+    assert context is None
 
 
 def test__sigterm_handler_does_nothing_when_loop_is_not_running(mocker):
@@ -81,27 +133,30 @@ def test__sigint_handler_calls_service_stop_when_loop_is_running(mocker):
     Given:
         A running event loop and WorkerService
     When:
-        _sigint_handler is called with SIGINT
+        _sigint_handler is called with SIGINT and the callback it
+        scheduled on the loop executes
     Then:
-        It should schedule service.stop with timeout=None via call_soon_threadsafe
+        It should await service.stop with a negative-timeout
+        StopRequest — an unbounded drain — and no context
     """
     # Arrange
+    scheduled = []
     mock_loop = mocker.MagicMock()
     mock_loop.is_running.return_value = True
+    mock_loop.call_soon_threadsafe.side_effect = scheduled.append
     mock_service = mocker.MagicMock()
-
-    mock_stop_request = mocker.MagicMock()
-    mocker.patch(
-        "wool.runtime.worker.process.protocol.StopRequest",
-        return_value=mock_stop_request,
-    )
+    mock_service.stop = mocker.AsyncMock()
 
     # Act
     _sigint_handler(mock_loop, mock_service, signal.SIGINT, None)
+    _run_scheduled_callback(scheduled)
 
     # Assert
     mock_loop.is_running.assert_called_once()
-    mock_loop.call_soon_threadsafe.assert_called_once()
+    mock_service.stop.assert_awaited_once()
+    request, context = mock_service.stop.await_args.args
+    assert request.timeout == -1
+    assert context is None
 
 
 def test__sigint_handler_does_nothing_when_loop_is_not_running(mocker):
@@ -213,6 +268,157 @@ async def test__signal_handlers_restores_handlers_even_on_exception(mocker):
     assert signal_calls[3] == (signal.SIGINT, old_sigint)
 
 
+def test__parent_watchdog_should_do_nothing_when_no_parent_process(mocker):
+    """Test _parent_watchdog does nothing outside a multiprocessing child.
+
+    Given:
+        A process that was not spawned by multiprocessing
+    When:
+        _parent_watchdog is called
+    Then:
+        It should return None without starting a watchdog thread
+    """
+    # Arrange
+    mock_loop = mocker.MagicMock()
+    mock_service = mocker.MagicMock()
+    mocker.patch.object(process_module._mp, "parent_process", return_value=None)
+
+    # Act
+    thread = _parent_watchdog(mock_loop, mock_service, 1.0)
+
+    # Assert
+    assert thread is None
+    mock_loop.call_soon_threadsafe.assert_not_called()
+
+
+def test__parent_watchdog_should_stop_service_and_exit_when_parent_dies(
+    mocker, watchdog_env
+):
+    """Test _parent_watchdog shuts the worker down on parent death.
+
+    Given:
+        A watchdog whose parent process exits immediately and a
+        running event loop
+    When:
+        _parent_watchdog is called
+    Then:
+        It should run on a daemon thread, schedule the service stop
+        on the loop, and hard-exit the process once the grace window
+        elapses
+    """
+    # Arrange
+    mock_parent, mock_exit, exited = watchdog_env
+    mock_loop = mocker.MagicMock()
+    mock_loop.is_running.return_value = True
+    mock_service = mocker.MagicMock()
+
+    # Act
+    thread = _parent_watchdog(mock_loop, mock_service, 0.01)
+
+    # Assert
+    assert thread is not None
+    # The daemon flag is load-bearing: a non-daemon watchdog blocked
+    # on parent.join() would keep every gracefully stopped worker
+    # process alive for as long as its parent lives.
+    assert thread.daemon is True
+    _join_watchdog(thread, exited)
+    mock_parent.join.assert_called_once()
+    mock_loop.call_soon_threadsafe.assert_called_once()
+    mock_exit.assert_called_once_with(1)
+
+
+def test__parent_watchdog_should_still_exit_when_loop_not_running(mocker, watchdog_env):
+    """Test _parent_watchdog hard-exits even with a stopped loop.
+
+    Given:
+        A watchdog whose parent process exits immediately and an
+        event loop that is no longer running
+    When:
+        _parent_watchdog is called
+    Then:
+        It should skip the service stop and still hard-exit the
+        process after the grace window
+    """
+    # Arrange
+    _, mock_exit, exited = watchdog_env
+    mock_loop = mocker.MagicMock()
+    mock_loop.is_running.return_value = False
+    mock_service = mocker.MagicMock()
+
+    # Act
+    thread = _parent_watchdog(mock_loop, mock_service, 0.01)
+
+    # Assert
+    _join_watchdog(thread, exited)
+    mock_loop.call_soon_threadsafe.assert_not_called()
+    mock_exit.assert_called_once_with(1)
+
+
+def test__parent_watchdog_should_dispatch_stop_request_with_zero_timeout(
+    mocker, watchdog_env
+):
+    """Test _parent_watchdog's scheduled callback stops the service.
+
+    Given:
+        A watchdog whose parent process exits immediately and a
+        running event loop
+    When:
+        The callback the watchdog scheduled on the loop executes
+    Then:
+        It should await service.stop with a zero-timeout StopRequest
+        and no context, matching SIGTERM semantics
+    """
+    # Arrange
+    _, _, exited = watchdog_env
+    scheduled = []
+    mock_loop = mocker.MagicMock()
+    mock_loop.is_running.return_value = True
+    mock_loop.call_soon_threadsafe.side_effect = scheduled.append
+    mock_service = mocker.MagicMock()
+    mock_service.stop = mocker.AsyncMock()
+
+    thread = _parent_watchdog(mock_loop, mock_service, 0.01)
+    _join_watchdog(thread, exited)
+
+    # Act
+    _run_scheduled_callback(scheduled)
+
+    # Assert
+    mock_service.stop.assert_awaited_once()
+    request, context = mock_service.stop.await_args.args
+    assert request.timeout == 0
+    assert context is None
+
+
+def test__parent_watchdog_should_still_exit_when_loop_closed_concurrently(
+    mocker, watchdog_env
+):
+    """Test _parent_watchdog survives a loop closing mid-dispatch.
+
+    Given:
+        A watchdog whose parent process exits immediately and a loop
+        that reports running but raises RuntimeError on scheduling
+    When:
+        _parent_watchdog runs through the grace window
+    Then:
+        It should swallow the scheduling error and still hard-exit
+        the process
+    """
+    # Arrange
+    _, mock_exit, exited = watchdog_env
+    mock_loop = mocker.MagicMock()
+    mock_loop.is_running.return_value = True
+    mock_loop.call_soon_threadsafe.side_effect = RuntimeError("Event loop is closed")
+    mock_service = mocker.MagicMock()
+
+    # Act
+    thread = _parent_watchdog(mock_loop, mock_service, 0.01)
+
+    # Assert
+    _join_watchdog(thread, exited)
+    mock_exit.assert_called_once_with(1)
+
+
 class TestWorkerProcess:
     """Test suite for WorkerProcess."""
 
@@ -283,8 +489,6 @@ class TestWorkerProcess:
         Then:
             It should be an instance of SpawnProcess from the spawn context
         """
-        import multiprocessing.context
-
         # Act
         process = WorkerProcess()
 
@@ -633,7 +837,7 @@ class TestWorkerProcess:
         When:
             start() is called
         Then:
-            It should raise RuntimeError and terminate the process
+            It should raise RuntimeError and reap the process
         """
         # Arrange
         mock_get_meta = mocker.MagicMock()
@@ -647,8 +851,7 @@ class TestWorkerProcess:
         mocker.patch.object(process_module.Process, "start")
 
         process = WorkerProcess()
-        mock_terminate = mocker.patch.object(process, "terminate")
-        mock_join = mocker.patch.object(process, "join")
+        mock_reap = mocker.patch.object(process, "reap")
 
         # Act & assert
         with pytest.raises(
@@ -656,8 +859,7 @@ class TestWorkerProcess:
         ):
             process.start(timeout=1.0)
 
-        mock_terminate.assert_called_once()
-        mock_join.assert_called_once()
+        mock_reap.assert_called_once_with(timeout=0)
 
     def test_start_closes_pipe_after_receiving_port(self, mocker):
         """Test start closes the pipe connection after receiving port.
@@ -806,6 +1008,53 @@ class TestWorkerProcess:
         mock_close.assert_called_once()
         mock_service.stopped.wait.assert_called_once()
         mock_server.stop.assert_called_once_with(grace=30.0)
+
+    def test_run_should_install_parent_watchdog(self, mocker):
+        """Test run installs the parent-death watchdog.
+
+        Given:
+            A WorkerProcess with a custom shutdown grace period
+        When:
+            run() is called
+        Then:
+            It should install the parent watchdog once with the
+            running event loop, the worker service, and the grace
+            period
+        """
+        # This pins only the wiring; the behavioral contract is owned
+        # by tests/integration/test_worker_shutdown.py's
+        # test_worker_should_exit_when_parent_is_killed.
+        # Arrange
+        process = WorkerProcess(shutdown_grace_period=30.0)
+
+        mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
+        mocker.patch("wool.runtime.worker.process.ResourcePool")
+
+        mock_server = mocker.MagicMock()
+        mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
+        mock_server.start = mocker.AsyncMock()
+        mock_server.stop = mocker.AsyncMock()
+        mocker.patch.object(grpc.aio, "server", return_value=mock_server)
+
+        mock_service = mocker.MagicMock()
+        mock_service.stopped.wait = mocker.AsyncMock()
+        mocker.patch.object(process_module, "WorkerService", return_value=mock_service)
+
+        mocker.patch.object(process_module, "_signal_handlers")
+        mock_watchdog = mocker.patch.object(process_module, "_parent_watchdog")
+
+        mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
+
+        # Act
+        process.run()
+
+        # Assert
+        mock_watchdog.assert_called_once()
+        loop_arg, service_arg, grace_arg = mock_watchdog.call_args.args
+        assert isinstance(loop_arg, asyncio.AbstractEventLoop)
+        assert service_arg is mock_service
+        assert grace_arg == 30.0
 
     def test_run_sends_port_through_pipe(self, mocker):
         """Test run sends assigned port through multiprocessing pipe.
@@ -1040,8 +1289,6 @@ class TestWorkerProcess:
             process.run()
 
         mock_stop.assert_called_once_with(grace=45.0)
-
-    # === SINGLE-PORT ARCHITECTURE TESTS ===
 
     def test_serve_insecure_worker_single_port(self, mocker):
         """Test single insecure TCP port for insecure workers.
@@ -1922,3 +2169,168 @@ class TestWorkerProcess:
         # Assert
         assert len(captured_current) == 1
         assert captured_current[0] is None
+
+    def test_reap_should_do_nothing_when_never_started(self, mocker):
+        """Test reap is a no-op for a process that was never started.
+
+        Given:
+            A WorkerProcess that has not been started
+        When:
+            reap() is called
+        Then:
+            It should return without joining or signalling the process
+        """
+        # Arrange
+        process = WorkerProcess()
+        mock_join = mocker.patch.object(process, "join")
+        mock_terminate = mocker.patch.object(process, "terminate")
+
+        # Act
+        process.reap()
+
+        # Assert
+        mock_join.assert_not_called()
+        mock_terminate.assert_not_called()
+
+    def test_reap_should_return_when_process_exits_within_timeout(self, mocker):
+        """Test reap returns without escalating when the process exits.
+
+        Given:
+            A started WorkerProcess that exits within the join timeout
+        When:
+            reap() is called with a timeout
+        Then:
+            It should join with that timeout and not terminate or kill
+        """
+        # Arrange
+        process = WorkerProcess()
+        mocker.patch.object(
+            WorkerProcess, "pid", new_callable=mocker.PropertyMock, return_value=12345
+        )
+        mock_join = mocker.patch.object(process, "join")
+        mocker.patch.object(process, "is_alive", return_value=False)
+        mock_terminate = mocker.patch.object(process, "terminate")
+        mock_kill = mocker.patch.object(process, "kill")
+
+        # Act
+        process.reap(timeout=1.5)
+
+        # Assert
+        mock_join.assert_called_once_with(1.5)
+        mock_terminate.assert_not_called()
+        mock_kill.assert_not_called()
+
+    def test_reap_should_default_timeout_to_grace_period_when_none(self, mocker):
+        """Test reap falls back to the shutdown grace period as its bound.
+
+        Given:
+            A started WorkerProcess with a custom shutdown grace period
+        When:
+            reap() is called without a timeout
+        Then:
+            It should join with the shutdown grace period
+        """
+        # Arrange
+        process = WorkerProcess(shutdown_grace_period=30.0)
+        mocker.patch.object(
+            WorkerProcess, "pid", new_callable=mocker.PropertyMock, return_value=12345
+        )
+        mock_join = mocker.patch.object(process, "join")
+        mocker.patch.object(process, "is_alive", return_value=False)
+
+        # Act
+        process.reap()
+
+        # Assert
+        mock_join.assert_called_once_with(30.0)
+
+    def test_reap_should_not_default_timeout_when_zero(self, mocker):
+        """Test reap treats a zero timeout as an immediate poll.
+
+        Given:
+            A started WorkerProcess with a custom shutdown grace period
+        When:
+            reap() is called with timeout=0
+        Then:
+            It should join with 0 rather than the grace period
+        """
+        # Arrange
+        process = WorkerProcess(shutdown_grace_period=30.0)
+        mocker.patch.object(
+            WorkerProcess, "pid", new_callable=mocker.PropertyMock, return_value=12345
+        )
+        mock_join = mocker.patch.object(process, "join")
+        mocker.patch.object(process, "is_alive", return_value=False)
+
+        # Act
+        process.reap(timeout=0)
+
+        # Assert
+        mock_join.assert_called_once_with(0)
+
+    def test_reap_should_terminate_process_when_graceful_join_times_out(self, mocker):
+        """Test reap escalates to terminate when the process lingers.
+
+        Given:
+            A started WorkerProcess still alive after the graceful join
+        When:
+            reap() is called
+        Then:
+            It should terminate the process and join again with a
+            finite bound, without kill
+        """
+        # Arrange
+        process = WorkerProcess()
+        mocker.patch.object(
+            WorkerProcess, "pid", new_callable=mocker.PropertyMock, return_value=12345
+        )
+        mock_join = mocker.patch.object(process, "join")
+        mocker.patch.object(process, "is_alive", side_effect=[True, False])
+        mock_terminate = mocker.patch.object(process, "terminate")
+        mock_kill = mocker.patch.object(process, "kill")
+
+        # Act
+        process.reap(timeout=0.1)
+
+        # Assert
+        mock_terminate.assert_called_once()
+        assert mock_join.call_args_list[0] == mocker.call(0.1)
+        # A SIGTERM-ignoring worker must not stall reap before the
+        # kill rung, so the post-terminate join must be bounded.
+        post_terminate_bound = mock_join.call_args_list[1].args[0]
+        assert post_terminate_bound is not None
+        assert 0 < post_terminate_bound < float("inf")
+        mock_kill.assert_not_called()
+
+    def test_reap_should_kill_process_when_terminate_fails(self, mocker):
+        """Test reap escalates to kill when termination is ignored.
+
+        Given:
+            A started WorkerProcess still alive after terminate
+        When:
+            reap() is called
+        Then:
+            It should kill the process after terminating it and join
+            a final, unbounded time
+        """
+        # Arrange
+        process = WorkerProcess()
+        mocker.patch.object(
+            WorkerProcess, "pid", new_callable=mocker.PropertyMock, return_value=12345
+        )
+        mock_join = mocker.patch.object(process, "join")
+        mocker.patch.object(process, "is_alive", side_effect=[True, True])
+        mock_terminate = mocker.patch.object(process, "terminate")
+        mock_kill = mocker.patch.object(process, "kill")
+        escalation = mocker.MagicMock()
+        escalation.attach_mock(mock_terminate, "terminate")
+        escalation.attach_mock(mock_kill, "kill")
+
+        # Act
+        process.reap(timeout=0.1)
+
+        # Assert
+        assert escalation.mock_calls == [mocker.call.terminate(), mocker.call.kill()]
+        assert mock_join.call_args_list[0] == mocker.call(0.1)
+        assert mock_join.call_args_list[1].args[0] is not None
+        assert mock_join.call_args_list[2] == mocker.call()


### PR DESCRIPTION
## Summary

Worker subprocesses could outlive the process that spawned them: a parent that crashed, was SIGKILLed, or never completed the graceful stop RPC left orphaned gRPC workers reparented to init and accumulating across runs. Close every escape path with layered defenses on both sides of the process boundary: the parent always force-terminates workers through a bounded reap escalation, the graceful stop RPC carries a deadline so a wedged worker cannot dodge that reap, and the worker itself watches for parent death and hard-exits as a backstop when no parent-side path runs at all. Rework ResourcePool's TTL deferral from a parked sleep-task to a plain timer so the worker's own teardown no longer leaks pending cleanup tasks or emits "coroutine never awaited" warnings. Closes #260.

## Proposed changes

### Bounded reap escalation in `WorkerProcess`

Add `WorkerProcess.reap(timeout=None)`: join with the caller's bound (defaulting to the worker's shutdown grace period), escalate to SIGTERM with a bounded follow-up join (`_REAP_GRACE`, 5s), then SIGKILL. `LocalWorker._stop` reaps unconditionally in a `finally`, running the blocking escalation in an executor thread so it completes even when the stopping coroutine is cancelled by a pool teardown deadline. Reuse the same escalation on `start()`'s failure path via `reap(timeout=0)`, replacing a weaker inline terminate/unbounded-join.

### Deadline on the graceful stop RPC

Bound `stub.stop` with `timeout + _STOP_RPC_MARGIN` (5s over the worker's drain bound, which the server may fully consume before responding); `timeout=None` preserves the caller's explicit unbounded-graceful contract. A wedged worker now surfaces `DEADLINE_EXCEEDED` instead of hanging `stop()` forever, and the finally-reap escalates to force-termination.

### Parent-death watchdog in the worker

Install `_parent_watchdog` in `_serve`: a daemon thread blocks on `multiprocessing.parent_process().join()` — which fires even for SIGKILL — then schedules the same graceful stop as SIGTERM and hard-exits via `os._exit(1)` once the grace window elapses, surviving an event loop that closes mid-dispatch. Extract the shared `_schedule_stop(loop, service, timeout)` dispatcher used by the watchdog and both signal handlers, documenting the divergent semantics (SIGTERM and the watchdog cancel in-flight tasks immediately; SIGINT drains indefinitely).

### ResourcePool TTL deferral via timer

Replace the parked sleep-task with a `loop.call_later` timer whose `_expire` callback spawns the cleanup task only when the TTL actually fires: an unfired `TimerHandle` is discarded silently at loop close, eliminating the "Task was destroyed but it is pending!" teardown noise and the "coroutine never awaited" RuntimeWarning. Extract `_cancel_timer` and `_cancel_cleanup` for the same-loop (cancel and await) and cross-loop (best-effort `call_soon_threadsafe`) cancellation paths, guard the expiry path against cancelling its own `_finalize` task, and correct the documented contracts (`release` is a silent no-op for missing keys and raises `ValueError` on over-release; `clear` raises `KeyError`).

### Documentation homes

Home the reap/cancellation contract — including the executor-thread cancellation survival and its second-cancel caveat — in `LocalWorker._stop`'s docstring, with `WorkerPool.shutdown_timeout` documenting only the pool-observable consequence (teardown may overrun the deadline by the reap escalation) and pointing back.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerOrphanPrevention` | A started LocalWorker backed by a real subprocess | `stop()` is called | It returns only once the worker pid no longer exists | Parent-side reap |
| 2 | `TestWorkerOrphanPrevention` | A parent process holding no teardown path | The parent is killed with SIGKILL | The orphaned worker detects parent death and exits within the grace window | Parent-death watchdog |
| 3 | `TestWorkerOrphanPrevention` | An ephemeral WorkerPool with two spawned workers | The pool context exits normally | No worker subprocess remains alive | Pool-scale teardown |
| 4 | `TestWorkerOrphanPrevention` | An entered single-worker pool whose worker was SIGKILLed mid-context | The pool context exits | Teardown completes without raising and the corpse is reaped | Crashed-worker tolerance |
| 5 | `TestWorkerOrphanPrevention` | A started real WorkerProcess that never receives a stop RPC | `reap()` is called with a short timeout | The worker subprocess is terminated | Reap escalation against a live process |
| 6 | `TestWorkerOrphanPrevention` | A started worker suspended with SIGSTOP | `stop()` is awaited with a short timeout | DEADLINE_EXCEEDED surfaces within a bound and the worker is killed | Stop RPC deadline plus SIGKILL rung |
| 7 | `test_process.py` | A running event loop and worker service | `_sigterm_handler` fires and its scheduled callback executes | `service.stop` is awaited with a zero-timeout StopRequest and no context | SIGTERM semantics |
| 8 | `test_process.py` | A running event loop and worker service | `_sigint_handler` fires and its scheduled callback executes | `service.stop` is awaited with a negative-timeout StopRequest — an unbounded drain | SIGINT semantics |
| 9 | `test_process.py` | A process not spawned by multiprocessing | `_parent_watchdog` is called | It returns None without starting a thread | Watchdog no-op outside a child |
| 10 | `test_process.py` | A watchdog whose parent exits immediately and a running loop | `_parent_watchdog` is called | A daemon thread schedules the service stop and hard-exits after the grace window | Watchdog happy path |
| 11 | `test_process.py` | A parent that exits and a loop no longer running | The watchdog runs through the grace window | It skips the dispatch and still hard-exits | Watchdog exit without a loop |
| 12 | `test_process.py` | A watchdog whose scheduled callback is captured | The callback executes on a real loop | `service.stop` is awaited with a zero-timeout StopRequest and no context | Watchdog dispatch payload |
| 13 | `test_process.py` | A loop that reports running but raises RuntimeError on scheduling | The watchdog runs through the grace window | It swallows the error and still hard-exits | Closed-loop race guard |
| 14 | `TestWorkerProcess` | A WorkerProcess with a custom grace period | `run()` is called | The watchdog is installed once with the running loop, service, and grace period | Watchdog wiring |
| 15 | `TestWorkerProcess` | A WorkerProcess never started | `reap()` is called | It returns without touching the process | Reap no-op guard |
| 16 | `TestWorkerProcess` | A process that exits within the join bound | `reap()` is called | It neither terminates nor kills | Graceful fast path |
| 17 | `TestWorkerProcess` | No explicit timeout | `reap()` is called | It joins with the shutdown grace period | Timeout defaulting |
| 18 | `TestWorkerProcess` | An explicit zero timeout | `reap(timeout=0)` is called | It joins with 0, not the grace default | `is not None` pin |
| 19 | `TestWorkerProcess` | A process that survives the graceful join | `reap()` escalates | SIGTERM is sent with a bounded follow-up join | Terminate rung |
| 20 | `TestWorkerProcess` | A process that survives SIGTERM | `reap()` escalates further | SIGKILL follows terminate, in order | Kill rung ordering |
| 21 | `TestWorkerProcess` | A pipe that never reports metadata | `start()` times out | RuntimeError is raised and the process is reaped with `timeout=0` | Start-failure escalation |
| 22 | `TestLocalWorker` | A started worker whose stop RPC succeeds | `stop(timeout=12.5)` is called | The request carries the timeout and reap follows the RPC | Stop ordering contract |
| 23 | `TestLocalWorker` | Any finite positive stop timeout (Hypothesis) | `stop()` is called with it | `deadline == timeout + _STOP_RPC_MARGIN`, strictly above the timeout, and reap gets the same bound | Deadline-margin invariant |
| 24 | `TestLocalWorker` | No stop timeout | `stop()` is called | The RPC carries no gRPC deadline | Unbounded contract arm |
| 25 | `TestLocalWorker` | A stop RPC that raises | `stop()` is called | The error propagates, the process is still reaped, and the channel is closed | Failure-path reap |
| 26 | `TestLocalWorker` | A worker process no longer alive | `stop()` is called | The RPC is skipped but the process is still reaped | Dead-process arm |
| 27 | `TestLocalWorker` | A stop RPC that never completes | The `stop()` task is cancelled mid-RPC | CancelledError propagates and the process is still reaped | Cancellation-surviving reap |
| 28 | `TestResourcePool` | An unfired TTL timer bound to a since-closed loop | The key is re-acquired from another loop | The timer is cancelled threadsafe and the cached object returned | Cross-loop timer cancel |
| 29 | `TestResourcePool` | An unfired TTL timer bound to a since-closed loop | The key is cleared from another loop | The finalizer still runs and the entry is evicted | Cross-loop clear |
| 30 | `TestResourcePool` | A released entry on a dedicated loop | The loop closes and is collected before the TTL elapses | No pending task remains and no RuntimeWarning is emitted | Timer-deferral regression |
| 31 | `TestResourcePool` | A fired cleanup queued behind a re-acquire on the pool lock | The re-acquire runs | The in-flight cleanup is cancelled and the cached object survives | Fired-timer race, acquire |
| 32 | `TestResourcePool` | A fired cleanup queued behind a clear on the pool lock | The clear runs | The finalizer runs exactly once and the entry is evicted | Fired-timer race, clear |
| 33 | `TestResourcePool` | Any interleaved acquire/release sequence (Hypothesis) | Applied step by step to a long-TTL pool | Entry, reference, and pending-cleanup counts match the model at every step | TTL bookkeeping invariants |

https://claude.ai/code/session_011Xw7kU5GN556rbn6sZBdzg