### PR TITLE
Implement a Wool-picklable contextvars.Token wrapper — Closes #231

### DIFF
--- a/wool/proto/wire.proto
+++ b/wool/proto/wire.proto
@@ -40,9 +40,27 @@ message ContextVar {
     string namespace = 1;
     // Name component of the ContextVar identity.
     string name = 2;
-    // Cloudpickled value. Unset when the var has no 
+    // Cloudpickled value. Unset when the var has no
     // current value in this snapshot.
     optional bytes value = 3;
+    // Hex ids of this var's wool.Token instances that have been spent
+    // (successfully reset) somewhere in the chain. Propagates
+    // cross-process single-use enforcement: a token whose id appears
+    // here has already been used and any further reset raises. Rides on
+    // both Request and Response frames so the spent state flows in both
+    // directions. Chain-local and ephemeral — carried per-var on the
+    // chain, unioned on ingress, pruned when the var is re-set, and
+    // dropped with the chain (and on an asyncio.create_task fork).
+    repeated string spent_tokens = 4;
+    // Hex ids of this var's live (unspent) wool.Token instances minted
+    // in the context this manifest snapshots. The receiver's mount
+    // anchors a wire-reconstituted token — making it resettable there —
+    // only if its id appears here: a token minted in a sibling context
+    // the sender does not continue is absent and stays an orphan. Like
+    // spent_tokens this is chain-local and ephemeral — dropped on an
+    // asyncio.create_task fork; a spent id is pruned from here so the
+    // live and spent sets stay disjoint.
+    repeated string unspent_tokens = 5;
 }
 
 // wool.Chain wire shape — the manifest of a chain crossing the
@@ -55,8 +73,8 @@ message ChainManifest {
     // asyncio.create_task boundaries. Empty for root dispatches
     // that will start a new chain on the receiver.
     string id = 1;
-    // ContextVar entries — each one carries identity, optional
-    // value, and any consumed-token ids for that var.
+    // ContextVar entries — each one carries identity, optional value,
+    // and its per-var spent/unspent token ids.
     repeated ContextVar vars = 2;
 }
 

--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -1,4 +1,6 @@
 import contextvars
+from contextvars import Context
+from contextvars import copy_context
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version
 from typing import TYPE_CHECKING
@@ -101,6 +103,7 @@ __all__ = [
     "BoundWorkerFactory",
     "ChainContention",
     "ChainSerializationError",
+    "Context",
     "ContextVar",
     "ContextVarCollision",
     "Discovery",
@@ -144,6 +147,7 @@ __all__ = [
     "WorkerPool",
     "WorkerProxy",
     "WorkerService",
+    "copy_context",
     "current_task",
     "install_task_factory",
     "routine",

--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -1,5 +1,4 @@
 import contextvars
-from contextvars import Token
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version
 from typing import TYPE_CHECKING
@@ -18,6 +17,7 @@ from wool.runtime.context.exceptions import TaskFactoryDisplaced
 from wool.runtime.context.factory import install_task_factory
 from wool.runtime.context.runtime import RuntimeContext
 from wool.runtime.context.threading import to_thread
+from wool.runtime.context.token import Token
 from wool.runtime.context.var import ContextVar
 from wool.runtime.discovery.base import Discovery
 from wool.runtime.discovery.base import DiscoveryEvent

--- a/wool/src/wool/runtime/context/chain.py
+++ b/wool/src/wool/runtime/context/chain.py
@@ -22,114 +22,110 @@ import wool
 from wool.runtime.context.factory import ensure_task_factory_installed
 from wool.runtime.context.manifest import ChainManifest
 from wool.runtime.context.registry import var_registry
+from wool.runtime.context.token import anchor_tokens
 from wool.runtime.typing import Undefined
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from wool.runtime.context.manifest import ContextVarManifest
+    from wool.runtime.context.token import Token
 
 
 @dataclass(frozen=True, eq=False)
 class Chain:
     """Immutable index of Wool chain state.
 
-    Wool chain state — i.e., the logical-chain UUID, the set of bound
-    `wool.ContextVar` instances, and their resets — rides in a
-    single Wool-owned `contextvars.ContextVar` as a
-    `Chain` instance. The chain is an *index*, not a value
-    store: each `wool.ContextVar`'s value lives in its own
-    backing `contextvars.ContextVar`.
+    Wool chain state — the logical-chain ID, the bound `wool.ContextVar`
+    instances, and their resets — rides in one Wool-owned
+    `contextvars.ContextVar` as a `Chain`. The chain is an *index*, not a
+    value store: each variable's value lives in its own backing
+    `contextvars.ContextVar`.
 
-    A chain identifies one serial branch of the program's async call
-    tree: the logical call stack descending from the most recent
-    `asyncio.create_task` fork, on which every frame executes
-    strictly in sequence. The branch is not one
-    `contextvars.Context` — it spans every context copy
-    descended from its arming, e.g., event-loop callback copies, explicit
-    `contextvars.Context.run` re-entries, even the worker-side
-    context a dispatch arms with the caller's chain id — which is what
-    gives a routine awaited on a worker the same context continuity
-    as a process-local await. `asyncio.create_task` always
-    forks onto a fresh chain, the chain-level analogue of stdlib
-    copy-on-fork, so concurrent branches can never mutate one
-    another's chain state; an execution that enters a chain it does
-    not own has circumvented that discipline and fails loudly instead
-    (see `wool.ChainContention`).
+    A chain identifies one serial branch of the async call tree — the
+    logical call stack descending from the most recent
+    `asyncio.create_task` fork, executing strictly in sequence. It is not a
+    single `contextvars.Context`: it spans every context copy descended
+    from its arming (event-loop callbacks, `contextvars.Context.run`
+    re-entries, the worker-side context a dispatch arms with the caller's
+    ID), which is what gives a routine awaited on a worker the same context
+    continuity as a local await. `asyncio.create_task` forks onto a fresh
+    chain, so concurrent branches never mutate one another's state;
+    entering a chain the running execution does not own raises
+    `wool.ChainContention`.
 
-    The Wool-owned `contextvars.ContextVar` becomes a permanent
-    member of any `contextvars.Context` once that context is
-    armed with a `Chain` instance. An armed context
-    additionally carries one backing variable per bound
-    `wool.ContextVar`, so a `contextvars.copy_context`
-    of an armed context enumerates ``1 + N`` Wool-owned variables.
-    An unarmed context holds none of them and is indistinguishable
-    from a plain `contextvars.Context`. A context is armed when a
-    chain is mounted into it (see *Lifecycle*).
+    Arming a context with a chain makes the Wool-owned variable a permanent
+    member of it: an armed context carries ``1 + N`` Wool-owned variables
+    (the chain, plus one backing per bound variable), so a
+    `contextvars.copy_context` of it enumerates them all, while an unarmed
+    context is indistinguishable from a plain `contextvars.Context`.
+    Because chain and backings live in a `contextvars.Context`, Wool state
+    obeys standard context semantics — copied into new tasks and event-loop
+    callbacks, observed and mutated under `contextvars.Context.run`, and
+    isolated to each copy.
 
-    Because the chain and every backing context variable live in a
-    `contextvars.Context`, Wool state is governed by standard
-    context semantics: it's copied into new tasks at creation (by
-    default) and into event-loop callbacks at scheduling; code run
-    explicitly inside a captured context — e.g., via
-    `contextvars.Context.run` — observes and mutates the Wool
-    state that context carries; and writes made inside a copy stay in
-    that copy, never leaking back into the originating scope.
-
-    **Lifecycle**
-
-    A `Chain` instance is strictly *live*:
-    fresh (constructed directly or via `_fork`) or mounted
-    (installed in a `contextvars.Context` via `mount`).
+    **Lifecycle.** A `Chain` is always *live* — fresh (constructed or
+    ``_fork``-ed) or mounted (installed in a context via `mount`).
     Decoded-but-unmounted wire state lives on
-    `~wool.runtime.context.manifest.ChainManifest` and is
-    installed by `from_manifest`. `mount` is the single transition
-    from pure data → installed: it stamps ``thread`` / ``task`` from
-    the calling scope and applies any pending resets.
-
-    **Indexing asymmetry**
-
-    ``vars`` keys on `wool.ContextVar`
-    instance identity (safe because the process-wide var registry
-    enforces a singleton per ``(namespace, name)`` key); ``resets``
-    keys on the ``(namespace, name)`` tuple directly so the reset
-    signal survives a wire round-trip without requiring the receiver
-    to have declared the variable. The two indices reference the same
-    logical concept under different key spaces by design.
+    `~wool.runtime.context.manifest.ChainManifest`; `from_manifest`
+    installs it.
 
     :param id:
-        UUID identifying the logical execution chain. Defaults to a
-        freshly minted UUID. Re-minted on every task fork by the Wool
-        task factory; an explicit value lets a worker preserve the
-        caller's chain id when arming on an inbound wire frame.
+        UUID identifying the logical execution chain. Re-minted on every
+        task fork; a worker preserves the caller's ID when arming an
+        inbound wire frame.
     :param thread:
-        `threading.get_ident` of the OS thread that owns this
-        chain — stamped by `mount`. Defaults to ``0`` (no owner)
-        so construction is pure data; `mount` is the single
-        owner-stamping site. The chain-contention guard compares it
-        against the accessing thread; see `wool.ChainContention`.
+        OS thread (`threading.get_ident`) that owns this chain; the
+        contention guard compares it against the accessing thread. Stamped
+        by `mount` (``0`` until then).
     :param task:
-        Weak reference to the `asyncio.Task` that owns this
-        chain — stamped by `mount`. Defaults to ``None`` (no
-        owner). ``None`` also marks a chain armed outside any task
-        (synchronous code, or a `wool.to_thread` worker thread).
-        The chain-contention guard compares it against the running
-        task so a second task entering the chain fails loud. This
-        field is process-local and never crosses the wire.
+        Weak reference to the `asyncio.Task` that owns this chain — ``None``
+        outside any task (synchronous code, or a `wool.to_thread` worker
+        thread). The contention guard compares it against the running task.
+        Process-local; never crosses the wire.
     :param vars:
-        Set of bound `wool.ContextVar` instances. Membership
-        is the index of "bound in this chain": ``X in vars`` is
-        equivalent to ``X._backing`` resolving to a
-        non-`~wool.runtime.typing.Undefined` value in the active
-        `contextvars.Context`.
+        Bound `wool.ContextVar` instances. ``X in vars`` iff ``X``'s
+        backing resolves to a non-`~wool.runtime.typing.Undefined` value in
+        the active `contextvars.Context`.
     :param resets:
-        ``(namespace, name)`` keys of variables reset to no prior
-        value and not since re-set. The token-independent "drop this
-        variable" signal for the wire merge (`from_manifest`); survives
-        even if the resetting token is collected before the reset
-        propagates.
+        ``(namespace, name)`` keys reset to no prior value and not since
+        re-set — the token-independent "drop this variable" signal for the
+        wire merge, surviving even if the resetting token is collected
+        first.
     :param stubs:
-        Undeclared-stub `wool.ContextVar` instances observed
-        while decoding a chain manifest, held strongly so a lazy-import
-        receiver can still promote them when it declares the variable.
+        Undeclared-stub `wool.ContextVar` instances observed while decoding
+        a manifest, held strongly so a lazy-import receiver can promote them
+        on declaration.
+    :param unspent_tokens:
+        Live (unspent) `wool.Token` IDs per ``(namespace, name)`` key. The
+        receiver's mount consults it to decide which wire tokens to anchor
+        (see `~wool.runtime.context.token.anchor_tokens`).
+    :param spent_tokens:
+        Consumed (spent) `wool.Token` IDs per ``(namespace, name)`` key —
+        the cross-process single-use ledger. An ID present under its key
+        has been reset somewhere in this chain lineage, so any further reset
+        of it, in this or any process the chain reaches, raises
+        `RuntimeError`.
+
+    .. rubric:: Implementation notes
+
+    **Indexing asymmetry.** ``vars`` keys on `wool.ContextVar` instance
+    identity (safe because the process-wide var registry enforces a
+    singleton per ``(namespace, name)`` key); ``resets`` keys on the
+    ``(namespace, name)`` tuple directly so the reset signal survives a
+    wire round-trip without requiring the receiver to have declared the
+    variable. The two indices reference the same logical concept under
+    different key spaces by design.
+
+    **Token ledgers.** ``unspent_tokens`` and ``spent_tokens`` are excluded
+    from identity but snapshotted onto the wire (by `to_manifest`, unioned
+    by `from_manifest`), so token bookkeeping rides every frame. A `reset`
+    adds the consumed ID to ``spent_tokens``, and a fresh `set` of that var
+    retains it: a token consumed off-origin leaves its local ``_used`` flag
+    unset, so this ledger is the sole witness of the consumption and pruning
+    it would readmit a double reset. The ledger therefore grows for the
+    chain's lifetime; bounding that growth to token lifespan is issue #226's
+    ownership model.
     """
 
     id: UUID = field(default_factory=uuid4)
@@ -142,19 +138,31 @@ class Chain:
     vars: frozenset[ContextVarManifest[Any]] = field(default_factory=frozenset)
     resets: frozenset[tuple[str, str]] = field(default_factory=frozenset)
     stubs: frozenset[ContextVarManifest[Any]] = field(default_factory=frozenset)
+    unspent_tokens: dict[tuple[str, str], frozenset[str]] = field(
+        default_factory=dict, repr=False, compare=False
+    )
+    spent_tokens: dict[tuple[str, str], frozenset[str]] = field(
+        default_factory=dict, repr=False, compare=False
+    )
 
     def __post_init__(self) -> None:
-        """Coerce the container fields to frozensets.
-
-        Callers — including `dataclasses.replace` — may pass any
-        iterable; coercion preserves the frozen facade regardless.
-        """
+        """Coerce the container fields to frozensets."""
         if not isinstance(self.vars, frozenset):
             object.__setattr__(self, "vars", frozenset(self.vars))
         if not isinstance(self.resets, frozenset):
             object.__setattr__(self, "resets", frozenset(self.resets))
         if not isinstance(self.stubs, frozenset):
             object.__setattr__(self, "stubs", frozenset(self.stubs))
+        for name in ("unspent_tokens", "spent_tokens"):
+            mapping = getattr(self, name)
+            if not isinstance(mapping, dict) or not all(
+                isinstance(tokens, frozenset) for tokens in mapping.values()
+            ):
+                object.__setattr__(
+                    self,
+                    name,
+                    {key: frozenset(tokens) for key, tokens in dict(mapping).items()},
+                )
 
     def to_manifest(self) -> ChainManifest:
         """Snapshot this live chain into a decoded `ChainManifest`.
@@ -172,16 +180,17 @@ class Chain:
         A variable whose backing resolves to
         `~wool.runtime.typing.Undefined` is absent from the snapshot; a
         variable reset to no prior value still rides along via ``resets``
-        so the reset propagates regardless of source.
+        so the reset propagates regardless of source. This is a pure read
+        — it never serialises, so it cannot raise a serialisation error.
 
-        This is a pure read — it never serialises, so it cannot raise a
-        serialisation error. The bound-key singleton and the
-        bound/reset disjointness invariants are asserted here, at the
-        snapshot boundary, so any manifest reaching ``to_protobuf`` is
-        already well-formed: ``vars`` holds singletons keyed by
-        ``(namespace, name)`` (enforced at construction via
-        ``var_registry`` and `ContextVarCollision`), and no key is both
-        bound and reset-pending.
+        .. rubric:: Implementation notes
+
+        The bound-key singleton and the bound/reset disjointness
+        invariants are asserted here, at the snapshot boundary, so any
+        manifest reaching ``to_protobuf`` is already well-formed: ``vars``
+        holds singletons keyed by ``(namespace, name)`` (enforced at
+        construction via ``var_registry`` and `ContextVarCollision`), and
+        no key is both bound and reset-pending.
         """
         assert len({(v.namespace, v.name) for v in self.vars}) == len(self.vars), (
             "singleton invariant violated: duplicate var keys in Chain.vars"
@@ -200,9 +209,17 @@ class Chain:
             vars=vars,
             resets=self.resets,
             stubs=self.stubs,
+            spent_tokens=self.spent_tokens,
+            unspent_tokens=self.unspent_tokens,
         )
 
-    def mount(self, *, owned: bool = True) -> Chain:
+    def mount(
+        self,
+        *,
+        owned: bool = True,
+        wire_tokens: Iterable[Token] = (),
+        **changes: Any,
+    ) -> Chain:
         """Arm this chain as the live chain in the current `contextvars.Context`.
 
         Installs an evolved copy of this chain — re-stamped so the
@@ -242,25 +259,54 @@ class Chain:
             task-agnostically — stamping any one step-task would make
             the next trip the guard. The OS-thread stamp is applied
             either way.
+        :param wire_tokens:
+            Wire tokens reconstituted during the frame decode, anchored
+            here if live in this chain — see
+            `~wool.runtime.context.token.anchor_tokens` for the gate. Empty
+            for the local arming paths.
+        :param changes:
+            Optional chain-delta keywords folded into the single owner-stamp
+            evolve — the set path passes its ``vars``/``resets``/token-map
+            update here so arming builds one Chain, not two. Empty for the
+            reset, fork, and wire-ingress paths, which arm an already-evolved
+            chain.
         :returns:
             The installed Chain — the evolved copy with the owner
             re-stamped.
+
+        .. rubric:: Implementation notes
+
+        ``anchor_tokens`` runs here because mount is the arming boundary
+        that executes inside the chain's target context (the worker's
+        cached context or the caller's task) — exactly where a reset must
+        be valid from.
+
+        Both the anchor pass and the reset-drain read the *installed*
+        copy rather than ``self``, so a ``resets`` delta folded in through
+        *changes* is already in effect: a set-path fold that cleared a
+        var's key leaves that var's backing untouched by the drain, and
+        `wool.ContextVar.set` writes the new value straight after mount.
         """
         ensure_task_factory_installed()
-        for key in self.resets:
-            receiver_var = var_registry.get(key)
-            if receiver_var is not None:
-                receiver_var._backing.set(Undefined)
         task = None
         if owned:
             try:
                 task = asyncio.current_task()
             except RuntimeError:
                 pass
+        # Single evolve: fold the owner stamp and *changes* into one Chain.
         installed = self._evolve(
             thread=threading.get_ident(),
             task=weakref.ref(task) if task is not None else None,
+            **changes,
         )
+        # Anchor the wire tokens live in this chain; a no-op when empty.
+        anchor_tokens(wire_tokens, installed)
+        # Rewind each reset signal's backing to Undefined.
+        for key in installed.resets:
+            receiver_var = var_registry.get(key)
+            if receiver_var is not None:
+                receiver_var._backing.set(Undefined)
         wool.__chain__.set(installed)
         return installed
 
@@ -271,6 +317,7 @@ class Chain:
         *,
         owned: bool,
         merge_with: Chain | None = None,
+        wire_tokens: Iterable[Token] = (),
     ) -> Chain:
         """Drain a decoded `ChainManifest` into the backings and arm it.
 
@@ -278,7 +325,7 @@ class Chain:
         `Frame.mount`. Drains the manifest's decoded values into their
         backing variables, builds the receiver chain — merging onto a live
         receiver when *merge_with* is given (the receiver keeps its chain
-        id), or seeding fresh state from the manifest alone when it is
+        ID), or seeding fresh state from the manifest alone when it is
         ``None`` — and delegates the arming (reset rewind, owner stamp,
         task factory, `wool.__chain__` set) to `mount`.
 
@@ -292,35 +339,79 @@ class Chain:
         :param merge_with:
             The live receiver chain to union the manifest onto, or ``None``
             to seed a fresh chain from the manifest alone.
+        :param wire_tokens:
+            Forwarded to `mount`, which anchors the ones live in the
+            mounted chain — see `~wool.runtime.context.token.anchor_tokens`
+            for the gate.
+
+        .. rubric:: Implementation notes
+
+        Values drain into the backings first so the built `Chain` observes
+        them through ``vars``. Those backing writes mint stray native
+        tokens, discarded with the local scope.
+
+        On a merge, both token maps union per var: an awaited dispatch
+        continues the caller's context, so a token live (or spent) on
+        either side of the hop is live (or spent) in the continuation. The
+        spent union is what rejects here a token already reset upstream.
+
+        The anchor ledger (``unspent_tokens``) is then pruned by the
+        consumed ledger (``spent_tokens``) on both the fresh and merged
+        paths, so an ID a reset has spent never lingers as anchor-eligible.
+        This drops no reachable reset — `wool.ContextVar.reset`'s used-gate
+        rejects a spent ID before the anchor gate is consulted — while
+        bounding the anchor ledger to live tokens rather than growing it
+        one ID per frame.
+
+        Reset-only keys drop out of ``vars`` so the reset propagates; the
+        backing rewind itself happens in `mount`.
         """
-        # Drain values into the backings first so the built Chain
-        # observes them via ``vars``. Backing writes mint stray native
-        # tokens — discarded with the local scope.
+        # Drain manifest values into the backings first.
         for var, value in manifest.vars.items():
             var._backing.set(value)
-        # Build the vars index from the manifest, optionally unioned with
-        # the live receiver's bindings (the receiver keeps its chain id
-        # through the merge).
+        # Build the vars index, unioned with the receiver on a merge.
         manifest_vars = frozenset(manifest.vars.keys())
         if merge_with is None:
             merged_vars = manifest_vars
             resets = manifest.resets
             stubs = manifest.stubs
             chain_id = manifest.id
+            unspent_tokens = dict(manifest.unspent_tokens)
+            spent_tokens = dict(manifest.spent_tokens)
         else:
             merged_vars = merge_with.vars | manifest_vars
             manifest_touched = {var._key for var in manifest_vars} | manifest.resets
             resets = manifest.resets | (merge_with.resets - manifest_touched)
             stubs = merge_with.stubs | manifest.stubs
             chain_id = merge_with.id
-        # Reset-only keys drop out of ``vars`` so the reset propagates; the
-        # rewind itself happens in mount.
+            # Union both token maps per var across the hop.
+            unspent_tokens = dict(merge_with.unspent_tokens)
+            for key, tokens in manifest.unspent_tokens.items():
+                unspent_tokens[key] = unspent_tokens.get(key, frozenset()) | tokens
+            spent_tokens = dict(merge_with.spent_tokens)
+            for key, tokens in manifest.spent_tokens.items():
+                spent_tokens[key] = spent_tokens.get(key, frozenset()) | tokens
+        # Prune spent IDs out of the anchor ledger, both paths.
+        for key, spent in spent_tokens.items():
+            live = unspent_tokens.get(key, frozenset()) - spent
+            if live:
+                unspent_tokens[key] = live
+            else:
+                unspent_tokens.pop(key, None)
+        # Drop reset-only keys from vars; mount does the rewind.
         for key in manifest.resets:
             receiver_var = var_registry.get(key)
             if receiver_var is not None:
                 merged_vars = merged_vars - {receiver_var}
-        target = cls(id=chain_id, vars=merged_vars, resets=resets, stubs=stubs)
-        return target.mount(owned=owned)
+        target = cls(
+            id=chain_id,
+            vars=merged_vars,
+            resets=resets,
+            stubs=stubs,
+            unspent_tokens=unspent_tokens,
+            spent_tokens=spent_tokens,
+        )
+        return target.mount(owned=owned, wire_tokens=wire_tokens)
 
     def _evolve(self, **changes: Any) -> Chain:
         """Return a copy of this chain with *changes* applied."""
@@ -329,17 +420,15 @@ class Chain:
     def _fork(self) -> Chain:
         """Fork this chain into a fresh logical chain.
 
-        The fork inherits the variable bindings (the ``vars`` index)
-        and stub pins on a freshly minted ``id``, with no owner
-        stamps — like any fresh Chain, it acquires its owners at the
-        subsequent `mount`. The reset signals are dropped: a
-        `wool.Token` minted in the parent chain is already
-        incompatible with the fork's chain for
-        `wool.ContextVar.reset`, so the fork starts clean. The
-        backing variables' values ride the fork natively — the forked
-        task runs in a `contextvars.copy_context` copy. This is
-        the copy-on-fork the task factory applies at every task
-        creation.
+        The fork inherits the variable bindings (the ``vars`` index) and
+        stub pins on a freshly minted ``id``, with no owner stamps — like
+        any fresh Chain, it acquires its owners at the subsequent `mount`.
+        The reset signals and token ledgers are dropped, so the fork
+        starts clean: a `wool.Token` minted in the parent chain is already
+        incompatible with the fork's chain for `wool.ContextVar.reset`.
+        The backing variables' values ride the fork natively — the forked
+        task runs in a `contextvars.copy_context` copy. This is the
+        copy-on-fork the task factory applies at every task creation.
 
         **Re-handoff is undefined behaviour.** A fork minted on one
         thread/task and then re-driven elsewhere — e.g., a
@@ -349,6 +438,18 @@ class Chain:
         `wool.ContextVar` access on the re-handed chain, via
         the chain-contention guard. Forks are intended to be owned and
         retired by the scope that created them.
+
+        .. rubric:: Implementation notes
+
+        ``unspent_tokens`` is dropped because the child snapshots none of
+        the parent's live token IDs under any var, so a parent-minted wire
+        token finds no anchor in the child (see
+        `~wool.runtime.context.token.anchor_tokens`). ``spent_tokens`` is
+        dropped too: a parent-spent token cannot be re-reset in the child
+        — its native anchor belongs to the parent's `contextvars.Context`,
+        so reset raises there regardless — so the child need carry no
+        consumed ledger, the same bound-per-branch discipline the live IDs
+        follow.
         """
         return Chain(
             id=uuid4(),

--- a/wool/src/wool/runtime/context/manifest.py
+++ b/wool/src/wool/runtime/context/manifest.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import contextvars
 import warnings
 from dataclasses import dataclass
+from dataclasses import field
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Generic
@@ -112,23 +113,23 @@ class ContextVarManifest(Generic[T]):
     def __reduce_ex__(self, _protocol: SupportsIndex) -> NoReturn:
         """Reject vanilla pickling.
 
-        ContextVar identity is registered against the process-wide
-        `~wool.runtime.context.registry.var_registry`; restoring an
-        instance outside Wool's dispatch path bypasses the stub-
-        promotion and collision-detection that
-        `~wool.runtime.context.var.ContextVar._reconstitute` relies on.
-        Wool's own pickler consults ``reducer_override`` (and therefore
-        `~wool.runtime.context.var.ContextVar.__wool_reduce__`) before
-        ``__reduce_ex__``, so this guard is invisible to Wool's
-        serialization.
-
-        `copy.copy` and `copy.deepcopy` also route
-        through ``__reduce_ex__`` and are rejected for the same
-        reason — a registry-bound ContextVar has no meaningful copy
-        semantics.
+        `copy.copy` and `copy.deepcopy` route through ``__reduce_ex__`` and
+        are rejected too.
 
         :raises TypeError:
             Always.
+
+        .. rubric:: Implementation notes
+
+        ContextVar identity is registered against the process-wide
+        `~wool.runtime.context.registry.var_registry`; restoring an instance
+        outside Wool's dispatch path bypasses the stub-promotion and
+        collision-detection that
+        `~wool.runtime.context.var.ContextVar._reconstitute` relies on, and a
+        registry-bound ContextVar has no meaningful copy semantics. Wool's own
+        pickler consults ``reducer_override`` (and therefore
+        `~wool.runtime.context.var.ContextVar.__wool_reduce__`) before
+        ``__reduce_ex__``, so this guard is invisible to Wool's serialization.
         """
         raise TypeError(
             "wool.ContextVar cannot be pickled via vanilla pickle/cloudpickle; "
@@ -156,17 +157,20 @@ class ContextVarManifest(Generic[T]):
     ) -> ContextVarManifest[Any]:
         """Construct a `ContextVarManifest` instance with field assignment.
 
-        Single source of truth for the
-        ``object.__new__`` + per-field-assignment idiom shared by
+        Single source of truth for the ``object.__new__`` +
+        per-field-assignment idiom shared by
         `~wool.runtime.context.var.ContextVar.__new__` (the user-facing
         construction path, which builds the subtype) and `resolve_stub`
         (the wire-boundary path). The instance is *not* registered in
         `~wool.runtime.context.registry.var_registry` — callers do that
-        under the registry lock. The backing stdlib variable is created
-        once and shared by every chain for the process lifetime; it
-        carries no ``contextvars``-level default —
-        `~wool.runtime.context.var.ContextVar.get` owns the default-
-        resolution ladder, and "unset" is the
+        under the registry lock.
+
+        .. rubric:: Implementation notes
+
+        The backing stdlib variable is created once and shared by every
+        chain for the process lifetime; it carries no ``contextvars``-level
+        default — `~wool.runtime.context.var.ContextVar.get` owns the
+        default-resolution ladder, and "unset" is the
         `~wool.runtime.typing.Undefined` sentinel value.
         """
         namespace, name = key
@@ -199,6 +203,12 @@ def resolve_stub(
     instance per key regardless of whether the value arrived as a bare
     wire entry or embedded in a pickled variable reference.
 
+    Pass *default* to seed the constructor default before promotion when
+    that information is available on the ingress side (the pickle path
+    carries it; the chain-manifest path does not).
+
+    .. rubric:: Implementation notes
+
     A freshly created stub is registered in
     `~wool.runtime.context.registry.var_registry` (a
     `weakref.WeakValueDictionary`, so it needs a strong referent to
@@ -212,10 +222,6 @@ def resolve_stub(
     is a process-wide singleton anyway. If the receiver never declares
     the variable, it is collected with whatever held it and the
     propagated value is dropped.
-
-    Pass *default* to seed the constructor default before promotion when
-    that information is available on the ingress side (the pickle path
-    carries it; the chain-manifest path does not).
     """
     with lock:
         existing = var_registry.get(key)
@@ -252,30 +258,71 @@ class ChainManifest:
     `~wool.runtime.context.exceptions.ChainSerializationError` instead.
 
     Present on a `Frame` iff the frame carried non-empty receive-side
-    state: a chain manifest with bindings or resets. An empty chain
-    manifest decodes to ``None`` so `Frame.mount` can no-op.
+    state: a chain manifest with bindings, resets, or token bookkeeping
+    (spent or unspent token IDs). An empty chain manifest decodes to
+    ``None`` so `Frame.mount` can no-op.
 
     The transition into a live `Chain` is one-way and lives on `Chain`:
     `Chain.from_manifest` drains `vars` into the backing variables,
     merges the decoded state onto a live receiver (or seeds a fresh chain
     when unarmed), and arms the result. `Frame.mount` is the entry point.
+
+    :param spent_tokens:
+        Spent (consumed) `~wool.runtime.context.token.Token` IDs per var key
+        — the cross-process single-use ledger (see
+        `~wool.runtime.context.chain.Chain.spent_tokens` for the contract).
+    :param unspent_tokens:
+        Live (unspent) `~wool.runtime.context.token.Token` IDs per var key,
+        consulted by the receiver's mount to anchor wire tokens (see
+        `~wool.runtime.context.token.anchor_tokens`).
+
+    .. rubric:: Implementation notes
+
+    ``spent_tokens`` and ``unspent_tokens`` are chain-local and ride every
+    frame, snapshotted by `~wool.runtime.context.chain.Chain.to_manifest`
+    and unioned by `~wool.runtime.context.chain.Chain.from_manifest`. Each
+    piggybacks on the var entry that already exists for the value or reset it
+    accompanies, never emitting a standalone entry (a value-less entry is
+    unambiguously a reset).
     """
 
     id: UUID
     vars: dict[ContextVarManifest[Any], Any]
     resets: frozenset[tuple[str, str]]
     stubs: frozenset[ContextVarManifest[Any]]
+    spent_tokens: dict[tuple[str, str], frozenset[str]] = field(default_factory=dict)
+    unspent_tokens: dict[tuple[str, str], frozenset[str]] = field(default_factory=dict)
+
+    @property
+    def has_state(self) -> bool:
+        """Report whether this manifest carries observable state to install.
+
+        Bindings, resets, or token bookkeeping (spent or unspent IDs) all
+        count; an all-empty manifest has nothing to install and mounts as a
+        no-op.
+
+        .. rubric:: Implementation notes
+
+        Token bookkeeping counts because the ledger ingest and the
+        pending-anchor drain live inside the mount, so a manifest carrying
+        only bookkeeping must still transit it.
+        """
+        return bool(self.vars or self.resets or self.spent_tokens or self.unspent_tokens)
 
     @classmethod
     def empty(cls) -> ChainManifest:
-        """Return a fresh empty manifest carrying a new chain id.
+        """Return a fresh empty manifest carrying a new chain ID.
 
-        The default for `DispatchSession.decoded` when the initial
-        dispatch frame carries no chain manifest. A present-but-empty
-        manifest keeps ``session.decoded.vars`` an empty dict so the
-        backpressure hook's attribute access stays shape-consistent
-        whether or not the inbound frame carried chain state. Returned
-        fresh per call to avoid sharing mutable state across dispatches.
+        The default for `DispatchSession.decoded` when the initial dispatch
+        frame carries no chain manifest.
+
+        .. rubric:: Implementation notes
+
+        A present-but-empty manifest keeps ``session.decoded.vars`` an empty
+        dict so the backpressure hook's attribute access stays
+        shape-consistent whether or not the inbound frame carried chain
+        state. Returned fresh per call to avoid sharing mutable state across
+        dispatches.
         """
         return cls(
             id=uuid4(),
@@ -307,21 +354,25 @@ class ChainManifest:
         A malformed wire chain ID falls back to a fresh UUID. Under
         strict mode the failures aggregate into a single
         `ChainSerializationError` raised after the decode loop — no
-        partial manifest is surfaced. `Frame.from_protobuf` captures
-        that error as the frame's ``chain_manifest`` value instead of
-        letting it propagate, so `Frame.mount` (and, for the initial
-        dispatch frame, `DispatchSession.__aenter__`) can raise it or
-        walk-and-append it onto an exception payload's ``__context__``
-        chain rather than preempting the payload.
+        partial manifest is surfaced.
 
         :raises ChainSerializationError:
             Under strict mode, when one or more entries fail to decode.
+
+        .. rubric:: Implementation notes
+
+        `Frame.from_protobuf` captures a raised `ChainSerializationError`
+        as the frame's ``chain_manifest`` value instead of letting it
+        propagate, so `Frame.mount` (and, for the initial dispatch frame,
+        `DispatchSession.__aenter__`) can raise it or walk-and-append it
+        onto an exception payload's ``__context__`` chain rather than
+        preempting the payload.
         """
         failures: list[SerializationWarning] = []
-        # Chain-id parse failure is a *structural* protocol
+        # Chain-ID parse failure is a *structural* protocol
         # error, distinct from per-var data errors. Raise
         # unconditionally regardless of strict-mode warning filter:
-        # without a valid chain id the receiver cannot correlate
+        # without a valid chain ID the receiver cannot correlate
         # subsequent frames against the same logical caller, and a
         # silently-replaced ``uuid4()`` would route follow-up frames
         # to a fresh cached contextvars.Context (silent state loss).
@@ -330,7 +381,7 @@ class ChainManifest:
         except ValueError as e:
             raise ChainSerializationError(
                 SerializationWarning(
-                    f"Failed to decode chain id {wire.id!r}: {e}",
+                    f"Failed to decode chain ID {wire.id!r}: {e}",
                     cause=e,
                     direction="decode",
                 ),
@@ -338,6 +389,8 @@ class ChainManifest:
         vars: dict[ContextVarManifest[Any], Any] = {}
         resets: set[tuple[str, str]] = set()
         stubs: set[ContextVarManifest[Any]] = set()
+        spent_tokens: dict[tuple[str, str], frozenset[str]] = {}
+        unspent_tokens: dict[tuple[str, str], frozenset[str]] = {}
         failed_keys: set[tuple[str, str]] = set()
         seen_keys: set[tuple[str, str]] = set()
         for entry in wire.vars:
@@ -363,6 +416,13 @@ class ChainManifest:
                     failures.append(raised)
                 continue
             seen_keys.add(var_key)
+            # Spent/unspent token IDs ride independently of the value/reset
+            # state, so capture them before any value-decode failure can
+            # ``continue`` past this entry.
+            if entry.spent_tokens:
+                spent_tokens[var_key] = frozenset(entry.spent_tokens)
+            if entry.unspent_tokens:
+                unspent_tokens[var_key] = frozenset(entry.unspent_tokens)
             var = resolve_stub(var_key)
             if var._stub:
                 stubs.add(var)
@@ -409,6 +469,8 @@ class ChainManifest:
             vars=vars,
             resets=frozenset(resets),
             stubs=frozenset(stubs),
+            spent_tokens=spent_tokens,
+            unspent_tokens=unspent_tokens,
         )
 
     def to_protobuf(
@@ -435,13 +497,20 @@ class ChainManifest:
         aggregate into a single `ChainSerializationError` raised after the
         loop.
 
-        Encoding is deterministic: entries are emitted in sorted key order,
-        so identical manifest state encodes to byte-identical frames across
-        processes — preserving content-addressed caching and replay-style
-        fingerprinting despite hash-randomised set iteration.
+        Encoding is deterministic — identical manifest state encodes to
+        byte-identical frames across processes, preserving content-addressed
+        caching and replay-style fingerprinting.
 
         :raises ChainSerializationError:
             Under strict mode, when one or more variables fail to encode.
+
+        .. rubric:: Implementation notes
+
+        Determinism comes from sorted emission: entries in sorted key order,
+        and each entry's ``spent_tokens`` and ``unspent_tokens`` ID lists
+        likewise sorted — there is no manifest-level ID list — so the frame
+        is byte-identical despite hash-randomised ``frozenset``/``set``
+        iteration.
         """
         if serializer is None:
             serializer = wool.__serializer__
@@ -474,6 +543,15 @@ class ChainManifest:
             entry = wire.vars.add(namespace=namespace, name=name)
             if var_key in encoded_values:
                 entry.value = encoded_values[var_key]
+            # Spent/unspent IDs ride on the entry that already exists for
+            # this key (a spent key is in vars∪resets; an unspent key is
+            # value-bearing → both have an entry). Sorted per the docstring.
+            spent = self.spent_tokens.get(var_key)
+            if spent:
+                entry.spent_tokens.extend(sorted(spent))
+            unspent = self.unspent_tokens.get(var_key)
+            if unspent:
+                entry.unspent_tokens.extend(sorted(unspent))
         if failures:
             raise ChainSerializationError(*failures)
         return wire

--- a/wool/src/wool/runtime/context/token.py
+++ b/wool/src/wool/runtime/context/token.py
@@ -1,0 +1,296 @@
+"""The reset token minted by `~wool.runtime.context.var.ContextVar.set`.
+
+Houses `Token`, the Wool counterpart to `contextvars.Token`, together
+with the anchor (`anchor_tokens`) and collector (`token_sink`) machinery
+that lets a token survive a Wool dispatch and reset on the receiver.
+Unlike the stdlib token, a `wool.Token` may ride a `@wool.routine` dispatch
+as an argument, kwarg, or return value (or nested inside a propagated
+`~wool.runtime.context.var.ContextVar` value). Vanilla
+``pickle``/``cloudpickle`` still reject it; only the dispatch path
+serialises it.
+
+The single-use enforcement and per-context reset semantics live on `wool.Token`
+and `~wool.runtime.context.var.ContextVar.reset`. Cross-process use rides the
+chain's ``spent_tokens`` ledger (see `~wool.runtime.context.chain.Chain`).
+
+.. rubric:: Implementation notes
+
+A token ID is recorded in the ``spent_tokens`` ledger on reset, retained for
+the chain's lifetime (never pruned by a re-set, since an off-origin
+consumption is witnessed only by that ledger), and propagated on every frame.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Generator
+from collections.abc import Iterable
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import Final
+from typing import Generic
+from typing import NoReturn
+from typing import TypeVar
+
+from wool.runtime.typing import UndefinedType
+
+if TYPE_CHECKING:
+    from wool.runtime.context.chain import Chain
+    from wool.runtime.context.var import ContextVar
+
+
+T = TypeVar("T")
+
+_NO_TOKENS = frozenset()
+
+#: Anchor for wire-reconstituted tokens. A live wire token, on the
+#: receiver, mints a native stdlib token here inside its chain's context at
+#: mount time; `~wool.runtime.context.var.ContextVar.reset` validates
+#: through ``_token_anchor.reset(native)``, delegating "same Context as the
+#: mount" to stdlib's own machinery. The value written (the token ID) is
+#: never read — only the returned native token's context binding matters.
+token_anchor: Final[contextvars.ContextVar[str]] = contextvars.ContextVar(
+    "__wool_token_anchor__"
+)
+
+#: Wire tokens reconstituted within a `token_sink` context. ``_reconstitute``
+#: runs deep in the cloudpickle arg/payload graph — a different context from the
+#: eventual mount, with no handle on the frame — so it appends each live wire
+#: token here rather than receiving a frame reference.
+_token_sink: Final[contextvars.ContextVar[list["Token"] | None]] = (
+    contextvars.ContextVar("__wool_token_sink__", default=None)
+)
+
+
+@contextmanager
+def token_sink() -> Generator[list[Token]]:
+    """Collect the wire tokens reconstituted within the block into a fresh list.
+
+    Wraps a single frame's decode: `Token.__wool_reduce__`'s reconstitution
+    appends each live wire token to the yielded list, which the caller hands to
+    the frame's mount for anchoring (see `anchor_tokens`).
+    """
+    collected: list[Token] = []
+    reset = _token_sink.set(collected)
+    try:
+        yield collected
+    finally:
+        _token_sink.reset(reset)
+
+
+def anchor_tokens(wire_tokens: Iterable[Token], chain: Chain) -> None:
+    """Mint anchors for the decoded wire tokens live on *chain*, in this context.
+
+    Runs inside the chain's target context (the worker's cached context, or the
+    caller's awaiting task) — where reset must be valid from. This is where the
+    context-ownership gate is decided: a token earns an anchor, becoming
+    resettable here, only if its ID is in the mounted chain's ``unspent_tokens``
+    under the token's own var key, i.e., the manifest that carried it snapshots
+    the context it was minted in. A token minted in a sibling context the sender
+    does not continue is absent from that snapshot and is left an orphan
+    (``_native`` unset), reclaimed with the frame.
+
+    .. rubric:: Implementation notes
+
+    The gate lives here rather than at serialization time because the payload may
+    be pickled outside the context it ships (a worker serialises its result in the
+    gRPC handler, not the routine's context). The manifest, captured inside the
+    right context by ``to_manifest``, is the reliable witness. Idempotent: an
+    already-bound token is skipped, so a streaming routine's per-frame re-mounts
+    neither re-mint nor double-consume an anchor.
+    """
+    for token in wire_tokens:
+        if token._native is None and token._id in chain.unspent_tokens.get(
+            token._var._key, _NO_TOKENS
+        ):
+            token._native = token_anchor.set(token._id)
+
+
+# public
+class Token(Generic[T]):
+    """Single-use authorization to `~wool.runtime.context.var.ContextVar.reset`.
+
+    Returned by `~wool.runtime.context.var.ContextVar.set` and accepted only
+    by that variable's `~wool.runtime.context.var.ContextVar.reset`. Direct
+    construction raises `TypeError`; a token is minted only by `set` (and
+    dispatch reconstitution). A `wool.Token` may be passed through a
+    `@wool.routine` dispatch (arg, kwarg, return value, or nested in a
+    propagated value) and reset on the receiver; passing, storing, returning,
+    or re-dispatching a token in any state never raises. Only
+    `~wool.runtime.context.var.ContextVar.reset` raises, and its
+    `RuntimeError` / `ValueError` check order is documented there. Vanilla
+    pickling is rejected; the token serialises only through Wool's dispatch
+    pickler.
+    """
+
+    __slots__ = ("_var", "_old_value", "_native", "_id", "_used")
+
+    _var: ContextVar[T]
+    _old_value: T | UndefinedType
+    _native: contextvars.Token[Any] | None
+    _id: str
+    _used: bool
+
+    #: Sentinel returned by ``old_value`` when the variable had no prior value.
+    # Aliased for stdlib muscle memory: ``tok.old_value is wool.Token.MISSING``
+    # mirrors ``tok.old_value is contextvars.Token.MISSING``, though the value
+    # is Wool's `~wool.runtime.typing.Undefined`, not stdlib's ``MISSING``.
+    MISSING: Final = UndefinedType.Undefined
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> NoReturn:
+        """Reject direct construction; a `Token` is minted only by `set`.
+
+        Mirrors `contextvars.Token`, which is likewise not user-constructible.
+
+        :raises TypeError:
+            Always.
+
+        .. rubric:: Implementation notes
+
+        A `Token`'s single-use authorization rests on wire and anchor state
+        and the cross-process consumed-token ledger that only
+        `~wool.runtime.context.var.ContextVar.set` (and dispatch
+        reconstitution) populate correctly, so hand-construction — which
+        could forge a token in any state and bypass that ledger — is refused.
+        """
+        raise TypeError("Tokens can only be created by wool.ContextVar.set")
+
+    def __repr__(self) -> str:
+        """Return a stdlib-shaped `Token` repr for canonical reset error strings."""
+        # Mirror stdlib's ``<Token [used ]var=<...> at 0x...>``; the ``var`` is
+        # this token's `wool.ContextVar` (the failure is about the wool token).
+        used = "used " if self._used else ""
+        return f"<Token {used}var={self._var!r} at 0x{id(self):x}>"
+
+    def __reduce__(self) -> NoReturn:
+        """Reject vanilla pickling; the dispatch pickler uses `__wool_reduce__`.
+
+        :raises TypeError:
+            Always.
+
+        .. rubric:: Implementation notes
+
+        A `Token`'s authorization is bound to a live context and the
+        cross-process, single-use ledger; reconstructing one outside Wool's
+        dispatch path would bypass that bookkeeping. Wool's pickler consults
+        ``reducer_override`` (and therefore `__wool_reduce__`) before
+        ``__reduce_ex__``, so this guard is invisible to dispatch while
+        blocking ``pickle``/``cloudpickle``/``copy`` at every protocol.
+        """
+        raise TypeError(
+            "wool.Token cannot be pickled via vanilla pickle/cloudpickle; "
+            "it is serialized automatically when passed through a Wool dispatch."
+        )
+
+    def __wool_reduce__(self) -> tuple[Any, tuple[Any, ...]]:
+        """Return constructor args for reconstitution via Wool's pickler.
+
+        Reduction never raises for any token state; an orphan (``live=False``,
+        or nominated but rejected at the mount gate) reconstitutes into a
+        usable `Token` whose only restriction is that ``reset`` fails with the
+        reason "token was created in a different Context".
+
+        .. rubric:: Implementation notes
+
+        Ships the token's captured old value, ID, and used flag, plus ``live``
+        (whether a native token is bound at serialize time). ``live`` only
+        nominates the token for an anchor; the actual context-ownership
+        decision happens receiver-side at mount (see `anchor_tokens`), gated
+        on the carrying manifest's per-var ``unspent_tokens`` rather than the
+        ambient chain at reduce time.
+        """
+        live = self._native is not None
+        return (
+            _reconstitute,
+            (
+                self._var,
+                self._old_value,
+                self._id,
+                live,
+                self._used,
+            ),
+        )
+
+    @property
+    def var(self) -> ContextVar[T]:
+        """The `~wool.runtime.context.var.ContextVar` this token resets.
+
+        Mirrors `contextvars.Token.var`: this is the `ContextVar` the caller
+        holds, so ``var.set(x).var is var`` holds as it does in stdlib.
+        """
+        return self._var
+
+    @property
+    def old_value(self) -> T | UndefinedType:
+        """The value the variable held before this token's `set`.
+
+        Mirrors `contextvars.Token.old_value`, except the "no prior value"
+        case reports Wool's `~wool.runtime.typing.Undefined` sentinel rather
+        than `contextvars.Token.MISSING` — consistent with the rest of the
+        Wool context API, and picklable so it survives a dispatch.
+        """
+        return self._old_value
+
+    @classmethod
+    def _mint(
+        cls,
+        *,
+        var: ContextVar[T],
+        old_value: T | UndefinedType,
+        native: contextvars.Token[Any] | None,
+        id: str,
+        used: bool = False,
+    ) -> Token[T]:
+        """Construct a `Token`, bypassing the public constructor guard.
+
+        The sole mint path — `~wool.runtime.context.var.ContextVar.set` and
+        dispatch reconstitution (`_reconstitute`) — building the token from its
+        wire and anchor state directly rather than through the refusing
+        ``__init__``.
+        """
+        token: Token[T] = object.__new__(cls)
+        token._var = var
+        token._old_value = old_value
+        token._native = native
+        token._id = id
+        token._used = used
+        return token
+
+
+def _reconstitute(
+    var: ContextVar[Any],
+    old_value: Any,
+    id: str,
+    live: bool,
+    used: bool,
+) -> Token:
+    """Rebuild a wire token; collect it for anchoring when ``live``.
+
+    The reduce callable for `Token.__wool_reduce__`. A ``live`` token appends
+    itself to the active frame decode's collector (see `token_sink`) so that
+    frame's mount decides — against its manifest-borne per-var
+    ``unspent_tokens`` — whether to mint its anchor in the target context (see
+    `anchor_tokens`). An orphan keeps ``_native`` unset. Reconstitution never
+    raises: an orphan is a usable object whose only constraint is that reset
+    fails.
+
+    .. rubric:: Implementation notes
+
+    A module-level function (not a `Token` classmethod) so it pickles by
+    reference — a classmethod's dotted qualname resolves to a fresh bound
+    method that fails cloudpickle's identity check, forcing a by-value pickle
+    that would capture this module's `~wool.runtime.context.registry.lock`.
+    """
+    token = Token._mint(
+        var=var,
+        old_value=old_value,
+        native=None,
+        id=id,
+        used=used,
+    )
+    if live:
+        collected = _token_sink.get()
+        if collected is not None:
+            collected.append(token)
+    return token

--- a/wool/src/wool/runtime/context/var.py
+++ b/wool/src/wool/runtime/context/var.py
@@ -8,6 +8,7 @@ from typing import Final
 from typing import TypeVar
 from typing import cast
 from typing import overload
+from uuid import uuid4
 
 import wool
 from wool.runtime.context.chain import Chain
@@ -17,6 +18,8 @@ from wool.runtime.context.manifest import ContextVarManifest
 from wool.runtime.context.manifest import resolve_stub
 from wool.runtime.context.registry import lock
 from wool.runtime.context.registry import var_registry
+from wool.runtime.context.token import Token
+from wool.runtime.context.token import token_anchor
 from wool.runtime.typing import Undefined
 from wool.runtime.typing import UndefinedType
 
@@ -37,14 +40,15 @@ class ContextVar(ContextVarManifest[T]):
     asyncio task other than the one that owns it — stdlib
     `contextvars.ContextVar` never raises it; see
     `wool.ChainContention` for the full scenario catalogue. Second,
-    the `contextvars.Token` that `set` returns is process-local, and
-    its ``var`` attribute references the variable's internal backing
-    rather than this `ContextVar`, so ``wool_var.set(x).var is
-    wool_var`` is `False` where stdlib's is `True` — the supported
-    reset path is ``wool_var.reset(token)`` and ``token.var`` is not a
-    supported attribute. Unlike `contextvars.ContextVar`, instances
-    pickle across process boundaries and their values propagate through
-    ``@wool.routine`` dispatches.
+    `set` returns a `~wool.runtime.context.token.Token` rather than a
+    `contextvars.Token`: it preserves stdlib's single-use and
+    per-context reset semantics (including the canonical `RuntimeError`
+    / `ValueError` messages) but, unlike the stdlib token, survives a
+    Wool dispatch — it may be passed to a `@wool.routine` and reset on
+    the receiver. `reset` accepts only that token type. Unlike
+    `contextvars.ContextVar`, instances pickle across process
+    boundaries and their values propagate through ``@wool.routine``
+    dispatches.
 
     **Identity model** — Every `ContextVar` has a unique
     ``(namespace, name)`` key. The ``name`` is the first positional
@@ -64,26 +68,18 @@ class ContextVar(ContextVarManifest[T]):
     explicitly; the construction raises `ContextVarCollision`
     instead.
 
-    **Storage model** — Values ride in a single immutable
-    `~wool.runtime.context.chain.Chain` held in one
-    Wool-owned stdlib `contextvars.ContextVar`. Because the
-    Wool chain rides in stdlib ``contextvars``, ``wool.ContextVar``
-    values propagate with stdlib visibility across every conformant
-    event loop and every cooperative asyncio scheduling edge — task
-    creation, ``call_soon``/``call_later``/``call_at``,
-    ``add_reader``/``add_writer``/``add_signal_handler``,
-    ``Future.add_done_callback``. The first `set` on a context
-    *arms* it: a chain UUID is minted and the chain-contention guard
-    engages. A context in which no `ContextVar` has been set
-    is unarmed and behaves as a plain `contextvars.Context`.
-    Once armed, the Wool-owned variable is a permanent member of the
-    `contextvars.Context`: a `contextvars.copy_context`
-    of an armed context carries one extra variable, and it stays even
-    after every `ContextVar` is reset.
-
-    Child tasks fork a copy of the parent's context under a fresh
-    chain UUID when Wool's task factory is installed on the running
-    loop.
+    **Storage model** — Wool state rides in stdlib ``contextvars`` (as a
+    `~wool.runtime.context.chain.Chain`), so ``wool.ContextVar`` values
+    propagate with the same visibility a `contextvars.ContextVar` has —
+    across every conformant event loop and asyncio scheduling edge. The
+    first `set` on a context *arms* it, engaging the chain-contention
+    guard; an unset context is unarmed and behaves as a plain
+    `contextvars.Context`. Once armed, the Wool-owned variable is a
+    permanent member of the `contextvars.Context`: a
+    `contextvars.copy_context` of it carries one extra variable, kept
+    even after every `ContextVar` is reset. Child tasks fork a copy of
+    the parent's context onto a fresh chain — the copy-on-fork applied
+    at task creation.
 
     Values propagated across the wire must be cloudpicklable.
     Variable serialisation is dispatch-path-only — vanilla
@@ -129,25 +125,24 @@ class ContextVar(ContextVarManifest[T]):
     ) -> ContextVar[T]:
         """Resolve or construct the `ContextVar` for *namespace:name*.
 
-        The lookup, the registry insert, and the new instance's
-        observable state are all serialized under the registry lock
-        so concurrent declarations of the same key cannot observe an
-        intermediate registration.
-
         Three outcomes:
 
         * No prior registration — a fresh instance is constructed and
           registered.
-        * A stub already registered (seeded by an earlier wire
-          ingress — pickle-embedded or chain-manifest — before any user
-          declaration) — promoted in place.
-          An explicit ``default=`` wins; an implicit
-          `~wool.runtime.typing.Undefined` preserves whatever
-          default the stub already carries, mirroring
-          `resolve_stub`'s
-          "don't silently discard a known default" rule.
+        * A stub already registered by an earlier wire ingress, before
+          any user declaration — promoted in place. An explicit
+          ``default=`` wins; an implicit `~wool.runtime.typing.Undefined`
+          keeps whatever default the stub already carries.
         * A non-stub registration already exists — `ContextVarCollision`
           raises; keys must be unique within a namespace.
+
+        .. rubric:: Implementation notes
+
+        The lookup, the registry insert, and the new instance's observable
+        state are all serialized under the registry lock, so concurrent
+        declarations of the same key cannot observe an intermediate
+        registration. The implicit-default case mirrors `resolve_stub`'s
+        "don't silently discard a known default" rule.
         """
         if not isinstance(name, str):
             raise TypeError("context variable name must be a str")
@@ -179,18 +174,21 @@ class ContextVar(ContextVarManifest[T]):
         A `ContextVar` is a key for resolving a value from the active
         `~wool.runtime.context.chain.Chain`; its pickled state is
         therefore the key plus the constructor default, never a captured
-        value. State propagation rides on the chain-manifest path
-        (`~wool.runtime.context.chain.Chain.to_manifest` snapshots the
+        value. The pickle path stays pure-identity: a reconstituted
+        variable is a key only — ``var.get()`` on the receiver resolves
+        through the receiver's context without the unpickle ever writing
+        to it.
+
+        .. rubric:: Implementation notes
+
+        State propagation rides on the chain-manifest path, not the pickle:
+        `~wool.runtime.context.chain.Chain.to_manifest` snapshots the
         sender's context and
-        `~wool.runtime.context.manifest.ChainManifest.to_protobuf`
-        encodes it;
-        `~wool.runtime.context.manifest.ChainManifest.from_protobuf`
+        `~wool.runtime.context.manifest.ChainManifest.to_protobuf` encodes
+        it; `~wool.runtime.context.manifest.ChainManifest.from_protobuf`
         decodes the wire frame and
         `~wool.runtime.context.chain.Chain.from_manifest` populates the
-        receiver's context). The pickle path stays pure-identity so a
-        reconstituted variable is a key only — ``var.get()`` on the
-        receiver resolves through the receiver's context without the
-        unpickle ever writing to it.
+        receiver's context.
 
         The pickle surface lives on `ContextVar` rather than
         `~wool.runtime.context.manifest.ContextVarManifest` because
@@ -210,10 +208,6 @@ class ContextVar(ContextVarManifest[T]):
     @overload
     def get(self, default: T, /) -> T: ...
 
-    # ``*args`` sentinel pattern mirrors `contextvars.ContextVar.get` —
-    # distinguishes "no default supplied" (raise `LookupError`) from
-    # "default is `None`" (return `None`). The user-facing surface
-    # is constrained by the two ``@overload`` declarations above.
     def get(self, *args: T) -> T:
         """Return the current value in the active context.
 
@@ -231,18 +225,24 @@ class ContextVar(ContextVarManifest[T]):
             If the active chain is being entered by a thread or asyncio
             task other than the one that owns it. See
             `wool.ChainContention` for full detail.
+
+        .. rubric:: Implementation notes
+
+        The ``*args`` signature mirrors `contextvars.ContextVar.get` so a
+        `LookupError` for "no default supplied" stays distinct from a
+        returned ``None`` for "default is ``None``"; the two ``@overload``
+        declarations constrain the user-facing surface. Resolution falls
+        through a ladder keyed on `~wool.runtime.typing.Undefined` — an
+        `Undefined` backing (never set in this chain, or reset/merged to the
+        sentinel) defers to the *default* argument, then the constructor
+        default, then `LookupError`. The chain-ownership guard runs at this
+        API boundary, as in `set`/`reset`.
         """
         if len(args) > 1:
             raise TypeError(f"get expected at most 1 argument, got {len(args)}")
-        # Resolve through the backing variable. ``Undefined`` — whether
-        # the backing variable was never set in this Chain or was
-        # reset/merged to the sentinel value — means "fall through to
-        # the default ladder" (get argument, constructor default,
-        # LookupError). Guard at the user-facing API boundary to
-        # match `set` and `reset` — the storage layer
-        # (raw stdlib contextvars.ContextVar) carries no guard, so
-        # ``self._backing.get`` is direct stdlib plumbing.
+        # Guard at the API boundary.
         assert_chain_owner(wool.__chain__.get(None))
+        # An Undefined backing falls through to the default ladder.
         value = self._backing.get(Undefined)
         if value is not Undefined:
             return value
@@ -252,155 +252,259 @@ class ContextVar(ContextVarManifest[T]):
             return self._default
         raise LookupError(self)
 
-    def set(self, value: T) -> contextvars.Token[T | UndefinedType]:
-        """Set the variable's value in the active context.
+    def set(self, value: T) -> Token[T]:
+        """Set the variable's value in the active context and return a reset `Token`.
 
-        The first `set` on an unarmed context arms it — mints a
-        fresh chain UUID, installs the first context, and self-installs
-        Wool's task factory on the running loop (raising
-        `~wool.TaskFactoryDisplaced` if Wool's factory was
-        previously installed on the loop but has since been displaced
-        by a third-party factory installed after it). The value rides
-        in the variable's backing
-        `contextvars.ContextVar`; the context's ``vars`` index
-        gains an entry for this variable the first time it is bound in
-        the chain. The factory install is performed by
-        `~wool.runtime.context.chain.Chain.mount`, which this
-        method routes through on every set, but the user-visible effect
-        chain is the same.
+        The first `set` in a context *arms* it (see the class **Storage
+        model**) and installs Wool's task factory on the running loop.
 
         :param value:
             The new value.
         :returns:
-            A `contextvars.Token` usable with `reset` to
-            restore the previous value. The token is process-local, and
-            its ``var`` attribute references the variable's internal
-            backing `contextvars.ContextVar` rather than this
-            `ContextVar` (see the class docstring); the supported reset
-            path is ``wool_var.reset(token)``.
+            A `~wool.runtime.context.token.Token` usable with `reset`
+            to restore the previous value. Unlike `contextvars.Token`,
+            it survives a Wool dispatch — it may be passed to a
+            `@wool.routine` and reset on the receiver — while still
+            refusing vanilla pickling. Its ``var`` is this `ContextVar`.
         :raises ChainContention:
             If the active chain is being entered by a thread or asyncio
             task other than the one that owns it. See
             `wool.ChainContention` for full detail.
+        :raises TaskFactoryDisplaced:
+            If arming the context must install Wool's task factory but a
+            third-party factory has displaced a Wool factory previously
+            installed on the running loop.
+
+        .. rubric:: Implementation notes
+
+        The chain-ownership guard runs against the *currently installed*
+        `~wool.runtime.context.chain.Chain` before any other work.
+        `~wool.runtime.context.chain.Chain.mount` re-stamps the owning
+        thread and task, so a guard placed after mount would silently
+        transfer ownership to the calling thread — the exact corruption
+        `wool.ChainContention` exists to surface. The guard sits at the
+        user-facing boundary (`get`, `set`, `reset`); the backing
+        `contextvars.ContextVar` is unguarded plumbing.
+
+        The token ID is minted before the chain evolve so it rides the
+        same evolve as the binding. Recording it under the variable's
+        key in ``unspent_tokens`` marks that the token was minted while
+        the chain was live in *this* stdlib `contextvars.Context`; the
+        receiver's mount checks that per-variable set against the wire
+        manifest to decide whether the token may anchor a reset (see
+        `~wool.runtime.context.token.anchor_tokens`).
+
+        Spent token IDs survive a fresh set. A token consumed on a
+        remote worker leaves its local ``_used`` flag unset — the
+        consumption is known here only through the chain's
+        ``spent_tokens`` ledger — so pruning the key's spent IDs on a
+        re-set would let the caller reset a token already consumed on
+        another process a second time. The ledger therefore grows one
+        entry per consumed token for the chain's lifetime; bounding that
+        growth to token lifespan is issue #226's ownership model, not a
+        prune that forgets consumptions. The freshly minted ID is never
+        spent, so it always survives the subtraction that keeps
+        ``unspent_tokens`` free of dead IDs.
+
+        The bookkeeping delta folds into mount's single owner-stamp
+        evolve — one `~wool.runtime.context.chain.Chain` construction,
+        not two — and mount runs before the backing mutation so a
+        mount-time raise (e.g., `wool.TaskFactoryDisplaced`) rolls back
+        cleanly. Mount on the set path leaves this variable's backing
+        untouched: the delta has already cleared the key from
+        ``resets``, so mount's reset-drain skips it and
+        ``self._backing.set`` writes to a freshly mounted-but-unmodified
+        backing.
+
+        The native token's "no prior value" sentinel
+        (`contextvars.Token.MISSING`) is normalised to
+        `~wool.runtime.typing.Undefined` so it survives the wire: a wire
+        reset applies the captured old value directly, while the local
+        path reads the native token instead.
         """
-        # Enforce the chain-ownership invariant against the *currently
-        # installed* `Chain` before doing anything else.
-        # `Chain.mount` below unconditionally re-stamps the
-        # owning thread/task, so a guard check that runs after mount
-        # would silently transfer ownership to the calling thread —
-        # the exact corruption `ChainContention` is meant to
-        # surface. The guard lives at the user-facing API boundary
-        # (here, plus `get` and `reset`); the storage
-        # layer (raw stdlib contextvars.ContextVar) is plumbing.
+        # Guard the installed chain before mount re-stamps ownership.
         assert_chain_owner(wool.__chain__.get(None))
         chain = wool.__chain__.get(None)
         if chain is None:
-            # First set on this chain: arm it with a fresh chain
-            # UUID. ``Chain.mount`` below is the single point at
-            # which Wool's task factory self-installs on the running
-            # loop — every code path that arms a chain transits
-            # through here.
+            # First set arms the context (see the class Storage model).
             chain = Chain()
-        # Add this variable to the chain's vars index the first time
-        # it is bound in the chain, and clear any prior reset signal —
-        # the variable now carries a value again. When it is already
-        # indexed and not reset, the chain is unchanged.
+        # Mint the ID up front so it rides the binding's evolve.
+        token_id = uuid4().hex
+        # Bind the variable in the chain, clearing any prior reset signal.
         if self not in chain.vars or self._key in chain.resets:
-            chain = chain._evolve(
-                vars=chain.vars | {self},
-                resets=chain.resets - {self._key},
-            )
-        # Mount before mutating the backing so that a mount-time
-        # raise (e.g., ``TaskFactoryDisplaced``) rolls back cleanly
-        # without leaving the backing in a state inconsistent with the
-        # Wool Chain. Mount in the set path doesn't touch this
-        # variable's backing — the evolve above removed ``self._key``
-        # from ``resets``, so mount's reset-drain loop skips it, so
-        # the later ``self._backing.set(value)`` operates on a freshly
-        # mounted-but-unmodified backing.
-        chain.mount()
-        return self._backing.set(value)
+            new_vars = chain.vars | {self}
+            new_resets = chain.resets - {self._key}
+        else:
+            new_vars, new_resets = chain.vars, chain.resets
+        # Record the fresh ID; drop any IDs already spent for this key.
+        new_unspent = {
+            **chain.unspent_tokens,
+            self._key: (chain.unspent_tokens.get(self._key, frozenset()) | {token_id})
+            - chain.spent_tokens.get(self._key, frozenset()),
+        }
+        # Fold the delta into mount's evolve; mount before the backing write.
+        chain.mount(
+            vars=new_vars,
+            resets=new_resets,
+            unspent_tokens=new_unspent,
+        )
+        native = self._backing.set(value)
+        # Normalise the native "unset" sentinel to Undefined for the wire.
+        old_value = native.old_value
+        if old_value is contextvars.Token.MISSING:
+            old_value = Undefined
+        return Token._mint(
+            var=self,
+            old_value=old_value,
+            native=native,
+            id=token_id,
+        )
 
-    def reset(self, token: contextvars.Token[T | UndefinedType]) -> None:
+    def reset(self, token: Token[T]) -> None:
         """Restore the variable to the value it had before *token*.
 
-        Matches `contextvars.ContextVar.reset` semantics. The
-        reset delegates to the backing variable's native
-        `contextvars.ContextVar.reset`, so stdlib itself
-        enforces single-use, rejects a token whose ``var`` is not this
-        variable's backing, and rejects a token reset in a different
-        `contextvars.Context` than the one it was minted in.
+        Mirrors `contextvars.ContextVar.reset`, extended to accept a
+        `~wool.runtime.context.token.Token` that may have crossed a Wool
+        dispatch. Only a `~wool.runtime.context.token.Token` is accepted; a
+        raw `contextvars.Token` raises `TypeError`. Enforcement follows
+        stdlib's order and error types:
+
+        * **Already used** — locally, or consumed elsewhere in the chain
+          (this process or another) — raises `RuntimeError`.
+        * **Wrong variable** — a token minted by a different `ContextVar`
+          than the one being reset — raises `ValueError`.
+        * **Different context** — a token minted in a different
+          `contextvars.Context` than the reset runs in (a
+          `contextvars.Context.run` sibling, a ``create_task`` fork, or a
+          wire token that arrived orphaned) — raises `ValueError`.
+
+        Reset is single-use everywhere the token's ID has reached: once a
+        reset succeeds, any further reset of the same token raises
+        `RuntimeError`, whether attempted in this process or another the
+        chain reaches. Atomicity mirrors stdlib — the used and context
+        checks run before any state mutation, so a rejected reset leaves
+        the variable and chain unchanged.
 
         :param token:
-            A `contextvars.Token` previously returned by
-            `set`. ``token.var`` references the variable's
-            internal backing `contextvars.ContextVar` rather
-            than this `ContextVar` instance — supported reset
-            path is ``wool_var.reset(token)``, not direct stdlib
-            reset.
+            A `~wool.runtime.context.token.Token` returned by this
+            variable's `set`.
+        :raises TypeError:
+            If *token* is not a `~wool.runtime.context.token.Token`.
         :raises ValueError:
-            If the token was created by a different
-            `ContextVar` or in a different
-            `contextvars.Context` (surfaced by stdlib
-            `contextvars.ContextVar.reset`).
+            If the token was minted by a different `ContextVar`, or in a
+            different `contextvars.Context` (or arrived orphaned across
+            the wire).
         :raises RuntimeError:
-            If the token has already been used (surfaced by stdlib
-            single-use enforcement).
+            If the token has already been used, on this or any process.
         :raises ChainContention:
             If the active chain is being entered by a thread or asyncio
             task other than the one that owns it. See
             `wool.ChainContention` for full detail.
+
+        .. rubric:: Implementation notes
+
+        The chain-ownership guard runs against the currently installed
+        `~wool.runtime.context.chain.Chain` first, as in `set`. That
+        chain is stable through the reset — the backing mutations never
+        touch ``wool.__chain__`` — so it is bound once and reused for the
+        spent-ledger read and the closing evolve.
+
+        The used-gate runs before the wrong-variable check to match
+        stdlib's order (a token that is both used and for the wrong
+        variable raises the used error). It consults the local ``_used``
+        flag and the chain's ``spent_tokens`` ledger keyed on the
+        *token's own* variable, so a token consumed elsewhere in the
+        chain is rejected at its origin too; keying on the token's
+        variable rather than ``self`` keeps a used token handed to the
+        wrong variable tripping this gate first. When the ledger is the
+        discoverer, the local flag is stamped so the canonical error repr
+        still carries stdlib's ``used`` marker (``<Token used var=...>``)
+        and later gates see the settled flag.
+
+        Context validity is decided per token flavor, before any backing
+        mutation. A local token (its native backing is this variable's)
+        validates and restores through the native reset, delegating
+        "same Context" to stdlib. A wire token validates through its
+        receiver-side anchor (see `~wool.runtime.context.token.Token`)
+        and then has its captured old value applied to the backing
+        directly, the native reset being unavailable off-origin; an
+        orphan wire token has no anchor and always raises "different
+        Context". A single guarded reset translates stdlib's
+        `RuntimeError` / `ValueError` into the canonical wool messages.
+
+        Once the backing has committed, the chain bookkeeping mirrors it:
+        the token's ID moves from the variable's ``unspent_tokens`` set
+        (dropping the key once it empties) into ``spent_tokens`` — which
+        rides the next frame so the consumption propagates across the
+        wire — and the token is flagged used locally. The spent ID then
+        persists for the chain's lifetime (see
+        `~wool.runtime.context.chain.Chain`); a later set never prunes it,
+        since an off-origin consumption is witnessed only by this ledger.
         """
-        # Enforce the chain-ownership invariant against the *currently
-        # installed* `Chain` before doing anything else.
-        # `Chain.mount` below unconditionally re-stamps the
-        # owning thread/task, so a guard check that runs after mount
-        # would silently transfer ownership to the calling thread.
-        # See `set` for the analogous guard placement.
-        assert_chain_owner(wool.__chain__.get(None))
-        # Atomicity: run the native reset first. Stdlib
-        # ``ContextVar.reset`` is atomic — if it rejects (wrong var,
-        # wrong Context, already used) observable state is unchanged.
-        # Mounting first would break that contract: by the time
-        # stdlib raised, the Wool ``Chain`` would already have been
-        # evolved + installed and (for the unset case) the backing
-        # rewound to ``Undefined`` via the mount drain.
-        # Native-reset-first preserves stdlib parity:
-        # if the native reset raises, no Wool bookkeeping happens;
-        # if it succeeds, evolve + mount commit the Wool view.
-        self._backing.reset(token)
-        # Below this point the native reset has succeeded; mutate Wool
-        # bookkeeping. A subsequent mount-time raise (e.g.
-        # ``TaskFactoryDisplaced``) does leave the backing in its
-        # restored state — but mount-time raises on the reset path
-        # are pathological (the chain was already armed; reset just
-        # rewound it) and the diagnostic surface intent of mount
-        # raising is unrelated to reset atomicity.
+        # Guard the installed chain first (see set); bind it once for reuse.
         context = wool.__chain__.get(None)
-        if context is None:
-            # Unarmed context — native reset already raised the
-            # appropriate ValueError, so this branch is unreachable
-            # except via test mocks. Safe to no-op.
-            return
-        # ``token.old_value`` is `contextvars.Token.MISSING` when
-        # the variable was never set in this Chain (true first-set),
-        # ``Undefined`` (Wool's sentinel) when the backing was
-        # rewound by a prior ``mount`` drain, and the prior value
-        # otherwise. Both ``MISSING`` and ``Undefined`` mean "reset to
-        # no observable value" for the Wool ``Chain`` bookkeeping.
-        old_value = token.old_value
-        old_was_unset = old_value is contextvars.Token.MISSING or old_value is Undefined
-        if old_was_unset:
-            new_vars = context.vars - {self}
-            new_resets = context.resets | {self._key}
-        else:
-            new_vars = context.vars | {self}
-            new_resets = context.resets - {self._key}
-        evolved = context._evolve(
-            vars=new_vars,
-            resets=new_resets,
+        assert_chain_owner(context)
+        if not isinstance(token, Token):
+            raise TypeError(f"expected an instance of Token, got {token!r}")
+        # Used-gate first (stdlib order), keyed on the token's own var.
+        consumed = context is not None and token._id in context.spent_tokens.get(
+            token._var._key, frozenset()
         )
-        evolved.mount()
+        if token._used or consumed:
+            # Stamp _used so a ledger-discovered rejection reprs as "used".
+            token._used = True
+            raise RuntimeError(f"{token!r} has already been used once")
+        # Then reject a token minted by a different variable.
+        if token._var is not self:
+            raise ValueError(f"{token!r} was created by a different ContextVar")
+        # Context check before any backing mutation (stdlib atomicity); an
+        # orphan wire token has no native and no anchor.
+        if token._native is None:
+            raise ValueError(f"{token!r} was created in a different Context")
+        # Local token validates via the backing; a wire token via its anchor.
+        local = token._native.var is self._backing
+        try:
+            (self._backing if local else token_anchor).reset(token._native)
+        except RuntimeError:
+            raise RuntimeError(f"{token!r} has already been used once") from None
+        except ValueError:
+            raise ValueError(f"{token!r} was created in a different Context") from None
+        if local:
+            native_old = token._native.old_value
+            old_was_unset = (
+                native_old is contextvars.Token.MISSING or native_old is Undefined
+            )
+        else:
+            # Native reset is unavailable off-origin; apply old value directly.
+            old_was_unset = token._old_value is Undefined
+            self._backing.set(Undefined if old_was_unset else token._old_value)
+        # Mirror the committed reset into the chain: move the ID from
+        # unspent to spent, dropping the key once unspent empties.
+        if context is not None:
+            if old_was_unset:
+                new_vars = context.vars - {self}
+                new_resets = context.resets | {self._key}
+            else:
+                new_vars = context.vars | {self}
+                new_resets = context.resets - {self._key}
+            remaining = context.unspent_tokens.get(self._key, frozenset()) - {token._id}
+            new_unspent = {**context.unspent_tokens}
+            if remaining:
+                new_unspent[self._key] = remaining
+            else:
+                new_unspent.pop(self._key, None)
+            new_spent = {
+                **context.spent_tokens,
+                self._key: context.spent_tokens.get(self._key, frozenset())
+                | {token._id},
+            }
+            context._evolve(
+                vars=new_vars,
+                resets=new_resets,
+                unspent_tokens=new_unspent,
+                spent_tokens=new_spent,
+            ).mount()
+        token._used = True
 
     @classmethod
     def _reconstitute(
@@ -411,19 +515,21 @@ class ContextVar(ContextVarManifest[T]):
     ) -> ContextVar[Any]:
         """Rebuild or resolve a usable `ContextVar` from pickled parts.
 
+        Restores identity only — the receiver's context, populated via the
+        chain-manifest path, is the source of truth for value lookup.
+
+        .. rubric:: Implementation notes
+
         Routes through `~wool.runtime.context.manifest.resolve_stub` so
         the chain-manifest ingress and the pickle ingress (this method)
         converge on a single registry entry per key. Where the manifest
         ingress is content with a bare
         `~wool.runtime.context.manifest.ContextVarManifest`, the pickle
-        ingress needs behavior — the receiver invokes `get`/`set`/`reset`
-        — so `_as_contextvar` upgrades a freshly minted manifest to a
+        ingress needs behavior — the receiver invokes `get`/`set`/`reset` —
+        so `_as_contextvar` upgrades a freshly minted manifest to a
         functional `ContextVar` in place. The instance stays flagged as a
-        stub
-        (``_stub`` is untouched) so a later user declaration still
-        promotes it without `ContextVarCollision`. Pickle restores
-        identity only — the receiver's context, populated via the
-        chain-manifest path, is the source of truth for value lookup.
+        stub (``_stub`` is untouched) so a later user declaration still
+        promotes it without `ContextVarCollision`.
         """
         return _as_contextvar(resolve_stub((namespace, name), default=default))
 
@@ -431,10 +537,14 @@ class ContextVar(ContextVarManifest[T]):
 def _infer_namespace() -> str:
     """Infer the namespace for a `ContextVar` constructor call.
 
-    Walks up the call stack from the current frame, skipping frames
-    from any ``wool.runtime.context`` submodule, and returns the
-    top-level package of the first user frame encountered. Falls back
-    to ``"__main__"`` if the walk reaches the top of the stack.
+    The namespace is the top-level package of the first non-Wool caller
+    frame, or ``"__main__"`` when the walk finds none.
+
+    .. rubric:: Implementation notes
+
+    Walks up the call stack from the current frame, skipping frames from
+    any ``wool.runtime.context`` submodule, and returns the top-level
+    package of the first frame that remains.
     """
     frame = inspect.currentframe()
     while frame is not None:
@@ -452,12 +562,15 @@ def _as_contextvar(manifest: ContextVarManifest[T]) -> ContextVar[T]:
     `contextvars.ContextVar` and its registry registration, so a value
     drained into the backing before the upgrade survives, and every
     immutable `~wool.runtime.context.chain.Chain` that already captured
-    the manifest observes the upgrade without rebuild. In-place is
-    mandatory: a fresh object would leave those chains pointing at a
-    stale manifest and break the one-instance-per-key invariant.
+    the manifest observes the upgrade without rebuild. ``_stub`` is left
+    untouched — this only grants behavior, not declared status (`promote`
+    is the declaration transition).
 
-    ``_stub`` is left untouched — this only grants behavior, not
-    declared status (`promote` is the declaration transition).
+    .. rubric:: Implementation notes
+
+    In-place is mandatory: a fresh object would leave those chains
+    pointing at a stale manifest and break the one-instance-per-key
+    invariant.
 
     Reassigning ``__class__`` is sound only because `ContextVar` adds no
     instance slots over `ContextVarManifest` (``__slots__ = ()``),

--- a/wool/src/wool/runtime/worker/frame.py
+++ b/wool/src/wool/runtime/worker/frame.py
@@ -33,11 +33,13 @@ from wool.runtime.context.chain import Chain
 from wool.runtime.context.exceptions import ChainSerializationError
 from wool.runtime.context.exceptions import SerializationWarning
 from wool.runtime.context.manifest import ChainManifest
+from wool.runtime.context.token import token_sink
 from wool.runtime.routine.task import Task
 from wool.runtime.typing import Undefined
 from wool.runtime.typing import UndefinedType
 
 if TYPE_CHECKING:
+    from wool.runtime.context.token import Token
     from wool.runtime.serializer import Serializer
 
 
@@ -72,6 +74,11 @@ class Frame(Generic[T]):
         default=None, init=False, repr=False
     )
     _serializer: Serializer | None = field(default=None, init=False, repr=False)
+    # Wire tokens reconstituted while decoding this frame, handed to `mount` so
+    # it anchors the ones live in the mounted chain; the rest are orphans (see
+    # `~wool.runtime.context.token.token_sink` for the frame-scoping and
+    # leak-avoidance rationale).
+    _wire_tokens: list[Token] = field(default_factory=list, init=False, repr=False)
     _frame_by_field: ClassVar[dict[str, type[Frame]]] = {}
     _chain_exceptions: ClassVar[bool] = False
 
@@ -139,21 +146,27 @@ class Frame(Generic[T]):
         # invariant violation (registry/schema drift) and fails loudly
         # via ``KeyError`` rather than being a reachable input error.
         frame_cls = cls._frame_by_field[field_name]
-        payload = frame_cls._decode_payload(wire, serializer=serializer)
-        chain_manifest: ChainManifest | ChainSerializationError | None
-        if wire.HasField("context"):
-            try:
-                chain_manifest = ChainManifest.from_protobuf(
-                    wire.context, serializer=serializer
-                )
-            except ChainSerializationError as decode_err:
-                # Defer the strict-mode failure: carry it as the manifest
-                # value so `mount` raises it (or chains it onto an
-                # exception payload) instead of preempting the payload here.
-                chain_manifest = decode_err
-        else:
-            chain_manifest = None
-        return frame_cls(payload=payload, chain_manifest=chain_manifest)
+        # Collect wire tokens reconstituted anywhere in this decode — the
+        # payload graph and the manifest's variable values alike — so the
+        # frame's mount can anchor the ones live in the mounted chain.
+        with token_sink() as wire_tokens:
+            payload = frame_cls._decode_payload(wire, serializer=serializer)
+            chain_manifest: ChainManifest | ChainSerializationError | None
+            if wire.HasField("context"):
+                try:
+                    chain_manifest = ChainManifest.from_protobuf(
+                        wire.context, serializer=serializer
+                    )
+                except ChainSerializationError as decode_err:
+                    # Defer the strict-mode failure: carry it as the manifest
+                    # value so `mount` raises it (or chains it onto an
+                    # exception payload) instead of preempting the payload here.
+                    chain_manifest = decode_err
+            else:
+                chain_manifest = None
+        frame = frame_cls(payload=payload, chain_manifest=chain_manifest)
+        frame._wire_tokens = wire_tokens
+        return frame
 
     def to_protobuf(self) -> protocol.Request | protocol.Response:
         """Encode this frame as its wire envelope.
@@ -294,9 +307,9 @@ class Frame(Generic[T]):
             # `from_protobuf`. Raising routes it through `mount`'s
             # raise-or-chain handler.
             raise self.chain_manifest
-        # Short-circuit a manifest that decoded successfully but binds
-        # no vars and records no resets — nothing to install.
-        if not (self.chain_manifest.vars or self.chain_manifest.resets):
+        # Short-circuit a manifest that decoded successfully but carries no
+        # observable state — nothing to install (see ChainManifest.has_state).
+        if not self.chain_manifest.has_state:
             return
 
         if ctx is None:
@@ -308,6 +321,7 @@ class Frame(Generic[T]):
                 self.chain_manifest,
                 owned=True,
                 merge_with=wool.__chain__.get(None),
+                wire_tokens=self._wire_tokens,
             )
         else:
             # Worker-side: install inside the chain's cached
@@ -315,11 +329,13 @@ class Frame(Generic[T]):
             # successive step-tasks, so the chain is armed
             # task-agnostically (``owned=False``); the factory is still
             # ensured (a no-op on the worker loop, but the displacement
-            # tripwire).
+            # tripwire). Anchoring the pending tokens runs inside ``ctx``
+            # too, so each anchor binds to the mount's context.
             ctx.run(
                 Chain.from_manifest,
                 self.chain_manifest,
                 owned=False,
+                wire_tokens=self._wire_tokens,
             )
 
 

--- a/wool/src/wool/runtime/worker/session.py
+++ b/wool/src/wool/runtime/worker/session.py
@@ -411,6 +411,27 @@ class DispatchSession:
                 # minted chain id, so the back-propagated next frame
                 # (now carrying that id) reuses it.
                 dispatch_ctx: contextvars.Context | None = None
+                # A routine argument can be a live ``wool.Token``. Such tokens
+                # were reconstituted when the initial TaskRequestFrame was
+                # decoded in the parse phase (``__aenter__``), so they sit on
+                # that frame's ``_wire_tokens``. But parse only reads the task
+                # off that frame — it never mounts it, and mounting is what
+                # anchors a token — mints its native reset binding in the
+                # chain's context so the routine can ``reset`` it on this
+                # worker. The only frames mounted here are the mid-stream
+                # Next/Send/Throw ones, and the caller chain those arg tokens
+                # belong to is armed by the *first* of them. So carry the arg
+                # tokens over to that first frame and let its mount anchor them
+                # alongside the chain they rode in on. Once only: after that
+                # mount they are anchored (or, if the caller shipped no chain
+                # to anchor into, left as orphans reclaimed with the dispatch),
+                # and every later frame just re-mounts that same chain —
+                # re-carrying them would be redundant.
+                initial_wire_tokens = (
+                    list(self._initial_frame._wire_tokens)
+                    if self._initial_frame is not None
+                    else []
+                )
 
                 try:
                     async with routine_scope(work_task) as routine:
@@ -488,15 +509,17 @@ class DispatchSession:
                                     chain_registry[manifest.id] = cached
                                 ctx = cached
 
-                            # Single mount entry point. Frame.mount
-                            # routes through the unified
-                            # `Chain.from_manifest` pipeline inside
-                            # ``ctx.run(...)`` and handles the
-                            # exception-frame decode-error-chaining
-                            # (ThrowRequestFrame's
-                            # ``_chain_exceptions`` walk) so
-                            # the worker driver no longer needs the
-                            # hand-rolled apply/walk block.
+                            # First mounted frame only: prepend the arg tokens
+                            # carried over from the initial TaskRequestFrame
+                            # (see above) so this mount anchors them onto the
+                            # caller chain, then clear them so subsequent frames
+                            # don't re-apply them.
+                            if initial_wire_tokens:
+                                request._wire_tokens = [
+                                    *initial_wire_tokens,
+                                    *request._wire_tokens,
+                                ]
+                                initial_wire_tokens = []
                             request.mount(ctx)
 
                             # Drive the step via the top-level

--- a/wool/tests/integration/_token_ops.py
+++ b/wool/tests/integration/_token_ops.py
@@ -1,0 +1,252 @@
+"""Op-script model for cross-process wool.Token parity checks.
+
+NOT a test file — no ``test_`` prefix — so pytest does not collect it.
+
+A *script* is a sequence of frozen op dataclasses (:class:`SetOp`,
+:class:`ResetOp`, :class:`GetOp`), each tagged with the actor that
+performs it: ``"caller"`` (the dispatching test process) or
+``"worker"`` (a pool subprocess, reached through the key-addressed
+``oracle_*`` routines in :mod:`tests.integration.routines`). One script
+can be executed two ways:
+
+* :func:`run_stdlib_oracle` — locally, against a fresh
+  :class:`contextvars.ContextVar`, ignoring actor tags entirely. This
+  is the ground truth: a Wool dispatch chain is a logical continuation
+  of one context, so actor placement must not change outcomes.
+* :func:`run_wool_script` — against a :class:`wool.ContextVar` inside
+  an entered pool context, with caller ops applied locally and worker
+  ops dispatched to real worker subprocesses.
+
+Both executors return one :class:`Observation` per op;
+:func:`observations_match` compares the traces and
+:func:`describe_mismatch` renders a per-op diff for assertion messages.
+
+Script values must be picklable primitives (int/str) — worker ops ship
+them across the dispatch wire — and must not collide with the
+:data:`UNSET` sentinel string.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from itertools import zip_longest
+from typing import Any
+from typing import Final
+
+from hypothesis import strategies as st
+
+import wool
+
+from . import routines
+
+#: Actor tag for ops executed locally by the dispatching test process.
+CALLER: Final = "caller"
+
+#: Actor tag for ops dispatched to a worker subprocess.
+WORKER: Final = "worker"
+
+_ACTORS: Final = (CALLER, WORKER)
+
+#: Sentinel recorded as an :class:`Observation` value when the variable
+#: is unbound. Shared with the worker-side oracle routines so worker
+#: and caller observations of "unset" compare equal.
+UNSET: Final = routines.ORACLE_UNSET
+
+
+@dataclass(frozen=True)
+class _Op:
+    """Base op: the actor that performs it (``CALLER`` or ``WORKER``)."""
+
+    actor: str
+
+    def __post_init__(self) -> None:
+        if self.actor not in _ACTORS:
+            raise ValueError(f"actor must be one of {_ACTORS}, got {self.actor!r}")
+
+
+@dataclass(frozen=True)
+class SetOp(_Op):
+    """Set the variable to *value* (a picklable int/str)."""
+
+    value: Any
+
+
+@dataclass(frozen=True)
+class ResetOp(_Op):
+    """Reset the variable with the *token_index*-th minted token.
+
+    ``token_index`` indexes the ordered list of tokens the script has
+    minted so far, normalized modulo the list length — indexes are
+    drawn with replacement, so an already-consumed token may be
+    retried. A reset drawn before any set is a no-op observation.
+    """
+
+    token_index: int
+
+
+@dataclass(frozen=True)
+class GetOp(_Op):
+    """Read the variable's current value."""
+
+
+Op = SetOp | ResetOp | GetOp
+
+
+@dataclass(frozen=True)
+class Observation:
+    """Per-op record comparable between the wool and stdlib executors.
+
+    ``kind`` is the op kind (``"set"`` / ``"reset"`` / ``"get"``);
+    ``value`` is the variable's value observed at the op's actor site
+    after the op (:data:`UNSET` when unbound); ``error`` is the raised
+    — or worker-reported — exception class name, ``None`` on success.
+    """
+
+    kind: str
+    value: Any
+    error: str | None
+
+
+def scripts(*, max_ops: int = 12) -> st.SearchStrategy[list[Op]]:
+    """Hypothesis strategy drawing op scripts over both actors.
+
+    Values are picklable primitives (int/str) per the module contract;
+    token indexes are drawn with replacement over ``range(max_ops)``
+    and normalized modulo the minted-token count at execution time.
+    """
+    actors = st.sampled_from(_ACTORS)
+    ops = st.one_of(
+        st.builds(SetOp, actor=actors, value=st.integers() | st.text()),
+        st.builds(
+            ResetOp,
+            actor=actors,
+            token_index=st.integers(min_value=0, max_value=max_ops - 1),
+        ),
+        st.builds(GetOp, actor=actors),
+    )
+    return st.lists(ops, max_size=max_ops)
+
+
+def run_stdlib_oracle(script: Sequence[Op]) -> list[Observation]:
+    """Execute *script* on a fresh stdlib ContextVar in one local context.
+
+    Actor tags are ignored — every op runs locally. That is the point:
+    location transparency means actor placement must not change
+    outcomes, so this all-local trace is the ground truth
+    :func:`run_wool_script` is compared against. Reset rejections are
+    captured as the exception class name; the observed value is
+    ``var.get(UNSET)`` after each op.
+    """
+    var: contextvars.ContextVar[Any] = contextvars.ContextVar(
+        f"token_ops_oracle_{uuid.uuid4().hex}"
+    )
+    tokens: list[contextvars.Token[Any]] = []
+    observations: list[Observation] = []
+    for op in script:
+        error: str | None = None
+        if isinstance(op, SetOp):
+            kind = "set"
+            tokens.append(var.set(op.value))
+        elif isinstance(op, ResetOp):
+            kind = "reset"
+            if tokens:
+                try:
+                    var.reset(tokens[op.token_index % len(tokens)])
+                except (RuntimeError, ValueError, TypeError) as exc:
+                    error = type(exc).__name__
+        elif isinstance(op, GetOp):
+            kind = "get"
+        else:
+            raise TypeError(f"unknown op type: {op!r}")
+        observations.append(Observation(kind, var.get(UNSET), error))
+    return observations
+
+
+async def run_wool_script(
+    script: Sequence[Op],
+    var: wool.ContextVar[Any],
+) -> list[Observation]:
+    """Execute *script* against *var*, dispatching worker ops to a live pool.
+
+    Caller ops run locally; worker ops dispatch the ``oracle_*``
+    routines, addressed by ``var.namespace`` / ``var.name``. Tokens
+    minted on either side land in ONE shared ordered list (mint order =
+    script order), mirroring :func:`run_stdlib_oracle`'s token list.
+    Each observation records the value at the op's actor site: caller
+    ops read ``var.get(UNSET)`` locally (for worker sets this checks
+    back-propagation), worker resets report the worker-side
+    ``value_after``, and worker gets return the worker-side read.
+
+    Must run inside an entered pool context; *var* should be declared
+    without a constructor default for parity with the default-less
+    stdlib oracle variable.
+    """
+    namespace = var.namespace
+    name = var.name
+    tokens: list[Any] = []
+    observations: list[Observation] = []
+    for op in script:
+        error: str | None = None
+        if isinstance(op, SetOp):
+            kind = "set"
+            if op.actor == CALLER:
+                tokens.append(var.set(op.value))
+            else:
+                tokens.append(await routines.oracle_set(namespace, name, op.value))
+            value = var.get(UNSET)
+        elif isinstance(op, ResetOp):
+            kind = "reset"
+            if not tokens:
+                value = var.get(UNSET)
+            else:
+                token = tokens[op.token_index % len(tokens)]
+                if op.actor == CALLER:
+                    try:
+                        var.reset(token)
+                    except (RuntimeError, ValueError, TypeError) as exc:
+                        error = type(exc).__name__
+                    value = var.get(UNSET)
+                else:
+                    outcome_kind, _message, value = await routines.oracle_reset(
+                        namespace, name, token
+                    )
+                    if outcome_kind != "ok":
+                        error = outcome_kind
+        elif isinstance(op, GetOp):
+            kind = "get"
+            if op.actor == CALLER:
+                value = var.get(UNSET)
+            else:
+                value = await routines.oracle_get(namespace, name, UNSET)
+        else:
+            raise TypeError(f"unknown op type: {op!r}")
+        observations.append(Observation(kind, value, error))
+    return observations
+
+
+def observations_match(
+    wool_observations: Sequence[Observation],
+    stdlib_observations: Sequence[Observation],
+) -> bool:
+    """Return True when the two observation traces are identical."""
+    return list(wool_observations) == list(stdlib_observations)
+
+
+def describe_mismatch(
+    wool_observations: Sequence[Observation],
+    stdlib_observations: Sequence[Observation],
+) -> str:
+    """Render a per-op wool-vs-stdlib diff for assertion messages.
+
+    Divergent rows are flagged with ``!!``; missing rows (unequal trace
+    lengths) render as ``None`` on the shorter side.
+    """
+    lines = ["wool vs stdlib observation trace:"]
+    pairs = zip_longest(wool_observations, stdlib_observations)
+    for index, (wool_obs, stdlib_obs) in enumerate(pairs):
+        marker = "  " if wool_obs == stdlib_obs else "!!"
+        lines.append(f"{marker} [{index}] wool={wool_obs!r} stdlib={stdlib_obs!r}")
+    return "\n".join(lines)

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -10,7 +10,6 @@ import asyncio
 import datetime
 import ipaddress
 import uuid
-from collections.abc import Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from dataclasses import fields
@@ -1492,83 +1491,5 @@ def retry_grpc_internal():
                     await asyncio.sleep(_GRPC_INTERNAL_BACKOFF * (2**attempt))
                     continue
                 raise
-
-    return run
-
-
-def _needs_picklable_token(scenario: Scenario) -> bool:
-    """Report whether the scenario resets a token across a nested dispatch.
-
-    The DOWNSTREAM_RESET pattern deposits a reset token for the inner
-    worker via the `_RESET_TOKENS` ContextVar (see ``routines.py``).
-    Now that nested routines genuinely dispatch to the pool (#278), that
-    token must cross the wire — which only succeeds with the picklable
-    `wool.Token` from #231. Until #231 lands, the stdlib
-    `contextvars.Token` cannot pickle, so the reset is dropped at the
-    serialization boundary and the caller observes the un-reset value.
-
-    Gate the affected cases here; remove this guard with #231.
-    """
-    if scenario.shape not in _NESTED_SHAPES:
-        return False
-    patterns = (scenario.ctx_var_1, scenario.ctx_var_2, scenario.ctx_var_3)
-    return ContextVarPattern.DOWNSTREAM_RESET in patterns
-
-
-@dataclass(frozen=True)
-class _KnownBug:
-    """A scenario region that hits a known, still-open bug.
-
-    ``match`` selects the affected scenarios, ``raises`` constrains the
-    expected failure mode so that an unrelated regression in the same
-    region still surfaces as a real failure, and ``reason`` cites the
-    tracking issue. ``retries``/``backoff``/``retryable`` let a transient
-    known bug be retried before it is marked ``xfail``; the default
-    zero-retry entry marks on the first matching failure.
-    """
-
-    match: Callable[[Scenario], bool]
-    raises: tuple[type[BaseException], ...]
-    reason: str
-    retries: int = 0
-    backoff: float = 0.5
-    retryable: Callable[[BaseException], bool] = lambda _: False
-
-
-_KNOWN_BUGS: list[_KnownBug] = [
-    _KnownBug(
-        match=_needs_picklable_token,
-        raises=(AssertionError,),
-        reason="nested DOWNSTREAM_RESET needs the picklable wool.Token (#231)",
-    ),
-]
-
-
-@pytest.fixture
-def xfail_known_bugs():
-    """Run a test body under the known-bug registry.
-
-    Returns an async callable used as ``await xfail_known_bugs(scenario,
-    body)`` where ``body`` is a no-argument async callable holding the
-    test logic. When the scenario matches a ``_KnownBug`` and ``body``
-    raises the registered failure mode, the test is marked ``xfail``
-    (retrying transient matches with exponential backoff first); once the
-    bug is fixed the body passes and the test goes green. Scenarios with
-    no matching bug run ``body`` unguarded, and any exception outside a
-    registered failure mode propagates as a real failure.
-    """
-
-    async def run(scenario, body):
-        bug = next((b for b in _KNOWN_BUGS if b.match(scenario)), None)
-        if bug is None:
-            return await body()
-        for attempt in range(bug.retries + 1):
-            try:
-                return await body()
-            except bug.raises as exc:
-                if bug.retryable(exc) and attempt < bug.retries:
-                    await asyncio.sleep(bug.backoff * (2**attempt))
-                    continue
-                pytest.xfail(bug.reason)
 
     return run

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -710,18 +710,27 @@ def _build_patterns_dict(scenario):
 def _setup_caller_vars(patterns):
     """Set caller-side initial values for patterns that need them.
 
-    Returns a dict of {var_name: token} for cleanup, and a dict of
-    {var_name: initial_value} for later assertion.
+    Returns a dict of {var_name: token} for cleanup, a dict of
+    {var_name: initial_value} for later assertion, and the
+    _RESET_TOKENS reset token (or None) minted when a
+    TOKEN_REMOTE_RESET_THEN_FRESH_SET pattern deposits caller-minted
+    tokens for the worker to consume.
     """
     tokens = {}
     initial_values = {}
+    ferry = {}
     for var_name, pattern in patterns.items():
         var = _CALLER_VARS[var_name]
         if pattern is not ContextVarPattern.NONE:
             initial = f"caller-initial-{var_name}"
             tokens[var_name] = var.set(initial)
             initial_values[var_name] = initial
-    return tokens, initial_values
+        if pattern is ContextVarPattern.TOKEN_REMOTE_RESET_THEN_FRESH_SET:
+            # Mint the token the worker will consume; it rides to the
+            # worker nested inside _RESET_TOKENS' propagated value.
+            ferry[var_name] = var.set(f"remote-reset-{var_name}")
+    ferry_token = routines._RESET_TOKENS.set(ferry) if ferry else None
+    return tokens, initial_values, ferry_token
 
 
 def _assert_caller_vars(patterns, initial_values, *, shape=None):
@@ -803,6 +812,22 @@ def _assert_caller_vars(patterns, initial_values, *, shape=None):
                 # Forward propagation is asserted worker-side per
                 # frame — a mismatch raises a dispatch exception.
                 pass  # validated worker-side during iteration
+            case ContextVarPattern.TOKEN_REMOTE_RESET_THEN_FRESH_SET:
+                # The worker consumed the ferried token (restoring the
+                # caller's initial value) then re-set the var; the
+                # fresh set back-propagates home.
+                assert var.get() == f"fresh-{var_name}", (
+                    f"TOKEN_REMOTE_RESET_THEN_FRESH_SET: expected the "
+                    f"worker's fresh value, got {var.get()!r}"
+                )
+                # The regression this pattern pins: the worker's fresh
+                # set must not have erased the consumed id from the
+                # spent ledger, so the caller's stale copy still
+                # raises. Read the ferry dict back from the var — the
+                # post-merge copy carries the same token id either way.
+                stale = routines._RESET_TOKENS.get()[var_name]
+                with pytest.raises(RuntimeError, match="has already been used once"):
+                    var.reset(stale)
 
 
 def _cleanup_caller_vars(tokens):
@@ -822,9 +847,10 @@ async def invoke_routine(scenario):
     patterns_token = None
     caller_tokens = {}
     initial_values = {}
+    ferry_token = None
     if patterns:
         patterns_token = routines.TEST_PATTERNS.set(patterns)
-        caller_tokens, initial_values = _setup_caller_vars(patterns)
+        caller_tokens, initial_values, ferry_token = _setup_caller_vars(patterns)
 
     try:
         obj = (
@@ -993,6 +1019,8 @@ async def invoke_routine(scenario):
     finally:
         if caller_tokens:
             _cleanup_caller_vars(caller_tokens)
+        if ferry_token is not None:
+            routines._RESET_TOKENS.reset(ferry_token)
         if patterns_token is not None:
             routines.TEST_PATTERNS.reset(patterns_token)
 
@@ -1114,7 +1142,10 @@ def _pairwise_filter(row):
     - D11/D12/D13 (ctx_var_1/2/3): DOWNSTREAM_OVERWRITE,
       DOWNSTREAM_RESET, UPSTREAM_RESET only valid with NESTED_* shapes;
       PER_YIELD and MID_STREAM_FORWARD only valid with ASYNC_GEN_*
-      shapes
+      shapes; TOKEN_REMOTE_RESET_THEN_FRESH_SET only valid with
+      non-nested shapes (on nested shapes non-nested patterns execute
+      on BOTH outer and inner workers, and its ferried token is
+      single-use)
     - D14 (quorum) ABOVE_DEFAULT (quorum=2) requires PoolMode.EPHEMERAL —
       every other pool mode in the builder produces only one worker, so
       quorum=2 would block forever.
@@ -1175,6 +1206,15 @@ def _pairwise_filter(row):
             if (
                 pattern is ContextVarPattern.MID_STREAM_FORWARD
                 and shape not in _MID_STREAM_FORWARD_SHAPES
+            ):
+                return False
+            # TOKEN_REMOTE_RESET_THEN_FRESH_SET's ferried token is
+            # single-use; on nested shapes non-nested patterns execute
+            # on both the outer and inner workers, so the second reset
+            # would raise mid-dispatch.
+            if (
+                pattern is ContextVarPattern.TOKEN_REMOTE_RESET_THEN_FRESH_SET
+                and shape in _NESTED_SHAPES
             ):
                 return False
             # NESTED_ASYNC_GEN_READBACK's routine self-mutates
@@ -1331,6 +1371,15 @@ def scenarios_strategy(draw):
             valid = [p for p in valid if p is not ContextVarPattern.PER_YIELD]
         if shape not in _MID_STREAM_FORWARD_SHAPES:
             valid = [p for p in valid if p is not ContextVarPattern.MID_STREAM_FORWARD]
+        if shape in _NESTED_SHAPES:
+            # Mirrors ``_pairwise_filter``: the ferried token is
+            # single-use, but nested shapes execute non-nested
+            # patterns on both the outer and inner workers.
+            valid = [
+                p
+                for p in valid
+                if p is not ContextVarPattern.TOKEN_REMOTE_RESET_THEN_FRESH_SET
+            ]
         return draw(st.sampled_from(valid))
 
     ctx_var_1 = _draw_ctx_var_pattern(draw)

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -10,6 +10,7 @@ import asyncio
 import datetime
 import ipaddress
 import uuid
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from dataclasses import fields
@@ -296,8 +297,13 @@ class _DirectDiscovery:
         return self._discovery.subscribe(filter)
 
 
+# The return annotation is load-bearing for tooling, not just docs: pyright's
+# inference gives up on this large unannotated async generator and models it
+# as a plain coroutine, breaking ``async with`` analysis at every call site.
 @asynccontextmanager
-async def build_pool_from_scenario(scenario, credentials_map, *, backpressure=None):
+async def build_pool_from_scenario(
+    scenario, credentials_map, *, backpressure=None
+) -> AsyncIterator[WorkerPool]:
     """Build and enter a WorkerPool from a complete Scenario.
 
     Resolves each dimension to its concrete runtime value and yields the

--- a/wool/tests/integration/routines.py
+++ b/wool/tests/integration/routines.py
@@ -1416,3 +1416,139 @@ async def enter_proxies_in_separate_tasks_on_worker() -> str:
 
     await asyncio.gather(use_proxy(), use_proxy())
     return "ok"
+
+
+# Key-addressed oracle routines used by the token-parity op scripts
+# (tests/integration/_token_ops.py). Each addresses a wool.ContextVar
+# by its ``(namespace, name)`` key so tests can mint per-test variables
+# without touching the module-level ones above.
+
+#: Sentinel reported by the oracle routines when the addressed variable
+#: is unbound. A distinctive string (script values are picklable
+#: primitives) rather than an object sentinel so it compares equal
+#: across process boundaries.
+ORACLE_UNSET = "<wool-oracle-unset>"
+
+# Per-process cache backing ``_resolve_oracle_var``. A second
+# ``wool.ContextVar`` declaration for an already-declared (non-stub)
+# key raises ContextVarCollision, so repeated dispatches to the same
+# worker must reuse the instance minted by the first resolution.
+_ORACLE_VARS: dict = {}
+
+
+def _resolve_oracle_var(namespace: str, name: str) -> wool.ContextVar:
+    """Get-or-create the :class:`wool.ContextVar` keyed (*namespace*, *name*).
+
+    The first resolution in a process declares the variable — promoting
+    a wire-seeded stub in place when the dispatch frame registered the
+    key before the routine body ran (the
+    :func:`declare_and_read_unregistered_key` path) — and caches it;
+    every later resolution returns the cached instance, keeping
+    worker-side resolution idempotent across repeated dispatches.
+    """
+    key = (namespace, name)
+    var = _ORACLE_VARS.get(key)
+    if var is None:
+        var = wool.ContextVar(name, namespace=namespace)
+        _ORACLE_VARS[key] = var
+    return var
+
+
+async def _oracle_reset_outcome(namespace: str, name: str, token) -> tuple:
+    """Reset the (*namespace*, *name*) oracle var by *token*; report the outcome.
+
+    Shared tail for the oracle reset routines — never raises for the
+    documented reset rejections. Returns ``("ok", "", value_after)`` on
+    success or ``(type_name, str(error), value_after)`` when the reset
+    raises RuntimeError, ValueError, or TypeError, where ``value_after``
+    is the variable's current value or :data:`ORACLE_UNSET` when unbound.
+    """
+    var = _resolve_oracle_var(namespace, name)
+    try:
+        var.reset(token)
+    except (RuntimeError, ValueError, TypeError) as error:
+        return type(error).__name__, str(error), var.get(ORACLE_UNSET)
+    return "ok", "", var.get(ORACLE_UNSET)
+
+
+@wool.routine
+async def oracle_set(namespace: str, name: str, value):
+    """Set the (*namespace*, *name*) oracle var on the worker; return the token.
+
+    The minted :class:`wool.Token` rides home on the response frame.
+    The awaiting caller's context continues the minting context, so the
+    token may later be reset caller-side — or dispatched onward and
+    reset on another worker — exactly as if the set had happened in an
+    awaited local coroutine.
+    """
+    return _resolve_oracle_var(namespace, name).set(value)
+
+
+@wool.routine
+async def oracle_reset(namespace: str, name: str, token) -> tuple:
+    """Attempt to reset the (*namespace*, *name*) oracle var by *token*.
+
+    Never raises transport-side. Returns
+    ``(outcome_kind, message, value_after)`` where ``outcome_kind`` is
+    ``"ok"``, ``"RuntimeError"``, ``"ValueError"``, or ``"TypeError"``,
+    ``message`` is ``str(exception)`` (empty on success), and
+    ``value_after`` is the variable's current worker-side value or
+    :data:`ORACLE_UNSET` when unbound.
+    """
+    return await _oracle_reset_outcome(namespace, name, token)
+
+
+@wool.routine
+async def oracle_get(namespace: str, name: str, default=None):
+    """Return the (*namespace*, *name*) oracle var's worker-side value.
+
+    Falls back to *default* when the variable is unbound — callers that
+    need to distinguish "unbound" pass a sentinel such as
+    :data:`ORACLE_UNSET`.
+    """
+    return _resolve_oracle_var(namespace, name).get(default)
+
+
+@wool.routine
+async def oracle_set_report(namespace: str, name: str, value) -> tuple:
+    """Set the (*namespace*, *name*) oracle var; return ``(pid, token)``.
+
+    Attributed variant of :func:`oracle_set` — the worker's
+    ``os.getpid()`` rides alongside the minted token so multi-worker
+    tests can attribute each mint to the process that performed it.
+    """
+    return os.getpid(), _resolve_oracle_var(namespace, name).set(value)
+
+
+@wool.routine
+async def oracle_reset_report(namespace: str, name: str, token) -> tuple:
+    """Attempt a (*namespace*, *name*) oracle reset; report with the worker pid.
+
+    Attributed variant of :func:`oracle_reset`: returns
+    ``(pid, outcome_kind, message, value_after)`` so multi-worker tests
+    can attribute the reset attempt to the process that performed it.
+    """
+    return os.getpid(), *await _oracle_reset_outcome(namespace, name, token)
+
+
+@wool.routine
+async def nested_oracle_set(namespace: str, name: str, value):
+    """Mint a (*namespace*, *name*) token on an inner worker via nested dispatch.
+
+    The outer worker dispatches :func:`oracle_set` back into the pool, so
+    the token is minted one hop deeper and rides home through both
+    response frames — the "inner worker mints, caller resets" topology.
+    """
+    return await oracle_set(namespace, name, value)
+
+
+@wool.routine
+async def nested_oracle_set_report(namespace: str, name: str, value) -> tuple:
+    """Nested-mint a (*namespace*, *name*) token; report both worker pids.
+
+    Attributed variant of :func:`nested_oracle_set`: returns
+    ``(outer_pid, inner_pid, token)`` so tests can attribute the mint to
+    the inner process the outer worker dispatched to.
+    """
+    inner_pid, token = await oracle_set_report(namespace, name, value)
+    return os.getpid(), inner_pid, token

--- a/wool/tests/integration/routines.py
+++ b/wool/tests/integration/routines.py
@@ -641,6 +641,196 @@ async def get_tenant_id() -> str:
 
 
 @wool.routine
+async def reset_tenant_id_token(token) -> str:
+    """Reset a caller-minted TENANT_ID token on the worker.
+
+    The token crosses the wire as an argument; resetting it on the worker
+    both restores TENANT_ID (returned for inspection) and records the token
+    as consumed, which the response frame propagates back so the caller's
+    original token also reads as used — cross-process single-use.
+    """
+    TENANT_ID.reset(token)
+    return TENANT_ID.get()
+
+
+@wool.routine
+async def describe_tenant_id_token(token) -> tuple:
+    """Receive a TENANT_ID token without resetting it.
+
+    Exercises lossless token transport: any token — including an orphan
+    minted in a context the worker is not continuing — must cross the wire,
+    reconstitute into a usable object, and travel back, without raising.
+    Returns the token itself alongside its var's name so the caller can
+    assert the reconstituted object is fully usable.
+    """
+    return token, token.var.name
+
+
+async def _reset_and_report(token) -> tuple:
+    """Reset TENANT_ID by *token* and report the outcome as a two-tuple.
+
+    Shared tail for the report-style token routines: ``("ok",
+    restored_value)`` when the reset succeeds, or ``(type_name, message)``
+    when it raises — so a caller can assert the failure without relying on a
+    builtin exception type surviving the wire.
+    """
+    try:
+        TENANT_ID.reset(token)
+    except Exception as error:
+        return type(error).__name__, str(error)
+    return "ok", TENANT_ID.get()
+
+
+@wool.routine
+async def set_tenant_id_and_return_token(value: str):
+    """Set TENANT_ID on the worker and return the minted token.
+
+    The token rides the response frame back to the caller, whose context
+    continues the worker's (the routine was awaited), so the caller may
+    reset it — restoring the pre-call value — exactly as if the set had
+    happened in an awaited local coroutine.
+    """
+    return TENANT_ID.set(value)
+
+
+@wool.routine
+async def reset_tenant_id_token_report(token) -> tuple:
+    """Attempt to reset a TENANT_ID token on the worker and report the outcome.
+
+    Catch-and-report variant of `reset_tenant_id_token` for cases where
+    the reset is expected to fail — the caller asserts on the reported
+    exception type name and message rather than relying on a builtin
+    exception type surviving the wire. Returns ``(pid, "ok", restored_value)``
+    on success or ``(pid, type_name, message)`` on failure.
+    """
+    return os.getpid(), *await _reset_and_report(token)
+
+
+@wool.routine
+async def reset_and_return_tenant_id_token(token):
+    """Reset a caller-minted TENANT_ID token on the worker and return it.
+
+    The token arrives live, is consumed by the reset, and travels back in
+    the return value already marked used — the caller can assert the used
+    state is visible on the returned copy and that resetting either copy
+    raises the single-use RuntimeError.
+    """
+    TENANT_ID.reset(token)
+    return token
+
+
+@wool.routine
+async def mint_orphan_tenant_id_token():
+    """Mint a TENANT_ID token inside a sibling stdlib context on the worker.
+
+    The set runs inside ``contextvars.copy_context().run``, so no live
+    context continues the minting context — the token is an orphan by
+    construction. It travels back in the return value so the caller can
+    assert lossless transport and the different-Context reset failure.
+    """
+    sibling = contextvars.copy_context()
+    return sibling.run(TENANT_ID.set, "worker-sibling")
+
+
+@wool.routine
+async def relay_reset_tenant_id_token(token) -> str:
+    """Relay a TENANT_ID token through a nested dispatch that resets it.
+
+    The token crosses two hops — caller to outer worker, outer worker to
+    inner worker — before `reset_tenant_id_token` consumes it. The
+    consumed state rides each response frame back so the caller's original
+    token also reads as used.
+    """
+    return await reset_tenant_id_token(token)
+
+
+@wool.routine
+async def nested_reset_then_report(token) -> tuple:
+    """Consume a token via nested dispatch, then retry the reset locally.
+
+    The inner dispatch resets the token; its response frame carries the
+    consumed state back one hop, so the outer worker's local retry must
+    fail the single-use gate. Returns ``(inner_value, type_name, message)``
+    on retry failure or ``(inner_value, "ok", current_value)`` if the retry
+    unexpectedly succeeds.
+    """
+    inner = await reset_tenant_id_token(token)
+    return inner, *await _reset_and_report(token)
+
+
+@wool.routine
+async def outer_mint_inner_reset() -> tuple:
+    """Mint a token on the outer worker and consume it via nested dispatch.
+
+    The outer routine sets TENANT_ID, sends the minted token to
+    `reset_tenant_id_token` on an inner worker (an awaited dispatch,
+    so the inner worker continues the minting context), then retries the
+    reset locally. Returns ``(inner_value, type_name, message)`` on retry
+    failure or ``(inner_value, "ok", current_value)`` if the retry
+    unexpectedly succeeds.
+    """
+    token = TENANT_ID.set("outer-mint")
+    inner = await reset_tenant_id_token(token)
+    return inner, *await _reset_and_report(token)
+
+
+@wool.routine
+async def stream_reset_tenant_id_token(token):
+    """Async generator that resets a caller-minted token between yields.
+
+    Yields the pre-reset TENANT_ID value, resets the token, then yields
+    the restored value. The consumed state rides the step frame back to
+    the caller mid-stream, before the generator is exhausted.
+    """
+    yield TENANT_ID.get()
+    TENANT_ID.reset(token)
+    yield TENANT_ID.get()
+
+
+@wool.routine
+async def set_tenant_id_and_yield_token(value: str, count: int):
+    """Async generator that sets TENANT_ID and yields the minted token first.
+
+    After yielding the token, suspends and yields the current TENANT_ID
+    value *count* times. The token's live anchor must survive each
+    per-yield re-mount so the caller can reset it exactly once after
+    exhaustion.
+    """
+    token = TENANT_ID.set(value)
+    yield token
+    for _ in range(count):
+        await asyncio.sleep(0)
+        yield TENANT_ID.get()
+
+
+@wool.routine
+async def stream_reset_token_twice(token):
+    """Async generator that resets the same token before two yields.
+
+    The first reset consumes the token; the second violates single-use and
+    raises before the second yield, surfacing as a mid-stream dispatch
+    error on the caller's ``__anext__``.
+    """
+    TENANT_ID.reset(token)
+    yield "first"
+    TENANT_ID.reset(token)
+    yield "never"
+
+
+@wool.routine
+async def stream_recv_and_reset():
+    """Async generator that receives a token via ``asend`` and resets it.
+
+    Yields ``"ready"``, receives a caller-minted token on the mid-stream
+    ``asend`` frame, resets it, and yields the restored TENANT_ID value.
+    Exercises token transport and consumption on the ``asend`` path.
+    """
+    received = yield "ready"
+    TENANT_ID.reset(received)
+    yield TENANT_ID.get()
+
+
+@wool.routine
 @context_pattern_aware
 async def stream_tenant_id(count: int):
     """Async generator that yields TENANT_ID.get() *count* times.

--- a/wool/tests/integration/routines.py
+++ b/wool/tests/integration/routines.py
@@ -37,6 +37,11 @@ class ContextVarPattern(Enum):
     UPSTREAM_RESET = auto()
     PER_YIELD = auto()
     MID_STREAM_FORWARD = auto()
+    # The caller mints a token and ferries it via _RESET_TOKENS; the worker
+    # consumes it and immediately re-sets the var. The caller then asserts
+    # the stale token stays rejected — the fresh set must not erase the
+    # consumed id from the chain's spent ledger.
+    TOKEN_REMOTE_RESET_THEN_FRESH_SET = auto()
 
 
 # Module-level wool.ContextVars used by the propagation integration tests.
@@ -112,6 +117,16 @@ def _execute_patterns(patterns, *, step=None):
                     var.reset(tokens[var_name])
             case ContextVarPattern.UPSTREAM_RESET:
                 var.set(f"inner-set-{var_name}")
+            case ContextVarPattern.TOKEN_REMOTE_RESET_THEN_FRESH_SET:
+                # Consume the caller-minted token ferried via
+                # _RESET_TOKENS, then immediately re-set the var. The
+                # fresh set must not erase the consumed id from the
+                # spent ledger — the caller asserts its stale copy
+                # still raises after the response merges home.
+                tokens = _RESET_TOKENS.get()
+                if var_name in tokens:
+                    var.reset(tokens[var_name])
+                var.set(f"fresh-{var_name}")
 
 
 def _pre_nested_setup(patterns):

--- a/wool/tests/integration/test_context_var_propagation.py
+++ b/wool/tests/integration/test_context_var_propagation.py
@@ -64,6 +64,142 @@ class TestContextVarPropagation:
         await retry_grpc_internal(body)
 
     @pytest.mark.asyncio
+    async def test_token_reset_on_worker_should_consume_it_for_the_caller(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token reset on a worker is consumed for the caller too.
+
+        Given:
+            A caller-minted TENANT_ID token dispatched to a worker as an
+            argument, where the worker resets it.
+        When:
+            The caller resets the same token after the dispatch returns.
+        Then:
+            It should raise RuntimeError — the worker's reset propagated
+            the consumed state back on the response frame, enforcing
+            single-use across processes.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("acme-corp")
+                observed = await routines.reset_tenant_id_token(token)
+                assert observed == "unknown"
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_orphan_token_should_transport_losslessly_without_raising(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test an orphaned token crosses the wire and back without raising.
+
+        Given:
+            A TENANT_ID token minted inside a sibling stdlib context (via
+            copy_context().run) that the dispatching context does not
+            continue, passed to a routine that inspects but does not reset
+            it.
+        When:
+            The routine is dispatched and the token travels to the worker
+            and back in the return value.
+        Then:
+            No error should surface anywhere in transport, and the returned
+            token should be a usable object naming the original variable —
+            failure is deferred exclusively to a reset attempt, which
+            raises stdlib's different-Context ValueError.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                ambient = routines.TENANT_ID.set("ambient")
+                try:
+                    sibling = contextvars.copy_context()
+                    orphan = sibling.run(routines.TENANT_ID.set, "sibling")
+                    returned, var_name = await routines.describe_tenant_id_token(orphan)
+                    assert var_name == routines.TENANT_ID.name
+                    assert returned.var.name == routines.TENANT_ID.name
+                    with pytest.raises(
+                        ValueError, match="was created in a different Context"
+                    ):
+                        routines.TENANT_ID.reset(returned)
+                finally:
+                    routines.TENANT_ID.reset(ambient)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_orphan_token_reset_on_worker_should_raise_different_context(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker cannot reset a token minted in a sibling context.
+
+        Given:
+            A TENANT_ID token minted inside a sibling stdlib context sharing
+            the dispatching context's chain — so the chain id matches but
+            the minting context is not the one the worker continues.
+        When:
+            A routine dispatched from the ambient context resets the token
+            on the worker.
+        Then:
+            The reset should raise stdlib's "was created in a different
+            Context" ValueError — token ownership follows the exact minting
+            context, not the chain.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                ambient = routines.TENANT_ID.set("ambient")
+                try:
+                    sibling = contextvars.copy_context()
+                    orphan = sibling.run(routines.TENANT_ID.set, "sibling")
+                    _, kind, message = await routines.reset_tenant_id_token_report(
+                        orphan
+                    )
+                    assert kind == "ValueError"
+                    assert "was created in a different Context" in message
+                finally:
+                    routines.TENANT_ID.reset(ambient)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_minted_token_should_be_resettable_by_the_caller(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token minted on a worker resets in the awaiting caller.
+
+        Given:
+            A routine that sets TENANT_ID on the worker and returns the
+            minted token to the awaiting caller.
+        When:
+            The caller resets the returned token.
+        Then:
+            The set should have propagated back to the caller (awaited
+            dispatch continues the caller's context), and the reset should
+            succeed there, restoring the pre-call default — stdlib parity
+            with an awaited local coroutine performing the same set.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = await routines.set_tenant_id_and_return_token("worker-set")
+                assert routines.TENANT_ID.get() == "worker-set"
+                routines.TENANT_ID.reset(token)
+                assert routines.TENANT_ID.get() == "unknown"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
     async def test_async_generator_dispatch_should_propagate_wool_context_var(
         self, credentials_map, retry_grpc_internal
     ):
@@ -2353,5 +2489,801 @@ class TestProxyCollisionAcrossDispatch:
                 gen = routines.stream_proxy_collision_in_shared_context()
                 collected = [value async for value in gen]
             assert collected == ["ready", "task"]
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestTokenSingleUseAcrossProcesses:
+    @pytest.mark.asyncio
+    async def test_second_reset_on_worker_should_report_used_token(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token consumed on a worker refuses a second worker reset.
+
+        Given:
+            A caller-minted TENANT_ID token already consumed by a
+            dispatched reset on a DEFAULT pool.
+        When:
+            The caller dispatches a second reset attempt of the same
+            token via the catch-and-report routine.
+        Then:
+            It should report RuntimeError with the single-use message,
+            and the caller's own local reset should raise the same
+            RuntimeError — the consumed state is authoritative on both
+            sides of the wire.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("acme-corp")
+                observed = await routines.reset_tenant_id_token(token)
+                assert observed == "unknown"
+                _, kind, message = await routines.reset_tenant_id_token_report(token)
+                assert kind == "RuntimeError"
+                assert "has already been used once" in message
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_caller_consumed_token_dispatched_should_report_used_gate_first(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a locally consumed token fails the used gate on the worker.
+
+        Given:
+            A caller that mints a TENANT_ID token and consumes it with a
+            successful LOCAL reset before any dispatch.
+        When:
+            The caller dispatches the catch-and-report reset routine
+            with the consumed token.
+        Then:
+            It should report RuntimeError — not ValueError — proving the
+            used gate fires before the context gate on the receiving
+            side of the wire.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("acme-corp")
+                routines.TENANT_ID.reset(token)
+                assert routines.TENANT_ID.get() == "unknown"
+                _, kind, message = await routines.reset_tenant_id_token_report(token)
+                assert kind == "RuntimeError"
+                assert kind != "ValueError"
+                assert "has already been used once" in message
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_consumed_token_relayed_between_workers_should_report_used(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the consumption ledger reaches a worker that never saw the reset.
+
+        Given:
+            An EPHEMERAL pool with two workers and a TENANT_ID token
+            consumed by a dispatched reset that reported one worker pid.
+        When:
+            The caller dispatches the report routine repeatedly (up to
+            eight times) so at least one dispatch is likely to land on
+            the other worker process.
+        Then:
+            Every post-consumption dispatch should report RuntimeError
+            with the single-use message — the ledger rides every frame in
+            both directions, so a worker that never performed the reset
+            still refuses the token.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(pool_mode=PoolMode.EPHEMERAL)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("acme-corp")
+                first_pid, first_kind, _ = await routines.reset_tenant_id_token_report(
+                    token
+                )
+                assert first_kind == "ok"
+                # Round-robin over the two-worker pool reaches the other
+                # worker within a few dispatches; keep dispatching until a
+                # different pid confirms the cross-worker relay was exercised.
+                observed_other_pid = False
+                for _ in range(8):
+                    pid, kind, message = await routines.reset_tenant_id_token_report(
+                        token
+                    )
+                    assert kind == "RuntimeError"
+                    assert "has already been used once" in message
+                    if pid != first_pid:
+                        observed_other_pid = True
+                        break
+                assert observed_other_pid, (
+                    "the report never landed on a second worker, so the "
+                    "cross-worker ledger relay was not exercised"
+                )
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_returned_used_token_should_carry_used_state_to_caller(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token reset on the worker returns visibly used.
+
+        Given:
+            A caller-minted TENANT_ID token dispatched to a routine that
+            resets it and returns the token itself.
+        When:
+            The caller inspects the returned token and attempts to reset
+            both the returned copy and the original.
+        Then:
+            The returned token's repr should carry the ``used`` marker,
+            and both reset attempts should raise the single-use
+            RuntimeError — every copy anywhere reads as consumed.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("acme-corp")
+                returned = await routines.reset_and_return_tenant_id_token(token)
+                assert "used " in repr(returned)
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(returned)
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_re_set_after_remote_consumption_should_mint_fresh_token(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the var stays fully usable after a token is consumed remotely.
+
+        Given:
+            A TENANT_ID token consumed by a dispatched reset, then a
+            fresh caller-side set minting a second token.
+        When:
+            The caller dispatches a reset of the second token and then
+            retries it locally.
+        Then:
+            The remote reset should succeed (restoring the default), the
+            local retry should raise the single-use RuntimeError —
+            consumption is per-token, not per-var — and the first token
+            should stay consumed: its remote use survives the fresh set,
+            so a local reset of it must also raise the single-use
+            RuntimeError.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token1 = routines.TENANT_ID.set("first")
+                await routines.reset_tenant_id_token(token1)
+                token2 = routines.TENANT_ID.set("fresh")
+                observed = await routines.reset_tenant_id_token(token2)
+                assert observed == "unknown"
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token2)
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token1)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_used_token_transport_should_be_lossless(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a consumed token still crosses the wire without raising.
+
+        Given:
+            A TENANT_ID token consumed by a dispatched reset on a
+            DEFAULT pool.
+        When:
+            The caller passes the used token to a routine that inspects
+            it without resetting and returns it.
+        Then:
+            No error should surface in transport, the returned token
+            should be a usable object naming the original variable, and
+            a caller reset of the returned copy should raise the
+            single-use RuntimeError.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("acme-corp")
+                await routines.reset_tenant_id_token(token)
+                returned, var_name = await routines.describe_tenant_id_token(token)
+                assert var_name == routines.TENANT_ID.name
+                assert returned.var.name == routines.TENANT_ID.name
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(returned)
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestTokenOwnershipTopologies:
+    @pytest.mark.asyncio
+    async def test_create_task_child_dispatch_should_report_different_context(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token dispatched from a child task arrives orphaned.
+
+        Given:
+            A parent-minted TENANT_ID token and an asyncio child task
+            created via ``create_task`` that dispatches the
+            catch-and-report reset routine with it — the fork drops the
+            chain's live token ids.
+        When:
+            The child's dispatch reports and the parent then resets the
+            token locally.
+        Then:
+            The worker should report stdlib's different-Context
+            ValueError, and the parent's local reset should still
+            succeed afterward — the failed remote attempt did not
+            consume the token.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("parent-mint")
+
+                async def _child():
+                    return await routines.reset_tenant_id_token_report(token)
+
+                _, kind, message = await asyncio.create_task(_child())
+                assert kind == "ValueError"
+                assert "was created in a different Context" in message
+                routines.TENANT_ID.reset(token)
+                assert routines.TENANT_ID.get() == "unknown"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_unarmed_dispatcher_sibling_token_should_report_different_context(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test an orphan token from a never-armed dispatcher stays an orphan.
+
+        Given:
+            A dispatching task that never sets any wool var and a
+            TENANT_ID token minted inside a stdlib ``copy_context``
+            sibling.
+        When:
+            The caller dispatches the describe routine and then the
+            catch-and-report reset routine with the orphan.
+        Then:
+            Transport should succeed, the reset should report stdlib's
+            different-Context ValueError, and a subsequent dispatch of
+            ``get_tenant_id`` should still observe the default — the
+            sibling's set never leaked into the dispatching context.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                sibling = contextvars.copy_context()
+                orphan = sibling.run(routines.TENANT_ID.set, "sibling-mint")
+                returned, var_name = await routines.describe_tenant_id_token(orphan)
+                assert var_name == routines.TENANT_ID.name
+                assert returned.var.name == routines.TENANT_ID.name
+                _, kind, message = await routines.reset_tenant_id_token_report(orphan)
+                assert kind == "ValueError"
+                assert "was created in a different Context" in message
+                assert await routines.get_tenant_id() == "unknown"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_twice_travelled_orphan_should_stay_usable(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test an orphan token survives two round trips unchanged.
+
+        Given:
+            A TENANT_ID token minted in a stdlib ``copy_context``
+            sibling and already round-tripped once through the describe
+            routine.
+        When:
+            The returned token is dispatched through the describe
+            routine a second time and the caller finally resets the
+            twice-travelled copy.
+        Then:
+            Both trips should transport losslessly, and the final reset
+            should raise stdlib's different-Context ValueError — orphan
+            state is preserved, never corrupted or upgraded, across
+            repeated travel.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                ambient = routines.TENANT_ID.set("ambient")
+                try:
+                    sibling = contextvars.copy_context()
+                    orphan = sibling.run(routines.TENANT_ID.set, "sibling")
+                    first, _ = await routines.describe_tenant_id_token(orphan)
+                    second, var_name = await routines.describe_tenant_id_token(first)
+                    assert var_name == routines.TENANT_ID.name
+                    assert second.var.name == routines.TENANT_ID.name
+                    with pytest.raises(
+                        ValueError, match="was created in a different Context"
+                    ):
+                        routines.TENANT_ID.reset(second)
+                finally:
+                    routines.TENANT_ID.reset(ambient)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_minted_orphan_should_refuse_caller_reset(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker-minted sibling token cannot be reset by the caller.
+
+        Given:
+            A routine that mints a TENANT_ID token inside a stdlib
+            ``copy_context`` sibling on the worker and returns it.
+        When:
+            The caller attempts to reset the returned token.
+        Then:
+            It should raise stdlib's different-Context ValueError, and
+            the caller's own TENANT_ID should be unchanged — the
+            sibling-scoped set never back-propagated.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                before = routines.TENANT_ID.get()
+                orphan = await routines.mint_orphan_tenant_id_token()
+                with pytest.raises(
+                    ValueError, match="was created in a different Context"
+                ):
+                    routines.TENANT_ID.reset(orphan)
+                assert routines.TENANT_ID.get() == before
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_gather_sibling_dispatches_should_orphan_token_for_both(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test gathered sibling dispatches both see the token as orphaned.
+
+        Given:
+            An EPHEMERAL pool, a caller-minted TENANT_ID token, and two
+            reset-report dispatches gathered concurrently — each gather
+            member runs in a forked child task whose chain drops live
+            token ids.
+        When:
+            Both siblings report, then the minting task itself awaits a
+            direct reset dispatch and finally retries locally.
+        Then:
+            Both siblings should report the different-Context
+            ValueError without consuming the token, the direct awaited
+            dispatch should succeed (continuation of the minting
+            context), and the final local reset should raise the
+            single-use RuntimeError.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(pool_mode=PoolMode.EPHEMERAL)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("gather-mint")
+                reports = await asyncio.gather(
+                    routines.reset_tenant_id_token_report(token),
+                    routines.reset_tenant_id_token_report(token),
+                )
+                for _, kind, message in reports:
+                    assert kind == "ValueError"
+                    assert "was created in a different Context" in message
+                observed = await routines.reset_tenant_id_token(token)
+                assert observed == "unknown"
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_mint_with_armed_caller_should_restore_pre_call_value(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test resetting a worker-minted token restores the caller's own value.
+
+        Given:
+            A caller that armed TENANT_ID with its own value before
+            dispatching a routine that sets the var on the worker and
+            returns the minted token.
+        When:
+            The caller resets the returned token.
+        Then:
+            The var should restore to the caller's pre-call value — not
+            the constructor default — because the worker's token
+            captured the propagated caller binding as its old value.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                pre_token = routines.TENANT_ID.set("caller-pre")
+                try:
+                    returned = await routines.set_tenant_id_and_return_token(
+                        "worker-set"
+                    )
+                    assert routines.TENANT_ID.get() == "worker-set"
+                    routines.TENANT_ID.reset(returned)
+                    assert routines.TENANT_ID.get() == "caller-pre"
+                finally:
+                    routines.TENANT_ID.reset(pre_token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_minted_token_reset_from_child_task_should_raise(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a child task cannot reset a token owned by the parent's context.
+
+        Given:
+            A token minted on the worker and returned to the awaiting
+            caller (whose context continues the minting context), and an
+            asyncio child task created via ``create_task``.
+        When:
+            The child performs a LOCAL reset of the token, then the
+            parent resets it after the child completes.
+        Then:
+            The child's reset should raise stdlib's different-Context
+            ValueError (the fork drops live ids), and the parent's reset
+            should succeed, restoring the default.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                returned = await routines.set_tenant_id_and_return_token("worker-set")
+                assert routines.TENANT_ID.get() == "worker-set"
+
+                async def _child():
+                    with pytest.raises(
+                        ValueError, match="was created in a different Context"
+                    ):
+                        routines.TENANT_ID.reset(returned)
+                    return True
+
+                assert await asyncio.create_task(_child())
+                routines.TENANT_ID.reset(returned)
+                assert routines.TENANT_ID.get() == "unknown"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_sequential_worker_mints_should_reset_independent_old_values(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test two worker-minted tokens restore their own captured old values.
+
+        Given:
+            Two sequential dispatches that each set TENANT_ID on the
+            worker ("first" then "second") and return their minted
+            tokens, plus an inline stdlib contextvars baseline computing
+            the same set/set/reset/reset sequence.
+        When:
+            The caller resets the first token, reads the var, resets the
+            second token, and reads again.
+        Then:
+            Each token should restore its own captured old value —
+            resetting token1 restores the pre-call state, resetting
+            token2 restores "first" — matching the stdlib baseline
+            exactly, with the final read equal to "first".
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            # Inline stdlib baseline for the same FIFO reset order.
+            baseline_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+                "fifo_baseline", default="unknown"
+            )
+            baseline_token1 = baseline_var.set("first")
+            baseline_token2 = baseline_var.set("second")
+            baseline_var.reset(baseline_token1)
+            baseline_after_first = baseline_var.get()
+            baseline_var.reset(baseline_token2)
+            baseline_final = baseline_var.get()
+
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token1 = await routines.set_tenant_id_and_return_token("first")
+                token2 = await routines.set_tenant_id_and_return_token("second")
+                assert routines.TENANT_ID.get() == "second"
+                routines.TENANT_ID.reset(token1)
+                after_first = routines.TENANT_ID.get()
+                routines.TENANT_ID.reset(token2)
+                final = routines.TENANT_ID.get()
+
+            assert after_first == baseline_after_first == "unknown"
+            assert final == baseline_final == "first"
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestTokenNestedDispatch:
+    @pytest.mark.asyncio
+    async def test_relay_reset_should_restore_and_consume_for_caller(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token consumed two hops away restores and consumes for the caller.
+
+        Given:
+            An EPHEMERAL pool with two workers and a caller-minted
+            TENANT_ID token dispatched through a relay routine that
+            nested-dispatches the actual reset.
+        When:
+            The relay returns and the caller reads its own var and then
+            retries the reset locally.
+        Then:
+            The relay should return the restored default, the caller
+            should observe the restored value, and the local retry
+            should raise the single-use RuntimeError — the consumed
+            state crossed both hops back.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(pool_mode=PoolMode.EPHEMERAL)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("relay-mint")
+                observed = await routines.relay_reset_tenant_id_token(token)
+                assert observed == "unknown"
+                assert routines.TENANT_ID.get() == "unknown"
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_nested_reset_then_outer_retry_should_report_used_token(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the ledger rides the inner response frame back to the outer worker.
+
+        Given:
+            A caller-minted TENANT_ID token dispatched to a routine that
+            consumes it via a nested dispatch and then retries the reset
+            locally on the outer worker.
+        When:
+            The routine returns its report and the caller retries the
+            reset locally.
+        Then:
+            The inner reset should have restored the default, the outer
+            retry should report the single-use RuntimeError (the ledger
+            rode the inner response frame back one hop), and the
+            caller's own retry should raise the same RuntimeError.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("nested-mint")
+                inner, kind, message = await routines.nested_reset_then_report(token)
+                assert inner == "unknown"
+                assert kind == "RuntimeError"
+                assert "already been used once" in message
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_outer_mint_inner_reset_should_consume_for_the_outer_worker(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker-minted token consumed downstream reads used upstream.
+
+        Given:
+            A routine that mints a TENANT_ID token on the outer worker,
+            has an awaited nested dispatch consume it, and then retries
+            the reset locally.
+        When:
+            The caller dispatches the routine and reads its own var
+            afterward.
+        Then:
+            The inner dispatch should observe the restored default, the
+            outer retry should report the single-use RuntimeError, and
+            the caller's TENANT_ID should be unchanged — the mint and
+            reset cancelled out before back-propagation.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                before = routines.TENANT_ID.get()
+                inner, kind, message = await routines.outer_mint_inner_reset()
+                assert inner == "unknown"
+                assert kind == "RuntimeError"
+                assert "already been used once" in message
+                assert routines.TENANT_ID.get() == before
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestTokenStreaming:
+    @pytest.mark.asyncio
+    async def test_stream_reset_should_consume_the_token_mid_stream(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a mid-stream reset consumes the caller's token before exhaustion.
+
+        Given:
+            A caller-minted TENANT_ID token passed to an async-generator
+            routine that yields the current value, resets the token, and
+            yields the restored value.
+        When:
+            The caller drives the first two yields and attempts a local
+            reset before exhausting the generator.
+        Then:
+            The first yield should observe the caller's value, the
+            second the restored default, and the local reset should
+            already raise the single-use RuntimeError — the ledger rode
+            the step frame back mid-stream.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("caller-set")
+                gen = routines.stream_reset_tenant_id_token(token)
+                try:
+                    first = await gen.__anext__()
+                    assert first == "caller-set"
+                    second = await gen.__anext__()
+                    assert second == "unknown"
+                    with pytest.raises(RuntimeError, match="already been used once"):
+                        routines.TENANT_ID.reset(token)
+                    with pytest.raises(StopAsyncIteration):
+                        await gen.__anext__()
+                finally:
+                    await gen.aclose()
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_token_yielded_mid_stream_should_survive_remounts_once(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker-minted token yielded early stays resettable exactly once.
+
+        Given:
+            An async-generator routine that sets TENANT_ID, yields the
+            minted token on its first yield, and yields the current
+            value three more times across suspensions.
+        When:
+            The caller collects the token, exhausts the stream, resets
+            the token, and retries the reset.
+        Then:
+            After exhaustion the caller should observe the worker-set
+            value, the first reset should succeed restoring the default,
+            and the retry should raise the single-use RuntimeError — the
+            token's anchor survived every per-yield re-mount exactly
+            once.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                gen = routines.set_tenant_id_and_yield_token("stream-set", 3)
+                try:
+                    token = await gen.__anext__()
+                    async for _ in gen:
+                        pass
+                finally:
+                    await gen.aclose()
+                assert routines.TENANT_ID.get() == "stream-set"
+                routines.TENANT_ID.reset(token)
+                assert routines.TENANT_ID.get() == "unknown"
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_stream_double_reset_should_raise_on_the_second_step(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a second reset of the same token inside a stream raises mid-stream.
+
+        Given:
+            A caller-minted TENANT_ID token passed to an async-generator
+            routine that resets it before each of two yields.
+        When:
+            The caller drives the first yield and then requests the
+            second.
+        Then:
+            The first yield should arrive with the caller observing the
+            restored default, and the second ``__anext__`` should raise
+            the single-use RuntimeError surfaced from the worker's
+            in-stream violation.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("twice-mint")
+                gen = routines.stream_reset_token_twice(token)
+                try:
+                    first = await gen.__anext__()
+                    assert first == "first"
+                    assert routines.TENANT_ID.get() == "unknown"
+                    with pytest.raises(RuntimeError, match="already been used once"):
+                        await gen.__anext__()
+                finally:
+                    await gen.aclose()
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_token_sent_via_asend_should_reset_on_the_worker(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token shipped on an asend frame resets and consumes correctly.
+
+        Given:
+            An async-generator routine that yields ``"ready"``, receives
+            a token via ``asend``, resets it, and yields the restored
+            value — with the caller minting the token only after the
+            stream is already open.
+        When:
+            The caller sends the token mid-stream and reads its own var
+            after the echo.
+        Then:
+            The echoed value should be the restored default, the caller
+            should observe the restored value, and a local reset should
+            raise the single-use RuntimeError — the asend frame carried
+            the live token out and the ledger rode the step frame back.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ASEND)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                gen = routines.stream_recv_and_reset()
+                try:
+                    ready = await gen.__anext__()
+                    assert ready == "ready"
+                    token = routines.TENANT_ID.set("mid")
+                    echoed = await gen.asend(token)
+                    assert echoed == "unknown"
+                    assert routines.TENANT_ID.get() == "unknown"
+                    with pytest.raises(RuntimeError, match="already been used once"):
+                        routines.TENANT_ID.reset(token)
+                finally:
+                    await gen.aclose()
 
         await retry_grpc_internal(body)

--- a/wool/tests/integration/test_integration.py
+++ b/wool/tests/integration/test_integration.py
@@ -58,9 +58,7 @@ def test_pairwise_scenarios_cover_all_discovery_members():
 @pytest.mark.integration
 @pytest.mark.asyncio
 @pytest.mark.parametrize("scenario", PAIRWISE_SCENARIOS, ids=str)
-async def test_dispatch_pairwise(
-    scenario, credentials_map, retry_grpc_internal, xfail_known_bugs
-):
+async def test_dispatch_pairwise(scenario, credentials_map, retry_grpc_internal):
     """Test routine dispatch across pairwise scenario combinations.
 
     Given:
@@ -87,10 +85,7 @@ async def test_dispatch_pairwise(
                 isolated = contextvars.copy_context()
                 await asyncio.create_task(invoke_routine(scenario), context=isolated)
 
-    async def guarded():
-        await retry_grpc_internal(body)
-
-    await xfail_known_bugs(scenario, guarded)
+    await retry_grpc_internal(body)
 
 
 @pytest.mark.integration
@@ -158,9 +153,7 @@ async def test_dispatch_pairwise(
     )
 )
 @given(scenario=scenarios_strategy())
-async def test_dispatch_hypothesis(
-    scenario, credentials_map, retry_grpc_internal, xfail_known_bugs
-):
+async def test_dispatch_hypothesis(scenario, credentials_map, retry_grpc_internal):
     """Test routine dispatch with Hypothesis-generated scenarios.
 
     Given:
@@ -181,10 +174,7 @@ async def test_dispatch_hypothesis(
                 isolated = contextvars.copy_context()
                 await asyncio.create_task(invoke_routine(scenario), context=isolated)
 
-    async def guarded():
-        await retry_grpc_internal(body)
-
-    await xfail_known_bugs(scenario, guarded)
+    await retry_grpc_internal(body)
 
 
 @pytest.mark.integration

--- a/wool/tests/integration/test_token_ops_model.py
+++ b/wool/tests/integration/test_token_ops_model.py
@@ -1,0 +1,465 @@
+"""Unit tests for the token-parity op-script model (``_token_ops``).
+
+Fast, pool-free tests that validate the script model and the stdlib
+oracle executor before the wire-facing suites build on them, plus one
+end-to-end smoke test proving ``run_wool_script`` matches
+``run_stdlib_oracle`` across a real worker pool.
+"""
+
+import dataclasses
+
+import pytest
+from hypothesis import given
+from hypothesis import settings
+
+import wool
+from tests.helpers import _unique
+
+from ._token_ops import CALLER
+from ._token_ops import UNSET
+from ._token_ops import WORKER
+from ._token_ops import GetOp
+from ._token_ops import Observation
+from ._token_ops import ResetOp
+from ._token_ops import SetOp
+from ._token_ops import describe_mismatch
+from ._token_ops import observations_match
+from ._token_ops import run_stdlib_oracle
+from ._token_ops import run_wool_script
+from ._token_ops import scripts
+from .conftest import build_pool_from_scenario
+from .conftest import default_scenario
+
+
+class TestOpModel:
+    def test___init___should_expose_actor_and_payload_fields(self):
+        """Test the op dataclasses expose their actor and payload fields.
+
+        Given:
+            One op of each kind constructed with an actor and its
+            payload.
+        When:
+            The fields are read back.
+        Then:
+            It should expose actor/value/token_index as constructed.
+        """
+        # Arrange & act
+        set_op = SetOp(CALLER, "v")
+        reset_op = ResetOp(WORKER, 3)
+        get_op = GetOp(CALLER)
+
+        # Assert
+        assert (set_op.actor, set_op.value) == (CALLER, "v")
+        assert (reset_op.actor, reset_op.token_index) == (WORKER, 3)
+        assert get_op.actor == CALLER
+
+    def test___post_init___should_raise_value_error_when_actor_unknown(self):
+        """Test op construction rejects actors outside the caller/worker pair.
+
+        Given:
+            An actor string that is neither "caller" nor "worker".
+        When:
+            A SetOp is constructed with it.
+        Then:
+            It should raise ValueError naming the accepted actors.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="actor must be one of"):
+            SetOp("elsewhere", 1)
+
+    def test___eq___should_compare_equal_when_fields_match(self):
+        """Test the op dataclasses compare by field value.
+
+        Given:
+            Ops of the same kind, one built with matching fields and one
+            with a differing field.
+        When:
+            They are compared for equality and inequality.
+        Then:
+            It should compare equal on identical field values and
+            unequal once a field differs.
+        """
+        # Arrange & act
+        set_op = SetOp(CALLER, "v")
+        reset_op = ResetOp(WORKER, 3)
+
+        # Assert
+        assert set_op == SetOp(CALLER, "v")
+        assert reset_op != ResetOp(CALLER, 3)
+
+    def test___setattr___should_reject_field_mutation_when_frozen(self):
+        """Test the op dataclasses are immutable.
+
+        Given:
+            A constructed SetOp.
+        When:
+            Its value field is assigned.
+        Then:
+            It should raise FrozenInstanceError.
+        """
+        # Arrange
+        op = SetOp(CALLER, 1)
+
+        # Act & assert
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            op.value = 2  # type: ignore[misc]
+
+
+def test_run_stdlib_oracle_should_restore_prior_values_when_resets_are_lifo():
+    """Test the stdlib oracle unwinds LIFO resets while ignoring actor tags.
+
+    Given:
+        A script that sets twice (once tagged caller, once worker),
+        resets the tokens in LIFO order, then reads.
+    When:
+        run_stdlib_oracle executes the script.
+    Then:
+        It should restore each token's captured old value in turn and
+        end unset — actor tags changing nothing since every op is
+        local.
+    """
+    # Arrange
+    script = [
+        SetOp(CALLER, "a"),
+        SetOp(WORKER, "b"),
+        ResetOp(WORKER, 1),
+        ResetOp(CALLER, 0),
+        GetOp(CALLER),
+    ]
+
+    # Act
+    observations = run_stdlib_oracle(script)
+
+    # Assert
+    assert observations == [
+        Observation("set", "a", None),
+        Observation("set", "b", None),
+        Observation("reset", "a", None),
+        Observation("reset", UNSET, None),
+        Observation("get", UNSET, None),
+    ]
+
+
+def test_run_stdlib_oracle_should_apply_captured_old_values_when_resets_out_of_order():
+    """Test out-of-order resets restore each token's own captured old value.
+
+    Given:
+        A script that sets "a" then "b", resets the FIRST token, reads,
+        then resets the second token.
+    When:
+        run_stdlib_oracle executes the script.
+    Then:
+        It should unset the variable on the first reset (the first
+        token captured no prior value) and restore "a" on the second —
+        stdlib tokens restore their mint-time snapshot, not a stack.
+    """
+    # Arrange
+    script = [
+        SetOp(CALLER, "a"),
+        SetOp(CALLER, "b"),
+        ResetOp(CALLER, 0),
+        GetOp(CALLER),
+        ResetOp(CALLER, 1),
+    ]
+
+    # Act
+    observations = run_stdlib_oracle(script)
+
+    # Assert
+    assert observations == [
+        Observation("set", "a", None),
+        Observation("set", "b", None),
+        Observation("reset", UNSET, None),
+        Observation("get", UNSET, None),
+        Observation("reset", "a", None),
+    ]
+
+
+def test_run_stdlib_oracle_should_report_runtime_error_when_token_reused():
+    """Test a double reset records the single-use RuntimeError.
+
+    Given:
+        A script that sets once, then resets the same token twice.
+    When:
+        run_stdlib_oracle executes the script.
+    Then:
+        It should record a clean first reset and a "RuntimeError"
+        observation for the second, with the value left unchanged.
+    """
+    # Arrange
+    script = [SetOp(CALLER, 1), ResetOp(CALLER, 0), ResetOp(CALLER, 0)]
+
+    # Act
+    observations = run_stdlib_oracle(script)
+
+    # Assert
+    assert observations == [
+        Observation("set", 1, None),
+        Observation("reset", UNSET, None),
+        Observation("reset", UNSET, "RuntimeError"),
+    ]
+
+
+def test_run_stdlib_oracle_should_track_new_sets_between_resets():
+    """Test a set interleaved between resets mints an independently valid token.
+
+    Given:
+        A script that sets 1 and 2, resets the second token, sets 3,
+        resets the first token, then reads.
+    When:
+        run_stdlib_oracle executes the script.
+    Then:
+        It should restore 1 from the second token, apply the new set of
+        3, then unset the variable via the first token's empty
+        snapshot.
+    """
+    # Arrange
+    script = [
+        SetOp(CALLER, 1),
+        SetOp(CALLER, 2),
+        ResetOp(CALLER, 1),
+        SetOp(CALLER, 3),
+        ResetOp(CALLER, 0),
+        GetOp(CALLER),
+    ]
+
+    # Act
+    observations = run_stdlib_oracle(script)
+
+    # Assert
+    assert observations == [
+        Observation("set", 1, None),
+        Observation("set", 2, None),
+        Observation("reset", 1, None),
+        Observation("set", 3, None),
+        Observation("reset", UNSET, None),
+        Observation("get", UNSET, None),
+    ]
+
+
+def test_run_stdlib_oracle_should_noop_when_reset_precedes_any_set():
+    """Test a reset drawn before any set observes without acting.
+
+    Given:
+        A script whose first op is a reset (no token minted yet)
+        followed by a read.
+    When:
+        run_stdlib_oracle executes the script.
+    Then:
+        It should record the reset as an error-free no-op observation
+        and leave the variable unset.
+    """
+    # Arrange
+    script = [ResetOp(CALLER, 4), GetOp(CALLER)]
+
+    # Act
+    observations = run_stdlib_oracle(script)
+
+    # Assert
+    assert observations == [
+        Observation("reset", UNSET, None),
+        Observation("get", UNSET, None),
+    ]
+
+
+def test_run_stdlib_oracle_should_return_unset_sentinel_when_get_on_unbound_var():
+    """Test a get on a never-set variable records the UNSET sentinel.
+
+    Given:
+        A script containing only a worker-tagged get.
+    When:
+        run_stdlib_oracle executes the script.
+    Then:
+        It should record a single error-free observation whose value is
+        the UNSET sentinel.
+    """
+    # Act
+    observations = run_stdlib_oracle([GetOp(WORKER)])
+
+    # Assert
+    assert observations == [Observation("get", UNSET, None)]
+
+
+def test_run_stdlib_oracle_should_normalize_token_index_when_out_of_range():
+    """Test an out-of-range token index wraps modulo the minted-token count.
+
+    Given:
+        A script with two sets and a reset whose index exceeds the
+        token list length.
+    When:
+        run_stdlib_oracle executes the script.
+    Then:
+        It should reset the token at index 7 % 2 == 1, restoring "a".
+    """
+    # Arrange
+    script = [SetOp(CALLER, "a"), SetOp(CALLER, "b"), ResetOp(CALLER, 7)]
+
+    # Act
+    observations = run_stdlib_oracle(script)
+
+    # Assert
+    assert observations[-1] == Observation("reset", "a", None)
+
+
+def test_run_stdlib_oracle_should_match_hand_computed_trace_when_ops_mixed():
+    """Test the stdlib oracle reproduces a fully hand-computed nontrivial trace.
+
+    Given:
+        A seven-op script mixing sets, an out-of-order reset, a
+        double-reset rejection, a set after an unset, a late reset of a
+        stale token, and a final read.
+    When:
+        run_stdlib_oracle executes the script.
+    Then:
+        It should equal the observation trace computed by hand from
+        stdlib contextvars semantics, op by op.
+    """
+    # Arrange
+    script = [
+        SetOp(CALLER, "a"),
+        SetOp(WORKER, "b"),
+        ResetOp(WORKER, 0),
+        ResetOp(CALLER, 0),
+        SetOp(CALLER, "c"),
+        ResetOp(WORKER, 1),
+        GetOp(CALLER),
+    ]
+
+    # Act
+    observations = run_stdlib_oracle(script)
+
+    # Assert
+    assert observations == [
+        Observation("set", "a", None),
+        Observation("set", "b", None),
+        Observation("reset", UNSET, None),
+        Observation("reset", UNSET, "RuntimeError"),
+        Observation("set", "c", None),
+        Observation("reset", "a", None),
+        Observation("get", "a", None),
+    ]
+
+
+@given(script=scripts())
+@settings(max_examples=50, deadline=None)
+def test_run_stdlib_oracle_should_return_one_observation_per_op(script):
+    """Test the stdlib oracle is total over the drawn script space.
+
+    Given:
+        Any script of up to twelve set/reset/get ops over both actors,
+        with int/str values and arbitrary token indexes.
+    When:
+        run_stdlib_oracle executes the script.
+    Then:
+        It should never raise and return exactly one Observation per
+        op, with errors reported only on reset observations.
+    """
+    # Act
+    observations = run_stdlib_oracle(script)
+
+    # Assert
+    assert len(observations) == len(script)
+    assert all(isinstance(entry, Observation) for entry in observations)
+    assert all(entry.error is None for entry in observations if entry.kind != "reset")
+
+
+def test_observations_match_should_return_true_when_traces_identical():
+    """Test the comparator accepts equal traces from either executor shape.
+
+    Given:
+        Two independently built but field-equal observation lists.
+    When:
+        observations_match compares them.
+    Then:
+        It should return True.
+    """
+    # Arrange
+    left = [Observation("set", 1, None), Observation("reset", UNSET, None)]
+    right = [Observation("set", 1, None), Observation("reset", UNSET, None)]
+
+    # Act & assert
+    assert observations_match(left, right)
+
+
+def test_observations_match_should_return_false_when_traces_diverge():
+    """Test the comparator rejects traces that differ in any entry.
+
+    Given:
+        Two observation lists equal except for one divergent entry.
+    When:
+        observations_match compares them.
+    Then:
+        It should return False.
+    """
+    # Arrange
+    left = [Observation("set", 1, None), Observation("reset", UNSET, None)]
+    diverged = [Observation("set", 1, None), Observation("reset", 1, None)]
+
+    # Act & assert
+    assert not observations_match(left, diverged)
+
+
+def test_describe_mismatch_should_flag_divergent_rows():
+    """Test the diff helper marks exactly the rows that diverge.
+
+    Given:
+        Two traces equal at index 0 and divergent at index 1.
+    When:
+        describe_mismatch renders them.
+    Then:
+        It should flag the divergent row with "!!" and leave the equal
+        row unflagged.
+    """
+    # Arrange
+    left = [Observation("set", 1, None), Observation("get", 1, None)]
+    right = [Observation("set", 1, None), Observation("get", 2, None)]
+
+    # Act
+    rendered = describe_mismatch(left, right)
+
+    # Assert
+    lines = rendered.splitlines()
+    assert lines[1].startswith("  ")
+    assert lines[2].startswith("!! [1]")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_run_wool_script_should_match_stdlib_oracle_when_ops_span_the_wire(
+    credentials_map, retry_grpc_internal
+):
+    """Test the wire executor reproduces the stdlib oracle trace end-to-end.
+
+    Given:
+        A DEFAULT pool of real worker subprocesses and a fixed script
+        mixing caller-side and worker-side set/reset/get ops against a
+        fresh wool.ContextVar.
+    When:
+        The script runs through run_wool_script and, separately,
+        through run_stdlib_oracle.
+    Then:
+        It should produce identical observation traces — location
+        transparency holds across the dispatch boundary.
+    """
+
+    # Arrange, act, & assert
+    async def body():
+        script = [
+            SetOp(CALLER, "caller-value"),
+            SetOp(WORKER, "worker-value"),
+            ResetOp(WORKER, 1),
+            ResetOp(CALLER, 0),
+            GetOp(CALLER),
+        ]
+        scenario = default_scenario()
+        async with build_pool_from_scenario(scenario, credentials_map):
+            var: wool.ContextVar[str] = wool.ContextVar(
+                _unique("token_ops_smoke"), namespace=_unique("token_ops_ns")
+            )
+            wool_observations = await run_wool_script(script, var)
+        stdlib_observations = run_stdlib_oracle(script)
+        assert observations_match(wool_observations, stdlib_observations), (
+            describe_mismatch(wool_observations, stdlib_observations)
+        )
+
+    await retry_grpc_internal(body)

--- a/wool/tests/integration/test_token_parity_caller_mints.py
+++ b/wool/tests/integration/test_token_parity_caller_mints.py
@@ -1,0 +1,358 @@
+"""Integration tests for caller-minted wool.Token stdlib parity (rows T1-T4).
+
+Each test mints a :class:`wool.Token` on the caller and drives one row of
+the cross-process token-parity matrix: T1 (an unrelated dispatch merges its
+response before a purely local reset), T2 (the token rides to a worker and
+back unreset, then either copy is consumed locally), T3 (a worker consumes
+the token and the consumption back-propagates), and T4 (the token relays
+through one worker to a second, which consumes it). An awaited dispatch is
+a logical continuation of the caller's context, so every sequence must
+match the same ops applied to a stdlib ContextVar in a single context:
+exact old-value restoration (non-default prior and previously-unset) and
+single-use enforcement via RuntimeError on any second reset.
+"""
+
+import uuid
+from dataclasses import replace
+
+import pytest
+
+import wool
+
+from . import routines
+from .conftest import CredentialType
+from .conftest import LazyMode
+from .conftest import PoolMode
+from .conftest import QuorumMode
+from .conftest import build_pool_from_scenario
+from .conftest import default_scenario
+
+# Curated pool configurations for the T3 remote-consumption row. The
+# other rows run on the default scenario only. MTLS is the canonical
+# secure credential variant (`replace` because ``default_scenario``
+# pins INSECURE and ``Scenario.__or__`` rejects conflicting fields).
+T3_POOL_SCENARIOS = [
+    default_scenario(),
+    default_scenario(pool_mode=PoolMode.EPHEMERAL),
+    default_scenario(
+        pool_mode=PoolMode.EPHEMERAL,
+        lazy=LazyMode.EAGER,
+        quorum=QuorumMode.ABOVE_DEFAULT,
+    ),
+    default_scenario(pool_mode=PoolMode.NESTED_DEFAULT_IN_EPHEMERAL),
+    replace(default_scenario(), credential=CredentialType.MTLS),
+]
+
+
+@pytest.mark.integration
+class TestCallerMintedTokenLocalReset:
+    """Rows T1 and T2 — the caller itself consumes the token it minted."""
+
+    @pytest.mark.asyncio
+    async def test_caller_reset_should_restore_prior_value_when_dispatch_merged(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token survives an unrelated dispatch merge and resets locally.
+
+        Given:
+            TENANT_ID set to "a" then "b" on the caller, and an unrelated
+            routine dispatched and merged between the set and the reset.
+        When:
+            The caller resets the "b" token locally, then resets it again.
+        Then:
+            It should restore "a" exactly as stdlib would — the merge must
+            not invalidate the token — and the second reset should raise
+            the single-use RuntimeError.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token_a = routines.TENANT_ID.set("a")
+                try:
+                    token_b = routines.TENANT_ID.set("b")
+                    assert token_b.old_value == "a"
+                    assert await routines.add(1, 2) == 3
+                    routines.TENANT_ID.reset(token_b)
+                    assert routines.TENANT_ID.get() == "a"
+                    with pytest.raises(RuntimeError, match="already been used once"):
+                        routines.TENANT_ID.reset(token_b)
+                finally:
+                    routines.TENANT_ID.reset(token_a)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_caller_reset_should_unbind_the_var_when_previously_unset(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test resetting a first-set token after a merge restores unbound state.
+
+        Given:
+            A fresh default-less wool.ContextVar first set on the caller
+            (its token's old_value is wool.Token.MISSING) and an unrelated
+            routine dispatched and merged before the reset.
+        When:
+            The caller resets the token locally, then resets it again.
+        Then:
+            It should return the variable to the unbound state — get()
+            raises LookupError, mirroring stdlib — and the second reset
+            should raise the single-use RuntimeError.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var: wool.ContextVar[str] = wool.ContextVar(f"a2_t1_{uuid.uuid4().hex}")
+                token = var.set("only")
+                assert token.old_value is wool.Token.MISSING
+                assert await routines.add(1, 2) == 3
+                var.reset(token)
+                with pytest.raises(LookupError):
+                    var.get()
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    var.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_original_token_should_reset_when_clone_rode_the_wire_unreset(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the original resets fine after its clone rides the wire as luggage.
+
+        Given:
+            TENANT_ID set to "a" then "b" on the caller, with the "b"
+            token carried to a worker and returned unreset alongside its
+            var name.
+        When:
+            The caller resets the ORIGINAL token, then resets the
+            returned clone.
+        Then:
+            It should restore "a" via the original — the round trip must
+            not consume or damage it — and the clone's reset should raise
+            the single-use RuntimeError: same id, one ledger.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                prior = routines.TENANT_ID.set("a")
+                try:
+                    token = routines.TENANT_ID.set("b")
+                    returned, var_name = await routines.describe_tenant_id_token(token)
+                    assert var_name == routines.TENANT_ID.name
+                    assert returned.var.name == routines.TENANT_ID.name
+                    assert returned.old_value == "a"
+                    routines.TENANT_ID.reset(token)
+                    assert routines.TENANT_ID.get() == "a"
+                    with pytest.raises(RuntimeError, match="already been used once"):
+                        routines.TENANT_ID.reset(returned)
+                finally:
+                    routines.TENANT_ID.reset(prior)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_returned_clone_should_reset_and_consume_the_original(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the returned clone resets like stdlib and consumes the original.
+
+        Given:
+            TENANT_ID set to "a" then "b" on the caller, with the "b"
+            token carried to a worker and returned unreset.
+        When:
+            The caller resets the RETURNED clone, then resets the
+            original token.
+        Then:
+            It should restore "a" — stdlib has one token object, so the
+            clone must behave as that one token — and the original's
+            reset should raise the single-use RuntimeError: same id, one
+            ledger.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                prior = routines.TENANT_ID.set("a")
+                try:
+                    token = routines.TENANT_ID.set("b")
+                    returned, _ = await routines.describe_tenant_id_token(token)
+                    routines.TENANT_ID.reset(returned)
+                    assert routines.TENANT_ID.get() == "a"
+                    with pytest.raises(RuntimeError, match="already been used once"):
+                        routines.TENANT_ID.reset(token)
+                finally:
+                    routines.TENANT_ID.reset(prior)
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestCallerMintedTokenRemoteReset:
+    """Rows T3 and T4 — a worker consumes the caller-minted token."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("scenario", T3_POOL_SCENARIOS, ids=str)
+    async def test_worker_reset_should_consume_the_callers_token(
+        self, scenario, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker-side reset back-propagates and consumes the token.
+
+        Given:
+            TENANT_ID set to "a" then "b" on the caller and the "b" token
+            dispatched to a routine that resets it on the worker, across
+            the curated pool configurations.
+        When:
+            The dispatch returns and the caller retries the reset.
+        Then:
+            It should restore "a" on both worker and caller and raise the
+            single-use RuntimeError on the caller's retry of the consumed
+            token, matching one stdlib context exactly.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            async with build_pool_from_scenario(scenario, credentials_map):
+                prior = routines.TENANT_ID.set("a")
+                try:
+                    token1 = routines.TENANT_ID.set("b")
+                    assert token1.old_value == "a"
+                    observed = await routines.reset_tenant_id_token(token1)
+                    assert observed == "a"
+                    assert routines.TENANT_ID.get() == "a"
+                    with pytest.raises(RuntimeError, match="already been used once"):
+                        routines.TENANT_ID.reset(token1)
+                finally:
+                    routines.TENANT_ID.reset(prior)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_consumed_token_should_stay_used_when_var_freshly_set(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a fresh caller set never resurrects a worker-consumed token.
+
+        Given:
+            TENANT_ID set to "a" then "b" on the caller with the "b"
+            token consumed by a worker-side reset that back-propagated
+            home, then a fresh caller-side set minting a new token.
+        When:
+            The caller retries the consumed token after the fresh set.
+        Then:
+            It should raise the single-use RuntimeError — the fresh set
+            must not prune the consumed token's ledger entry — while the
+            fresh token still resets cleanly, restoring "a".
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                prior = routines.TENANT_ID.set("a")
+                try:
+                    token1 = routines.TENANT_ID.set("b")
+                    await routines.reset_tenant_id_token(token1)
+                    assert routines.TENANT_ID.get() == "a"
+                    token2 = routines.TENANT_ID.set("c")
+
+                    with pytest.raises(RuntimeError, match="already been used once"):
+                        routines.TENANT_ID.reset(token1)
+                    routines.TENANT_ID.reset(token2)
+                    assert routines.TENANT_ID.get() == "a"
+                finally:
+                    routines.TENANT_ID.reset(prior)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_reset_should_unbind_the_var_when_previously_unset(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker-side reset of a first-set token restores unbound state.
+
+        Given:
+            A fresh default-less wool.ContextVar first set on the caller
+            (its token's old_value is wool.Token.MISSING) and the token
+            dispatched to the oracle reset routine on a worker.
+        When:
+            The worker resets the token, the caller retries the reset,
+            mints a fresh token via set, retries the old token again, and
+            finally resets the fresh token.
+        Then:
+            It should report an unbound variable on the worker, leave the
+            caller's variable unbound (get() raises LookupError), raise
+            the single-use RuntimeError on both retries of the consumed
+            token, and return to unbound via the fresh token.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var: wool.ContextVar[str] = wool.ContextVar(f"a2_t3_{uuid.uuid4().hex}")
+                token1 = var.set("only")
+                assert token1.old_value is wool.Token.MISSING
+                kind, message, value_after = await routines.oracle_reset(
+                    var.namespace, var.name, token1
+                )
+                assert (kind, message) == ("ok", "")
+                assert value_after == routines.ORACLE_UNSET
+                with pytest.raises(LookupError):
+                    var.get()
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    var.reset(token1)
+                # Regression: a fresh caller-side set() must not prune
+                # the consumed token's ledger entry.
+                token2 = var.set("again")
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    var.reset(token1)
+                var.reset(token2)
+                with pytest.raises(LookupError):
+                    var.get()
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_two_hop_relay_reset_should_consume_the_callers_token(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token consumed two hops away restores "a" and reads as used.
+
+        Given:
+            TENANT_ID set to "a" then "b" on the caller and the "b" token
+            dispatched through a relay routine on worker A that
+            nested-dispatches the actual reset to worker B in an
+            EPHEMERAL two-worker pool.
+        When:
+            The relay returns and the caller reads the var and retries
+            the reset locally.
+        Then:
+            It should observe "a" restored on both the inner worker and
+            the caller, and the local retry should raise the single-use
+            RuntimeError — the consumed state crossed both hops back.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(pool_mode=PoolMode.EPHEMERAL)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                prior = routines.TENANT_ID.set("a")
+                try:
+                    token = routines.TENANT_ID.set("b")
+                    assert token.old_value == "a"
+                    observed = await routines.relay_reset_tenant_id_token(token)
+                    assert observed == "a"
+                    assert routines.TENANT_ID.get() == "a"
+                    with pytest.raises(RuntimeError, match="already been used once"):
+                        routines.TENANT_ID.reset(token)
+                finally:
+                    routines.TENANT_ID.reset(prior)
+
+        await retry_grpc_internal(body)

--- a/wool/tests/integration/test_token_parity_errors.py
+++ b/wool/tests/integration/test_token_parity_errors.py
@@ -1,0 +1,596 @@
+"""Cross-process error-shape parity for wool.Token reset rejections.
+
+Matrix dimension D4 of the token-parity suite: every reset rejection —
+used token, wrong variable, different Context, non-token argument —
+must surface with stdlib-identical exception classes, check order, and
+canonical message phrases wherever the reset is attempted: locally
+after a remote consumption, remotely via the oracle routines, and on a
+second worker that never saw the original reset. Complements the
+single-use and ownership-topology coverage in
+tests/integration/test_context_var_propagation.py by exercising the
+oracle-addressed routes, the used-before-wrong-var gate order across
+the wire, and message-text parity against live stdlib contextvars
+twins.
+"""
+
+import asyncio
+import contextvars
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+import wool
+
+from . import routines
+from .conftest import PoolMode
+from .conftest import build_pool_from_scenario
+from .conftest import default_scenario
+
+
+def _fresh_var() -> wool.ContextVar[str]:
+    """Declare a unique default-less wool.ContextVar for one oracle route."""
+    return wool.ContextVar(f"a7_{uuid4().hex}")
+
+
+def _fresh_twin() -> contextvars.ContextVar[str]:
+    """Declare a unique stdlib contextvars twin for message-parity baselines."""
+    return contextvars.ContextVar(f"a7_twin_{uuid4().hex}")
+
+
+def _trailing_phrase(message: str) -> str:
+    """Return the canonical phrase following the token repr in *message*."""
+    return message.rsplit("> ", 1)[-1]
+
+
+@pytest.mark.integration
+class TestUsedTokenGateAcrossProcesses:
+    @pytest.mark.asyncio
+    async def test_local_retry_after_fresh_set_should_still_report_used_token(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test remote consumption survives an intervening fresh local set.
+
+        Given:
+            A DEFAULT pool, a fresh wool.ContextVar whose token was
+            consumed by a successful oracle reset on the worker, and a
+            subsequent fresh local set binding the same variable again.
+        When:
+            The caller retries the consumed token locally after the
+            fresh set.
+        Then:
+            It should raise RuntimeError with the canonical
+            "has already been used once" message and leave the fresh
+            binding untouched — the cross-process consumption is still
+            authoritative after the variable is re-armed locally.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var = _fresh_var()
+                token = var.set("first")
+                kind, message, value_after = await routines.oracle_reset(
+                    var.namespace, var.name, token
+                )
+                assert (kind, message) == ("ok", "")
+                assert value_after == routines.ORACLE_UNSET
+                var.set("fresh")
+                with pytest.raises(RuntimeError) as exc_info:
+                    var.reset(token)
+                assert "has already been used once" in str(exc_info.value)
+                # Ledger-discovered consumption stamps the used flag, so
+                # the repr carries stdlib's marker on this route too.
+                assert "<Token used var=" in str(exc_info.value)
+                assert var.get() == "fresh"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_locally_consumed_token_dispatched_should_report_used_remotely(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a locally consumed token is refused by a remote oracle reset.
+
+        Given:
+            A fresh wool.ContextVar bound to "base", a second set
+            minting a token, and a successful LOCAL reset consuming
+            that token before any dispatch.
+        When:
+            The caller dispatches the consumed token to the oracle
+            reset routine on a DEFAULT pool.
+        Then:
+            It should report RuntimeError with the canonical
+            "has already been used once" message and a worker-side
+            value still equal to "base" — the rejected remote reset
+            mutated nothing on either side of the wire.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var = _fresh_var()
+                var.set("base")
+                token = var.set("second")
+                var.reset(token)
+                assert var.get() == "base"
+                kind, message, value_after = await routines.oracle_reset(
+                    var.namespace, var.name, token
+                )
+                assert kind == "RuntimeError"
+                assert "has already been used once" in message
+                assert value_after == "base"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_token_consumed_on_one_worker_should_read_used_on_another(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a consumption on one worker is enforced by a different worker.
+
+        Given:
+            An EPHEMERAL pool with two workers and a fresh
+            wool.ContextVar token consumed by an attributed oracle
+            reset that reported one worker pid.
+        When:
+            The caller re-dispatches the attributed oracle reset
+            repeatedly (up to eight times) so at least one attempt
+            lands on the other worker process.
+        Then:
+            Every post-consumption attempt should report RuntimeError
+            with the canonical "has already been used once" message,
+            including at least one attempt attributed to a different
+            pid than the consuming worker's.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(pool_mode=PoolMode.EPHEMERAL)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var = _fresh_var()
+                token = var.set("relay-mint")
+                first_pid, first_kind, _, _ = await routines.oracle_reset_report(
+                    var.namespace, var.name, token
+                )
+                assert first_kind == "ok"
+                # Round-robin over the two-worker pool reaches the other
+                # worker within a few dispatches; keep dispatching until a
+                # different pid confirms the second worker enforced it.
+                observed_other_pid = False
+                for _ in range(8):
+                    pid, kind, message, _ = await routines.oracle_reset_report(
+                        var.namespace, var.name, token
+                    )
+                    assert kind == "RuntimeError"
+                    assert "has already been used once" in message
+                    if pid != first_pid:
+                        observed_other_pid = True
+                        break
+                assert observed_other_pid, (
+                    "the reset attempt never landed on a second worker, so "
+                    "cross-worker used-token enforcement was not exercised"
+                )
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestWrongVariableAcrossTheWire:
+    @pytest.mark.asyncio
+    async def test_remote_reset_addressed_to_wrong_var_should_report_value_error(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token dispatched to the wrong variable fails remotely.
+
+        Given:
+            Two fresh wool.ContextVars — B bound to "b-value" and a
+            live token minted by A — on a DEFAULT pool.
+        When:
+            The caller dispatches an oracle reset addressed to B with
+            A's token, then retries A's token locally.
+        Then:
+            It should report ValueError with the canonical
+            "was created by a different ContextVar" message, leave B's
+            worker-side value untouched, and the local retry on A
+            should still succeed — the rejection never consumed the
+            token.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var_a = _fresh_var()
+                var_b = _fresh_var()
+                var_b.set("b-value")
+                token = var_a.set("a-value")
+                kind, message, value_after = await routines.oracle_reset(
+                    var_b.namespace, var_b.name, token
+                )
+                assert kind == "ValueError"
+                assert "was created by a different ContextVar" in message
+                assert value_after == "b-value"
+                var_a.reset(token)
+                assert var_a.get("<unset>") == "<unset>"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_round_tripped_token_should_refuse_local_wrong_var_reset(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token that travelled as luggage still binds to its own var.
+
+        Given:
+            A live token minted by a fresh wool.ContextVar A, carried
+            to a worker and back as luggage by the describe routine,
+            and a second fresh wool.ContextVar B.
+        When:
+            The caller resets B with the round-tripped copy, then
+            resets A with the original token.
+        Then:
+            The wrong-var reset should raise ValueError with the
+            canonical "was created by a different ContextVar" message,
+            and the original token should still reset A successfully —
+            the round trip neither consumed nor rebound the token.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var_a = _fresh_var()
+                var_b = _fresh_var()
+                token = var_a.set("a-value")
+                returned, var_name = await routines.describe_tenant_id_token(token)
+                assert var_name == var_a.name
+                assert returned.var.name == var_a.name
+                with pytest.raises(
+                    ValueError, match="was created by a different ContextVar"
+                ):
+                    var_b.reset(returned)
+                var_a.reset(token)
+                assert var_a.get("<unset>") == "<unset>"
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestResetGateOrderAcrossProcesses:
+    @pytest.mark.asyncio
+    async def test_consumed_token_addressed_to_wrong_var_should_report_used_first(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the used gate outranks the wrong-var gate on the worker.
+
+        Given:
+            Two fresh wool.ContextVars — B bound to "b-armed" and a
+            token minted by A already consumed by a successful oracle
+            reset addressed to A on a DEFAULT pool.
+        When:
+            The caller dispatches a second oracle reset addressed to B
+            with the consumed token — a token that is BOTH used AND
+            for the wrong variable.
+        Then:
+            It should report RuntimeError with the canonical
+            "has already been used once" message — not the wrong-var
+            ValueError — proving the used gate fires first on the
+            receiving side, matching stdlib's check order, and B's
+            worker-side value should be untouched.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var_a = _fresh_var()
+                var_b = _fresh_var()
+                var_b.set("b-armed")
+                token = var_a.set("a-value")
+                kind, _, _ = await routines.oracle_reset(
+                    var_a.namespace, var_a.name, token
+                )
+                assert kind == "ok"
+                kind, message, value_after = await routines.oracle_reset(
+                    var_b.namespace, var_b.name, token
+                )
+                assert kind == "RuntimeError"
+                assert kind != "ValueError"
+                assert "has already been used once" in message
+                assert value_after == "b-armed"
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestOrphanTokenErrorsAcrossProcesses:
+    @pytest.mark.asyncio
+    async def test_child_task_minted_token_should_report_different_context(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token minted inside a create_task child is an orphan everywhere.
+
+        Given:
+            A fresh wool.ContextVar and a token minted INSIDE an
+            asyncio child task created via ``create_task`` — the
+            child's context fork drops the mint from the parent's
+            continuation.
+        When:
+            The parent round-trips the token as luggage, dispatches an
+            oracle reset with it, and finally resets it locally.
+        Then:
+            Transport should never raise, the remote reset should
+            report ValueError with the canonical "was created in a
+            different Context" message and an unbound worker-side
+            value, and the parent's local reset should raise the same
+            ValueError — the orphan is rejected identically on both
+            sides of the wire.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var = _fresh_var()
+
+                async def _mint():
+                    return var.set("child-mint")
+
+                orphan = await asyncio.create_task(_mint())
+                returned, var_name = await routines.describe_tenant_id_token(orphan)
+                assert var_name == var.name
+                assert returned.var.name == var.name
+                kind, message, value_after = await routines.oracle_reset(
+                    var.namespace, var.name, orphan
+                )
+                assert kind == "ValueError"
+                assert "was created in a different Context" in message
+                assert value_after == routines.ORACLE_UNSET
+                with pytest.raises(
+                    ValueError, match="was created in a different Context"
+                ):
+                    var.reset(orphan)
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestResetTypeErrorParity:
+    @pytest.mark.asyncio
+    async def test_local_reset_with_non_token_should_match_stdlib_type_error(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test local non-token rejections match stdlib's TypeError messages.
+
+        Given:
+            A fresh wool.ContextVar armed and already dispatched
+            through a DEFAULT pool, and a stdlib contextvars twin
+            rejecting the same non-token arguments.
+        When:
+            The caller resets the wool variable with a plain string
+            and with None.
+        Then:
+            Both should raise TypeError with messages equal to the
+            stdlib twin's — "expected an instance of Token, got ..." —
+            and the variable's live token should still reset
+            successfully afterward.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var = _fresh_var()
+                token = var.set("armed")
+                observed = await routines.oracle_get(
+                    var.namespace, var.name, routines.ORACLE_UNSET
+                )
+                assert observed == "armed"
+                twin = _fresh_twin()
+                not_a_token: Any = "not-a-token"
+                none_token: Any = None
+                with pytest.raises(TypeError) as stdlib_string:
+                    twin.reset(not_a_token)
+                with pytest.raises(TypeError) as stdlib_none:
+                    twin.reset(none_token)
+                with pytest.raises(TypeError) as wool_string:
+                    var.reset(not_a_token)
+                with pytest.raises(TypeError) as wool_none:
+                    var.reset(none_token)
+                assert "expected an instance of Token" in str(wool_string.value)
+                assert str(wool_string.value) == str(stdlib_string.value)
+                assert str(wool_none.value) == str(stdlib_none.value)
+                var.reset(token)
+                assert var.get("<unset>") == "<unset>"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_remote_reset_with_non_token_should_report_stdlib_type_error(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test remote non-token rejections match stdlib's TypeError messages.
+
+        Given:
+            A fresh wool.ContextVar bound to "armed" and a stdlib
+            contextvars twin rejecting the same non-token arguments
+            locally.
+        When:
+            The caller dispatches oracle resets carrying a plain
+            string and None instead of a token on a DEFAULT pool.
+        Then:
+            Both should report TypeError with messages equal to the
+            stdlib twin's, and the worker-side binding should remain
+            "armed" — the rejections mutated nothing.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var = _fresh_var()
+                var.set("armed")
+                twin = _fresh_twin()
+                not_a_token: Any = "not-a-token"
+                none_token: Any = None
+                with pytest.raises(TypeError) as stdlib_string:
+                    twin.reset(not_a_token)
+                with pytest.raises(TypeError) as stdlib_none:
+                    twin.reset(none_token)
+                kind, message, value_after = await routines.oracle_reset(
+                    var.namespace, var.name, "not-a-token"
+                )
+                assert kind == "TypeError"
+                assert message == str(stdlib_string.value)
+                assert value_after == "armed"
+                kind, message, value_after = await routines.oracle_reset(
+                    var.namespace, var.name, None
+                )
+                assert kind == "TypeError"
+                assert message == str(stdlib_none.value)
+                assert value_after == "armed"
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestStdlibMessageShapeParity:
+    @pytest.mark.asyncio
+    async def test_remote_used_error_should_match_stdlib_message_shape(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the remote used-token message mirrors stdlib's anatomy.
+
+        Given:
+            A stdlib contextvars twin whose double reset produced the
+            baseline RuntimeError message, and a fresh wool.ContextVar
+            token consumed locally then dispatched to the oracle reset
+            routine on a DEFAULT pool.
+        When:
+            The worker's rejection message is compared to the stdlib
+            baseline.
+        Then:
+            Both should lead with the used-token repr pattern
+            "<Token used var=" and both should end with exactly the
+            same canonical phrase "has already been used once".
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            twin = _fresh_twin()
+            twin_token = twin.set("twin-value")
+            twin.reset(twin_token)
+            with pytest.raises(RuntimeError) as stdlib_exc:
+                twin.reset(twin_token)
+            stdlib_message = str(stdlib_exc.value)
+            assert stdlib_message.startswith("<Token used var=")
+
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var = _fresh_var()
+                token = var.set("wool-value")
+                var.reset(token)
+                kind, message, _ = await routines.oracle_reset(
+                    var.namespace, var.name, token
+                )
+                assert kind == "RuntimeError"
+                assert message.startswith("<Token used var=")
+                assert _trailing_phrase(message) == _trailing_phrase(stdlib_message)
+                assert _trailing_phrase(message) == "has already been used once"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_remote_wrong_var_error_should_match_stdlib_message_shape(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the remote wrong-var message mirrors stdlib's anatomy.
+
+        Given:
+            Two stdlib contextvars twins whose cross-var reset
+            produced the baseline ValueError message, and a live token
+            minted by fresh wool.ContextVar A dispatched to an oracle
+            reset addressed to fresh wool.ContextVar B on a DEFAULT
+            pool.
+        When:
+            The worker's rejection message is compared to the stdlib
+            baseline.
+        Then:
+            Both should lead with the live-token repr pattern
+            "<Token var=" and both should end with exactly the same
+            canonical phrase "was created by a different ContextVar".
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            twin_a = _fresh_twin()
+            twin_b = _fresh_twin()
+            twin_token = twin_a.set("twin-value")
+            with pytest.raises(ValueError) as stdlib_exc:
+                twin_b.reset(twin_token)
+            stdlib_message = str(stdlib_exc.value)
+            assert stdlib_message.startswith("<Token var=")
+
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var_a = _fresh_var()
+                var_b = _fresh_var()
+                token = var_a.set("a-value")
+                kind, message, _ = await routines.oracle_reset(
+                    var_b.namespace, var_b.name, token
+                )
+                assert kind == "ValueError"
+                assert message.startswith("<Token var=")
+                assert _trailing_phrase(message) == _trailing_phrase(stdlib_message)
+                assert (
+                    _trailing_phrase(message) == "was created by a different ContextVar"
+                )
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_remote_orphan_error_should_match_stdlib_message_shape(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the remote different-Context message mirrors stdlib's anatomy.
+
+        Given:
+            A stdlib contextvars twin whose copy_context-sibling token
+            produced the baseline ValueError message, and a fresh
+            wool.ContextVar token minted in a stdlib copy_context
+            sibling dispatched to the oracle reset routine on a
+            DEFAULT pool.
+        When:
+            The worker's rejection message is compared to the stdlib
+            baseline.
+        Then:
+            Both should lead with the live-token repr pattern
+            "<Token var=" and both should end with exactly the same
+            canonical phrase "was created in a different Context".
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            twin = _fresh_twin()
+            twin_orphan = contextvars.copy_context().run(twin.set, "twin-sibling")
+            with pytest.raises(ValueError) as stdlib_exc:
+                twin.reset(twin_orphan)
+            stdlib_message = str(stdlib_exc.value)
+            assert stdlib_message.startswith("<Token var=")
+
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var = _fresh_var()
+                orphan = contextvars.copy_context().run(var.set, "wool-sibling")
+                kind, message, _ = await routines.oracle_reset(
+                    var.namespace, var.name, orphan
+                )
+                assert kind == "ValueError"
+                assert message.startswith("<Token var=")
+                assert _trailing_phrase(message) == _trailing_phrase(stdlib_message)
+                assert _trailing_phrase(message) == "was created in a different Context"
+
+        await retry_grpc_internal(body)

--- a/wool/tests/integration/test_token_parity_multivar.py
+++ b/wool/tests/integration/test_token_parity_multivar.py
@@ -1,0 +1,624 @@
+"""Multi-variable wool.Token parity across the dispatch wire (lane A8).
+
+Chain state carries EVERY registered wool.ContextVar's bookkeeping on
+every dispatch frame, so one variable's token ledger travels the wire
+alongside every other variable's — a real interleaving surface. These
+tests pin per-variable independence of that bookkeeping: a remote
+consumption touches only the consumed variable's ledger, a fresh set
+prunes only its own variable's spent key (the just-fixed regression),
+wrong-variable rejections keep stdlib's error precedence across
+processes (used beats wrong-var), and any interleaved multi-variable
+script decomposes into independent per-variable stdlib traces — each
+variable behaves exactly as if the others did not exist (the per-var
+projection property).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import uuid
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from hypothesis import HealthCheck
+from hypothesis import example
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
+
+import wool
+
+from . import routines
+from ._token_ops import CALLER
+from ._token_ops import UNSET
+from ._token_ops import WORKER
+from ._token_ops import GetOp
+from ._token_ops import Observation
+from ._token_ops import Op
+from ._token_ops import ResetOp
+from ._token_ops import SetOp
+from ._token_ops import describe_mismatch
+from ._token_ops import observations_match
+from ._token_ops import run_stdlib_oracle
+from ._token_ops import scripts
+from .conftest import build_pool_from_scenario
+from .conftest import default_scenario
+
+_SCRIPT_TIMEOUT = 30
+
+#: A tagged multi-var replay of the just-fixed ledger-prune regression:
+#: var A's first token is consumed remotely, a fresh set on A prunes
+#: A's spent key, and the caller's retry of the consumed token must
+#: still observe RuntimeError — while var B's token, minted before the
+#: whole A cycle, must stay cleanly spendable throughout.
+_LEDGER_PRUNE_REGRESSION: list[tuple[int, Op]] = [
+    (0, SetOp(CALLER, 1)),
+    (1, SetOp(CALLER, 10)),
+    (0, ResetOp(WORKER, 0)),
+    (0, SetOp(CALLER, 2)),
+    (0, ResetOp(CALLER, 0)),
+    (1, ResetOp(CALLER, 0)),
+]
+
+
+def _fresh_var() -> wool.ContextVar[Any]:
+    """Mint a unique default-less wool.ContextVar for one test or example."""
+    return wool.ContextVar(
+        f"a8_{uuid.uuid4().hex}", namespace=f"a8_ns_{uuid.uuid4().hex}"
+    )
+
+
+def _project(tagged_script: Sequence[tuple[int, Op]], var_index: int) -> list[Op]:
+    """Return the ops tagged for *var_index* in interleaving order.
+
+    The projection preserves per-var op order and per-var token-list
+    indexing: because the multi-var executor keeps one token list per
+    variable, a var's projected script replayed through the single-var
+    stdlib oracle selects exactly the tokens the interleaved run did.
+    """
+    return [op for tag, op in tagged_script if tag == var_index]
+
+
+def _tagged_scripts(*, max_ops: int = 8) -> st.SearchStrategy[list[tuple[int, Op]]]:
+    """Draw an interleaved two-var script: ops plus per-op var tags.
+
+    Each op drawn by ``_token_ops.scripts`` is assigned to var A (0) or
+    var B (1) via a boolean list of matching length. Reset token
+    indexes are interpreted against the tagged var's OWN token list at
+    execution time, so every tagging yields a valid per-var projection.
+    """
+
+    def tag(script: list[Op]) -> st.SearchStrategy[list[tuple[int, Op]]]:
+        return st.lists(st.booleans(), min_size=len(script), max_size=len(script)).map(
+            lambda tags: [(int(t), op) for t, op in zip(tags, script)]
+        )
+
+    return scripts(max_ops=max_ops).flatmap(tag)
+
+
+async def _run_wool_multivar_script(
+    tagged_script: Sequence[tuple[int, Op]],
+    variables: Sequence[wool.ContextVar[Any]],
+) -> list[list[Observation]]:
+    """Execute an interleaved multi-var script; return per-var traces.
+
+    Mirrors ``_token_ops.run_wool_script`` op mechanics exactly — caller
+    ops run locally, worker ops dispatch the key-addressed ``oracle_*``
+    routines — except each op is tagged with the index of the variable
+    it targets and every variable keeps its OWN ordered token list.
+    ``ResetOp.token_index`` is normalized modulo the tagged variable's
+    minted-token count, so each returned per-var observation trace is
+    directly comparable to ``run_stdlib_oracle`` on that variable's
+    projected script. Must run inside an entered pool context.
+    """
+    tokens: list[list[Any]] = [[] for _ in variables]
+    projections: list[list[Observation]] = [[] for _ in variables]
+    for var_index, op in tagged_script:
+        var = variables[var_index]
+        var_tokens = tokens[var_index]
+        namespace = var.namespace
+        name = var.name
+        error: str | None = None
+        if isinstance(op, SetOp):
+            kind = "set"
+            if op.actor == CALLER:
+                var_tokens.append(var.set(op.value))
+            else:
+                var_tokens.append(await routines.oracle_set(namespace, name, op.value))
+            value = var.get(UNSET)
+        elif isinstance(op, ResetOp):
+            kind = "reset"
+            if not var_tokens:
+                value = var.get(UNSET)
+            else:
+                token = var_tokens[op.token_index % len(var_tokens)]
+                if op.actor == CALLER:
+                    try:
+                        var.reset(token)
+                    except (RuntimeError, ValueError, TypeError) as exc:
+                        error = type(exc).__name__
+                    value = var.get(UNSET)
+                else:
+                    outcome_kind, _message, value = await routines.oracle_reset(
+                        namespace, name, token
+                    )
+                    if outcome_kind != "ok":
+                        error = outcome_kind
+        elif isinstance(op, GetOp):
+            kind = "get"
+            if op.actor == CALLER:
+                value = var.get(UNSET)
+            else:
+                value = await routines.oracle_get(namespace, name, UNSET)
+        else:
+            raise TypeError(f"unknown op type: {op!r}")
+        projections[var_index].append(Observation(kind, value, error))
+    return projections
+
+
+@pytest_asyncio.fixture
+async def default_pool(credentials_map):
+    """Enter one DEFAULT pool and hold it for the whole test.
+
+    Shared by every Hypothesis example of the projection property —
+    ``wool.__proxy__`` set here propagates into the test body
+    (pytest-asyncio runs async fixtures and tests in one context).
+    """
+    async with build_pool_from_scenario(default_scenario(), credentials_map) as pool:
+        yield pool
+
+
+@pytest.mark.integration
+class TestMultiVarLedgerIndependence:
+    """A consumption or fresh set on one var never disturbs another's ledger.
+
+    These example tests pin the independence invariant on fixed two-var
+    cycles. Its generalizing property home is ``TestPerVarProjection``:
+    ``test_interleaved_scripts_should_decompose_into_stdlib_projections``
+    sweeps drawn two-var interleavings and asserts each var decomposes
+    into its own single-var stdlib projection as if the other did not
+    exist.
+    """
+
+    @pytest.mark.asyncio
+    async def test_worker_consumption_should_leave_other_vars_token_usable(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test consuming var A's token remotely leaves var B's token spendable.
+
+        Given:
+            Two fresh default-less wool.ContextVars A and B, each set
+            once on the caller, and A's token dispatched to the oracle
+            reset routine on a worker.
+        When:
+            The worker consumes A's token and the caller then resets B's
+            token locally.
+        Then:
+            It should unbind A on both sides, leave B's value untouched
+            by A's consumption, and spend B's token cleanly — B's ledger
+            must be independent of A's remote consumption.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var_a = _fresh_var()
+                var_b = _fresh_var()
+                token_a = var_a.set("a-initial")
+                token_b = var_b.set("b-initial")
+                kind, message, value_after = await routines.oracle_reset(
+                    var_a.namespace, var_a.name, token_a
+                )
+                assert (kind, message, value_after) == ("ok", "", UNSET)
+                assert var_a.get(UNSET) == UNSET
+                assert var_b.get(UNSET) == "b-initial"
+                var_b.reset(token_b)
+                assert var_b.get(UNSET) == UNSET
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_consumed_token_should_stay_spent_when_its_var_freshly_set(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a fresh set on A prunes only A's key without reviving A's token.
+
+        Given:
+            Fresh vars A and B each set once on the caller, A's token
+            consumed on a worker, then a fresh caller-side set on A —
+            the op that previously erased A's consumed-token ledger.
+        When:
+            The caller retries the consumed token locally and via the
+            worker, then spends B's token and A's fresh token.
+        Then:
+            It should raise the single-use RuntimeError on both retries
+            with A's value left intact, spend B's untouched token
+            cleanly, and spend A's fresh token cleanly — the prune stays
+            per-var and never resurrects a consumed token.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var_a = _fresh_var()
+                var_b = _fresh_var()
+                token_a = var_a.set("a1")
+                token_b = var_b.set("b1")
+                kind, message, value_after = await routines.oracle_reset(
+                    var_a.namespace, var_a.name, token_a
+                )
+                assert (kind, message, value_after) == ("ok", "", UNSET)
+                token_a2 = var_a.set("a2")
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    var_a.reset(token_a)
+                kind, message, value_after = await routines.oracle_reset(
+                    var_a.namespace, var_a.name, token_a
+                )
+                assert kind == "RuntimeError"
+                assert "already been used once" in message
+                assert value_after == "a2"
+                assert var_a.get(UNSET) == "a2"
+                var_b.reset(token_b)
+                assert var_b.get(UNSET) == UNSET
+                var_a.reset(token_a2)
+                assert var_a.get(UNSET) == UNSET
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_consumed_token_should_stay_spent_when_roles_swapped(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the symmetric cycle: consuming and re-setting B leaves A intact.
+
+        Given:
+            Fresh vars A and B each set once on the caller, B's token
+            consumed on a worker, then a fresh caller-side set on B.
+        When:
+            The caller retries B's consumed token locally and via the
+            worker, then spends A's token and B's fresh token.
+        Then:
+            It should raise the single-use RuntimeError on both retries
+            of B's token, leave A's value and token family completely
+            unaffected, and spend A's token and B's fresh token cleanly.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var_a = _fresh_var()
+                var_b = _fresh_var()
+                token_a = var_a.set("a1")
+                token_b = var_b.set("b1")
+                kind, message, value_after = await routines.oracle_reset(
+                    var_b.namespace, var_b.name, token_b
+                )
+                assert (kind, message, value_after) == ("ok", "", UNSET)
+                token_b2 = var_b.set("b2")
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    var_b.reset(token_b)
+                kind, message, value_after = await routines.oracle_reset(
+                    var_b.namespace, var_b.name, token_b
+                )
+                assert kind == "RuntimeError"
+                assert "already been used once" in message
+                assert value_after == "b2"
+                assert var_a.get(UNSET) == "a1"
+                var_a.reset(token_a)
+                assert var_a.get(UNSET) == UNSET
+                var_b.reset(token_b2)
+                assert var_b.get(UNSET) == UNSET
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestCrossVarTokenRejection:
+    """A token presented to the wrong var keeps stdlib's error precedence."""
+
+    @pytest.mark.asyncio
+    async def test_reset_should_raise_value_error_when_token_from_other_var(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test an unconsumed token presented to the wrong var raises ValueError.
+
+        Given:
+            Fresh vars A and B each set once on the caller, and A's
+            live token presented to B's reset both locally and via the
+            worker-side oracle addressed at B — mirrored against a
+            stdlib ContextVar pair for parity.
+        When:
+            B rejects the foreign token at both sites.
+        Then:
+            It should raise the different-ContextVar ValueError in both
+            places with both values untouched, leave A's token still
+            spendable afterward, and match the stdlib pair's error.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var_a = _fresh_var()
+                var_b = _fresh_var()
+                token_a = var_a.set("a1")
+                var_b.set("b1")
+                stdlib_a: contextvars.ContextVar[str] = contextvars.ContextVar(
+                    f"a8_stdlib_{uuid.uuid4().hex}"
+                )
+                stdlib_b: contextvars.ContextVar[str] = contextvars.ContextVar(
+                    f"a8_stdlib_{uuid.uuid4().hex}"
+                )
+                stdlib_token_a = stdlib_a.set("a1")
+                stdlib_b.set("b1")
+                with pytest.raises(ValueError, match="different ContextVar"):
+                    stdlib_b.reset(stdlib_token_a)
+                with pytest.raises(ValueError, match="different ContextVar"):
+                    var_b.reset(token_a)
+                kind, message, value_after = await routines.oracle_reset(
+                    var_b.namespace, var_b.name, token_a
+                )
+                assert kind == "ValueError"
+                assert "different ContextVar" in message
+                assert value_after == "b1"
+                assert var_a.get(UNSET) == "a1"
+                assert var_b.get(UNSET) == "b1"
+                var_a.reset(token_a)
+                assert var_a.get(UNSET) == UNSET
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_reset_should_raise_runtime_error_when_foreign_token_consumed(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a consumed token presented to the wrong var raises RuntimeError.
+
+        Given:
+            Fresh vars A and B each set once on the caller, A's token
+            consumed on a worker, and the consumed token then presented
+            to B's reset both locally and via the worker-side oracle
+            addressed at B — mirrored against a stdlib ContextVar pair.
+        When:
+            B rejects the consumed foreign token at both sites.
+        Then:
+            It should raise the single-use RuntimeError in both places
+            — the used gate beats the wrong-var gate, exactly as stdlib
+            orders the checks — with B's value untouched.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var_a = _fresh_var()
+                var_b = _fresh_var()
+                token_a = var_a.set("a1")
+                var_b.set("b1")
+                stdlib_a: contextvars.ContextVar[str] = contextvars.ContextVar(
+                    f"a8_stdlib_{uuid.uuid4().hex}"
+                )
+                stdlib_b: contextvars.ContextVar[str] = contextvars.ContextVar(
+                    f"a8_stdlib_{uuid.uuid4().hex}"
+                )
+                stdlib_token_a = stdlib_a.set("a1")
+                stdlib_b.set("b1")
+                stdlib_a.reset(stdlib_token_a)
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    stdlib_b.reset(stdlib_token_a)
+                kind, message, value_after = await routines.oracle_reset(
+                    var_a.namespace, var_a.name, token_a
+                )
+                assert (kind, message, value_after) == ("ok", "", UNSET)
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    var_b.reset(token_a)
+                kind, message, value_after = await routines.oracle_reset(
+                    var_b.namespace, var_b.name, token_a
+                )
+                assert kind == "RuntimeError"
+                assert "already been used once" in message
+                assert value_after == "b1"
+                assert var_b.get(UNSET) == "b1"
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestPerVarProjection:
+    """Multi-var interleavings decompose into independent per-var traces."""
+
+    @pytest.mark.asyncio
+    async def test_interleaved_cycles_should_match_per_var_stdlib_projections(
+        self, default_pool, retry_grpc_internal
+    ):
+        """Test alternating two-var cross-process cycles decompose per var.
+
+        Given:
+            Two fresh wool.ContextVars A and B and a fixed script that
+            alternates set/reset/get ops between the vars and between
+            the caller and a worker, including a double reset on A that
+            must fail while B's ops all succeed.
+        When:
+            The interleaved script executes against a live pool and each
+            var's projected trace is compared with the stdlib oracle run
+            on that var's projected ops alone.
+        Then:
+            It should match both projections exactly — one RuntimeError
+            on A's doubly reset token, no errors on B — as if each var
+            ran its subsequence with the other var absent.
+        """
+        # Arrange
+        tagged_script: list[tuple[int, Op]] = [
+            (0, SetOp(CALLER, "a1")),
+            (1, SetOp(WORKER, "b1")),
+            (0, SetOp(WORKER, "a2")),
+            (1, GetOp(CALLER)),
+            (0, ResetOp(WORKER, 1)),
+            (1, SetOp(CALLER, "b2")),
+            (0, ResetOp(CALLER, 1)),
+            (1, ResetOp(CALLER, 1)),
+            (0, GetOp(WORKER)),
+            (1, GetOp(WORKER)),
+            (0, ResetOp(CALLER, 0)),
+            (1, ResetOp(WORKER, 0)),
+            (0, GetOp(CALLER)),
+            (1, GetOp(CALLER)),
+        ]
+
+        # Act
+        async def body():
+            async with asyncio.timeout(_SCRIPT_TIMEOUT):
+
+                async def run() -> list[list[Observation]]:
+                    variables = (_fresh_var(), _fresh_var())
+                    return await _run_wool_multivar_script(tagged_script, variables)
+
+                isolated = contextvars.copy_context()
+                return await asyncio.create_task(run(), context=isolated)
+
+        projections = await retry_grpc_internal(body)
+
+        # Assert
+        for var_index in (0, 1):
+            expected = run_stdlib_oracle(_project(tagged_script, var_index))
+            assert observations_match(projections[var_index], expected), (
+                f"var {var_index} projection diverged:\n"
+                + describe_mismatch(projections[var_index], expected)
+            )
+        errors_a = [entry.error for entry in projections[0] if entry.error]
+        assert errors_a == ["RuntimeError"]
+        assert all(entry.error is None for entry in projections[1])
+
+    @pytest.mark.asyncio
+    async def test_three_var_pipeline_should_consume_each_token_independently(
+        self, default_pool, retry_grpc_internal
+    ):
+        """Test three vars' tokens consumed in scrambled order stay independent.
+
+        Given:
+            Three fresh wool.ContextVars A, B, and C set once each on
+            the caller (C first), with C's token additionally round-
+            tripped through a worker as unreset luggage — the nearest
+            relay to a nested hop reachable with key-addressed routines.
+        When:
+            The tokens are consumed in an order scrambled against mint
+            order — B locally, A on a worker, then C's returned wire
+            copy on a worker — with the other vars observed after each
+            consumption, and every original token retried locally.
+        Then:
+            It should leave the not-yet-consumed vars untouched at each
+            step on both caller and worker, raise the single-use
+            RuntimeError on every retry — including C's original after
+            its wire copy was consumed — and end with each var matching
+            its own single-var stdlib projection: unbound.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            async with asyncio.timeout(_SCRIPT_TIMEOUT):
+                var_a = _fresh_var()
+                var_b = _fresh_var()
+                var_c = _fresh_var()
+                token_c = var_c.set("c0")
+                token_a = var_a.set("a0")
+                token_b = var_b.set("b0")
+                relayed, var_name = await routines.describe_tenant_id_token(token_c)
+                assert var_name == var_c.name
+
+                var_b.reset(token_b)
+                assert var_b.get(UNSET) == UNSET
+                assert var_a.get(UNSET) == "a0"
+                worker_a = await routines.oracle_get(var_a.namespace, var_a.name, UNSET)
+                assert worker_a == "a0"
+                assert var_c.get(UNSET) == "c0"
+
+                kind, message, value_after = await routines.oracle_reset(
+                    var_a.namespace, var_a.name, token_a
+                )
+                assert (kind, message, value_after) == ("ok", "", UNSET)
+                assert var_a.get(UNSET) == UNSET
+                assert var_c.get(UNSET) == "c0"
+                worker_c = await routines.oracle_get(var_c.namespace, var_c.name, UNSET)
+                assert worker_c == "c0"
+
+                kind, message, value_after = await routines.oracle_reset(
+                    var_c.namespace, var_c.name, relayed
+                )
+                assert (kind, message, value_after) == ("ok", "", UNSET)
+                assert var_c.get(UNSET) == UNSET
+
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    var_a.reset(token_a)
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    var_b.reset(token_b)
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    var_c.reset(token_c)
+
+                final_projections = [
+                    (var_a, [SetOp(CALLER, "a0"), ResetOp(WORKER, 0)]),
+                    (var_b, [SetOp(CALLER, "b0"), ResetOp(CALLER, 0)]),
+                    (var_c, [SetOp(CALLER, "c0"), ResetOp(WORKER, 0)]),
+                ]
+                for var, script in final_projections:
+                    assert var.get(UNSET) == run_stdlib_oracle(script)[-1].value
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    @settings(
+        max_examples=15,
+        deadline=None,
+        suppress_health_check=[
+            HealthCheck.function_scoped_fixture,
+            HealthCheck.too_slow,
+        ],
+    )
+    @example(tagged_script=_LEDGER_PRUNE_REGRESSION)
+    @given(tagged_script=_tagged_scripts())
+    async def test_interleaved_scripts_should_decompose_into_stdlib_projections(
+        self, tagged_script, default_pool, retry_grpc_internal
+    ):
+        """Test drawn two-var interleavings decompose into per-var stdlib runs.
+
+        Given:
+            Any script of up to eight set/reset/get ops across both
+            actors, each op tagged to one of two fresh wool.ContextVars
+            by a drawn boolean list, one DEFAULT pool shared across all
+            examples, and a pinned example replaying the ledger-prune
+            regression on var A beside an untouched var B.
+        When:
+            The merged interleaving executes against the pool and each
+            var's projected trace is compared with the stdlib oracle run
+            on that var's projected subsequence alone.
+        Then:
+            It should match both projections exactly — multi-var
+            interleaving must decompose so each var behaves as if the
+            other did not exist.
+        """
+
+        # Arrange & act
+        async def body():
+            async with asyncio.timeout(_SCRIPT_TIMEOUT):
+
+                async def run() -> list[list[Observation]]:
+                    variables = (_fresh_var(), _fresh_var())
+                    return await _run_wool_multivar_script(tagged_script, variables)
+
+                isolated = contextvars.copy_context()
+                return await asyncio.create_task(run(), context=isolated)
+
+        projections = await retry_grpc_internal(body)
+
+        # Assert
+        for var_index in (0, 1):
+            expected = run_stdlib_oracle(_project(tagged_script, var_index))
+            assert observations_match(projections[var_index], expected), (
+                f"var {var_index} projection diverged:\n"
+                + describe_mismatch(projections[var_index], expected)
+            )

--- a/wool/tests/integration/test_token_parity_oracle.py
+++ b/wool/tests/integration/test_token_parity_oracle.py
@@ -1,0 +1,315 @@
+"""Wire-lifted differential oracle for cross-process wool.Token parity.
+
+Hypothesis draws strictly sequential op scripts over both actors
+(caller and worker) and executes each script twice: through
+:func:`run_wool_script` against a fresh :class:`wool.ContextVar` on a
+live DEFAULT pool of real worker subprocesses, and through
+:func:`run_stdlib_oracle` on a stdlib ``contextvars.ContextVar`` in a
+single local context. An awaited dispatch is a continuation of the
+caller's context, so the two observation traces must be identical for
+every script. Known-regression scripts are pinned twice: as
+``@example`` scripts on the property and as longhand deterministic
+tests whose failures read without decoding oracle diffs.
+
+The property shares ONE pool across all examples — pool startup is far
+too expensive to repeat per example — by running the Hypothesis engine
+off-loop in a worker thread (``asyncio.to_thread`` propagates the
+pool-entered context) and submitting each example's script back onto
+the pool's loop with ``run_coroutine_threadsafe``, the same
+copied-context dispatch pattern ``test_dispatch_pairwise`` uses.
+Examples are isolated by per-example variable keys: every script runs
+against a freshly named wool.ContextVar, so chain state from one
+example is invisible to the next.
+"""
+
+import asyncio
+import uuid
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck
+from hypothesis import example
+from hypothesis import given
+from hypothesis import settings
+
+import wool
+
+from ._token_ops import CALLER
+from ._token_ops import UNSET
+from ._token_ops import WORKER
+from ._token_ops import GetOp
+from ._token_ops import Observation
+from ._token_ops import Op
+from ._token_ops import ResetOp
+from ._token_ops import SetOp
+from ._token_ops import describe_mismatch
+from ._token_ops import observations_match
+from ._token_ops import run_stdlib_oracle
+from ._token_ops import run_wool_script
+from ._token_ops import scripts
+from .conftest import build_pool_from_scenario
+from .conftest import default_scenario
+
+#: Per-attempt budget for one script's dispatches (excludes pool build).
+_EXAMPLE_TIMEOUT = 30
+
+#: Thread-side wait on a submitted example — covers every retry attempt
+#: of ``retry_grpc_internal`` (4 x 30 s plus backoff) with headroom.
+_RESULT_TIMEOUT = 150
+
+
+def _fresh_var() -> wool.ContextVar[Any]:
+    """Mint a uniquely keyed wool.ContextVar for one script execution."""
+    return wool.ContextVar(f"a4_{uuid.uuid4().hex}")
+
+
+@pytest.mark.integration
+class TestTokenParityOracle:
+    @pytest.mark.asyncio
+    async def test_caller_reset_should_raise_when_worker_already_consumed_token(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a caller retry of a worker-consumed token is rejected.
+
+        Given:
+            A DEFAULT pool and a script where the caller sets the
+            variable, a worker resets the caller-minted token, and the
+            caller sets a new value before retrying the same token.
+        When:
+            The script executes through run_wool_script against a
+            fresh wool.ContextVar.
+        Then:
+            It should observe the worker reset unbinding the variable,
+            and the caller's retry of the consumed token should
+            observe RuntimeError with the newest value left in place —
+            matching stdlib single-use token semantics.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            script = [
+                SetOp(CALLER, 1),
+                ResetOp(WORKER, 0),
+                SetOp(CALLER, 2),
+                ResetOp(CALLER, 0),
+            ]
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                observations = await run_wool_script(script, _fresh_var())
+            assert len(observations) == 4
+            assert observations[0] == Observation("set", 1, None)
+            assert observations[1] == Observation("reset", UNSET, None)
+            assert observations[2] == Observation("set", 2, None)
+            assert observations[3] == Observation("reset", 2, "RuntimeError")
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_resets_should_restore_captured_values_when_applied_out_of_order(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test out-of-order resets restore each token's captured value.
+
+        Given:
+            A DEFAULT pool and a script that interleaves caller and
+            worker sets with resets applied out of mint order — the
+            worker unwinds the second token, the caller sets a third
+            value, then the caller resets the first and third tokens.
+        When:
+            The script executes through run_wool_script against a
+            fresh wool.ContextVar.
+        Then:
+            It should restore each reset token's captured old value in
+            turn — second token back to the first set, first token
+            back to unset, third token back to the first set's value —
+            exactly as stdlib contextvars does locally.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            script = [
+                SetOp(CALLER, 1),
+                SetOp(WORKER, 2),
+                ResetOp(WORKER, 1),
+                SetOp(CALLER, 3),
+                ResetOp(CALLER, 0),
+                ResetOp(CALLER, 2),
+            ]
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                observations = await run_wool_script(script, _fresh_var())
+            assert len(observations) == 6
+            assert observations[0] == Observation("set", 1, None)
+            assert observations[1] == Observation("set", 2, None)
+            assert observations[2] == Observation("reset", 1, None)
+            assert observations[3] == Observation("set", 3, None)
+            assert observations[4] == Observation("reset", UNSET, None)
+            assert observations[5] == Observation("reset", 1, None)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_minted_tokens_should_unwind_when_reset_from_both_actors(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test worker-minted tokens unwind from either side of the wire.
+
+        Given:
+            A DEFAULT pool and a worker-heavy script — both sets and
+            their tokens minted on workers, the second token reset by
+            the caller, the first reset by a worker, then a caller
+            read.
+        When:
+            The script executes through run_wool_script against a
+            fresh wool.ContextVar.
+        Then:
+            It should unwind LIFO to unset — the caller reset restores
+            the first set's value, the worker reset restores unbound —
+            and the final caller read should observe the unset
+            sentinel with no errors anywhere.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            script = [
+                SetOp(WORKER, 1),
+                SetOp(WORKER, 2),
+                ResetOp(CALLER, 1),
+                ResetOp(WORKER, 0),
+                GetOp(CALLER),
+            ]
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                observations = await run_wool_script(script, _fresh_var())
+            assert len(observations) == 5
+            assert observations[0] == Observation("set", 1, None)
+            assert observations[1] == Observation("set", 2, None)
+            assert observations[2] == Observation("reset", 1, None)
+            assert observations[3] == Observation("reset", UNSET, None)
+            assert observations[4] == Observation("get", UNSET, None)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_second_worker_reset_should_report_runtime_error_when_token_spent(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a double remote reset of one token is rejected remotely.
+
+        Given:
+            A DEFAULT pool and a script where the caller sets the
+            variable once and a worker resets the caller-minted token
+            twice in a row.
+        When:
+            The script executes through run_wool_script against a
+            fresh wool.ContextVar.
+        Then:
+            It should observe the first worker reset unbinding the
+            variable and the second worker reset reporting
+            RuntimeError with the variable still unbound — the
+            consumed state survives the hop back to the caller and out
+            to the next dispatch.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            script = [
+                SetOp(CALLER, 1),
+                ResetOp(WORKER, 0),
+                ResetOp(WORKER, 0),
+            ]
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                observations = await run_wool_script(script, _fresh_var())
+            assert len(observations) == 3
+            assert observations[0] == Observation("set", 1, None)
+            assert observations[1] == Observation("reset", UNSET, None)
+            assert observations[2] == Observation("reset", UNSET, "RuntimeError")
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_run_wool_script_should_match_stdlib_oracle_when_scripts_are_drawn(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test drawn op scripts agree wool-vs-stdlib across a live pool.
+
+        Given:
+            Scripts of up to twelve strictly sequential set/reset/get
+            ops, each tagged caller or worker, with int/str values and
+            token indexes drawn with replacement, plus four pinned
+            regression scripts, all executed against one shared
+            DEFAULT pool of real worker subprocesses.
+        When:
+            Each script runs through run_wool_script against a fresh
+            wool.ContextVar and, separately, through
+            run_stdlib_oracle.
+        Then:
+            It should produce identical observation traces for every
+            script — location transparency holds over the whole drawn
+            op-script space.
+        """
+        # Arrange — build ONE pool for every Hypothesis example; the
+        # engine runs off-loop so each example can round-trip through
+        # the pool entered here.
+        scenario = default_scenario()
+        async with build_pool_from_scenario(scenario, credentials_map):
+            loop = asyncio.get_running_loop()
+
+            async def execute_on_pool(script: list[Op]) -> list[Observation]:
+                async def attempt() -> list[Observation]:
+                    async with asyncio.timeout(_EXAMPLE_TIMEOUT):
+                        return await run_wool_script(script, _fresh_var())
+
+                return await retry_grpc_internal(attempt)
+
+            @settings(
+                max_examples=30,
+                deadline=None,
+                suppress_health_check=[HealthCheck.too_slow],
+            )
+            @example(
+                script=[
+                    SetOp(CALLER, 1),
+                    ResetOp(WORKER, 0),
+                    SetOp(CALLER, 2),
+                    ResetOp(CALLER, 0),
+                ]
+            )
+            @example(
+                script=[
+                    SetOp(CALLER, 1),
+                    SetOp(WORKER, 2),
+                    ResetOp(WORKER, 1),
+                    SetOp(CALLER, 3),
+                    ResetOp(CALLER, 0),
+                    ResetOp(CALLER, 2),
+                ]
+            )
+            @example(
+                script=[
+                    SetOp(WORKER, 1),
+                    SetOp(WORKER, 2),
+                    ResetOp(CALLER, 1),
+                    ResetOp(WORKER, 0),
+                    GetOp(CALLER),
+                ]
+            )
+            @example(
+                script=[
+                    SetOp(CALLER, 1),
+                    ResetOp(WORKER, 0),
+                    ResetOp(WORKER, 0),
+                ]
+            )
+            @given(script=scripts())
+            def check_parity(script: list[Op]) -> None:
+                future = asyncio.run_coroutine_threadsafe(execute_on_pool(script), loop)
+                wool_observations = future.result(timeout=_RESULT_TIMEOUT)
+                stdlib_observations = run_stdlib_oracle(script)
+                assert observations_match(wool_observations, stdlib_observations), (
+                    describe_mismatch(wool_observations, stdlib_observations)
+                )
+
+            # Act & assert
+            await asyncio.to_thread(check_parity)

--- a/wool/tests/integration/test_token_parity_oracle_pools.py
+++ b/wool/tests/integration/test_token_parity_oracle_pools.py
@@ -1,0 +1,259 @@
+"""Differential token-parity oracle across varied pool topologies.
+
+Runs the op-script differential oracle from ``_token_ops`` — the same
+caller/worker set/reset/get scripts checked against a local stdlib
+``contextvars.ContextVar`` ground truth — over pools whose topology
+varies: a two-worker round-robin EPHEMERAL pool, an eagerly started
+quorum-2 variant, a nested DEFAULT-in-EPHEMERAL arrangement, and an
+mTLS-secured DEFAULT pool. The point under test is that pool topology
+(worker count, startup laziness, nesting, transport credentials) is
+invisible to ``wool.Token`` semantics: a dispatch chain is a logical
+continuation of one context, so the consumed-token ledger must follow
+the chain wherever the load balancer sends it. The single-worker
+DEFAULT/insecure baseline is covered by the companion oracle suite.
+
+Each parametrized topology enters ONE pool shared by every Hypothesis
+example (pool startup dominates runtime; the shared pool is the point
+of the ``function_scoped_fixture`` suppression), while every example
+executes against a fresh uniquely named ``wool.ContextVar`` inside its
+own stdlib context copy, keeping examples independent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import dataclasses
+import uuid
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from hypothesis import HealthCheck
+from hypothesis import example
+from hypothesis import given
+from hypothesis import settings
+
+import wool
+
+from . import routines
+from ._token_ops import CALLER
+from ._token_ops import UNSET
+from ._token_ops import WORKER
+from ._token_ops import Observation
+from ._token_ops import Op
+from ._token_ops import ResetOp
+from ._token_ops import SetOp
+from ._token_ops import describe_mismatch
+from ._token_ops import observations_match
+from ._token_ops import run_stdlib_oracle
+from ._token_ops import run_wool_script
+from ._token_ops import scripts
+from .conftest import CredentialType
+from .conftest import LazyMode
+from .conftest import PoolMode
+from .conftest import QuorumMode
+from .conftest import build_pool_from_scenario
+from .conftest import default_scenario
+
+_SCRIPT_TIMEOUT = 30
+
+#: Two workers, both deterministically up before the first dispatch:
+#: EAGER starts them at pool entry and quorum 2 blocks entry until both
+#: are serving, so round-robin alternation across workers is guaranteed
+#: from the first op. Shared by the parametrized property test and the
+#: deterministic worker-hopping example test.
+_EAGER_TWO_WORKER_SCENARIO = default_scenario(
+    pool_mode=PoolMode.EPHEMERAL,
+    lazy=LazyMode.EAGER,
+    quorum=QuorumMode.ABOVE_DEFAULT,
+)
+
+#: Pool topologies the oracle must be indifferent to. The DEFAULT
+#: insecure single-worker baseline is deliberately absent (companion
+#: suite); DURABLE modes are excluded for external-worker startup cost.
+POOL_TOPOLOGIES = [
+    # Two workers, sequential remote ops round-robin across BOTH.
+    default_scenario(pool_mode=PoolMode.EPHEMERAL),
+    # Both workers eagerly up from the start (quorum 2).
+    _EAGER_TWO_WORKER_SCENARIO,
+    # A second (nested) pool context entered inside the outer pool.
+    default_scenario(pool_mode=PoolMode.NESTED_DEFAULT_IN_EPHEMERAL),
+    # Canonical secure transport: mutual TLS on the default pool shape.
+    dataclasses.replace(default_scenario(), credential=CredentialType.MTLS),
+]
+
+#: The just-fixed cross-process double-reset regression: a worker
+#: consumes the caller's first token, and the caller's later reset of
+#: that same token must observe stdlib's single-use RuntimeError.
+_DOUBLE_RESET_REGRESSION: list[Op] = [
+    SetOp(CALLER, 1),
+    ResetOp(WORKER, 0),
+    SetOp(CALLER, 2),
+    ResetOp(CALLER, 0),
+]
+
+
+@pytest_asyncio.fixture
+async def topology_pool(request, credentials_map):
+    """Enter one pool for the requested scenario and hold it for the test.
+
+    Parametrized indirectly with a complete :class:`Scenario`. The pool
+    is entered once per test invocation and shared by every Hypothesis
+    example — ``wool.__proxy__`` set here propagates into the test body
+    (pytest-asyncio runs async fixtures and tests in one context).
+    """
+    async with build_pool_from_scenario(request.param, credentials_map):
+        yield request.param
+
+
+async def _wool_trace(script, retry_grpc_internal):
+    """Execute *script* over the entered pool and return its trace.
+
+    Each attempt runs against a fresh uniquely named ``wool.ContextVar``
+    inside its own stdlib context copy: retries never see a partially
+    mutated variable, and caller-side mutations cannot leak between
+    Hypothesis examples (which otherwise share one ambient context).
+    """
+
+    async def body():
+        async with asyncio.timeout(_SCRIPT_TIMEOUT):
+            var: wool.ContextVar[Any] = wool.ContextVar(f"a5_{uuid.uuid4().hex}")
+            isolated = contextvars.copy_context()
+            return await asyncio.create_task(
+                run_wool_script(script, var), context=isolated
+            )
+
+    return await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestTokenParityAcrossPoolTopologies:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("topology_pool", POOL_TOPOLOGIES, ids=str, indirect=True)
+    @settings(
+        max_examples=10,
+        deadline=None,
+        suppress_health_check=[
+            HealthCheck.function_scoped_fixture,
+            HealthCheck.too_slow,
+        ],
+    )
+    @example(script=_DOUBLE_RESET_REGRESSION)
+    @given(script=scripts())
+    async def test_run_wool_script_should_match_stdlib_oracle_when_topology_varies(
+        self, script, topology_pool, retry_grpc_internal
+    ):
+        """Test generated op scripts keep stdlib parity on every pool topology.
+
+        Given:
+            Any script of up to twelve set/reset/get ops spread across
+            the caller and worker actors, with int/str values and token
+            indexes drawn with replacement, plus one live pool per
+            parametrized topology (two-worker round-robin, eager
+            quorum-2, nested, mTLS) shared across all examples — and a
+            pinned example replaying the cross-process double-reset
+            regression whose final caller reset must observe
+            RuntimeError.
+        When:
+            The script runs through run_wool_script against a fresh
+            wool.ContextVar and, separately, through run_stdlib_oracle.
+        Then:
+            It should produce identical observation traces — pool
+            topology must be invisible to token semantics.
+        """
+        # Act
+        wool_observations = await _wool_trace(script, retry_grpc_internal)
+        stdlib_observations = run_stdlib_oracle(script)
+
+        # Assert
+        assert observations_match(wool_observations, stdlib_observations), (
+            describe_mismatch(wool_observations, stdlib_observations)
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "topology_pool", [_EAGER_TWO_WORKER_SCENARIO], ids=str, indirect=True
+    )
+    async def test_remote_resets_should_match_stdlib_oracle_when_they_hop_workers(
+        self, topology_pool, retry_grpc_internal
+    ):
+        """Test remote resets that alternate workers keep parity across the hop.
+
+        Given:
+            An EPHEMERAL pool with two eagerly started workers behind a
+            round-robin load balancer (quorum 2, so both serve from the
+            first op) and a fixed script of two worker sets, two worker
+            resets, and a final caller reset of the first token — driven
+            through the attributed oracle routines so each remote reset
+            reports the worker pid that performed it.
+        When:
+            The script runs op by op against a fresh wool.ContextVar
+            and, separately, through run_stdlib_oracle.
+        Then:
+            It should produce identical observation traces, the final
+            caller reset should observe RuntimeError because token 0 was
+            already consumed remotely on the other worker, and the two
+            remote resets should be attributed to at least two distinct
+            worker pids — proving the resets actually hopped workers.
+        """
+        # Arrange — the worker-heavy script whose two remote resets must
+        # land on alternating workers.
+        script = [
+            SetOp(WORKER, 1),
+            SetOp(WORKER, 2),
+            ResetOp(WORKER, 1),
+            ResetOp(WORKER, 0),
+            ResetOp(CALLER, 0),
+        ]
+
+        async def body() -> tuple[list[Observation], list[int]]:
+            async with asyncio.timeout(_SCRIPT_TIMEOUT):
+
+                async def drive() -> tuple[list[Observation], list[int]]:
+                    var: wool.ContextVar[Any] = wool.ContextVar(f"a5_{uuid.uuid4().hex}")
+                    tokens: list[Any] = []
+                    trace: list[Observation] = []
+                    reset_pids: list[int] = []
+                    for op in script:
+                        if isinstance(op, SetOp):
+                            _pid, token = await routines.oracle_set_report(
+                                var.namespace, var.name, op.value
+                            )
+                            tokens.append(token)
+                            trace.append(Observation("set", var.get(UNSET), None))
+                        elif op.actor == WORKER:
+                            token = tokens[op.token_index % len(tokens)]
+                            pid, kind, _msg, value = await routines.oracle_reset_report(
+                                var.namespace, var.name, token
+                            )
+                            reset_pids.append(pid)
+                            error = None if kind == "ok" else kind
+                            trace.append(Observation("reset", value, error))
+                        else:  # caller-side reset
+                            token = tokens[op.token_index % len(tokens)]
+                            error = None
+                            try:
+                                var.reset(token)
+                            except (RuntimeError, ValueError, TypeError) as exc:
+                                error = type(exc).__name__
+                            trace.append(Observation("reset", var.get(UNSET), error))
+                    return trace, reset_pids
+
+                isolated = contextvars.copy_context()
+                return await asyncio.create_task(drive(), context=isolated)
+
+        # Act
+        wool_observations, reset_pids = await retry_grpc_internal(body)
+        stdlib_observations = run_stdlib_oracle(script)
+
+        # Assert
+        assert observations_match(wool_observations, stdlib_observations), (
+            describe_mismatch(wool_observations, stdlib_observations)
+        )
+        assert wool_observations[-1].error == "RuntimeError"
+        assert len(set(reset_pids)) >= 2, (
+            "the two remote resets never landed on different workers, so the "
+            "cross-worker ledger relay the round-robin pool advertises was "
+            "not exercised"
+        )

--- a/wool/tests/integration/test_token_parity_streaming.py
+++ b/wool/tests/integration/test_token_parity_streaming.py
@@ -1,0 +1,427 @@
+"""Streaming (async-generator dispatch) wool.Token parity integration tests.
+
+Matrix dimension D5: token semantics across per-yield re-mounts of a
+streaming dispatch. These tests extend the precedents in
+``test_context_var_propagation.py`` (``TestTokenStreaming``,
+``TestSelfDispatchStreamingVarMutation``,
+``TestAsyncGenSetAndResetAcrossYield``) without duplicating them:
+
+* A caller-side local reset mid-stream forward-propagates to later
+  yield frames (the MID_STREAM_FORWARD direction, caller → worker per
+  ``__anext__`` request frame).
+* A token consumed inside a stream stays consumed after exhaustion —
+  including after a fresh caller-side set (ledger retention) and on a
+  worker-side retry (cross-process single-use).
+* A worker-minted token that reaches the caller mid-stream is
+  consumable exactly once; every later attempt at any subsequent yield
+  step or after completion raises — per-step re-mounts must not
+  re-mint anchors.
+* After a stream of worker-side mutation cycles the caller's local
+  set/reset behavior matches stdlib contextvars exactly.
+"""
+
+import asyncio
+import contextvars
+import uuid
+
+import pytest
+import pytest_asyncio
+from hypothesis import HealthCheck
+from hypothesis import example
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
+
+import wool
+
+from . import routines
+from ._token_ops import CALLER
+from ._token_ops import WORKER
+from ._token_ops import ResetOp
+from ._token_ops import SetOp
+from ._token_ops import run_stdlib_oracle
+from .conftest import RoutineShape
+from .conftest import build_pool_from_scenario
+from .conftest import default_scenario
+
+_SCRIPT_TIMEOUT = 30
+
+
+@st.composite
+def _stream_shapes(draw) -> tuple[int, int]:
+    """Draw an ``(n_yields, reset_step)`` streaming shape.
+
+    ``n_yields`` is the number of value yields (1..6); ``reset_step`` is
+    the yield index at which the caller resets the worker-minted token,
+    from 0 (before the first value yield) through ``n_yields`` (at the
+    exact final yield, after the last value read).
+    """
+    n_yields = draw(st.integers(min_value=1, max_value=6))
+    reset_step = draw(st.integers(min_value=0, max_value=n_yields))
+    return n_yields, reset_step
+
+
+@pytest_asyncio.fixture
+async def streaming_pool(credentials_map):
+    """Enter one async-generator pool shared by every property example.
+
+    ``wool.__proxy__`` set here propagates into the property body
+    (pytest-asyncio runs async fixtures and tests in one context), so
+    every drawn example round-trips through the pool entered once.
+    """
+    scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+    async with build_pool_from_scenario(scenario, credentials_map) as pool:
+        yield pool
+
+
+@pytest.mark.integration
+class TestStreamingTokenParity:
+    @pytest.mark.asyncio
+    async def test_caller_reset_mid_stream_should_forward_propagate_to_later_yields(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a caller-side local reset reaches later yield frames.
+
+        Given:
+            A caller that minted a TENANT_ID token before opening a
+            streaming dispatch of an async generator that yields the
+            var's current value on every iteration.
+        When:
+            The caller resets the token locally between the second and
+            third yields.
+        Then:
+            The yields before the reset should observe the caller's
+            set value, every yield after it should observe the
+            restored default — the reset forward-propagates on the
+            next ``__anext__`` request frame — and a caller-side
+            re-reset should raise the single-use RuntimeError.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("pre-stream")
+                gen = routines.stream_tenant_id_echo(4)
+                try:
+                    assert await anext(gen) == "pre-stream"
+                    assert await anext(gen) == "pre-stream"
+                    routines.TENANT_ID.reset(token)
+                    assert routines.TENANT_ID.get() == "unknown"
+                    assert await anext(gen) == "unknown"
+                    assert await anext(gen) == "unknown"
+                    with pytest.raises(StopAsyncIteration):
+                        await anext(gen)
+                finally:
+                    await gen.aclose()
+                assert routines.TENANT_ID.get() == "unknown"
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_stream_consumed_token_should_stay_rejected_when_caller_sets_fresh(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a stream-consumed token stays rejected past a fresh set.
+
+        Given:
+            A caller-minted TENANT_ID token consumed by an async
+            generator that resets it between its two yields, with the
+            stream driven to exhaustion.
+        When:
+            The caller retries the reset, sets a fresh value, and
+            retries the old token again.
+        Then:
+            It should raise the single-use RuntimeError on both
+            retries — the fresh set must not evict the consumed-token
+            ledger entry — while the fresh token itself resets
+            normally, restoring the default.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("stream-take")
+                gen = routines.stream_reset_tenant_id_token(token)
+                collected: list[str] = []
+                try:
+                    async for value in gen:
+                        collected.append(value)
+                finally:
+                    await gen.aclose()
+                assert collected == ["stream-take", "unknown"]
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+                fresh = routines.TENANT_ID.set("fresh-after-stream")
+                assert routines.TENANT_ID.get() == "fresh-after-stream"
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+                routines.TENANT_ID.reset(fresh)
+                assert routines.TENANT_ID.get() == "unknown"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_stream_consumed_token_should_be_rejected_on_a_worker_after_stream(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a stream-consumed token is rejected by a later dispatch.
+
+        Given:
+            A caller-minted TENANT_ID token consumed mid-stream by an
+            async generator that resets it between yields, with the
+            stream driven to exhaustion.
+        When:
+            The caller dispatches the same token to a coroutine that
+            retries the reset on a worker, then retries locally.
+        Then:
+            The worker retry should report the single-use RuntimeError
+            and the local retry should raise it — the consumed state
+            recorded mid-stream binds every later attempt on either
+            side of the wire.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = routines.TENANT_ID.set("stream-take-worker")
+                gen = routines.stream_reset_tenant_id_token(token)
+                try:
+                    async for _ in gen:
+                        pass
+                finally:
+                    await gen.aclose()
+                _, kind, message = await routines.reset_tenant_id_token_report(token)
+                assert kind == "RuntimeError"
+                assert "already been used once" in message
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_minted_token_should_reset_exactly_once_when_used_mid_stream(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker-minted token consumed mid-stream never revives.
+
+        Given:
+            An async generator that sets TENANT_ID on the worker,
+            yields the minted token first, and yields the current
+            value three more times across suspensions.
+        When:
+            The caller resets the yielded token mid-stream — after the
+            first value yield — and then retries the reset at every
+            remaining yield step and after exhaustion.
+        Then:
+            The mid-stream reset should succeed, restoring the default
+            for the caller and for every later worker-side read, and
+            every retry should raise the single-use RuntimeError —
+            per-step re-mounts must not re-mint the token's anchor.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                gen = routines.set_tenant_id_and_yield_token("stream-mint", 3)
+                try:
+                    token = await anext(gen)
+                    assert await anext(gen) == "stream-mint"
+                    routines.TENANT_ID.reset(token)
+                    assert routines.TENANT_ID.get() == "unknown"
+                    later_values: list[str] = []
+                    async for value in gen:
+                        later_values.append(value)
+                        with pytest.raises(RuntimeError, match="already been used once"):
+                            routines.TENANT_ID.reset(token)
+                finally:
+                    await gen.aclose()
+                assert later_values == ["unknown", "unknown"]
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_unary_mint_interleaved_with_stream_should_stay_single_use(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token minted by a unary dispatch mid-stream stays single-use.
+
+        Given:
+            A fresh default-less wool.ContextVar, an open streaming
+            dispatch, and a unary ``oracle_set`` dispatch issued
+            between two yield steps that mints a token on the worker.
+        When:
+            The caller resets the returned token after driving the
+            stream to exhaustion, then retries locally and via a
+            worker-side ``oracle_reset``.
+        Then:
+            The worker's set should back-propagate to the caller
+            mid-stream, the first reset should succeed unbinding the
+            var, and both retries should surface the single-use
+            RuntimeError — the interleaved stream frames must not
+            re-mint the unary token's anchor.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var: wool.ContextVar[str] = wool.ContextVar(
+                    f"a6_stream_{uuid.uuid4().hex}",
+                    namespace=f"a6_ns_{uuid.uuid4().hex}",
+                )
+                unset = routines.ORACLE_UNSET
+                gen = routines.stream_tenant_id_echo(3)
+                try:
+                    await anext(gen)
+                    token = await routines.oracle_set(
+                        var.namespace, var.name, "minted-mid-stream"
+                    )
+                    assert var.get(unset) == "minted-mid-stream"
+                    await anext(gen)
+                    await anext(gen)
+                    with pytest.raises(StopAsyncIteration):
+                        await anext(gen)
+                finally:
+                    await gen.aclose()
+                var.reset(token)
+                assert var.get(unset) == unset
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    var.reset(token)
+                kind, message, value_after = await routines.oracle_reset(
+                    var.namespace, var.name, token
+                )
+                assert kind == "RuntimeError"
+                assert "already been used once" in message
+                assert value_after == unset
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_post_stream_local_ledger_should_match_stdlib_after_worker_cycles(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test post-stream local set/reset behavior matches stdlib.
+
+        Given:
+            A caller that consumed one local TENANT_ID token before the
+            stream and an async generator that sets the var on the
+            worker on every one of its three yields, back-propagating
+            each mutation.
+        When:
+            The caller performs a fresh set/reset cycle after the
+            stream and then retries the pre-stream token.
+        Then:
+            The fresh token should reset normally — restoring the
+            final back-propagated worker value as its old value, per
+            stdlib non-LIFO reset semantics — and the pre-stream token
+            should raise the single-use RuntimeError, proving the
+            consumed ledger survived N per-yield back-propagations.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                pre_stream = routines.TENANT_ID.set("pre-stream-cycle")
+                routines.TENANT_ID.reset(pre_stream)
+                assert routines.TENANT_ID.get() == "unknown"
+                collected: list[str] = []
+                async for value in routines.mutate_on_each_yield(3):
+                    collected.append(value)
+                assert collected == ["step-0", "step-1", "step-2"]
+                assert routines.TENANT_ID.get() == "step-2"
+                fresh = routines.TENANT_ID.set("fresh-post-stream")
+                assert routines.TENANT_ID.get() == "fresh-post-stream"
+                routines.TENANT_ID.reset(fresh)
+                assert routines.TENANT_ID.get() == "step-2"
+                with pytest.raises(RuntimeError, match="already been used once"):
+                    routines.TENANT_ID.reset(pre_stream)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    @settings(
+        max_examples=20,
+        deadline=None,
+        suppress_health_check=[
+            HealthCheck.function_scoped_fixture,
+            HealthCheck.too_slow,
+        ],
+    )
+    @example(shape=(1, 0))  # single-yield stream, reset before the first yield
+    @example(shape=(1, 1))  # single-yield stream, reset at the exact final yield
+    @example(shape=(6, 0))  # longest stream, reset before the first yield
+    @example(shape=(6, 6))  # longest stream, reset at the exact final yield
+    @given(shape=_stream_shapes())
+    async def test_worker_minted_token_should_be_single_use_over_stream_shapes(
+        self, shape, streaming_pool, retry_grpc_internal
+    ):
+        """Test a mid-stream reset stays single-use across every stream shape.
+
+        Given:
+            A worker-minted TENANT_ID token yielded first by an N-yield
+            streaming dispatch (1 <= N <= 6) and a caller-side reset
+            applied at a drawn step in [0, N] — before the first value
+            yield, at any interior step, or at the exact final yield —
+            over one async-generator pool shared across all examples.
+        When:
+            The caller drives the stream to exhaustion, resetting the
+            token at the drawn step, then retries the reset.
+        Then:
+            Every value from the reset step onward should observe the
+            restored default that a run_stdlib_oracle projection of the
+            equivalent worker-set-then-reset script predicts, and the
+            retry should raise the single-use RuntimeError — per-yield
+            re-mounts must not re-mint the token's anchor.
+        """
+        # Arrange
+        n_yields, reset_step = shape
+        minted = "minted"
+        default = "unknown"  # routines.TENANT_ID's constructor default
+        oracle = run_stdlib_oracle([SetOp(WORKER, minted), ResetOp(CALLER, 0)])
+        restored = oracle[-1].value
+        expected_restored = default if restored == routines.ORACLE_UNSET else restored
+
+        async def run() -> tuple[list[str], str]:
+            gen = routines.set_tenant_id_and_yield_token(minted, n_yields)
+            observed: list[str] = []
+            try:
+                token = await anext(gen)
+                for step in range(n_yields):
+                    if step == reset_step:
+                        routines.TENANT_ID.reset(token)
+                    observed.append(await anext(gen))
+                if reset_step == n_yields:
+                    routines.TENANT_ID.reset(token)
+                with pytest.raises(StopAsyncIteration):
+                    await anext(gen)
+            finally:
+                await gen.aclose()
+            restored_value = routines.TENANT_ID.get()
+            with pytest.raises(RuntimeError, match="already been used once"):
+                routines.TENANT_ID.reset(token)
+            return observed, restored_value
+
+        async def body() -> tuple[list[str], str]:
+            async with asyncio.timeout(_SCRIPT_TIMEOUT):
+                isolated = contextvars.copy_context()
+                return await asyncio.create_task(run(), context=isolated)
+
+        # Act
+        observed, restored_value = await retry_grpc_internal(body)
+
+        # Assert
+        expected = [
+            minted if step < reset_step else expected_restored
+            for step in range(n_yields)
+        ]
+        assert observed == expected
+        assert restored_value == expected_restored

--- a/wool/tests/integration/test_token_parity_worker_mints.py
+++ b/wool/tests/integration/test_token_parity_worker_mints.py
@@ -1,0 +1,620 @@
+"""Cross-process wool.Token parity — rows T5-T8: a worker mints the token.
+
+Matrix rows covered here, complementing the caller-mints rows owned by
+sibling lane files:
+
+- T5: a worker sets a var and the minted token rides home; the awaiting
+  caller observes the back-propagated value, resets the token (both
+  previously-unset and non-default priors), and any further use of the
+  consumed token is rejected everywhere — including across a subsequent
+  dispatch and after a fresh caller-side set.
+- T6: the token returns to the SAME worker (DEFAULT pool, exactly one
+  worker process) on a later dispatch and is consumed there; every
+  subsequent reset attempt — third dispatch or caller-side — raises the
+  single-use RuntimeError.
+- T7: the token is minted on one worker of a two-worker EPHEMERAL pool
+  and consumed exactly once as reset attempts round-robin across BOTH
+  workers; the consumed-token ledger follows the token across both
+  processes and home.
+- T8: nested-dispatch mints — an outer worker mints and the inner
+  worker consumes (``outer_mint_inner_reset``), a worker-minted token
+  returned home is consumed through a two-hop nested relay
+  (``relay_reset_tenant_id_token``), and an INNER worker mints via a
+  nested dispatch with the token riding two hops home for the caller
+  to reset (``nested_oracle_set_report``).
+"""
+
+import os
+import uuid
+
+import pytest
+
+import wool
+
+from . import routines
+from .conftest import LazyMode
+from .conftest import PoolMode
+from .conftest import QuorumMode
+from .conftest import build_pool_from_scenario
+from .conftest import default_scenario
+
+#: Caller-side fallback mirroring the worker oracle's unbound sentinel,
+#: so caller and worker observations of "unset" compare equal.
+UNSET = routines.ORACLE_UNSET
+
+
+def _fresh_var() -> wool.ContextVar[str]:
+    """Mint a unique, default-less wool.ContextVar for a single test body."""
+    return wool.ContextVar(f"a3_{uuid.uuid4().hex}")
+
+
+@pytest.mark.integration
+class TestWorkerMintedTokenParity:
+    """T5/T6 — a worker-minted token honored at home and on the same worker."""
+
+    @pytest.mark.asyncio
+    async def test_worker_minted_token_should_restore_unset_state_when_prior_was_unset(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker-minted token restores the previously-unset state.
+
+        Given:
+            A default-less wool.ContextVar that is unbound on the caller
+            and a DEFAULT pool whose worker sets it via the oracle set
+            routine, returning the minted token.
+        When:
+            The caller resets the returned token after observing the
+            back-propagated value.
+        Then:
+            It should restore the exact pre-set state — get() raises
+            LookupError again, mirroring stdlib old-value semantics for
+            a previously-unset variable — and a second caller reset
+            should raise the single-use RuntimeError.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                with pytest.raises(LookupError):
+                    var.get()
+
+                # Act
+                token = await routines.oracle_set(var.namespace, var.name, "t5-value")
+
+                # Act & assert
+                assert var.get(UNSET) == "t5-value"
+                var.reset(token)
+                with pytest.raises(LookupError):
+                    var.get()
+                assert var.get(UNSET) == UNSET
+                with pytest.raises(RuntimeError, match="has already been used once"):
+                    var.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_minted_token_should_restore_prior_value_when_caller_preset_it(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker-minted token restores a caller-set non-default prior.
+
+        Given:
+            A wool.ContextVar the caller set to a prior value before
+            dispatch and a DEFAULT pool whose worker overwrites it via
+            the oracle set routine, returning the minted token.
+        When:
+            The caller resets the worker's token and then resets its own
+            earlier caller-minted token.
+        Then:
+            It should restore the caller's prior value exactly, reject a
+            second use of the worker token with RuntimeError while
+            leaving the value intact, and still honor the caller's own
+            unconsumed token afterwards — per-token single-use, exactly
+            as stdlib tracks each token independently.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                prior_token = var.set("t5-prior")
+
+                # Act
+                token = await routines.oracle_set(var.namespace, var.name, "t5-override")
+
+                # Act & assert
+                assert var.get(UNSET) == "t5-override"
+                var.reset(token)
+                assert var.get() == "t5-prior"
+                with pytest.raises(RuntimeError, match="has already been used once"):
+                    var.reset(token)
+                assert var.get() == "t5-prior"
+                var.reset(prior_token)
+                with pytest.raises(LookupError):
+                    var.get()
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_caller_consumed_worker_token_should_stay_rejected_after_a_fresh_set(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a consumed worker-minted token stays dead across a fresh set.
+
+        Given:
+            A worker-minted token already consumed by a caller-side
+            reset, then a fresh caller-side set minting an independent
+            token on the same variable.
+        When:
+            The caller attempts to reset the consumed worker token
+            again after the fresh set.
+        Then:
+            It should raise the single-use RuntimeError without
+            mutating the variable — the fresh set must not resurrect
+            the spent token — and the fresh token should remain
+            resettable, matching stdlib set-reset-set-reset behavior.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = await routines.oracle_set(var.namespace, var.name, "t5-remote")
+                var.reset(token)
+                fresh_token = var.set("t5-fresh")
+
+                # Act & assert
+                with pytest.raises(RuntimeError, match="has already been used once"):
+                    var.reset(token)
+                assert var.get() == "t5-fresh"
+                var.reset(fresh_token)
+                assert var.get(UNSET) == UNSET
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_caller_consumed_worker_token_should_report_used_when_redispatched(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a caller-consumed worker token is refused by a later dispatch.
+
+        Given:
+            A worker-minted token consumed by a caller-side reset after
+            it rode home on the response frame.
+        When:
+            The caller dispatches the oracle reset routine with the
+            consumed token as an argument.
+        Then:
+            It should report a RuntimeError outcome carrying the
+            single-use message and leave the worker-side variable
+            unbound — the consumed state travels forward on the next
+            dispatch frame, enforcing single-use across processes.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = await routines.oracle_set(var.namespace, var.name, "t5-once")
+                var.reset(token)
+
+                # Act
+                kind, message, value_after = await routines.oracle_reset(
+                    var.namespace, var.name, token
+                )
+
+                # Assert
+                assert kind == "RuntimeError"
+                assert "has already been used once" in message
+                assert value_after == UNSET
+                assert var.get(UNSET) == UNSET
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_minted_token_should_reset_on_the_same_worker_when_sent_back(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the minting worker consumes its own token on a later dispatch.
+
+        Given:
+            A DEFAULT pool with exactly one worker process, a caller-set
+            prior value, and a token minted on that worker by an earlier
+            attributed oracle set dispatch.
+        When:
+            The caller dispatches the attributed oracle reset routine
+            with the token as an argument.
+        Then:
+            It should report an ok outcome from the same pid that minted
+            the token, with the value restored to the caller's prior on
+            the worker and back-propagated home on the response merge.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                var.set("t6-prior")
+                mint_pid, token = await routines.oracle_set_report(
+                    var.namespace, var.name, "t6-mint"
+                )
+                assert var.get(UNSET) == "t6-mint"
+
+                # Act
+                (
+                    reset_pid,
+                    kind,
+                    message,
+                    value_after,
+                ) = await routines.oracle_reset_report(var.namespace, var.name, token)
+
+                # Assert
+                assert reset_pid == mint_pid
+                assert (kind, message, value_after) == ("ok", "", "t6-prior")
+                assert var.get(UNSET) == "t6-prior"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_consumed_token_should_be_rejected_by_worker_and_caller(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token consumed on its minting worker is dead everywhere after.
+
+        Given:
+            A DEFAULT pool with exactly one worker process where a
+            second dispatch already consumed the worker-minted token
+            via the oracle reset routine.
+        When:
+            A third dispatch re-resets the same token and the caller
+            then resets its own returned copy.
+        Then:
+            It should report a RuntimeError outcome with the single-use
+            message from the same worker, and the caller-side reset
+            should raise the same RuntimeError — the spent ledger, not
+            a local used flag, rejects the caller's never-locally-used
+            copy.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                mint_pid, token = await routines.oracle_set_report(
+                    var.namespace, var.name, "t6-remote"
+                )
+                (
+                    first_pid,
+                    first_kind,
+                    _,
+                    first_value,
+                ) = await routines.oracle_reset_report(var.namespace, var.name, token)
+                assert first_pid == mint_pid
+                assert first_kind == "ok"
+                assert first_value == UNSET
+
+                # Act
+                (
+                    third_pid,
+                    kind,
+                    message,
+                    value_after,
+                ) = await routines.oracle_reset_report(var.namespace, var.name, token)
+
+                # Assert
+                assert third_pid == mint_pid
+                assert kind == "RuntimeError"
+                assert "has already been used once" in message
+                assert value_after == UNSET
+                with pytest.raises(RuntimeError, match="has already been used once"):
+                    var.reset(token)
+                assert var.get(UNSET) == UNSET
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_remotely_consumed_worker_token_should_stay_rejected_after_fresh_set(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a remotely consumed token stays dead after a fresh caller set.
+
+        Given:
+            A worker-minted token consumed on the worker by a later
+            dispatch — so the caller's copy was never used locally and
+            its rejection rides solely on the propagated spent ledger —
+            followed by a fresh caller-side set on the same variable.
+        When:
+            The caller attempts to reset the remotely consumed token
+            after the fresh set.
+        Then:
+            It should raise the single-use RuntimeError without
+            mutating the variable — the fresh set's ledger housekeeping
+            must not forget a remote consumption — and the fresh token
+            should remain resettable afterwards.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                token = await routines.oracle_set(var.namespace, var.name, "t6-stale")
+                kind, message, _ = await routines.oracle_reset(
+                    var.namespace, var.name, token
+                )
+                assert (kind, message) == ("ok", "")
+                fresh_token = var.set("t6-fresh")
+
+                # Act & assert
+                with pytest.raises(RuntimeError, match="has already been used once"):
+                    var.reset(token)
+                assert var.get() == "t6-fresh"
+                var.reset(fresh_token)
+                assert var.get(UNSET) == UNSET
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestWorkerMintedTokenLedgerRelay:
+    """T7/T8 — the consumed-token ledger follows the token across workers
+    and nested dispatch chains."""
+
+    @pytest.mark.asyncio
+    async def test_worker_minted_token_should_be_single_use_across_two_workers_and_home(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test one consumption is honored across both pool workers and home.
+
+        Given:
+            An EPHEMERAL pool with two eagerly started workers (quorum
+            2, both guaranteed up) and a token minted on one worker by
+            the attributed oracle set routine.
+        When:
+            The caller dispatches attributed oracle reset attempts
+            repeatedly so the round-robin balancer reaches a pid other
+            than the minting worker's, then retries once more and
+            finally resets at home.
+        Then:
+            It should consume the token exactly once — the first
+            attempt reports ok wherever it lands, including on the
+            non-minting worker — and every subsequent attempt on either
+            worker or the caller should raise or report the single-use
+            RuntimeError, proving the ledger follows the token across
+            both processes and home.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            scenario = default_scenario(
+                pool_mode=PoolMode.EPHEMERAL,
+                lazy=LazyMode.EAGER,
+                quorum=QuorumMode.ABOVE_DEFAULT,
+            )
+            async with build_pool_from_scenario(scenario, credentials_map):
+                mint_pid, token = await routines.oracle_set_report(
+                    var.namespace, var.name, "t7-value"
+                )
+                assert var.get(UNSET) == "t7-value"
+
+                # Act — round-robin reaches the other worker within a
+                # few dispatches; keep dispatching until a different
+                # pid reports the reset outcome.
+                attempts = []
+                for _ in range(8):
+                    report = await routines.oracle_reset_report(
+                        var.namespace, var.name, token
+                    )
+                    attempts.append(report)
+                    if report[0] != mint_pid:
+                        break
+
+                # Assert
+                assert any(pid != mint_pid for pid, _, _, _ in attempts), (
+                    "no reset attempt ever landed on the second worker, so "
+                    "the cross-worker ledger relay was not exercised"
+                )
+                first_pid, first_kind, _, _ = attempts[0]
+                assert first_kind == "ok"
+                if first_pid != mint_pid:
+                    # The other worker consumed the token fresh.
+                    assert len(attempts) == 1
+                for _, kind, message, _ in attempts[1:]:
+                    assert kind == "RuntimeError"
+                    assert "has already been used once" in message
+                # One more worker attempt after consumption — on a
+                # two-worker round-robin this lands on the pid that did
+                # NOT perform the consuming reset.
+                _, extra_kind, extra_message, _ = await routines.oracle_reset_report(
+                    var.namespace, var.name, token
+                )
+                assert extra_kind == "RuntimeError"
+                assert "has already been used once" in extra_message
+                with pytest.raises(RuntimeError, match="has already been used once"):
+                    var.reset(token)
+                assert var.get(UNSET) == UNSET
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_outer_minted_token_should_be_single_use_when_inner_worker_consumes(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test an inner worker consumes an outer-minted token exactly once.
+
+        Given:
+            A DEFAULT pool and the nested routine in which the outer
+            worker sets TENANT_ID, sends the minted token to an inner
+            dispatch that resets it, then retries the reset locally.
+        When:
+            The caller awaits the nested routine with TENANT_ID at its
+            default.
+        Then:
+            It should report the inner reset restoring the propagated
+            default, the outer retry failing the single-use gate with
+            RuntimeError — the consumed state rode the inner response
+            frame back one hop — and the caller's own value unchanged
+            after the whole set-and-reset chain nets out.
+        """
+
+        async def body():
+            # Arrange
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                assert routines.TENANT_ID.get() == "unknown"
+
+                # Act
+                inner_value, kind, message = await routines.outer_mint_inner_reset()
+
+                # Assert
+                assert inner_value == "unknown"
+                assert kind == "RuntimeError"
+                assert "has already been used once" in message
+                assert routines.TENANT_ID.get() == "unknown"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_inner_reset_of_outer_minted_token_should_restore_the_callers_prior(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the inner worker's reset restores the caller's preset prior.
+
+        Given:
+            A DEFAULT pool, TENANT_ID set to a non-default prior on the
+            caller, and the nested routine in which the outer worker
+            mints a token that the inner dispatch consumes.
+        When:
+            The caller awaits the nested routine and afterwards resets
+            its own pre-dispatch token.
+        Then:
+            It should restore the caller's propagated prior on the
+            inner reset, back-propagate that prior home unchanged, and
+            leave the caller's own unconsumed token valid — resetting
+            it still restores the default, since worker-side
+            consumptions are per-token.
+        """
+
+        async def body():
+            # Arrange
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                prior_token = routines.TENANT_ID.set("t8-prior")
+
+                # Act
+                inner_value, kind, message = await routines.outer_mint_inner_reset()
+
+                # Assert
+                assert inner_value == "t8-prior"
+                assert kind == "RuntimeError"
+                assert "has already been used once" in message
+                assert routines.TENANT_ID.get() == "t8-prior"
+                routines.TENANT_ID.reset(prior_token)
+                assert routines.TENANT_ID.get() == "unknown"
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_worker_minted_token_should_be_consumed_through_a_nested_relay_chain(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker-minted token returned home dies via a nested relay.
+
+        Given:
+            A DEFAULT pool, a TENANT_ID token minted on a worker and
+            returned to the awaiting caller, and the relay routine that
+            forwards a token through a nested dispatch whose innermost
+            frame resets it.
+        When:
+            The caller dispatches the relay with the worker-minted
+            token, sending it caller-to-outer-to-inner before the
+            consumption, then resets its own copy at home.
+        Then:
+            It should restore the pre-mint default at the innermost
+            frame, back-propagate the restore across both hops home,
+            and reject the caller's copy with the single-use
+            RuntimeError — the consumed-token ledger followed the token
+            through the entire nested chain and back.
+        """
+
+        async def body():
+            # Arrange
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                assert routines.TENANT_ID.get() == "unknown"
+                token = await routines.set_tenant_id_and_return_token("t8-relay")
+                assert routines.TENANT_ID.get() == "t8-relay"
+
+                # Act
+                restored = await routines.relay_reset_tenant_id_token(token)
+
+                # Assert
+                assert restored == "unknown"
+                assert routines.TENANT_ID.get() == "unknown"
+                with pytest.raises(RuntimeError, match="has already been used once"):
+                    routines.TENANT_ID.reset(token)
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_inner_minted_token_should_reset_at_home_when_ridden_two_hops(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a nested-dispatch-minted token is caller-resettable after two hops.
+
+        Given:
+            A fresh default-less var and a two-worker EPHEMERAL pool
+            with both workers eagerly started.
+        When:
+            The caller dispatches nested_oracle_set_report — the outer
+            worker dispatches oracle_set back into the pool, so an
+            inner worker mints the token — and the token rides home
+            through both response frames for the caller to reset.
+        Then:
+            It should attribute the mint to worker processes distinct
+            from the caller, back-propagate the inner set home, reset
+            exactly once at home restoring the unset state, and reject
+            every further use — both the caller retry and a worker
+            retry.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            scenario = default_scenario(
+                pool_mode=PoolMode.EPHEMERAL,
+                lazy=LazyMode.EAGER,
+                quorum=QuorumMode.ABOVE_DEFAULT,
+            )
+            async with build_pool_from_scenario(scenario, credentials_map):
+                # Act
+                outer_pid, inner_pid, token = await routines.nested_oracle_set_report(
+                    var.namespace, var.name, "t8-inner"
+                )
+
+                # Assert
+                caller_pid = os.getpid()
+                assert outer_pid != caller_pid
+                assert inner_pid != caller_pid
+                assert token.var is var
+                assert token.old_value is wool.Token.MISSING
+                assert var.get(UNSET) == "t8-inner"
+                var.reset(token)
+                assert var.get(UNSET) == UNSET
+                with pytest.raises(RuntimeError, match="has already been used once"):
+                    var.reset(token)
+                kind, _message, value_after = await routines.oracle_reset(
+                    var.namespace, var.name, token
+                )
+                assert kind == "RuntimeError"
+                assert value_after == UNSET
+
+        await retry_grpc_internal(body)

--- a/wool/tests/protocol/test_wire.py
+++ b/wool/tests/protocol/test_wire.py
@@ -95,18 +95,21 @@ class TestMessageConstruction:
         """Test ChainManifest message field round-trip.
 
         Given:
-            An id hex string and a list of ContextVar entries.
+            An id hex string and a ContextVar entry carrying both its
+            spent wool.Token ids and its unspent (live) wool.Token ids.
         When:
-            A ChainManifest message is constructed.
+            A ChainManifest message is constructed and round-tripped
+            through ``SerializeToString`` / ``ParseFromString``.
         Then:
-            Both fields round-trip correctly and each ContextVar
-            entry preserves its namespace, name, and value. The
-            previous ``consumed_tokens`` repeated field is removed
-            from the wire schema (cross-process token transport is
-            deferred to a separate Wool Token wrapper ride; see
-            issue #231).
+            All fields round-trip correctly: each ContextVar entry
+            preserves its namespace, name, value, and its per-var spent
+            and unspent token ids. Cross-process wool.Token transport
+            rides the chain manifest — each ContextVar entry carries the
+            spent ids for its var (``spent_tokens``) and the ids the
+            receiver's mount may anchor (``unspent_tokens``); there is
+            no manifest-level token field.
         """
-        # Arrange, act, & assert
+        # Arrange
         ctx = protocol.ChainManifest(
             id="abc",
             vars=[
@@ -114,6 +117,8 @@ class TestMessageConstruction:
                     namespace="ns",
                     name="key",
                     value=b"value",
+                    spent_tokens=["tok-1", "tok-2"],
+                    unspent_tokens=["tok-3"],
                 )
             ],
         )
@@ -122,6 +127,19 @@ class TestMessageConstruction:
         entry = ctx.vars[0]
         assert (entry.namespace, entry.name) == ("ns", "key")
         assert entry.value == b"value"
+
+        # Act
+        parsed = protocol.ChainManifest()
+        parsed.ParseFromString(ctx.SerializeToString())
+
+        # Assert
+        assert parsed.id == "abc"
+        assert len(parsed.vars) == 1
+        roundtripped = parsed.vars[0]
+        assert (roundtripped.namespace, roundtripped.name) == ("ns", "key")
+        assert roundtripped.value == b"value"
+        assert list(roundtripped.spent_tokens) == ["tok-1", "tok-2"]
+        assert list(roundtripped.unspent_tokens) == ["tok-3"]
 
     def test_runtime_context_fields_with_dispatch_timeout(self):
         """Test RuntimeContext exposes dispatch_timeout when supplied.

--- a/wool/tests/runtime/context/test_chain.py
+++ b/wool/tests/runtime/context/test_chain.py
@@ -5,6 +5,7 @@ import contextvars
 import threading
 from uuid import uuid4
 
+import cloudpickle
 import pytest
 from hypothesis import given
 from hypothesis import settings
@@ -14,6 +15,8 @@ import wool
 from tests.helpers import _unique
 from tests.helpers import scoped_context
 from wool.runtime.context.chain import Chain
+from wool.runtime.context.manifest import ChainManifest
+from wool.runtime.context.token import token_sink
 from wool.runtime.context.var import ContextVar
 
 
@@ -44,8 +47,8 @@ class TestChain:
         When:
             A Chain is constructed with only chain_id and owner.
         Then:
-            It should expose empty data, resets, and stubs
-            collections by default.
+            It should expose empty data, resets, and stubs collections
+            and an empty unspent_tokens mapping by default.
         """
         # Arrange
         chain_id = uuid4()
@@ -60,12 +63,14 @@ class TestChain:
         assert context.vars == frozenset()
         assert context.resets == frozenset()
         assert context.stubs == frozenset()
+        assert context.unspent_tokens == {}
 
     def test___init___should_expose_supplied_collections_when_all_fields(self):
         """Test Chain construction with every field supplied.
 
         Given:
-            Explicit data, resets, and stubs collections.
+            Explicit data, resets, stubs, and unspent_tokens
+            collections.
         When:
             A Chain is constructed with all fields.
         Then:
@@ -75,6 +80,7 @@ class TestChain:
         var = ContextVar(_unique("snap_init"))
         bound = frozenset({var})
         resets = frozenset({("ns", "name")})
+        unspent = {(var.namespace, var.name): frozenset({"aa", "bb"})}
 
         # Act
         context = Chain(
@@ -83,12 +89,14 @@ class TestChain:
             vars=bound,
             resets=resets,
             stubs=frozenset({var}),
+            unspent_tokens=unspent,
         )
 
         # Assert
         assert context.vars == bound
         assert context.resets == resets
         assert context.stubs == frozenset({var})
+        assert context.unspent_tokens == unspent
 
     def test_mount_should_install_field_replacing_copy(self):
         """Test mount installs a field-replacing copy of the chain.
@@ -123,37 +131,43 @@ class TestChain:
 
         Given:
             Plain sets, lists, and tuples supplied for the data,
-            resets, and stubs fields — collections that
-            satisfy the typing intent of the field but are not
-            frozensets at the call site.
+            resets, and stubs fields, and a dict whose values are plain
+            sets supplied for unspent_tokens — collections that satisfy
+            the typing intent of the field but are not the frozen shapes
+            at the call site.
         When:
             A Chain is constructed with those iterables.
         Then:
-            All three fields should expose frozenset views after
-            construction — the post-init coerces non-frozenset
-            iterables so the dataclass invariant (hashable + immutable
-            container shape) holds regardless of what the caller
-            passed.
+            The three set-shaped fields should expose frozenset views
+            and unspent_tokens should expose a dict of frozensets after
+            construction — the post-init coerces the containers so the
+            dataclass invariant (hashable + immutable container shape)
+            holds regardless of what the caller passed.
         """
         # Arrange
         var = ContextVar(_unique("post_init_coerce"))
+        key = (var.namespace, var.name)
 
-        # Act — supply a plain set, list, and tuple respectively.
+        # Act — supply a plain set, list, tuple, and dict-of-set respectively.
         context = Chain(
             id=uuid4(),
             thread=threading.get_ident(),
             vars={var},  # set, not frozenset
             resets=[("ns", "name")],  # list, not frozenset
             stubs=(var,),  # tuple, not frozenset
+            unspent_tokens={key: {"aa", "bb"}},  # dict of set, not frozenset
         )
 
         # Assert
         assert isinstance(context.vars, frozenset)
         assert isinstance(context.resets, frozenset)
         assert isinstance(context.stubs, frozenset)
+        assert isinstance(context.unspent_tokens, dict)
+        assert isinstance(context.unspent_tokens[key], frozenset)
         assert context.vars == frozenset({var})
         assert context.resets == frozenset({("ns", "name")})
         assert context.stubs == frozenset({var})
+        assert context.unspent_tokens == {key: frozenset({"aa", "bb"})}
 
     def test_equality_should_be_identity_based(self):
         """Test Chain equality is identity-based.
@@ -256,6 +270,72 @@ class TestChain:
 
         contextvars.Context().run(_check)
 
+    @given(
+        ops=st.lists(
+            st.tuples(
+                st.sampled_from(["set", "reset"]),
+                st.integers(min_value=0, max_value=2),
+                st.integers(),
+            ),
+            max_size=30,
+        )
+    )
+    @settings(max_examples=50, deadline=None)
+    def test_unspent_tokens_should_track_live_token_count_when_arbitrary_sequences(
+        self, ops
+    ):
+        """Test the unspent-token snapshot tracks the live-token count.
+
+        Given:
+            Three fresh wool.ContextVars in a fresh context and an
+            arbitrary sequence of set/reset operations over them, where
+            each reset spends the most recent unspent token for its
+            variable.
+        When:
+            Each operation is applied through the public set/reset API
+            and the live chain is snapshotted via to_manifest after
+            each one.
+        Then:
+            The total id count across the snapshot's per-var
+            unspent_tokens should equal the number of unspent tokens —
+            each set adds one id under its var's key, each successful
+            reset removes one — and an id consumed by a reset should
+            never reappear in a later snapshot.
+        """
+
+        def _live_ids() -> frozenset[str]:
+            chain = wool.__chain__.get(None)
+            if chain is None:
+                return frozenset()
+            unspent = chain.to_manifest().unspent_tokens
+            return frozenset().union(*unspent.values()) if unspent else frozenset()
+
+        def _check() -> None:
+            targets = [ContextVar(_unique(f"live_oracle_{i}")) for i in range(3)]
+            tokens: dict[int, list] = {i: [] for i in range(3)}
+            unspent = 0
+            consumed: set[str] = set()
+
+            for op, slot, value in ops:
+                var = targets[slot]
+                if op == "set":
+                    tokens[slot].append(var.set(value))
+                    unspent += 1
+                else:
+                    if not tokens[slot]:
+                        continue  # no unspent token — nothing to reset
+                    before = _live_ids()
+                    var.reset(tokens[slot].pop())
+                    unspent -= 1
+                    consumed |= before - _live_ids()
+
+                live = _live_ids()
+                assert len(live) == unspent
+                assert not (consumed & live)
+
+        # Arrange, act, & assert
+        contextvars.Context().run(_check)
+
     def test_to_manifest_should_snapshot_bound_values_inline(self):
         """Test to_manifest captures each bound variable's live value.
 
@@ -337,6 +417,605 @@ class TestChain:
         assert manifest.id == chain_id
         assert manifest.resets == frozenset({(var.namespace, var.name)})
         assert manifest.vars == {}
+
+    def test_to_manifest_should_grow_unspent_tokens_when_var_set_repeatedly(self):
+        """Test each set grows the var's unspent-token snapshot by one id.
+
+        Given:
+            An armed chain where one variable is set twice, with a
+            snapshot taken after each set.
+        When:
+            to_manifest is called after each set.
+        Then:
+            The var's unspent_tokens entry should carry one token id
+            after the first set and two after the second, the second
+            snapshot a strict superset of the first — every set mints a
+            fresh live token id under the var's key.
+        """
+        # Arrange
+        var = ContextVar(_unique("live_grow"))
+        key = (var.namespace, var.name)
+
+        with scoped_context():
+            # Act
+            var.set("first")
+            first = wool.__chain__.get().to_manifest().unspent_tokens[key]
+            var.set("second")
+            second = wool.__chain__.get().to_manifest().unspent_tokens[key]
+
+        # Assert
+        assert len(first) == 1
+        assert len(second) == 2
+        assert second > first
+
+    def test_to_manifest_should_prune_unspent_tokens_when_token_reset(self):
+        """Test reset prunes the consumed token's id from the snapshot.
+
+        Given:
+            An armed chain where one variable was set twice, with a
+            snapshot taken after the first set.
+        When:
+            The second set's token is reset and to_manifest is called
+            again.
+        Then:
+            The new snapshot's per-var unspent token ids should equal
+            the first-set snapshot — the consumed token's id is pruned
+            from the var's live set.
+        """
+        # Arrange
+        var = ContextVar(_unique("live_prune"))
+        key = (var.namespace, var.name)
+
+        with scoped_context():
+            var.set("first")
+            baseline = wool.__chain__.get().to_manifest().unspent_tokens[key]
+            second = var.set("second")
+
+            # Act
+            var.reset(second)
+
+            # Assert
+            assert wool.__chain__.get().to_manifest().unspent_tokens[key] == baseline
+
+    def test_to_manifest_should_snapshot_spent_tokens_when_token_consumed(self):
+        """Test to_manifest snapshots the spent-token ledger for its keys.
+
+        Given:
+            An armed chain where a variable was set and its token
+            reset, recording the spent token id in the chain's ledger.
+        When:
+            to_manifest is called on the active chain.
+        Then:
+            It should carry a non-empty spent-id set under that
+            variable's (namespace, name) key in spent_tokens.
+        """
+        # Arrange
+        var = ContextVar(_unique("ledger_snapshot"))
+
+        with scoped_context():
+            token = var.set("v")
+            var.reset(token)
+
+            # Act
+            manifest = wool.__chain__.get().to_manifest()
+
+        # Assert
+        consumed = manifest.spent_tokens[(var.namespace, var.name)]
+        assert isinstance(consumed, frozenset)
+        assert consumed
+
+    def test_to_manifest_should_exclude_foreign_keys_from_spent_tokens(self):
+        """Test to_manifest omits ledger entries for keys outside the chain.
+
+        Given:
+            A token for one variable consumed inside a sibling
+            contextvars.Context — which arms its own chain — and a
+            separate armed chain binding only a different variable.
+        When:
+            to_manifest is called on the chain binding the other
+            variable.
+        Then:
+            It should carry no spent_tokens entry for the
+            sibling-consumed variable's key — the ledger is chain-local,
+            so a consumption in a sibling chain never reaches this one.
+        """
+        # Arrange
+        local_var = ContextVar(_unique("ledger_local"))
+        foreign_var = ContextVar(_unique("ledger_foreign"))
+
+        def _consume_foreign() -> None:
+            foreign_var.reset(foreign_var.set("x"))
+
+        contextvars.Context().run(_consume_foreign)
+
+        with scoped_context():
+            local_var.set("a")
+
+            # Act
+            manifest = wool.__chain__.get().to_manifest()
+
+        # Assert
+        assert (foreign_var.namespace, foreign_var.name) not in manifest.spent_tokens
+
+    def test_from_manifest_should_seed_unspent_tokens_when_receiver_unarmed(self):
+        """Test from_manifest seeds the manifest's unspent ids on a fresh receiver.
+
+        Given:
+            A manifest snapshotted from a sender scope holding two
+            live tokens, and a fresh unarmed receiver context.
+        When:
+            Chain.from_manifest installs the manifest with no merge
+            target.
+        Then:
+            The receiver chain's snapshot should carry exactly the
+            sender's per-var unspent token ids.
+        """
+        # Arrange
+        var = ContextVar(_unique("seed_live"))
+
+        def _sender() -> ChainManifest:
+            var.set("first")
+            var.set("second")
+            return wool.__chain__.get().to_manifest()
+
+        manifest = contextvars.Context().run(_sender)
+        assert manifest.unspent_tokens
+
+        def _receiver() -> dict[tuple[str, str], frozenset[str]]:
+            assert wool.__chain__.get(None) is None
+            Chain.from_manifest(manifest, owned=True)
+            return wool.__chain__.get().to_manifest().unspent_tokens
+
+        # Act
+        received = contextvars.Context().run(_receiver)
+
+        # Assert
+        assert received == manifest.unspent_tokens
+
+    def test_from_manifest_should_union_unspent_tokens_when_merging(self):
+        """Test from_manifest unions sender and receiver unspent token ids per var.
+
+        Given:
+            A live receiver chain holding one live token and a sender
+            manifest from a sibling scope holding a different live
+            token, each under its own variable's key.
+        When:
+            Chain.from_manifest installs the manifest merged onto the
+            receiver chain.
+        Then:
+            The installed chain should carry the per-var union of both
+            unspent-token mappings (two ids across two keys) under the
+            receiver's chain id.
+        """
+        # Arrange
+        sender_var = ContextVar(_unique("union_sender"))
+        receiver_var = ContextVar(_unique("union_receiver"))
+
+        def _sender() -> ChainManifest:
+            sender_var.set("s")
+            return wool.__chain__.get().to_manifest()
+
+        manifest = contextvars.Context().run(_sender)
+
+        with scoped_context():
+            receiver_var.set("r")
+            receiver = wool.__chain__.get()
+
+            # Act
+            merged = Chain.from_manifest(manifest, owned=True, merge_with=receiver)
+
+            # Assert
+            assert merged.unspent_tokens == {
+                **receiver.unspent_tokens,
+                **manifest.unspent_tokens,
+            }
+            assert sum(len(ids) for ids in merged.unspent_tokens.values()) == 2
+            assert merged.id == receiver.id
+
+    def test_from_manifest_should_seed_spent_tokens_when_receiver_unarmed(self):
+        """Test from_manifest seeds the manifest's spent ids on a fresh receiver.
+
+        Given:
+            A manifest snapshotted from a sender scope that set a variable
+            and reset its token, recording a spent id, and a fresh unarmed
+            receiver context.
+        When:
+            Chain.from_manifest installs the manifest with no merge target.
+        Then:
+            The receiver chain's snapshot should carry exactly the sender's
+            per-var spent token ids — the seed branch mirrors the unspent one.
+        """
+        # Arrange
+        var = ContextVar(_unique("seed_spent"))
+
+        def _sender() -> ChainManifest:
+            var.reset(var.set("v"))
+            return wool.__chain__.get().to_manifest()
+
+        manifest = contextvars.Context().run(_sender)
+        assert manifest.spent_tokens
+
+        def _receiver() -> dict[tuple[str, str], frozenset[str]]:
+            assert wool.__chain__.get(None) is None
+            Chain.from_manifest(manifest, owned=True)
+            return wool.__chain__.get().to_manifest().spent_tokens
+
+        # Act
+        received = contextvars.Context().run(_receiver)
+
+        # Assert
+        assert received == manifest.spent_tokens
+
+    def test_from_manifest_should_block_local_reset_when_ledger_ingested(self):
+        """Test an ingested consumed-token ledger blocks the local reset.
+
+        Given:
+            A live chain holding one live token, and a manifest
+            carrying the same chain id with that token's id in
+            spent_tokens — as if a remote hop had already spent the
+            token.
+        When:
+            Chain.from_manifest merges the manifest onto the live
+            chain and the original token is then reset locally.
+        Then:
+            The reset should raise RuntimeError reporting the token
+            has already been used once — cross-process single-use
+            holds even for the origin still holding the original
+            token.
+        """
+        # Arrange
+        var = ContextVar(_unique("ledger_ingest"))
+
+        with scoped_context():
+            token = var.set("v")
+            live = wool.__chain__.get()
+            key = (var.namespace, var.name)
+            token_id = next(iter(live.to_manifest().unspent_tokens[key]))
+            manifest = ChainManifest(
+                id=live.id,
+                vars={},
+                resets=frozenset(),
+                stubs=frozenset(),
+                spent_tokens={key: frozenset({token_id})},
+            )
+            Chain.from_manifest(manifest, owned=True, merge_with=live)
+
+            # Act & assert
+            with pytest.raises(RuntimeError, match="has already been used once"):
+                var.reset(token)
+
+    def test_to_manifest_should_retain_spent_tokens_when_var_re_set(self):
+        """Test re-setting a variable retains its spent-token ledger entry.
+
+        Given:
+            A variable whose token has been consumed by reset, leaving its
+            id in the chain snapshot's spent_tokens for that key.
+        When:
+            The variable is set again, minting a fresh token.
+        Then:
+            The new snapshot's spent_tokens should still carry the consumed
+            id under the key — a copy of the consumed token may live on any
+            process the id reached with its used flag unset, so this ledger
+            is the only witness rejecting a cross-process double reset.
+            (Bounding the ledger to token lifespan is issue #226.)
+        """
+        # Arrange
+        var = ContextVar(_unique("retain_spent_tokens"))
+        key = (var.namespace, var.name)
+
+        with scoped_context():
+            token = var.set("v")
+            token_id = next(iter(wool.__chain__.get().to_manifest().unspent_tokens[key]))
+            var.reset(token)
+
+            # Act
+            var.set("again")
+
+            # Assert
+            spent = wool.__chain__.get().to_manifest().spent_tokens
+            assert token_id in spent[key]
+
+    def test_from_manifest_should_restore_prior_value_when_wire_token_anchored(self):
+        """Test an anchored wire token restores a real prior value on reset.
+
+        Given:
+            A variable set to a prior value and then re-set, so its token's
+            old_value is that prior value rather than unset, serialized with
+            its manifest and reconstituted in a fresh receiver context.
+        When:
+            The manifest is installed via Chain.from_manifest and the
+            reconstituted token is reset.
+        Then:
+            The variable should rewind to the prior value — the wire reset
+            path applies the token's captured old value, not just the unset
+            sentinel.
+        """
+        # Arrange
+        var = ContextVar(_unique("wire_prior"))
+
+        def _sender() -> tuple[ChainManifest, bytes]:
+            var.set("prior")
+            token = var.set("current")
+            manifest = wool.__chain__.get().to_manifest()
+            return manifest, wool.__serializer__.dumps(token)
+
+        manifest, payload = contextvars.Context().run(_sender)
+
+        def _receiver() -> object:
+            with token_sink() as pending:
+                clone = cloudpickle.loads(payload)
+            Chain.from_manifest(manifest, owned=True, wire_tokens=pending)
+            var.reset(clone)
+            return var.get("<unset>")
+
+        # Act
+        restored = contextvars.Context().run(_receiver)
+
+        # Assert
+        assert restored == "prior"
+
+    def test_from_manifest_should_poison_origin_when_response_carries_consumption(self):
+        """Test a receiver's reset poisons the origin once the response carries it home.
+
+        Given:
+            A caller chain that sets a variable, snapshots its request
+            manifest, and serialises the minted token; a receiver that
+            reconstitutes and resets the clone against that request and
+            snapshots the response.
+        When:
+            The response manifest — now carrying the spent id — is merged
+            back onto the caller chain and the caller resets the original
+            token.
+        Then:
+            The receiver reset should rewind the variable there, and the
+            caller reset should raise RuntimeError — the consumption rode
+            home in the response's spent ledger, not a process-global one.
+        """
+        # Arrange
+        var = ContextVar(_unique("grant_reset"))
+        sentinel = object()
+
+        with scoped_context():
+            original = var.set("granted")
+            caller = wool.__chain__.get()
+            request = caller.to_manifest()
+            payload = wool.__serializer__.dumps(original)
+
+            def _receiver() -> ChainManifest:
+                with token_sink() as pending:
+                    clone = cloudpickle.loads(payload)
+                Chain.from_manifest(request, owned=True, wire_tokens=pending)
+                var.reset(clone)
+                assert var.get(sentinel) is sentinel
+                return wool.__chain__.get().to_manifest()
+
+            response = contextvars.Context().run(_receiver)
+
+            # Act — the response merges the receiver's consumption home.
+            Chain.from_manifest(response, owned=True, merge_with=caller)
+
+            # Assert
+            with pytest.raises(RuntimeError, match="has already been used once"):
+                var.reset(original)
+
+    def test_from_manifest_should_leave_origin_resettable_when_consumption_unpropagated(
+        self,
+    ):
+        """Test from_manifest keeps the ledger local when a consumption is unpropagated.
+
+        Given:
+            A caller chain that sets a variable and dispatches the minted
+            token to a receiver that resets the clone — but whose response,
+            carrying the consumption, is never merged back.
+        When:
+            The caller resets the original token, in a fresh context that
+            never ingested the spent id.
+        Then:
+            It should raise ValueError reporting a different Context, not
+            RuntimeError — spent is chain-local, so a consumption that never
+            rode a frame home cannot poison the origin; the context guard
+            catches the stale token instead. This is the deliberate parity
+            edge of moving the ledger off a process-global registry.
+        """
+        # Arrange
+        var = ContextVar(_unique("no_response"))
+
+        def _sender() -> tuple[wool.Token, ChainManifest, bytes]:
+            token = var.set("granted")
+            return (
+                token,
+                wool.__chain__.get().to_manifest(),
+                wool.__serializer__.dumps(token),
+            )
+
+        original, request, payload = contextvars.Context().run(_sender)
+
+        def _receiver() -> None:
+            with token_sink() as pending:
+                clone = cloudpickle.loads(payload)
+            Chain.from_manifest(request, owned=True, wire_tokens=pending)
+            var.reset(clone)
+
+        contextvars.Context().run(_receiver)
+
+        # Act & assert — no response merged, so the origin's context guard
+        # rejects it rather than the (chain-local, never-propagated) ledger.
+        with pytest.raises(ValueError, match="was created in a different Context"):
+            var.reset(original)
+
+    def test_from_manifest_should_orphan_sibling_token_when_absent_from_snapshot(
+        self,
+    ):
+        """Test a sibling-context token stays an orphan on the receiver.
+
+        Given:
+            An armed outer scope binding one variable, a token for a
+            second variable minted inside a copy_context sibling (same
+            chain id, id absent from the outer snapshot), and a
+            manifest taken in the outer scope.
+        When:
+            A fresh receiver reconstitutes the token, installs the
+            outer manifest, and resets the clone.
+        Then:
+            The reset should raise ValueError reporting the token was
+            created in a different Context — the mount gate anchors
+            only ids present in the manifest's live-token snapshot.
+        """
+        # Arrange
+        outer_var = ContextVar(_unique("sibling_outer"))
+        sibling_var = ContextVar(_unique("sibling_inner"))
+
+        with scoped_context():
+            outer_var.set("outer")
+            sibling_token = contextvars.copy_context().run(
+                lambda: sibling_var.set("sibling")
+            )
+            payload = wool.__serializer__.dumps(sibling_token)
+            manifest = wool.__chain__.get().to_manifest()
+            assert sum(len(ids) for ids in manifest.unspent_tokens.values()) == 1
+
+        def _receiver() -> None:
+            clone = cloudpickle.loads(payload)
+            Chain.from_manifest(manifest, owned=True)
+
+            # Act & assert
+            with pytest.raises(ValueError, match="was created in a different Context"):
+                sibling_var.reset(clone)
+
+        contextvars.Context().run(_receiver)
+
+    def test_from_manifest_should_bound_unspent_tokens_across_dispatch_reset_stream(
+        self,
+    ):
+        """Test the anchor ledger stays bounded across a dispatch-and-reset stream.
+
+        Given:
+            A single long-lived caller chain driving many iterations of
+            the dispatch-and-reset streaming pattern: each iteration sets
+            a variable to a fresh value — minting one live token — then
+            merges back the response manifest a worker would ship after
+            resetting that token, carrying the consumed id in
+            spent_tokens and a reset signal for the variable.
+        When:
+            The set-then-merge round-trip repeats N times against the one
+            chain, and after each set the caller's live-token ledger and
+            the unspent_tokens list that would be encoded onto the next
+            dispatch frame are measured.
+        Then:
+            Both the per-var unspent-token count on the chain and the
+            encoded frame's unspent_tokens length should stay pinned at
+            the single in-flight token rather than growing with N — each
+            reset's consumed id is pruned from the anchor ledger instead
+            of accumulating one dead id per frame.
+        """
+        # Arrange
+        n = 64
+        var = ContextVar(_unique("stream_bound"))
+        key = (var.namespace, var.name)
+        unspent_sizes: list[int] = []
+        wire_sizes: list[int] = []
+
+        def _stream() -> None:
+            for i in range(n):
+                live = wool.__chain__.get(None)
+                before = (
+                    live.to_manifest().unspent_tokens.get(key, frozenset())
+                    if live is not None
+                    else frozenset()
+                )
+                # Caller mints a fresh token for this dispatch frame.
+                var.set(i)
+                chain = wool.__chain__.get()
+                manifest = chain.to_manifest()
+                # The frame gains exactly the freshly minted id over the
+                # prior snapshot — the id a worker would consume and ship
+                # home spent.
+                minted = manifest.unspent_tokens.get(key, frozenset()) - before
+                unspent_sizes.append(len(chain.unspent_tokens.get(key, frozenset())))
+                wire = manifest.to_protobuf()
+                entry = next(e for e in wire.vars if (e.namespace, e.name) == key)
+                wire_sizes.append(len(entry.unspent_tokens))
+                # The response a worker ships after resetting the token:
+                # the consumed id in the spent ledger and the variable
+                # reset to no prior value.
+                response = ChainManifest(
+                    id=chain.id,
+                    vars={},
+                    resets=frozenset({key}),
+                    stubs=frozenset(),
+                    spent_tokens={key: frozenset(minted)},
+                )
+                Chain.from_manifest(response, owned=True, merge_with=chain)
+
+        # Act
+        contextvars.Context().run(_stream)
+
+        # Assert — exactly one in-flight token per iteration, independent of N.
+        assert max(unspent_sizes) == 1
+        assert max(wire_sizes) == 1
+
+    @pytest.mark.asyncio
+    async def test_child_task_should_fork_chain_with_empty_unspent_tokens(self):
+        """Test a child task's forked chain drops the parent's unspent token ids.
+
+        Given:
+            An armed parent chain holding one live token.
+        When:
+            A child task created under Wool's task factory snapshots
+            its own chain.
+        Then:
+            The child's snapshot should carry no unspent token ids — the
+            per-task fork drops them, so a parent-minted token is
+            never anchorable from the fork.
+        """
+        # Arrange
+        var = ContextVar(_unique("fork_live"))
+
+        with scoped_context():
+            var.set("bound")
+            parent = wool.__chain__.get().to_manifest()
+            assert parent.unspent_tokens
+
+            async def child() -> dict[tuple[str, str], frozenset[str]]:
+                return wool.__chain__.get().to_manifest().unspent_tokens
+
+            # Act
+            child_live = await asyncio.create_task(child())
+
+        # Assert
+        assert child_live == {}
+
+    @pytest.mark.asyncio
+    async def test_child_task_should_fork_chain_with_empty_spent_tokens(self):
+        """Test a child task's forked chain drops the parent's spent token ids.
+
+        Given:
+            An armed parent chain that set a variable and reset its token,
+            recording a spent id.
+        When:
+            A child task created under Wool's task factory snapshots its
+            own chain.
+        Then:
+            The child's snapshot should carry no spent token ids — the
+            per-task fork drops them like the unspent half, since a
+            parent-spent token can never be re-reset from the fork anyway.
+        """
+        # Arrange
+        var = ContextVar(_unique("fork_spent"))
+
+        with scoped_context():
+            var.reset(var.set("bound"))
+            parent = wool.__chain__.get().to_manifest()
+            assert parent.spent_tokens
+
+            async def child() -> dict[tuple[str, str], frozenset[str]]:
+                return wool.__chain__.get().to_manifest().spent_tokens
+
+            # Act
+            child_spent = await asyncio.create_task(child())
+
+        # Assert
+        assert child_spent == {}
 
     @pytest.mark.asyncio
     async def test_child_task_should_fork_fresh_chain_copying_bindings(self):
@@ -421,3 +1100,31 @@ def test_copy_context_should_carry_one_plus_n_wool_variables_when_armed(n):
 
     # Assert
     assert count == 1 + n
+
+
+def test_copy_context_should_carry_one_plus_n_wool_variables_when_tokens_live():
+    """Test repeated sets add no extra Wool-owned context variables.
+
+    Given:
+        A context armed with two bound wool.ContextVars, each set
+        three times so several live tokens accumulate on the chain.
+    When:
+        contextvars.copy_context enumerates its variables.
+    Then:
+        Exactly 1 + N Wool-owned contextvars.ContextVars should appear
+        — live-token bookkeeping rides on the chain itself, adding no
+        per-token context variables.
+    """
+    # Arrange
+    bound = [ContextVar(_unique("width_tokens")) for _ in range(2)]
+
+    def _arm() -> None:
+        for i, var in enumerate(bound):
+            for step in range(3):
+                var.set((i, step))
+
+    # Act
+    count = _count_wool_vars_in_a_fresh_context(_arm)
+
+    # Assert
+    assert count == 1 + 2

--- a/wool/tests/runtime/context/test_manifest.py
+++ b/wool/tests/runtime/context/test_manifest.py
@@ -26,6 +26,10 @@ from wool.runtime.context.manifest import resolve_stub
 from wool.runtime.context.var import ContextVar
 from wool.runtime.typing import Undefined
 
+# Wire-safe token-id strategy shared by the token-bookkeeping property tests —
+# hex-ish strings matching the ids ``ContextVar.set`` mints.
+token_ids = st.text(alphabet="0123456789abcdef", min_size=1, max_size=12)
+
 
 def _decode_manifest(wire: protocol.ChainManifest) -> ChainManifest:
     """Decode a wire `protocol.ChainManifest` into a
@@ -48,7 +52,7 @@ def _mount_manifest(manifest: ChainManifest) -> None:
     fresh-install branch automatically). Used by the tests that exercise
     the decode-then-mount round trip via the public API.
     """
-    if not (manifest.vars or manifest.resets):
+    if not manifest.has_state:
         return
     Chain.from_manifest(
         manifest,
@@ -74,6 +78,44 @@ def _adopt_chain(chain_id: UUID) -> None:
 
 
 class TestChainManifest:
+    def test_empty_should_return_fresh_manifest_with_no_token_bookkeeping(self):
+        """Test ChainManifest.empty mints a blank manifest.
+
+        Given:
+            No prior manifest state.
+        When:
+            ChainManifest.empty is called.
+        Then:
+            The manifest should carry no vars, resets, spent_tokens,
+            or unspent_tokens.
+        """
+        # Act
+        manifest = ChainManifest.empty()
+
+        # Assert
+        assert manifest.vars == {}
+        assert manifest.resets == frozenset()
+        assert manifest.spent_tokens == {}
+        assert manifest.unspent_tokens == {}
+
+    def test_empty_should_mint_a_distinct_id_per_call(self):
+        """Test ChainManifest.empty mints a distinct chain id per call.
+
+        Given:
+            No prior manifest state.
+        When:
+            ChainManifest.empty is called twice.
+        Then:
+            The two calls should mint distinct chain ids — no mutable
+            state is shared across calls.
+        """
+        # Act
+        first = ChainManifest.empty()
+        second = ChainManifest.empty()
+
+        # Assert
+        assert first.id != second.id
+
     def test_from_protobuf_should_round_trip_value(self):
         """Test from_protobuf recovers an encoded variable binding.
 
@@ -412,6 +454,167 @@ class TestChainManifest:
         assert decoded.resets == resets
         assert decoded.id == chain_id
 
+    def test_from_protobuf_should_default_token_fields_when_absent_from_wire(self):
+        """Test decoding a legacy wire manifest defaults the token fields.
+
+        Given:
+            A wire chain manifest carrying only an id and one value
+            entry, with the token-bookkeeping fields untouched.
+        When:
+            from_protobuf decodes it.
+        Then:
+            The decoded manifest should carry an empty spent_tokens
+            mapping and an empty unspent_tokens mapping — frames from
+            pre-token senders decode cleanly.
+        """
+        # Arrange
+        var = ContextVar(_unique("legacy_wire"))
+        wire = protocol.ChainManifest(id=uuid4().hex)
+        wire.vars.add(
+            namespace=var.namespace,
+            name=var.name,
+            value=wool.__serializer__.dumps("v"),
+        )
+
+        # Act
+        decoded = _decode_manifest(wire)
+
+        # Assert
+        assert decoded.spent_tokens == {}
+        assert decoded.unspent_tokens == {}
+        assert decoded.vars[var] == "v"
+
+    def test_from_protobuf_should_retain_ledger_when_value_decode_fails(self):
+        """Test a failed value entry still contributes its spent and unspent ids.
+
+        Given:
+            A wire entry whose value bytes are not valid pickle data
+            but which carries both spent and unspent token ids, under
+            non-strict warning filtering.
+        When:
+            from_protobuf decodes it.
+        Then:
+            The decoded manifest should retain the entry's spent and
+            unspent ids under its key — the token bookkeeping rides
+            independently of value state — while the key stays absent
+            from both vars and resets.
+        """
+        # Arrange
+        var = ContextVar(_unique("bad_value_ledger"))
+        wire = protocol.ChainManifest(id=uuid4().hex)
+        wire.vars.add(
+            namespace=var.namespace,
+            name=var.name,
+            value=b"not-pickle",
+            spent_tokens=["aa", "bb"],
+            unspent_tokens=["cc"],
+        )
+
+        # Act
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            decoded = _decode_manifest(wire)
+
+        # Assert
+        key = (var.namespace, var.name)
+        assert decoded.spent_tokens[key] == frozenset({"aa", "bb"})
+        assert decoded.unspent_tokens[key] == frozenset({"cc"})
+        assert var not in decoded.vars
+        assert key not in decoded.resets
+
+    def test_from_protobuf_should_raise_when_strict_mode_with_token_fields(self):
+        """Test strict mode raises even when token fields decode cleanly.
+
+        Given:
+            A wire manifest whose single entry has undecodable value
+            bytes alongside both spent and unspent token ids, under
+            strict SerializationWarning filtering.
+        When:
+            from_protobuf decodes it.
+        Then:
+            It should raise ChainSerializationError and surface no
+            partial manifest — the cleanly-decodable token bookkeeping
+            does not rescue a strict-mode failure.
+        """
+        # Arrange
+        var = ContextVar(_unique("strict_ledger"))
+        wire = protocol.ChainManifest(id=uuid4().hex)
+        wire.vars.add(
+            namespace=var.namespace,
+            name=var.name,
+            value=b"not-pickle",
+            spent_tokens=["aa"],
+            unspent_tokens=["ff"],
+        )
+
+        # Act & assert
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error", category=wool.SerializationWarning)
+            with pytest.raises(wool.ChainSerializationError):
+                _decode_manifest(wire)
+
+    @given(
+        value_entries=st.lists(
+            st.tuples(
+                st.integers() | st.text(),
+                st.frozensets(token_ids, max_size=3),
+                st.frozensets(token_ids, max_size=3),
+            ),
+            max_size=3,
+        ),
+        reset_ledgers=st.lists(st.frozensets(token_ids, max_size=3), max_size=2),
+    )
+    @settings(max_examples=50, deadline=None)
+    def test_from_protobuf_should_round_trip_token_bookkeeping(
+        self, value_entries, reset_ledgers
+    ):
+        """Test the codec round-trips per-var spent and unspent token ids.
+
+        Given:
+            A manifest mixing value-bearing and reset-only keys, a
+            per-var spent-token ledger over both populations with
+            possibly-empty entry sets, and per-var unspent token ids on
+            the value-bearing keys.
+        When:
+            The manifest is encoded with to_protobuf and decoded back
+            with from_protobuf.
+        Then:
+            The decoded manifest should recover exactly the non-empty
+            spent_tokens and unspent_tokens entries as frozensets — an
+            unspent id rides only its value-bearing var's entry.
+        """
+        # Arrange
+        bound = [ContextVar(_unique("rt_ledger_val")) for _ in value_entries]
+        reset_vars = [ContextVar(_unique("rt_ledger_reset")) for _ in reset_ledgers]
+        spent_tokens = {}
+        unspent_tokens = {}
+        for var, (_, spent, unspent) in zip(bound, value_entries):
+            spent_tokens[(var.namespace, var.name)] = spent
+            unspent_tokens[(var.namespace, var.name)] = unspent
+        for var, spent in zip(reset_vars, reset_ledgers):
+            spent_tokens[(var.namespace, var.name)] = spent
+        manifest = ChainManifest(
+            id=uuid4(),
+            vars={var: value for var, (value, _, _) in zip(bound, value_entries)},
+            resets=frozenset((v.namespace, v.name) for v in reset_vars),
+            stubs=frozenset(),
+            spent_tokens=spent_tokens,
+            unspent_tokens=unspent_tokens,
+        )
+
+        # Act
+        decoded = _decode_manifest(manifest.to_protobuf())
+
+        # Assert
+        assert decoded.spent_tokens == {
+            key: ids for key, ids in spent_tokens.items() if ids
+        }
+        assert decoded.unspent_tokens == {
+            key: ids for key, ids in unspent_tokens.items() if ids
+        }
+        assert all(isinstance(ids, frozenset) for ids in decoded.spent_tokens.values())
+        assert all(isinstance(ids, frozenset) for ids in decoded.unspent_tokens.values())
+
 
 class TestChainManifestToProtobuf:
     def test_to_protobuf_should_return_empty_manifest_when_none(self):
@@ -645,6 +848,276 @@ class TestChainManifestToProtobuf:
         # Assert
         keys = {(entry.namespace, entry.name) for entry in wire.vars}
         assert (var.namespace, var.name) not in keys
+
+    def test_to_protobuf_should_ride_spent_tokens_on_value_entry(self):
+        """Test spent ids ride sorted on the key's value entry.
+
+        Given:
+            A manifest binding one variable to a value, with spent
+            token ids recorded for that variable's key.
+        When:
+            to_protobuf is called.
+        Then:
+            The single wire entry should carry the value and the
+            spent ids sorted within the entry — no standalone entry
+            is emitted for the ledger.
+        """
+        # Arrange
+        var = ContextVar(_unique("piggyback_value"))
+        manifest = ChainManifest(
+            id=uuid4(),
+            vars={var: "v"},
+            resets=frozenset(),
+            stubs=frozenset(),
+            spent_tokens={(var.namespace, var.name): frozenset({"bb", "aa"})},
+        )
+
+        # Act
+        wire = manifest.to_protobuf()
+
+        # Assert
+        assert len(wire.vars) == 1
+        entry = wire.vars[0]
+        assert entry.HasField("value")
+        assert list(entry.spent_tokens) == ["aa", "bb"]
+
+    def test_to_protobuf_should_ride_unspent_tokens_on_value_entry(self):
+        """Test unspent ids ride sorted on the key's value entry.
+
+        Given:
+            A manifest binding one variable to a value, with unspent
+            (live) token ids recorded for that variable's key.
+        When:
+            to_protobuf is called.
+        Then:
+            The single wire entry should carry the value and the
+            unspent ids sorted within the entry — an unspent id always
+            rides its value-bearing var's entry.
+        """
+        # Arrange
+        var = ContextVar(_unique("piggyback_unspent"))
+        manifest = ChainManifest(
+            id=uuid4(),
+            vars={var: "v"},
+            resets=frozenset(),
+            stubs=frozenset(),
+            unspent_tokens={(var.namespace, var.name): frozenset({"bb", "aa"})},
+        )
+
+        # Act
+        wire = manifest.to_protobuf()
+
+        # Assert
+        assert len(wire.vars) == 1
+        entry = wire.vars[0]
+        assert entry.HasField("value")
+        assert list(entry.unspent_tokens) == ["aa", "bb"]
+
+    def test_to_protobuf_should_ride_spent_tokens_on_reset_entry(self):
+        """Test spent ids ride on a value-less reset entry.
+
+        Given:
+            A manifest whose only key is reset-pending, with spent
+            token ids recorded for that key.
+        When:
+            to_protobuf is called.
+        Then:
+            Exactly one value-less wire entry should be emitted,
+            carrying the spent ids sorted within it.
+        """
+        # Arrange
+        key = ("reset_ns", _unique("piggyback_reset"))
+        manifest = ChainManifest(
+            id=uuid4(),
+            vars={},
+            resets=frozenset({key}),
+            stubs=frozenset(),
+            spent_tokens={key: frozenset({"cc", "aa"})},
+        )
+
+        # Act
+        wire = manifest.to_protobuf()
+
+        # Assert
+        assert len(wire.vars) == 1
+        entry = wire.vars[0]
+        assert not entry.HasField("value")
+        assert list(entry.spent_tokens) == ["aa", "cc"]
+
+    def test_to_protobuf_should_omit_token_ids_when_key_not_bound_or_reset(self):
+        """Test spent/unspent ids under a key outside vars and resets emit nothing.
+
+        Given:
+            A manifest with no bindings or resets whose spent_tokens
+            and unspent_tokens carry ids under keys absent from both.
+        When:
+            to_protobuf is called.
+        Then:
+            The wire manifest should carry no entries at all — token
+            ids only piggyback on an entry that exists for a bound or
+            reset key, never a standalone entry.
+        """
+        # Arrange
+        manifest = ChainManifest(
+            id=uuid4(),
+            vars={},
+            resets=frozenset(),
+            stubs=frozenset(),
+            spent_tokens={("ghost_ns", _unique("ghost_spent")): frozenset({"zz"})},
+            unspent_tokens={("ghost_ns", _unique("ghost_unspent")): frozenset({"yy"})},
+        )
+
+        # Act
+        wire = manifest.to_protobuf()
+
+        # Assert
+        assert len(wire.vars) == 0
+
+    def test_to_protobuf_should_omit_empty_token_bookkeeping(self):
+        """Test empty ledger and live-id sets leave no wire footprint.
+
+        Given:
+            Two manifests identical except one carries an empty
+            spent-id set and an empty unspent-id set for its key.
+        When:
+            Both manifests are encoded with to_protobuf.
+        Then:
+            The serialised wire bytes should be identical — empty
+            token bookkeeping is omitted from the wire entirely.
+        """
+        # Arrange
+        var = ContextVar(_unique("empty_ledger"))
+        chain_id = uuid4()
+        with_empty = ChainManifest(
+            id=chain_id,
+            vars={var: "v"},
+            resets=frozenset(),
+            stubs=frozenset(),
+            spent_tokens={(var.namespace, var.name): frozenset()},
+            unspent_tokens={(var.namespace, var.name): frozenset()},
+        )
+        without = ChainManifest(
+            id=chain_id,
+            vars={var: "v"},
+            resets=frozenset(),
+            stubs=frozenset(),
+        )
+
+        # Act
+        first = with_empty.to_protobuf().SerializeToString()
+        second = without.to_protobuf().SerializeToString()
+
+        # Assert
+        assert first == second
+
+    def test_to_protobuf_should_suppress_token_ids_when_value_encode_fails(self):
+        """Test an encode failure suppresses the failed key's spent and unspent ids.
+
+        Given:
+            A manifest binding one unpicklable value whose key carries
+            both spent and unspent token ids, alongside one
+            serializable binding, under non-strict warning filtering.
+        When:
+            to_protobuf is called.
+        Then:
+            It should warn, emit only the good entry, and ship the
+            failed key's spent and unspent ids nowhere on the wire —
+            the whole entry is suppressed, token bookkeeping included.
+        """
+        # Arrange
+        good = ContextVar(_unique("ledger_good"))
+        bad = ContextVar(_unique("ledger_bad"))
+        manifest = ChainManifest(
+            id=uuid4(),
+            vars={good: "ok", bad: threading.Lock()},
+            resets=frozenset(),
+            stubs=frozenset(),
+            spent_tokens={(bad.namespace, bad.name): frozenset({"deadbeef"})},
+            unspent_tokens={(bad.namespace, bad.name): frozenset({"cafef00d"})},
+        )
+
+        # Act
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            wire = manifest.to_protobuf()
+
+        # Assert
+        emitted = [
+            w for w in caught if issubclass(w.category, wool.SerializationWarning)
+        ]
+        assert emitted
+        keys = {(entry.namespace, entry.name) for entry in wire.vars}
+        assert keys == {(good.namespace, good.name)}
+        assert all("deadbeef" not in entry.spent_tokens for entry in wire.vars)
+        assert all("cafef00d" not in entry.unspent_tokens for entry in wire.vars)
+
+    @given(
+        entries=st.lists(
+            st.tuples(
+                st.integers() | st.text(),
+                st.frozensets(token_ids, max_size=3),
+                st.frozensets(token_ids, max_size=3),
+            ),
+            max_size=4,
+        ),
+    )
+    @settings(max_examples=50, deadline=None)
+    def test_to_protobuf_should_encode_identically_when_insertion_order_differs(
+        self, entries
+    ):
+        """Test byte-determinism of the encode across insertion orders.
+
+        Given:
+            Two manifests carrying the same chain id, variable
+            bindings, per-var spent-token ids, and per-var
+            unspent-token ids, with their vars, spent_tokens, and
+            unspent_tokens mappings built in opposite insertion orders.
+        When:
+            Both manifests are encoded with to_protobuf.
+        Then:
+            The serialised wire bytes should be identical — sorted
+            emission of the entries and of each entry's spent and
+            unspent id lists makes identical logical state encode to
+            byte-identical frames.
+        """
+        # Arrange
+        chain_id = uuid4()
+        bound = [ContextVar(_unique("det_order")) for _ in entries]
+        pairs = [(var, value) for var, (value, _, _) in zip(bound, entries)]
+        spent = [
+            ((var.namespace, var.name), ids)
+            for var, (_, ids, _) in zip(bound, entries)
+            if ids
+        ]
+        unspent = [
+            ((var.namespace, var.name), ids)
+            for var, (_, _, ids) in zip(bound, entries)
+            if ids
+        ]
+
+        def _build(vars_pairs, spent_pairs, unspent_pairs):
+            return ChainManifest(
+                id=chain_id,
+                vars=dict(vars_pairs),
+                resets=frozenset(),
+                stubs=frozenset(),
+                spent_tokens=dict(spent_pairs),
+                unspent_tokens=dict(unspent_pairs),
+            )
+
+        forward = _build(pairs, spent, unspent)
+        backward = _build(
+            list(reversed(pairs)),
+            list(reversed(spent)),
+            list(reversed(unspent)),
+        )
+
+        # Act
+        first = forward.to_protobuf().SerializeToString()
+        second = backward.to_protobuf().SerializeToString()
+
+        # Assert
+        assert first == second
 
 
 class TestChainMount:

--- a/wool/tests/runtime/context/test_token.py
+++ b/wool/tests/runtime/context/test_token.py
@@ -1,19 +1,30 @@
+import copy
+import pickle
 import uuid
-from contextvars import Token
 
 import cloudpickle
 import pytest
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
 
 import wool
 from tests.helpers import scoped_context
+from wool.runtime.context.token import Token
+from wool.runtime.context.token import token_sink
 from wool.runtime.context.var import ContextVar
+from wool.runtime.typing import Undefined
 
-# ``dumps`` is the wool serializer — ContextVar serialises only through
-# it. ``loads`` is plain ``cloudpickle.loads``: wool-encoded bytes are
-# cloudpickle-loadable, so a separate wool deserializer is not needed
-# here.
+# ``dumps`` is the wool serializer — a Token serialises only through it.
+# ``loads`` is plain ``cloudpickle.loads``: wool-encoded bytes are
+# cloudpickle-loadable, so a separate wool deserializer is not needed here.
 dumps = wool.__serializer__.dumps
 loads = cloudpickle.loads
+
+
+# Sentinel distinguishing "the variable was never set" from a drawn prior
+# value of None in the roundtrip property below.
+_UNSET = object()
 
 
 def _unique(stem: str) -> str:
@@ -22,18 +33,32 @@ def _unique(stem: str) -> str:
 
 
 class TestToken:
-    def test___repr___should_reference_backing_contextvar(self):
-        """Test Token repr references the backing ContextVar.
+    def test___init___should_reject_direct_construction(self):
+        """Test wool.Token cannot be constructed directly.
+
+        Given:
+            The public wool.Token type.
+        When:
+            It is instantiated directly rather than minted by set().
+        Then:
+            It should raise TypeError — mirroring contextvars.Token, which
+            is likewise not user-constructible, so a forged token cannot
+            bypass the single-use ledger.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(TypeError, match="can only be created"):
+            wool.Token()
+
+    def test___repr___should_name_the_wool_context_var(self):
+        """Test Token repr names the wool ContextVar.
 
         Given:
             A Token produced by set() on a wool.ContextVar.
         When:
             repr() is called on it.
         Then:
-            It should include the backing stdlib ContextVar's
-            qualified name — wool encodes ``(namespace, name)`` into
-            the backing's name so the repr names the originating
-            wool variable in a stdlib-shaped form.
+            It should include the variable's name and namespace in a
+            stdlib-shaped ``<Token var=<...> at 0x...>`` form.
         """
         # Arrange
         var = ContextVar(_unique("repr_token_var"))
@@ -44,28 +69,76 @@ class TestToken:
             text = repr(token)
 
         # Assert
+        assert "Token" in text
         assert var.namespace in text
         assert var.name in text
 
-    def test_old_value_should_report_missing_when_var_previously_unset(self):
-        """Test Token.old_value is MISSING when the var was previously unset.
+    def test___repr___should_flip_used_marker_when_consumed(self):
+        """Test Token repr gains the used marker once the token is consumed.
+
+        Given:
+            A Token minted by set() on a wool.ContextVar.
+        When:
+            repr() is read before and after the token is consumed by
+            reset().
+        Then:
+            It should show no used marker while the token is live and
+            the stdlib-shaped ``<Token used var=`` marker after
+            consumption.
+        """
+        # Arrange
+        var = ContextVar(_unique("repr_flip"))
+
+        # Act
+        with scoped_context():
+            token = var.set("x")
+            before = repr(token)
+            var.reset(token)
+            after = repr(token)
+
+        # Assert
+        assert "used " not in before
+        assert "<Token used var=" in after
+
+    def test_var_should_be_the_wool_context_var(self):
+        """Test Token.var is the wool ContextVar that minted it.
+
+        Given:
+            A ContextVar in an armed context.
+        When:
+            set() mints a Token and its ``var`` is read.
+        Then:
+            It should be the wool ContextVar itself, so ``var.set(x).var is
+            var`` holds as it does in stdlib.
+        """
+        # Arrange
+        var = ContextVar(_unique("token_var"))
+
+        # Act & assert
+        with scoped_context():
+            token = var.set("x")
+            assert token.var is var
+
+    def test_old_value_should_report_undefined_when_var_previously_unset(self):
+        """Test Token.old_value is Undefined when the var was previously unset.
 
         Given:
             A previously-unset ContextVar.
         When:
             set() mints a Token and its old_value is read.
         Then:
-            It should be Token.MISSING.
+            It should be Wool's Undefined sentinel (not the stdlib
+            contextvars.Token.MISSING).
         """
         # Arrange
-        var = ContextVar(_unique("old_value_missing"))
+        var = ContextVar(_unique("old_value_unset"))
 
         # Act
         with scoped_context():
             token = var.set("x")
 
         # Assert
-        assert token.old_value is Token.MISSING
+        assert token.old_value is Undefined
 
     def test_old_value_should_report_prior_value_when_nested_set(self):
         """Test Token.old_value reports the prior value for a nested set.
@@ -88,52 +161,196 @@ class TestToken:
         # Assert
         assert token.old_value == "first"
 
-    def test_token_should_reject_pickle_cloudpickle_and_copy(self):
-        """Test wool.Token rejects pickle, cloudpickle, copy.copy, and deepcopy.
+    def test_old_value_should_be_undefined_when_set_follows_reset_to_unset(self):
+        """Test old_value reports Undefined for a set after a reset to unset.
 
         Given:
-            A live wool.Token (stdlib contextvars.Token under the alias).
+            A ContextVar set once and then reset via its token,
+            returning the variable to the unset state.
         When:
-            pickle.dumps, cloudpickle.dumps, copy.copy, and
-            copy.deepcopy are each invoked on it.
+            The variable is set again, minting a new Token.
         Then:
-            All four raise TypeError — stdlib :class:`contextvars.Token`
-            is not picklable, and a chain-bound Token has no meaningful
-            copy semantics. Cross-process Token transport is deferred;
-            see issue #231.
+            The new token's old_value should be the Undefined sentinel
+            by identity — a reset-to-unset variable has no prior value.
         """
         # Arrange
-        import copy as _copy
-        import pickle
+        var = ContextVar(_unique("old_value_reset_unset"))
 
+        # Act
+        with scoped_context():
+            first = var.set("x")
+            var.reset(first)
+            token = var.set("y")
+
+        # Assert
+        assert token.old_value is Undefined
+
+    @pytest.mark.parametrize(
+        "state",
+        ["live", "used", "orphan"],
+    )
+    @pytest.mark.parametrize(
+        "channel",
+        [pickle.dumps, cloudpickle.dumps, copy.copy, copy.deepcopy],
+        ids=["pickle", "cloudpickle", "copy", "deepcopy"],
+    )
+    def test_token_should_reject_vanilla_serialization(self, channel, state):
+        """Test a Token rejects the vanilla channels in every lifecycle state.
+
+        Given:
+            A wool.Token that is live, already consumed by reset, or an
+            orphan reconstituted from a wool-serializer roundtrip, and
+            one of the vanilla serialization or copy channels — pickle,
+            cloudpickle, copy.copy, or copy.deepcopy.
+        When:
+            The channel is invoked on the token outside a Wool dispatch.
+        Then:
+            It should raise TypeError pointing at Wool's dispatch path —
+            arbitrary transport is disallowed in every token state even
+            though dispatch transport is supported.
+        """
+        # Arrange
         var = ContextVar(_unique("token_reject_channels"))
 
         # Act & assert
         with scoped_context():
             token = var.set("x")
-            for channel in (
-                pickle.dumps,
-                cloudpickle.dumps,
-                _copy.copy,
-                _copy.deepcopy,
-            ):
-                with pytest.raises(TypeError, match="cannot pickle"):
-                    channel(token)
+            if state == "used":
+                var.reset(token)
+            elif state == "orphan":
+                token = loads(dumps(token))
+            with pytest.raises(TypeError, match="Wool dispatch"):
+                channel(token)
+
+    def test_token_should_roundtrip_through_the_wool_serializer(self):
+        """Test a Token survives serialization through the Wool serializer.
+
+        Given:
+            A live wool.Token.
+        When:
+            It is serialized with the Wool serializer and deserialized.
+        Then:
+            It should reconstruct as a Token whose var is the original
+            ContextVar and whose old_value equals the original's — the
+            dispatch-transport path the vanilla guard does not block.
+        """
+        # Arrange
+        var = ContextVar(_unique("token_roundtrip"))
+
+        # Act
+        with scoped_context():
+            token = var.set("x")
+            restored = loads(dumps(token))
+
+        # Assert
+        assert isinstance(restored, Token)
+        assert restored.var is var
+        assert restored.old_value == token.old_value
+
+    def test_old_value_should_be_undefined_identity_after_wire_roundtrip(self):
+        """Test a first-set token's old_value survives the wire as the sentinel.
+
+        Given:
+            A Token minted by the first set on a previously-unset
+            ContextVar, so its old_value is the Undefined sentinel.
+        When:
+            The token is serialized with the Wool serializer and
+            deserialized.
+        Then:
+            The restored token's old_value should be the
+            UndefinedType.Undefined singleton by identity, not a copy.
+        """
+        # Arrange
+        var = ContextVar(_unique("old_value_wire_unset"))
+
+        # Act
+        with scoped_context():
+            token = var.set("x")
+            restored = loads(dumps(token))
+
+        # Assert
+        assert restored.old_value is Undefined
+
+    @given(
+        prior=st.just(_UNSET)
+        | st.none()
+        | st.text()
+        | st.integers()
+        | st.lists(st.integers())
+    )
+    @settings(max_examples=50, deadline=None)
+    def test_token_should_roundtrip_with_arbitrary_prior_value(self, prior):
+        """Test the wool-serializer roundtrip preserves old_value for any prior.
+
+        Given:
+            A ContextVar either left unset or set to any drawn None,
+            text, integer, or list-of-integers prior value, then set
+            again to mint a Token.
+        When:
+            The token is serialized with the Wool serializer and
+            deserialized in-process.
+        Then:
+            The restored token's var should be the original ContextVar
+            and its old_value should equal the original token's — with
+            the Undefined sentinel preserved by identity when the var
+            was previously unset.
+        """
+        # Arrange
+        var = ContextVar(_unique("token_roundtrip_prior"))
+
+        # Act
+        with scoped_context():
+            if prior is not _UNSET:
+                var.set(prior)
+            token = var.set("current")
+            restored = loads(dumps(token))
+
+        # Assert
+        assert restored.var is var
+        if prior is _UNSET:
+            assert token.old_value is Undefined
+            assert restored.old_value is Undefined
+        else:
+            assert restored.old_value == token.old_value
+
+    def test_token_should_survive_repeated_wool_serialization(self):
+        """Test a Token survives two consecutive wool-serializer hops.
+
+        Given:
+            A live wool.Token roundtripped through the Wool serializer
+            once, yielding an orphan clone that is serialized again.
+        When:
+            The double-hop clone is inspected and reset.
+        Then:
+            It should still be a usable Token naming the original var
+            with the original old_value, and its reset should raise
+            ValueError — it was created in a different Context.
+        """
+        # Arrange
+        var = ContextVar(_unique("token_double_hop"))
+
+        # Act & assert
+        with scoped_context():
+            token = var.set("x")
+            clone = loads(dumps(loads(dumps(token))))
+            assert isinstance(clone, Token)
+            assert clone.var is var
+            assert clone.old_value == token.old_value
+            with pytest.raises(ValueError, match="was created in a different Context"):
+                var.reset(clone)
 
 
-def test_token_should_pin_context_var_in_weak_registry():
-    """Test a live Token keeps its backing variable reachable.
+def test_token_should_keep_its_wool_var_reachable():
+    """Test a live Token keeps its wool variable reachable.
 
     Given:
-        A Token minted by ContextVar.set, with no other strong
-        reference to the wool variable.
+        A Token minted by ContextVar.set, with no other strong reference to
+        the wool variable.
     When:
         A garbage collection runs while the token is held.
     Then:
-        The token's ``var`` attribute — the backing stdlib
-        :class:`contextvars.ContextVar` whose qualified name encodes
-        the wool ``(namespace, name)`` identity — should still
-        resolve.
+        The token's ``var`` should still resolve to the wool ContextVar with
+        the original namespace and name.
     """
     import gc
 
@@ -145,6 +362,36 @@ def test_token_should_pin_context_var_in_weak_registry():
     # Act
     gc.collect()
 
-    # Assert — the backing carries the qualified key in its name.
-    assert namespace in token.var.name
-    assert "pinned_var" in token.var.name
+    # Assert
+    assert token.var.namespace == namespace
+    assert token.var.name == "pinned_var"
+
+
+def test_token_sink_should_scope_wire_token_capture_to_the_decode():
+    """Test the decode collector captures live wire tokens only within its scope.
+
+    Given:
+        A live token serialized through the Wool serializer.
+    When:
+        It is reconstituted inside a token_sink() scope and, separately,
+        outside any scope.
+    Then:
+        The in-scope reconstitution should be captured for the frame's mount to
+        anchor, while an out-of-scope reconstitution is captured by nothing — a
+        token whose frame never mounts is reclaimed with the frame's list rather
+        than accumulating in a process-global registry.
+    """
+    # Arrange
+    var = ContextVar(_unique("collect_scope"))
+    with scoped_context():
+        payload = dumps(var.set("x"))
+
+    # Act
+    with token_sink() as collected:
+        clone = loads(payload)
+    outside = loads(payload)
+
+    # Assert
+    assert collected == [clone]
+    assert isinstance(outside, Token)
+    assert outside not in collected

--- a/wool/tests/runtime/context/test_var.py
+++ b/wool/tests/runtime/context/test_var.py
@@ -5,7 +5,7 @@ import gc
 import pickle
 import threading
 import uuid
-from contextvars import Token
+from typing import Any
 
 import cloudpickle
 import pytest
@@ -17,6 +17,7 @@ from hypothesis import strategies as st
 import wool
 from tests.helpers import _unique
 from tests.helpers import scoped_context
+from wool import Token
 from wool import protocol
 
 # ``Chain`` is imported so the task-adoption test can seed an ownerless
@@ -36,6 +37,15 @@ loads = cloudpickle.loads
 # argument supplied" from a supplied ``None``, which is itself a valid
 # default value.
 _NOTHING = object()
+
+
+def _outcome(reset, token):
+    """Return the exception type raised by ``reset(token)``, or None on success."""
+    try:
+        reset(token)
+    except (RuntimeError, ValueError) as error:
+        return type(error)
+    return None
 
 
 class TestContextVar:
@@ -484,18 +494,16 @@ class TestContextVar:
             # Assert
             assert isinstance(token, Token)
 
-    def test_set_should_return_token_whose_var_is_not_the_wool_var(self):
-        """Test the returned token does not reference the wool ContextVar.
+    def test_set_should_return_token_whose_var_is_the_wool_var(self):
+        """Test the returned token references the wool ContextVar.
 
         Given:
             A ContextVar in an armed context.
         When:
             set is called and the returned token's ``var`` is inspected.
         Then:
-            ``token.var`` should not be the wool ContextVar — the
-            deliberate, disclosed divergence from stdlib, where
-            ``var.set(x).var is var`` holds. The supported reset path is
-            ``var.reset(token)``.
+            ``token.var`` should be the wool ContextVar itself, so
+            ``var.set(x).var is var`` holds as it does in stdlib.
         """
         # Arrange
         var = ContextVar(_unique("set_token_var"))
@@ -505,8 +513,7 @@ class TestContextVar:
             token = var.set("x")
 
             # Assert
-            assert token.var is not var
-            assert token.var is var._backing
+            assert token.var is var
 
     def test_set_should_rebuild_the_context_on_each_call(self):
         """Test each set rebuilds a new immutable context.
@@ -715,8 +722,9 @@ class TestContextVar:
         When:
             reset() is called with the same token again.
         Then:
-            It should raise RuntimeError — the reset routes through the
-            backing variable's native single-use bit.
+            It should raise RuntimeError — the wool-level single-use gate
+            (local used flag or the cross-process consumed ledger) fires
+            first.
         """
         # Arrange
         var = ContextVar(_unique("once"), default=0)
@@ -736,7 +744,7 @@ class TestContextVar:
         When:
             reset() is called on one with the other's token.
         Then:
-            Stdlib's `contextvars.ContextVar.reset` raises
+            `ContextVar.reset` raises
             `ValueError` naming the different ContextVar.
         """
         # Arrange
@@ -752,22 +760,31 @@ class TestContextVar:
                 b.reset(token)
 
     @pytest.mark.parametrize(
-        "not_a_token",
-        ["a-string", 42, None],
-        ids=["str", "int", "none"],
+        "make_not_a_token",
+        [
+            lambda: "a-string",
+            lambda: 42,
+            lambda: None,
+            lambda: contextvars.ContextVar(_unique("stdlib_native")).set("native"),
+        ],
+        ids=["str", "int", "none", "native-token"],
     )
-    def test_reset_should_raise_type_error_when_argument_not_token(self, not_a_token):
-        """Test ContextVar.reset rejects an argument that is not a Token.
+    def test_reset_should_raise_type_error_when_argument_not_token(
+        self, make_not_a_token
+    ):
+        """Test ContextVar.reset rejects an argument that is not a wool Token.
 
         Given:
             An armed ContextVar and an argument that is not a
-            wool.Token — a string, an int, or None.
+            wool.Token — a string, an int, None, or a native
+            contextvars.Token minted by a stdlib variable's set().
         When:
             reset() is called with that argument.
         Then:
-            Stdlib's `contextvars.ContextVar.reset` raises
+            `ContextVar.reset` raises
             `TypeError` naming Token — the type check guards
-            reset before any token-state inspection.
+            reset before any token-state inspection, and even the
+            stdlib token type is rejected.
         """
         # Arrange
         var = ContextVar(_unique("reset_not_token"))
@@ -775,8 +792,8 @@ class TestContextVar:
         # Act & assert
         with scoped_context():
             var.set("x")
-            with pytest.raises(TypeError, match="instance of Token"):
-                var.reset(not_a_token)
+            with pytest.raises(TypeError, match="expected an instance of Token"):
+                var.reset(make_not_a_token())
 
     def test_reset_should_raise_runtime_error_when_used_token_for_different_var(self):
         """Test ContextVar.reset rejects an already-used token even on a different var.
@@ -789,7 +806,7 @@ class TestContextVar:
         When:
             reset() is called with that token on the other var.
         Then:
-            Stdlib's `contextvars.ContextVar.reset` raises
+            `ContextVar.reset` raises
             `RuntimeError` for the used token — the used-token
             check runs first, before the different-ContextVar check.
         """
@@ -854,6 +871,269 @@ class TestContextVar:
                 copy_ctx.run(var.reset, token)
             var.reset(token)
             assert var.get("<unset>") == "<unset>"
+
+    def test_reset_should_raise_runtime_error_when_used_token_reset_in_copied_context(
+        self,
+    ):
+        """Test resetting an already-used token in a copied context.
+
+        Given:
+            A Token consumed by reset() in its own context, and a copy
+            of that context taken via contextvars.copy_context.
+        When:
+            reset() is called with the consumed token inside the copy —
+            where a live token would already fail the context check.
+        Then:
+            It should raise RuntimeError — the used-token gate fires
+            before the different-Context gate.
+        """
+        # Arrange
+        var = ContextVar(_unique("reset_used_in_copy"))
+
+        # Act & assert
+        with scoped_context():
+            token = var.set("x")
+            var.reset(token)
+            copied = contextvars.copy_context()
+            with pytest.raises(RuntimeError, match="has already been used once"):
+                copied.run(var.reset, token)
+
+    def test_reset_should_raise_value_error_when_other_vars_token_reset_in_copy(self):
+        """Test resetting another variable's token in a copied context.
+
+        Given:
+            A Token minted by one ContextVar, a second distinct
+            ContextVar, and a copy of the context taken via
+            contextvars.copy_context.
+        When:
+            The second variable's reset() is called with the first
+            variable's token inside the copy — where even the right
+            variable would fail the context check.
+        Then:
+            It should raise ValueError naming the different ContextVar —
+            the wrong-variable gate fires before the different-Context
+            gate.
+        """
+        # Arrange
+        a = ContextVar(_unique("cross_copy_a"))
+        b = ContextVar(_unique("cross_copy_b"))
+
+        # Act & assert
+        with scoped_context():
+            token = a.set("x")
+            copied = contextvars.copy_context()
+            with pytest.raises(
+                ValueError, match="was created by a different ContextVar"
+            ):
+                copied.run(b.reset, token)
+
+    def test_reset_should_raise_value_error_when_token_roundtripped_without_mount(
+        self,
+    ):
+        """Test resetting an unmounted wool-roundtripped token clone.
+
+        Given:
+            A ContextVar set to "x" whose token is roundtripped through
+            the Wool serializer in-process, with no intervening set to
+            mount the chain and anchor the clone.
+        When:
+            reset() is called with the clone immediately, then with the
+            original token.
+        Then:
+            The clone's reset should raise ValueError — it arrived as an
+            orphan with no anchor in this context — leaving the value
+            intact, while the original token's reset still succeeds.
+        """
+        # Arrange
+        var = ContextVar(_unique("reset_orphan_clone"))
+
+        # Act & assert
+        with scoped_context():
+            token = var.set("x")
+            clone = loads(dumps(token))
+            with pytest.raises(ValueError, match="was created in a different Context"):
+                var.reset(clone)
+            assert var.get() == "x"
+            var.reset(token)
+            assert var.get("<unset>") == "<unset>"
+
+    def test_reset_should_raise_runtime_error_when_token_consumed_before_clone_taken(
+        self,
+    ):
+        """Test resetting a clone of a token consumed before serialization.
+
+        Given:
+            A Token consumed by reset() and only then roundtripped
+            through the Wool serializer, so the used flag rides the
+            wire onto the clone.
+        When:
+            reset() is called with the clone.
+        Then:
+            It should raise RuntimeError — the serialized used flag
+            fires the used-token gate before the orphan context check.
+        """
+        # Arrange
+        var = ContextVar(_unique("reset_clone_used_flag"))
+
+        # Act & assert
+        with scoped_context():
+            token = var.set("x")
+            var.reset(token)
+            clone = loads(dumps(token))
+            with pytest.raises(RuntimeError, match="has already been used once"):
+                var.reset(clone)
+
+    def test_reset_should_raise_runtime_error_when_original_consumed_after_clone_taken(
+        self,
+    ):
+        """Test resetting a live-taken clone after the original is consumed.
+
+        Given:
+            A clone of a live Token taken via a wool-serializer
+            roundtrip, after which the original token is consumed by
+            reset().
+        When:
+            reset() is called with the clone, whose own used flag is
+            still False.
+        Then:
+            It should raise RuntimeError — the consumed-token ledger
+            blocks every copy of a consumed token id, not just the
+            object that was reset.
+        """
+        # Arrange
+        var = ContextVar(_unique("reset_clone_ledger"))
+
+        # Act & assert
+        with scoped_context():
+            token = var.set("x")
+            clone = loads(dumps(token))
+            var.reset(token)
+            with pytest.raises(RuntimeError, match="has already been used once"):
+                var.reset(clone)
+
+    def test_reset_should_raise_runtime_error_when_consumed_elsewhere_for_wrong_var(
+        self,
+    ):
+        """Test a ledger-consumed token reset on the wrong var reports used.
+
+        Given:
+            A clone of a live Token whose id was recorded in the
+            cross-process consumed ledger — the original was reset after
+            the clone was taken, so the clone's own used flag is still
+            False — passed to reset on a different ContextVar, so the
+            clone is BOTH consumed elsewhere AND created by a different
+            variable.
+        When:
+            reset() is called with that clone on the other variable.
+        Then:
+            It should raise RuntimeError for the consumed token — the
+            used-gate keys on the token's own variable and fires before
+            the different-ContextVar check, matching stdlib's order.
+        """
+        # Arrange
+        a = ContextVar(_unique("consumed_elsewhere_a"), default=0)
+        b = ContextVar(_unique("consumed_elsewhere_b"), default=0)
+
+        # Act & assert
+        with scoped_context():
+            token = a.set(1)
+            clone = loads(dumps(token))
+            a.reset(token)
+            with pytest.raises(RuntimeError, match="has already been used once"):
+                b.reset(clone)
+
+    @pytest.mark.parametrize(
+        "rejection, expected",
+        [
+            ("not_a_token", TypeError),
+            ("different_var", ValueError),
+            ("consumed", RuntimeError),
+        ],
+        ids=["type-error", "value-error", "runtime-error"],
+    )
+    def test_reset_should_leave_state_intact_when_rejected(self, rejection, expected):
+        """Test a rejected reset leaves the variable and its tokens intact.
+
+        Given:
+            A ContextVar set to "outer" then "inner" with the inner
+            token held, and a reset argument doomed to rejection — a
+            non-token object, another variable's token, or an
+            already-consumed token of this variable.
+        When:
+            reset() is called with the doomed argument.
+        Then:
+            It should raise the matching TypeError, ValueError, or
+            RuntimeError while the value stays "inner" and the held
+            inner token still resets the variable back to "outer".
+        """
+        # Arrange
+        var = ContextVar(_unique("reset_atomicity"))
+
+        # Act & assert
+        with scoped_context():
+            var.set("outer")
+            inner_token = var.set("inner")
+            doomed: Any
+            if rejection == "not_a_token":
+                doomed = "not-a-token"
+            elif rejection == "different_var":
+                other = ContextVar(_unique("reset_atomicity_other"))
+                doomed = other.set("other")
+            else:
+                doomed = var.set("stale")
+                var.reset(doomed)
+            with pytest.raises(expected):
+                var.reset(doomed)
+            assert var.get() == "inner"
+            var.reset(inner_token)
+            assert var.get() == "outer"
+
+    @given(
+        ops=st.lists(
+            st.one_of(
+                st.tuples(st.just("set"), st.integers() | st.text()),
+                st.tuples(st.just("reset"), st.integers(min_value=0, max_value=11)),
+            ),
+            max_size=12,
+        )
+    )
+    @settings(max_examples=50, deadline=None)
+    def test_reset_should_agree_with_stdlib_over_drawn_op_sequences(self, ops):
+        """Test wool set/reset agree with a stdlib contextvars oracle.
+
+        Given:
+            Any sequence of at most 12 operations, each either a set of
+            a drawn value or a reset of a randomly chosen
+            previously-minted token (drawn with replacement, so
+            consumed tokens are retried), applied in lockstep to one
+            wool ContextVar and one stdlib contextvars.ContextVar in a
+            single context.
+        When:
+            Each operation is applied to both variables in turn.
+        Then:
+            After every operation the two variables should observe the
+            same value (or both be unset) and every reset should either
+            succeed on both or raise the same exception type on both.
+        """
+        # Arrange
+        wool_var = ContextVar(_unique("oracle_wool"))
+        stdlib_var = contextvars.ContextVar(_unique("oracle_stdlib"))
+        sentinel = object()
+        wool_tokens = []
+        stdlib_tokens = []
+
+        # Act & assert
+        with scoped_context():
+            for op, argument in ops:
+                if op == "set":
+                    wool_tokens.append(wool_var.set(argument))
+                    stdlib_tokens.append(stdlib_var.set(argument))
+                elif wool_tokens:
+                    index = argument % len(wool_tokens)
+                    wool_outcome = _outcome(wool_var.reset, wool_tokens[index])
+                    stdlib_outcome = _outcome(stdlib_var.reset, stdlib_tokens[index])
+                    assert wool_outcome is stdlib_outcome
+                assert wool_var.get(sentinel) == stdlib_var.get(sentinel)
 
     def test_reset_should_not_raise_when_chain_unarmed_after_native_reset(self, mocker):
         """Test reset no-ops when the active context reads unarmed post-native-reset.

--- a/wool/tests/runtime/worker/test_frame.py
+++ b/wool/tests/runtime/worker/test_frame.py
@@ -11,9 +11,12 @@ from hypothesis import settings
 from hypothesis import strategies as st
 
 import wool
+from tests.helpers import _unique
 from tests.helpers import scoped_context
 from wool import protocol
 from wool.runtime.context.exceptions import SerializationWarning
+from wool.runtime.context.manifest import ChainManifest
+from wool.runtime.context.var import ContextVar
 from wool.runtime.worker.frame import AckResponseFrame
 from wool.runtime.worker.frame import ExceptionResponseFrame
 from wool.runtime.worker.frame import Frame
@@ -641,6 +644,147 @@ class TestFrameToProtobuf:
 
         # Assert
         assert isinstance(restored, AckResponseFrame)
+
+
+class TestFrameMount:
+    """Tests for `Frame.mount` token-bookkeeping ingress."""
+
+    def test_mount_should_ingest_ledger_when_manifest_carries_only_spent_tokens(self):
+        """Test a ledger-only manifest still transits the mount.
+
+        Given:
+            An armed context holding one live token, and a result
+            frame whose manifest carries no vars or resets — only the
+            live token's id in spent_tokens under its variable's key.
+        When:
+            frame.mount() runs caller-side.
+        Then:
+            The context should remain armed and a reset of the
+            original token should raise RuntimeError — the ledger-only
+            manifest was not short-circuited, so the consumption
+            ingested.
+        """
+        # Arrange
+        var = ContextVar(_unique("mount_ledger_only"))
+
+        with scoped_context():
+            token = var.set("v")
+            chain = wool.__chain__.get()
+            key = (var.namespace, var.name)
+            token_id = next(iter(chain.to_manifest().unspent_tokens[key]))
+            manifest = ChainManifest(
+                id=chain.id,
+                vars={},
+                resets=frozenset(),
+                stubs=frozenset(),
+                spent_tokens={key: frozenset({token_id})},
+            )
+            frame = ResultResponseFrame(payload="ok", chain_manifest=manifest)
+
+            # Act
+            frame.mount()
+
+            # Assert
+            assert wool.__chain__.get(None) is not None
+            with pytest.raises(RuntimeError, match="has already been used once"):
+                var.reset(token)
+
+    def test_mount_should_anchor_wire_token_when_manifest_carries_unspent_id(self):
+        """Test a manifest carrying a var's unspent id anchors its wire token.
+
+        Given:
+            An armed context holding one live token and a wire Response
+            carrying that token in its payload and, in its context, the
+            chain id and a value entry for the token's var carrying that
+            token's id in unspent_tokens.
+        When:
+            The response is decoded via Frame.from_protobuf — which
+            reconstitutes and collects the payload token — and mounted.
+        Then:
+            Resetting the reconstituted token should succeed and rewind
+            the variable to unset — the manifest's per-var unspent id
+            transited the mount, which anchored the collected wire token.
+        """
+        # Arrange
+        var = ContextVar(_unique("mount_live_only"))
+        sentinel = object()
+
+        with scoped_context():
+            token = var.set("v")
+            chain = wool.__chain__.get()
+            key = (var.namespace, var.name)
+            token_id = next(iter(chain.to_manifest().unspent_tokens[key]))
+            response = protocol.Response(
+                result=protocol.Message(dump=wool.__serializer__.dumps(token))
+            )
+            response.context.CopyFrom(
+                protocol.ChainManifest(
+                    id=chain.id.hex,
+                    vars=[
+                        protocol.ContextVar(
+                            namespace=var.namespace,
+                            name=var.name,
+                            value=wool.__serializer__.dumps("v"),
+                            unspent_tokens=[token_id],
+                        )
+                    ],
+                )
+            )
+
+            # Act
+            frame = Frame.from_protobuf(response)
+            frame.mount()
+
+            # Assert
+            var.reset(frame.payload)
+            assert var.get(sentinel) is sentinel
+
+    def test_mount_should_noop_when_manifest_carries_no_state(self):
+        """Test an all-empty manifest mounts as a no-op.
+
+        Given:
+            An unarmed context and a result frame carrying
+            ChainManifest.empty() — no vars, resets, or token
+            bookkeeping.
+        When:
+            frame.mount() runs caller-side.
+        Then:
+            The context should remain unarmed — a state-less manifest
+            short-circuits before any install.
+        """
+        # Arrange
+        frame = ResultResponseFrame(payload="ok", chain_manifest=ChainManifest.empty())
+
+        with scoped_context():
+            assert wool.__chain__.get(None) is None
+
+            # Act
+            frame.mount()
+
+            # Assert
+            assert wool.__chain__.get(None) is None
+
+    def test_mount_should_noop_when_frame_has_no_chain_manifest(self):
+        """Test a frame with no chain manifest mounts without raising.
+
+        Given:
+            An unarmed context and a result frame whose chain_manifest
+            is None — the wire envelope carried no context field.
+        When:
+            frame.mount() runs caller-side.
+        Then:
+            It should return without raising and leave the context
+            unarmed.
+        """
+        # Arrange
+        frame = ResultResponseFrame(payload="ok", chain_manifest=None)
+
+        with scoped_context():
+            # Act
+            frame.mount()
+
+            # Assert
+            assert wool.__chain__.get(None) is None
 
 
 class TestChainsDecodeErrorOntoPayload:

--- a/wool/tests/stdlib_parity/test_context_parity.py
+++ b/wool/tests/stdlib_parity/test_context_parity.py
@@ -17,7 +17,9 @@ fixture in ``conftest.py``; the ``1 + N``-width tests are pure
 :class:`contextvars.Context` enumeration and need no running loop.
 """
 
+import asyncio
 import contextvars
+import re
 import uuid
 
 import pytest
@@ -31,6 +33,20 @@ pytestmark = pytest.mark.stdlib_parity
 def _unique(stem: str) -> str:
     """Return a process-unique variable name to avoid registry collisions."""
     return f"{stem}_{uuid.uuid4().hex}"
+
+
+def _masked(message: str) -> str:
+    """Mask variable reprs and hex addresses in a reset error message.
+
+    The ``var=<...>`` segment is masked greedily up to the token
+    repr's trailing `` at `` so a nested ``>`` inside the variable
+    repr (wool's carries a namespace) cannot truncate the mask; the
+    remaining ``0x...`` id is masked separately. What survives is the
+    canonical stdlib message skeleton, so masked equality proves the
+    wool message reads identically to stdlib's.
+    """
+    masked = re.sub(r"var=<.*> at ", "var=<VAR> at ", message)
+    return re.sub(r"0x[0-9a-f]+", "0xADDR", masked)
 
 
 def _wool_owned(context: contextvars.Context) -> list[contextvars.ContextVar]:
@@ -124,7 +140,7 @@ class TestResetCrossContextRejection:
         foreign = contextvars.copy_context()
 
         # Act & assert
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="was created in a different Context"):
             foreign.run(lambda: var.reset(token))
 
     @pytest.mark.asyncio
@@ -152,6 +168,72 @@ class TestResetCrossContextRejection:
 
         # Assert
         assert var.get("unset") == "unset"
+
+    @pytest.mark.asyncio
+    async def test_reset_should_succeed_when_minted_and_reset_in_sibling_context(
+        self, make_var
+    ):
+        """Test a token minted and reset inside one sibling context succeeds.
+
+        Given:
+            A context variable and a copy_context() sibling of the
+            current context.
+        When:
+            A token is minted and reset by the same function invoked
+            through the sibling's run().
+        Then:
+            It should reset without raising — the minting context is
+            the resetting context — and the outer context should never
+            observe the value, identically for a stdlib and a wool
+            variable.
+        """
+        # Arrange
+        var = make_var("reset_sibling")
+        sibling = contextvars.copy_context()
+
+        def mint_and_reset() -> str:
+            token = var.set("inner")
+            var.reset(token)
+            return var.get("fallback")
+
+        # Act
+        inner = sibling.run(mint_and_reset)
+
+        # Assert
+        assert inner == "fallback"
+        assert var.get("fallback") == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_reset_should_raise_value_error_when_in_child_task(self, make_var):
+        """Test reset of a parent-minted token in a child task is rejected.
+
+        Given:
+            A context variable set in the parent task, yielding a
+            token.
+        When:
+            A child task created with asyncio.create_task resets the
+            token, and the parent then resets the same token.
+        Then:
+            The child's reset should raise ValueError ("was created in
+            a different Context") while the parent's subsequent reset
+            still succeeds — the rejection consumed nothing —
+            identically for a stdlib and a wool variable.
+        """
+        # Arrange
+        var = make_var("reset_child_task")
+        token = var.set("value")
+
+        async def child() -> None:
+            with pytest.raises(ValueError, match="was created in a different Context"):
+                var.reset(token)
+
+        # Act & assert — the child's reset is rejected, consuming nothing,
+        # so the parent's subsequent reset still succeeds.
+        await asyncio.create_task(child())
+        var.reset(token)
+
+        # Assert
+        assert var.get("fallback") == "fallback"
 
 
 class TestResetWrongVariableRejection:
@@ -200,8 +282,222 @@ class TestTokenSingleUse:
         var.reset(token)
 
         # Act & assert
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="has already been used once"):
             var.reset(token)
+
+
+class TestResetOrderIndependence:
+    @pytest.mark.asyncio
+    async def test_reset_should_apply_captured_state_when_older_token_reset_first(
+        self, make_var
+    ):
+        """Test out-of-order reset applies each token's captured state.
+
+        Given:
+            A context variable set twice, minting token t1 (before
+            "a") and token t2 (before "b").
+        When:
+            t1 is reset first, then t2.
+        Then:
+            It should restore t1's captured unset state first, then
+            t2's captured prior value "a" — each reset applies its own
+            token's snapshot regardless of minting order, identically
+            for a stdlib and a wool variable.
+        """
+        # Arrange
+        var = make_var("order_older_first")
+        token_one = var.set("a")
+        token_two = var.set("b")
+
+        # Act & assert — t1's snapshot is the unset state.
+        var.reset(token_one)
+        assert var.get("fallback") == "fallback"
+
+        # Act & assert — t2's snapshot is the prior value "a".
+        var.reset(token_two)
+        assert var.get("fallback") == "a"
+
+    @pytest.mark.asyncio
+    async def test_reset_should_apply_captured_state_when_newer_token_reset_first(
+        self, make_var
+    ):
+        """Test in-order reset applies each token's captured state.
+
+        Given:
+            A context variable set twice, minting token t1 (before
+            "a") and token t2 (before "b").
+        When:
+            t2 is reset first, then t1.
+        Then:
+            It should restore t2's captured prior value "a" first,
+            then t1's captured unset state, identically for a stdlib
+            and a wool variable.
+        """
+        # Arrange
+        var = make_var("order_newer_first")
+        token_one = var.set("a")
+        token_two = var.set("b")
+
+        # Act & assert — t2's snapshot is the prior value "a".
+        var.reset(token_two)
+        assert var.get("fallback") == "a"
+
+        # Act & assert — t1's snapshot is the unset state.
+        var.reset(token_one)
+        assert var.get("fallback") == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_reset_should_succeed_when_token_superseded_by_later_set(
+        self, make_var
+    ):
+        """Test resetting a token superseded by a later set succeeds.
+
+        Given:
+            A context variable set to "a" yielding a token, then set
+            again to "b" with the newer token discarded.
+        When:
+            The older token alone is reset.
+        Then:
+            It should succeed and restore the token's captured unset
+            state — a later set does not invalidate an outstanding
+            token, identically for a stdlib and a wool variable.
+        """
+        # Arrange
+        var = make_var("order_superseded")
+        token = var.set("a")
+        var.set("b")
+
+        # Act
+        var.reset(token)
+
+        # Assert
+        assert var.get("fallback") == "fallback"
+
+
+class TestResetErrorMessageParity:
+    def test_reset_should_match_stdlib_message_when_arg_is_not_a_token(self):
+        """Test the non-token reset TypeError matches stdlib byte-for-byte.
+
+        Given:
+            A stdlib and a wool context variable.
+        When:
+            reset is called on each with a plain string instead of a
+            token.
+        Then:
+            It should raise TypeError with the exact stdlib message —
+            "expected an instance of Token, got 'x'" — with no masking
+            required.
+        """
+        # Arrange
+        stdlib_var = contextvars.ContextVar(_unique("msg_type"))
+        wool_var = ContextVar(_unique("msg_type"))
+
+        # Act
+        with pytest.raises(TypeError) as stdlib_exc:
+            stdlib_var.reset("x")  # type: ignore[arg-type]
+        with pytest.raises(TypeError) as wool_exc:
+            wool_var.reset("x")  # type: ignore[arg-type]
+
+        # Assert
+        assert str(stdlib_exc.value) == "expected an instance of Token, got 'x'"
+        assert str(wool_exc.value) == str(stdlib_exc.value)
+
+    def test_reset_should_match_stdlib_message_when_token_already_used(self):
+        """Test the double-reset RuntimeError matches stdlib after masking.
+
+        Given:
+            A stdlib and a wool context variable, each set and reset
+            once so its token is consumed.
+        When:
+            Each consumed token is reset a second time.
+        Then:
+            It should raise RuntimeError whose masked message equals
+            the freshly captured stdlib message — including the
+            ``used`` marker inside the token repr.
+        """
+        # Arrange
+        stdlib_var = contextvars.ContextVar(_unique("msg_used"))
+        stdlib_token = stdlib_var.set("value")
+        stdlib_var.reset(stdlib_token)
+        wool_var = ContextVar(_unique("msg_used"))
+        wool_token = wool_var.set("value")
+        wool_var.reset(wool_token)
+
+        # Act
+        with pytest.raises(RuntimeError) as stdlib_exc:
+            stdlib_var.reset(stdlib_token)
+        with pytest.raises(RuntimeError) as wool_exc:
+            wool_var.reset(wool_token)
+
+        # Assert
+        assert "<Token used var=" in str(stdlib_exc.value)
+        assert "<Token used var=" in str(wool_exc.value)
+        assert _masked(str(wool_exc.value)) == _masked(str(stdlib_exc.value))
+
+    def test_reset_should_match_stdlib_message_when_token_from_another_variable(
+        self,
+    ):
+        """Test the wrong-variable ValueError matches stdlib after masking.
+
+        Given:
+            Two stdlib and two wool context variables, with a token
+            minted by the first variable of each pair.
+        When:
+            The second variable of each pair is reset with the first
+            variable's token.
+        Then:
+            It should raise ValueError whose masked message equals the
+            freshly captured stdlib message — "... was created by a
+            different ContextVar".
+        """
+        # Arrange
+        stdlib_minter = contextvars.ContextVar(_unique("msg_wrong_a"))
+        stdlib_other = contextvars.ContextVar(_unique("msg_wrong_b"))
+        stdlib_token = stdlib_minter.set("a")
+        wool_minter = ContextVar(_unique("msg_wrong_a"))
+        wool_other = ContextVar(_unique("msg_wrong_b"))
+        wool_token = wool_minter.set("a")
+
+        # Act
+        with pytest.raises(ValueError) as stdlib_exc:
+            stdlib_other.reset(stdlib_token)
+        with pytest.raises(ValueError) as wool_exc:
+            wool_other.reset(wool_token)
+
+        # Assert
+        assert "was created by a different ContextVar" in str(stdlib_exc.value)
+        assert _masked(str(wool_exc.value)) == _masked(str(stdlib_exc.value))
+
+    def test_reset_should_match_stdlib_message_when_in_foreign_context(self):
+        """Test the cross-context ValueError matches stdlib after masking.
+
+        Given:
+            A stdlib and a wool context variable, each set in the
+            current context, and a copy_context() taken afterwards.
+        When:
+            Each token is reset inside the copy's run() — a different
+            contextvars.Context than the one it was minted in.
+        Then:
+            It should raise ValueError whose masked message equals the
+            freshly captured stdlib message — "... was created in a
+            different Context".
+        """
+        # Arrange
+        stdlib_var = contextvars.ContextVar(_unique("msg_ctx"))
+        stdlib_token = stdlib_var.set("value")
+        wool_var = ContextVar(_unique("msg_ctx"))
+        wool_token = wool_var.set("value")
+        foreign = contextvars.copy_context()
+
+        # Act
+        with pytest.raises(ValueError) as stdlib_exc:
+            foreign.run(lambda: stdlib_var.reset(stdlib_token))
+        with pytest.raises(ValueError) as wool_exc:
+            foreign.run(lambda: wool_var.reset(wool_token))
+
+        # Assert
+        assert "was created in a different Context" in str(stdlib_exc.value)
+        assert _masked(str(wool_exc.value)) == _masked(str(stdlib_exc.value))
 
 
 class TestCopyContextPropagation:

--- a/wool/tests/test_public.py
+++ b/wool/tests/test_public.py
@@ -1,3 +1,5 @@
+import contextvars
+
 import wool
 
 
@@ -38,8 +40,10 @@ def test_public_api_completeness_should_match_expected_surface():
         "ChainContention",
         "ChainSerializationError",
         "TaskFactoryDisplaced",
+        "Context",
         "ContextVar",
         "ContextVarCollision",
+        "copy_context",
         "RuntimeContext",
         "SerializationError",
         "SerializationWarning",
@@ -103,13 +107,12 @@ def test_removed_symbols_should_not_be_accessible():
     When:
         Checking for the presence of each removed symbol by name.
     Then:
-        It should not expose any of the five removed symbols as attributes.
+        It should not expose any of the four removed symbols as attributes.
     """
     # Arrange
     removed_names = [
         "Chain",
         "current_context",
-        "copy_context",
         "create_task",
         "ContextAlreadyBound",
     ]
@@ -119,6 +122,41 @@ def test_removed_symbols_should_not_be_accessible():
         assert not hasattr(wool, name), (
             f"Removed symbol '{name}' is still accessible on the wool package"
         )
+
+
+def test_context_primitives_should_be_verbatim_stdlib_reexports():
+    """Test wool.Context and wool.copy_context are the stdlib objects themselves.
+
+    Given:
+        The wool package, which builds on contextvars rather than
+        replacing it.
+    When:
+        wool.Context and wool.copy_context are compared by identity to
+        their contextvars counterparts.
+    Then:
+        Each should be the very same object — verbatim re-exports, not
+        wool-native wrappers — so a contextvars-to-wool migration keeps
+        stdlib Context semantics exactly.
+    """
+    # Arrange, act, & assert
+    assert wool.Context is contextvars.Context
+    assert wool.copy_context is contextvars.copy_context
+
+
+def test_token_should_not_be_the_stdlib_token_alias():
+    """Test wool.Token is a distinct wrapper, not the stdlib Token.
+
+    Given:
+        The wool package, whose wool.Token is a picklable wrapper rather
+        than a re-export of contextvars.Token.
+    When:
+        wool.Token is compared by identity to contextvars.Token.
+    Then:
+        It should not be the very same object — wool.Token must never
+        regress into an alias of the stdlib token.
+    """
+    # Arrange, act, & assert
+    assert wool.Token is not contextvars.Token
 
 
 def test_wool_error_should_subclass_exception_not_runtime_error():


### PR DESCRIPTION
## Summary

`wool.Token` was a bare alias for the stdlib `contextvars.Token`, which cannot pickle. A token passed to a routine as an argument, or nested inside a propagated `ContextVar` value, was silently dropped at the dispatch boundary. Now that nested routines genuinely dispatch to the pool (#278), the downstream-reset pattern — set on the caller, reset on a worker — was broken end to end.

Introduce a first-class `wool.Token` returned by `wool.ContextVar.set`. It wraps the native stdlib token locally and serializes only through the dispatch pickler via a wool-reduce hook; vanilla `pickle`, `cloudpickle`, `copy`, and `deepcopy` are rejected with a `TypeError` that points at the dispatch path. Reset reproduces the stdlib contract: single use enforced used-first through a chain-local spent-token ledger, per-variable token binding, and per-context ownership with the canonical stdlib error types and messages.

Context ownership follows the exact minting context, not the chain. A wire token earns a reset anchor on the receiver only when its id appears in the mounted manifest's per-var `unspent_tokens` — the snapshot the sender captured inside the context it ships. The decision cannot be made at serialize time, because a worker pickles its result in the gRPC handler, outside the routine's context, so the ambient chain there is not a reliable witness. Reconstituted tokens are collected during the frame's decode, and `Chain.mount` anchors those live in the mounted chain inside the target context, minting an anchor stdlib token that delegates same-context validation to the stdlib machinery. A token that fails the gate arrives as an orphan: freely holdable, returnable, and re-dispatchable, failing only at an actual reset attempt with the stdlib different-Context error.

Token bookkeeping rides on every request and response frame — per var, as the consumed (`spent_tokens`) and live (`unspent_tokens`) id sets on each `ContextVar` wire entry — so consumption propagates in both directions and the receiver can decide which wire tokens belong to the context it continues. Both ledgers live on the `Chain` rather than any process-global registry, so they are bounded to the chain's lifetime and a worker never accumulates consumed ids across unrelated chains. The change also removes the temporary xfail gate that #278 landed for the coupled nested `DOWNSTREAM_RESET` scenarios, which now pass on their own.

Closes #231

## Proposed changes

### Carry token bookkeeping on the wire chain manifest

Give each `ContextVar` wire entry two per-var id sets: `spent_tokens`, the hex ids of that variable's `wool.Token` instances already consumed by a reset somewhere in the chain, and `unspent_tokens`, the ids of its live tokens minted in the context the manifest snapshots. Both ride every request and response frame, so consumption propagates in both directions and the receiver can decide which wire tokens belong to the context it continues. The ids are per-var on the entry rather than a manifest-level list, so a value-less entry stays unambiguously a reset and the ids piggyback on the entry that already exists for the variable's value or reset. Encoding stays byte-deterministic: both id sets emit sorted, with no manifest-level id list to order.

### Introduce a first-class picklable `wool.Token`

Return a `wool.Token` from `wool.ContextVar.set` instead of aliasing the stdlib token. The token wraps the native stdlib token locally, exposes stdlib-shaped `var`/`old_value`/`repr`, and serializes only through `wool.__serializer__` via a wool-reduce hook — every other serialization channel (`pickle`, `cloudpickle`, `copy`, `deepcopy`) raises a `TypeError` pointing at the dispatch path. Reset reproduces the stdlib contract: the used gate fires before the wrong-variable and different-Context gates, single use is enforced across the chain through its chain-local spent-token ledger, and the canonical error types and messages are preserved byte for byte.

### Anchor wire tokens in the receiving context with chain-local bookkeeping

Reconstitute tokens without deciding ownership at serialize time. Reconstituted tokens are collected during the frame's decode; `Chain.mount` anchors those whose id is present in the mounted manifest's per-var `unspent_tokens`, minting an anchor stdlib token inside the target context that delegates same-context validation to the stdlib machinery. Both the live (`unspent_tokens`) and consumed (`spent_tokens`) ledgers are per-var fields on the `Chain` itself — chain-local runtime bookkeeping excluded from identity, snapshotted onto the manifest by `to_manifest`, merged per var by `from_manifest`, and dropped on a task fork. Keeping them on the chain rather than a process-global registry bounds them to the chain's lifetime and keeps a worker from accumulating consumed ids across unrelated chains. `Frame.mount` no longer short-circuits a manifest whose only state is token bookkeeping, since ledger ingest and anchor drain now live inside the mount. Tokens that fail the gate survive as orphans that raise the stdlib different-Context error only on an actual reset; a consumption that never rides a response frame home leaves the origin's later reset to the context guard — a different-Context `ValueError` rather than the single-use `RuntimeError`.

### Remove the temporary picklable-token xfail gate

Drop the `_needs_picklable_token` predicate, the `_KnownBug` registry, and the `xfail_known_bugs` fixture that #278 added to gate the coupled nested `DOWNSTREAM_RESET` scenarios. Those cases now pass because the reset token pickles across the wire, so `test_dispatch_pairwise` and `test_dispatch_hypothesis` run directly and the region is covered rather than expected-to-fail.

### Add a stdlib-parity-oracle integration test harness

Add an integration harness that pins `wool.Token` reset semantics to stdlib `contextvars` across real worker pools. A small op-script model (`SetOp`/`ResetOp`/`GetOp` over key-addressed `(namespace, name)` variables) is executed two ways: through the wool runtime across a dispatched pool, and against a local stdlib `contextvars.ContextVar` oracle in one context. Both record an observable trace — the post-op value and the exception class at each step — and `observations_match` compares them, so parity is asserted on observable behavior rather than internal bookkeeping. Key-addressed routines (`oracle_set`/`oracle_reset`/`oracle_get` and pid-reporting variants) let a worker mint, reset, and report a token without shipping a `ContextVar` as an argument. Hypothesis drives drawn op-scripts and, for streaming, drawn `(n_yields, reset_step)` shapes, while curated pool topologies (DEFAULT and two-worker EPHEMERAL) exercise the cross-worker ledger relay.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestToken` | A `wool.Token` minted by `ContextVar.set` on a wool variable | Its repr, `var`, and `old_value` are read and direct construction is attempted | Repr names the variable namespace and name and gains a `used` marker once consumed, `var` is the minting variable, `old_value` is `Undefined` when previously unset or the prior value on a nested set, and `wool.Token()` raises TypeError | `wool.Token` identity surface and stdlib-shaped repr |
| 2 | `TestToken` | A live `wool.Token` including first-set, nested-set, and arbitrary drawn prior values | It is serialized through `wool.__serializer__` and reloaded, once or twice | It reconstructs as a `Token` naming the original variable with `old_value` preserved and the `Undefined` sentinel kept by identity, and a double-hop clone stays usable but its reset raises the different-Context ValueError | Token dispatch-transport serialization roundtrip |
| 3 | `TestToken` | A `wool.Token` that is live, already-used, or an orphan clone | `pickle`, `cloudpickle`, `copy.copy`, or `copy.deepcopy` is invoked on it | Each raises TypeError pointing at Wool's dispatch path in every lifecycle state | Token vanilla-serialization guard |
| 4 | `test_token` module | A token serialized through the wool serializer with no other strong reference to its variable | It is reconstituted inside and outside a `collecting_tokens` scope and a gc runs while it is held | Only the in-scope reconstitution is captured for a frame mount to anchor, and the token keeps its wool variable reachable after collection | `collecting_tokens` decode-scope capture |
| 5 | `TestContextVar` (test_var) | An armed `wool.ContextVar` and reset arguments spanning a non-token, a stdlib-native token, a wrong-variable token, an already-used token, and a token from a copied Context | `reset` is called with each | It raises TypeError, ValueError, or RuntimeError matching the violation with the used gate ordered before the wrong-variable and different-Context gates, leaving the variable and its live tokens intact | `ContextVar.reset` single-use and ownership gates |
| 6 | `TestContextVar` (test_var) | A `wool.Token` roundtripped through the wool serializer with no intervening mount, or consumed before or after the clone was taken, alongside drawn set/reset op sequences | The clone or original is reset and the sequences run in lockstep against a stdlib variable | An unanchored clone raises the different-Context ValueError, a serialized used flag or the chain's spent-token ledger raises the single-use RuntimeError for every copy, and every outcome matches the stdlib oracle | Cross-process token clone reset and spent-token ledger |
| 7 | `TestContextVar` (test_var) | A registered `wool.ContextVar`, optionally with a value set or a wire-decoded stub | It is dumped through the wool serializer and reloaded, or run through vanilla pickle and copy channels | The wool roundtrip returns the same registered instance carrying identity only with no value leaking into a receiver context and seeds a default into an existing stub, while pickle, cloudpickle, `copy.copy`, and `deepcopy` all raise TypeError | `wool.ContextVar` identity-only serialization |
| 8 | `TestChain` | Fresh wool variables driven through arbitrary set/reset sequences in a fresh Chain | The live chain is snapshotted via `to_manifest` after each operation | `unspent_tokens` cardinality tracks live tokens per var with each set adding and each reset pruning, `spent_tokens` snapshots consumed ids per bound-or-reset key while a sibling-chain consumption stays excluded and a re-set prunes the key, and bookkeeping adds no per-token context variables | Chain live-token and spent-token bookkeeping |
| 9 | `TestChain` | A sender manifest carrying per-var live and spent token ids, and a fresh or armed receiver chain | `Chain.from_manifest` seeds or merges it and reconstituted wire tokens are reset | `unspent_tokens` and `spent_tokens` seed on a fresh receiver or union per var under the receiver chain id, an ingested spent ledger blocks the origin's local reset with the single-use RuntimeError, an anchored wire token restores its captured prior value, and a receiver reset poisons the origin once its consumption rides the response home while a token absent from the live snapshot stays a different-Context orphan | Chain manifest token merge and wire-token anchoring |
| 10 | `TestChain` | An armed parent chain holding a live token and a consumed token | A child task is created under Wool's task factory | The child forks a fresh chain id that copies bindings, drops the parent resets, and carries empty `unspent_tokens` and `spent_tokens` so neither a parent-minted nor a parent-spent token crosses the fork | Per-task chain fork token isolation |
| 11 | `TestChainManifest` | Wire manifests carrying per-var spent and live token ids, including legacy frames without the token fields and entries whose value bytes fail to decode | `ChainManifest.from_protobuf` decodes them under default and strict warning filters | It round-trips non-empty `spent_tokens` and `unspent_tokens` frozensets per var verbatim, defaults both to empty when absent, retains a failed entry's token ids independently of its value, and still raises `ChainSerializationError` under strict mode | ChainManifest token-field decode |
| 12 | `TestChainManifestToProtobuf` | Manifests whose keys carry spent and live token ids on value-bearing and reset-only entries, built in differing insertion orders | `to_protobuf` encodes them | Both id sets ride sorted on the key's single entry, keys outside `vars` and `resets` and empty token sets emit nothing, an encode failure suppresses the whole entry, and identical logical state serializes to byte-identical frames | Deterministic sorted token-bookkeeping encode |
| 13 | `TestFrameMount` | An armed context holding a live token and a result frame whose manifest carries only `spent_tokens` or only `unspent_tokens`, plus empty and manifest-less frames | `frame.mount` runs caller-side | A spent-only manifest is not short-circuited and ingests the consumption so a later reset raises RuntimeError, an unspent-only manifest anchors the reconstituted wire token so its reset succeeds, and state-less or manifest-less frames mount as a no-op | `Frame.mount` token-bookkeeping ingress |
| 14 | `TestMessageConstruction` (test_wire) | A `protocol.ChainManifest` whose `ContextVar` entry carries per-var `spent_tokens` and `unspent_tokens` ids | It is round-tripped through `SerializeToString` and `ParseFromString` | Each entry preserves its namespace, name, value, and both token-id sets | ChainManifest protobuf token-transport fields |
| 15 | `TestResetCrossContextRejection` and siblings (test_context_parity) | A `wool.ContextVar` and a stdlib `contextvars.ContextVar` exercised side by side | A token is reset in a foreign Context, a child task, with the wrong variable, twice, or out of mint order, and across drawn op sequences | Both variables raise the same exception type or restore the same captured state at every step, pinning single-use, per-variable, and per-Context reset as native stdlib behavior | `wool.ContextVar` reset stdlib parity |
| 16 | `TestResetErrorMessageParity` (test_context_parity) | A `wool.ContextVar` and a stdlib variable each driven into the same reset violation | The non-token, already-used, wrong-variable, and foreign-Context errors are raised | The wool message equals the freshly captured stdlib message byte-for-byte after masking variable reprs and hex addresses, including the `used` marker inside the token repr | Reset error-message stdlib parity |
| 17 | `TestTokenSingleUseAcrossProcesses` | A caller-minted token dispatched to a worker that resets it, across DEFAULT and two-worker EPHEMERAL pools | The caller, the resetting worker, and other workers subsequently attempt to reset the token | The worker reset consumes the token for the caller too, the used gate fires before the context gate on the receiving side, the spent-token ledger reaches a worker that never saw the reset, a returned token reads as used everywhere, and a fresh set mints an independently resettable token | Cross-process single-use token consumption |
| 18 | `TestTokenOwnershipTopologies` | Tokens minted in sibling `copy_context` scopes, in child tasks, or on the worker, dispatched across the wire | They transport to a worker and back and resets are attempted from various contexts | Orphan tokens transport losslessly and refuse reset with the different-Context ValueError even after twice-travelling, a worker-minted token returned to the awaiting caller resets there restoring the pre-call value with awaited-coroutine parity, a child task cannot reset a parent-owned token, and sequential worker mints restore their own captured old values matching a stdlib baseline | Token ownership and orphan transport topologies |
| 19 | `TestTokenNestedDispatch` | A token consumed through a relay or nested dispatch two hops from the caller | The relay returns and the caller and outer worker retry the reset | The inner reset restores the default while the spent-token ledger rides each response frame back one hop, so the outer worker and the caller both report the single-use RuntimeError | Nested-dispatch token ledger propagation |
| 20 | `TestTokenStreaming` | A token carried into or minted inside an async-generator routine across yield suspensions | The routine resets it mid-stream, yields it early, sends it via `asend`, or resets it twice | The mid-stream reset consumes the token before exhaustion with the spent-token ledger riding the step frame back, a yielded worker-minted token survives every per-yield re-mount to stay resettable exactly once, and a second in-stream reset surfaces the single-use RuntimeError | Streaming-dispatch token reset and anchoring |
| 21 | `TestOpModel` and the oracle harness (test_token_ops_model) | The op-script dataclasses (`SetOp`/`ResetOp`/`GetOp`), the stdlib `run_stdlib_oracle` executor, and the `observations_match` comparator the differential suite is built on | The op models are constructed and compared, and a script is executed against a local stdlib `contextvars` oracle | Fields, actor validation, equality, and frozen immutability hold, the oracle records an observable value-and-error-class trace per op, and identical traces compare equal while a divergent entry does not | Cross-process differential-oracle test harness |
| 22 | `TestCallerMintedTokenLocalReset` and `TestCallerMintedTokenRemoteReset` (caller_mints) | A caller-minted token across curated pools, reset at home after an unrelated dispatch, ridden out and back as luggage, passed as a direct worker argument, or relayed two hops | It is reset locally, on the worker, or through the relay | The prior value restores exactly after every hop, the worker reset consumes it for the caller, single use survives an intervening fresh `set`, and each outcome matches the stdlib oracle | Caller-mint reset topologies across processes |
| 23 | `TestWorkerMintedTokenParity` and `TestWorkerMintedTokenLedgerRelay` (worker_mints) | A worker-minted token returned home, including previously-unset and non-default priors, or ridden two hops and across two workers | It is returned to the awaiting caller and reset, or relayed and retried | It restores its own captured old value matching a stdlib baseline, the spent-token ledger rides each response frame home, and single use holds in every process the id reached | Worker-mint reset topologies and ledger relay |
| 24 | `TestTokenParityOracle` (oracle) | Hypothesis-drawn sequential actor-and-op scripts over a wool variable, lockstepped against a stdlib `contextvars` oracle run in one context | The script runs across a real worker pool and against the local oracle | The observed value and exception class agree after every op, pinning single-use, per-variable, and per-Context reset as native stdlib behavior | Cross-process reset stdlib differential parity |
| 25 | `TestTokenParityAcrossPoolTopologies` (oracle_pools) | The differential oracle run over a two-worker EPHEMERAL round-robin pool | Sequential remote resets hop across workers | The trace matches the stdlib oracle, at least two distinct worker pids service the resets, and the spent-token ledger follows the token through both workers | Oracle parity across pool topologies |
| 26 | `TestMultiVarLedgerIndependence`, `TestCrossVarTokenRejection`, and `TestPerVarProjection` (multivar) | Two or three interleaved wool variables driven through per-var set/reset/consume sequences | Tokens are consumed per var, a token is reset against the wrong variable across the wire, and interleaved scripts run against the oracle | Each variable's spent-token ledger stays independent, a wrong-variable reset raises across the wire, and any interleaving decomposes into independent per-var stdlib projections | Per-variable ledger independence and cross-var rejection |
| 27 | `TestUsedTokenGateAcrossProcesses` and siblings (errors) | A wool variable and a stdlib twin driven into the same reset violation across processes | A used, wrong-variable, different-Context, or non-token reset is attempted, including cross-worker and gate-order cases | Both raise the same exception type with the used gate ordered before the wrong-variable and different-Context gates, and the wool message equals the stdlib message byte-for-byte after masking variable reprs and hex addresses | Cross-process reset error-shape and message parity |
| 28 | `TestStreamingTokenParity` (streaming) | A token minted or carried inside an async-generator routine over Hypothesis-drawn stream shapes (`n_yields` by `reset_step`) plus fixed edge examples | It is reset between yields across the stream | Single use holds and per-yield values match a stdlib-oracle projection, and the anchor is not re-minted by later per-yield re-mounts | Streaming-dispatch reset parity by example and property |
