### PR TITLE
Bound the consumed-token ledger to token lifespan — Closes #226, #286

### DIFF
--- a/wool/src/wool/runtime/context/chain.py
+++ b/wool/src/wool/runtime/context/chain.py
@@ -8,6 +8,7 @@ ships across the wire, forks per task, and polices for contention.
 from __future__ import annotations
 
 import asyncio
+import itertools
 import threading
 import weakref
 from dataclasses import dataclass
@@ -23,6 +24,7 @@ from wool.runtime.context.factory import ensure_task_factory_installed
 from wool.runtime.context.manifest import ChainManifest
 from wool.runtime.context.registry import var_registry
 from wool.runtime.context.token import anchor_tokens
+from wool.runtime.context.token import dead_token_ids
 from wool.runtime.typing import Undefined
 
 if TYPE_CHECKING:
@@ -122,10 +124,17 @@ class Chain:
     by `from_manifest`), so token bookkeeping rides every frame. A `reset`
     adds the consumed ID to ``spent_tokens``, and a fresh `set` of that var
     retains it: a token consumed off-origin leaves its local ``_used`` flag
-    unset, so this ledger is the sole witness of the consumption and pruning
-    it would readmit a double reset. The ledger therefore grows for the
-    chain's lifetime; bounding that growth to token lifespan is issue #226's
-    ownership model.
+    unset, so this ledger is the sole witness of the consumption, and pruning
+    it on a re-set would readmit a double reset. Its growth is instead bounded
+    by *token* lifespan: `mount` reaps a spent ID once *no* live
+    `wool.Token` instance of it remains in this process (see
+    `~wool.runtime.context.token.dead_token_ids`), since nothing local can then
+    reset or forward it. The ID re-arrives with its own instance if the token
+    is ever forwarded back, so single-use is preserved — including when a token
+    and its returned clone coexist in one process (a round-trip), where the ID
+    is held until both instances are collected. Counting every instance is also
+    what keeps a long-lived streaming set/reset chain from accumulating a dead
+    ID per cycle even as consumed IDs round-trip through the caller's frames.
     """
 
     id: UUID = field(default_factory=uuid4)
@@ -294,10 +303,24 @@ class Chain:
                 task = asyncio.current_task()
             except RuntimeError:
                 pass
-        # Single evolve: fold the owner stamp and *changes* into one Chain.
+        # Fold the owner stamp, *changes*, and the ledger reap into one evolve.
+        # Reap consumed IDs whose tokens are gone — see the class "Token
+        # ledgers" rubric. The reap only ever shrinks ``spent_tokens``; it
+        # never introduces a key, so ``unspent_tokens`` and the "spent key in
+        # vars or resets" invariant are untouched.
+        spent_tokens = changes.pop("spent_tokens", self.spent_tokens)
+        if spent_tokens:
+            dead = dead_token_ids(itertools.chain.from_iterable(spent_tokens.values()))
+            if dead:
+                spent_tokens = {
+                    key: live
+                    for key, ids in spent_tokens.items()
+                    if (live := ids - dead)
+                }
         installed = self._evolve(
             thread=threading.get_ident(),
             task=weakref.ref(task) if task is not None else None,
+            spent_tokens=spent_tokens,
             **changes,
         )
         # Anchor the wire tokens live in this chain; a no-op when empty.

--- a/wool/src/wool/runtime/context/token.py
+++ b/wool/src/wool/runtime/context/token.py
@@ -15,14 +15,17 @@ chain's ``spent_tokens`` ledger (see `~wool.runtime.context.chain.Chain`).
 
 .. rubric:: Implementation notes
 
-A token ID is recorded in the ``spent_tokens`` ledger on reset, retained for
-the chain's lifetime (never pruned by a re-set, since an off-origin
-consumption is witnessed only by that ledger), and propagated on every frame.
+A token ID is recorded in the ``spent_tokens`` ledger on reset and propagated
+on every frame; its retention is bounded to the lifespan of the `wool.Token`
+instances carrying it, reaped by `~wool.runtime.context.chain.Chain.mount` once
+none remains (see `~wool.runtime.context.chain.Chain`).
 """
 
 from __future__ import annotations
 
 import contextvars
+import threading
+import weakref
 from collections.abc import Generator
 from collections.abc import Iterable
 from contextlib import contextmanager
@@ -62,6 +65,17 @@ _token_sink: Final[contextvars.ContextVar[list["Token"] | None]] = (
     contextvars.ContextVar("__wool_token_sink__", default=None)
 )
 
+#: Count of live `Token` instances per ID, consulted by
+#: `~wool.runtime.context.chain.Chain`'s ledger reap to bound ``spent_tokens``
+#: to token lifespan (see `_register_token` and `dead_token_ids`).
+_token_counts: Final[dict[str, int]] = {}
+
+#: Serialises the read-modify-write on `_token_counts` so a register on one
+#: thread and a `weakref.finalize` release on another (finalizers fire during
+#: GC on whatever thread drops the token) cannot lose an increment — a lost
+#: increment could zero a count early and reap an ID whose token is still live.
+_token_lock: Final[threading.Lock] = threading.Lock()
+
 
 @contextmanager
 def token_sink() -> Generator[list[Token]]:
@@ -77,6 +91,51 @@ def token_sink() -> Generator[list[Token]]:
         yield collected
     finally:
         _token_sink.reset(reset)
+
+
+def _register_token(token: Token) -> None:
+    """Record *token* as a live instance of its ID for ledger reaping.
+
+    Increments the ID's live-instance count and attaches a `weakref.finalize`
+    that decrements it when this instance is collected. Counts each instance
+    rather than a single canonical one, so coexisting copies of one ID (a
+    returned clone alongside its origin, or a token both held and re-decoded)
+    keep the ID live until the last is collected.
+    """
+    with _token_lock:
+        _token_counts[token._id] = _token_counts.get(token._id, 0) + 1
+    weakref.finalize(token, _release_token, token._id)
+
+
+def _release_token(token_id: str) -> None:
+    """Decrement *token_id*'s live-instance count, dropping the key at zero.
+
+    The `weakref.finalize` callback `_register_token` attaches to each instance;
+    it fires during garbage collection when that instance is reclaimed.
+    """
+    with _token_lock:
+        remaining = _token_counts.get(token_id, 0) - 1
+        if remaining > 0:
+            _token_counts[token_id] = remaining
+        else:
+            _token_counts.pop(token_id, None)
+
+
+def dead_token_ids(ids: Iterable[str]) -> frozenset[str]:
+    """Return the *ids* whose tokens no longer live in this process.
+
+    The reap oracle for `~wool.runtime.context.chain.Chain.mount`: an ID absent
+    from `_token_counts` has no surviving instance, so nothing local can reset
+    or forward it and its consumed-token entry can be dropped. Keeps the
+    registry encapsulated here: callers pass the spent IDs and get back the
+    dead ones.
+
+    .. rubric:: Implementation notes
+
+    The membership read needs no lock: a transient miscount can only retain an
+    ID one mount longer, never reap one early.
+    """
+    return frozenset(id for id in ids if id not in _token_counts)
 
 
 def anchor_tokens(wire_tokens: Iterable[Token], chain: Chain) -> None:
@@ -124,7 +183,14 @@ class Token(Generic[T]):
     pickler.
     """
 
-    __slots__ = ("_var", "_old_value", "_native", "_id", "_used")
+    __slots__ = (
+        "_var",
+        "_old_value",
+        "_native",
+        "_id",
+        "_used",
+        "__weakref__",
+    )
 
     _var: ContextVar[T]
     _old_value: T | UndefinedType
@@ -162,6 +228,25 @@ class Token(Generic[T]):
         # this token's `wool.ContextVar` (the failure is about the wool token).
         used = "used " if self._used else ""
         return f"<Token {used}var={self._var!r} at 0x{id(self):x}>"
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether *other* is a `Token` for the same underlying token.
+
+        Two `wool.Token` handles are equal when they share an ID, so the handle
+        a caller holds and the one returned from a dispatch round-trip compare
+        equal — as a `contextvars.Token` compares equal to itself. Direct
+        construction is refused and an ID is minted per `set`, so the ID is a
+        faithful token identity.
+        """
+        return isinstance(other, Token) and other._id == self._id
+
+    def __hash__(self) -> int:
+        """Hash by token ID so equal tokens hash alike and survive a round-trip.
+
+        The ID is fixed for the token's life, so the hash is stable even as the
+        ``used`` flag settles.
+        """
+        return hash(self._id)
 
     def __reduce__(self) -> NoReturn:
         """Reject vanilla pickling; the dispatch pickler uses `__wool_reduce__`.
@@ -247,7 +332,9 @@ class Token(Generic[T]):
         The sole mint path — `~wool.runtime.context.var.ContextVar.set` and
         dispatch reconstitution (`_reconstitute`) — building the token from its
         wire and anchor state directly rather than through the refusing
-        ``__init__``.
+        ``__init__``. Every minted instance is counted for ledger reaping via
+        `_register_token`, so a consumed ID is reclaimed once no instance of it
+        remains live in this process.
         """
         token: Token[T] = object.__new__(cls)
         token._var = var
@@ -255,6 +342,7 @@ class Token(Generic[T]):
         token._native = native
         token._id = id
         token._used = used
+        _register_token(token)
         return token
 
 
@@ -281,6 +369,10 @@ def _reconstitute(
     reference — a classmethod's dotted qualname resolves to a fresh bound
     method that fails cloudpickle's identity check, forcing a by-value pickle
     that would capture this module's `~wool.runtime.context.registry.lock`.
+
+    `Token._mint` counts this instance in `_token_counts`, so while the
+    reconstituted token lives its ID's consumed-token entry is retained for
+    reaping (see `dead_token_ids`) and reclaimed once it is collected.
     """
     token = Token._mint(
         var=var,

--- a/wool/src/wool/runtime/context/var.py
+++ b/wool/src/wool/runtime/context/var.py
@@ -299,11 +299,13 @@ class ContextVar(ContextVarManifest[T]):
         consumption is known here only through the chain's
         ``spent_tokens`` ledger — so pruning the key's spent IDs on a
         re-set would let the caller reset a token already consumed on
-        another process a second time. The ledger therefore grows one
-        entry per consumed token for the chain's lifetime; bounding that
-        growth to token lifespan is issue #226's ownership model, not a
-        prune that forgets consumptions. The freshly minted ID is never
-        spent, so it always survives the subtraction that keeps
+        another process a second time. A re-set therefore never forgets a
+        consumption; instead each spent ID's lifetime is bounded by the
+        `wool.Token` instances carrying it — `_mint` counts this instance
+        (see `~wool.runtime.context.token._register_token`), and
+        `~wool.runtime.context.chain.Chain.mount` reaps the ID once no
+        instance of it survives in this process. The freshly minted ID is
+        never spent, so it always survives the subtraction that keeps
         ``unspent_tokens`` free of dead IDs.
 
         The bookkeeping delta folds into mount's single owner-stamp
@@ -436,10 +438,12 @@ class ContextVar(ContextVarManifest[T]):
         the token's ID moves from the variable's ``unspent_tokens`` set
         (dropping the key once it empties) into ``spent_tokens`` — which
         rides the next frame so the consumption propagates across the
-        wire — and the token is flagged used locally. The spent ID then
-        persists for the chain's lifetime (see
-        `~wool.runtime.context.chain.Chain`); a later set never prunes it,
-        since an off-origin consumption is witnessed only by this ledger.
+        wire — and the token is flagged used locally. The spent ID's lifetime is
+        then bounded by the live `wool.Token` instances carrying it — a
+        later set never prunes it (an off-origin consumption is witnessed
+        only by this ledger), and `~wool.runtime.context.chain.Chain.mount`
+        reaps it once no instance of it remains (see
+        `~wool.runtime.context.chain.Chain`).
         """
         # Guard the installed chain first (see set); bind it once for reuse.
         context = wool.__chain__.get(None)

--- a/wool/tests/integration/routines.py
+++ b/wool/tests/integration/routines.py
@@ -12,6 +12,7 @@ Routines are organized by dimension:
 import asyncio
 import contextvars
 import functools
+import gc
 import inspect
 import os
 from enum import Enum
@@ -984,6 +985,30 @@ async def stream_chain_id_hex(count: int):
 
 
 @wool.routine
+async def stream_spent_ledger_size_for(namespace: str, name: str, count: int):
+    """Yield the worker-side spent-ledger size after each set/reset cycle on a var.
+
+    Performs *count* set-then-reset cycles on the (*namespace*, *name*) oracle
+    var, dropping and collecting each consumed token, and yields the number of
+    spent-token ids recorded under that var's key after each cycle. A
+    ``sleep(0)`` between yields forces a genuine suspend across each
+    ``__anext__``. The reap reclaims each collected token, so the size stays
+    bounded rather than growing one id per cycle. Keying on the caller-supplied
+    var lets independent streams share one chain.
+    """
+    var = _resolve_oracle_var(namespace, name)
+    key = (var.namespace, var.name)
+    for i in range(count):
+        token = var.set(f"cycle-{i}")
+        var.reset(token)
+        del token
+        gc.collect()
+        chain = wool.__chain__.get()
+        yield len(chain.spent_tokens.get(key, frozenset()))
+        await asyncio.sleep(0)
+
+
+@wool.routine
 async def append_to_list(items: list, value) -> list:
     """Coroutine that appends *value* to *items* in place and returns it.
 
@@ -1567,3 +1592,48 @@ async def nested_oracle_set_report(namespace: str, name: str, value) -> tuple:
     """
     inner_pid, token = await oracle_set_report(namespace, name, value)
     return os.getpid(), inner_pid, token
+
+
+@wool.routine
+async def relay_consume_then_forward_report(namespace: str, name: str, token) -> tuple:
+    """Consume a token via a nested reset, then forward it onward to reset again.
+
+    The nested inner reset consumes the token on a further worker, so the
+    consumed signal rides home into this worker's chain ledger while this
+    worker's own token instance stays unused. Forwarding that still-unused
+    instance onward must be rejected downstream purely by the consumed-token
+    ledger carried on the request frame. Returns ``(inner_report,
+    downstream_report)`` — each an oracle ``(pid, kind, message, value_after)``
+    tuple.
+    """
+    inner = await oracle_reset_report(namespace, name, token)
+    downstream = await oracle_reset_report(namespace, name, token)
+    return inner, downstream
+
+
+class TokenCarrier(Exception):
+    """Exception that ferries a wool.Token payload for reset on the receiver.
+
+    The token rides in ``args[0]`` so a raised instance pickles through an
+    ExceptionResponseFrame like any other picklable exception payload, and
+    ``token`` reads it back on the receiver. Used to exercise token transport
+    and anchoring on the exception channel rather than the return-value channel.
+    """
+
+    @property
+    def token(self):
+        """Return the wool.Token payload this exception ferried."""
+        return self.args[0]
+
+
+@wool.routine
+async def set_var_and_raise_with_token(namespace: str, name: str, value) -> None:
+    """Set the (*namespace*, *name*) oracle var, then raise carrying its token.
+
+    The minted token rides home inside a raised `TokenCarrier` instead of
+    a return value, so the caller decodes it through the exception frame. The
+    caller catches the exception, extracts the token, and resets it — exercising
+    the token-transport-and-anchor path on the exception channel.
+    """
+    token = _resolve_oracle_var(namespace, name).set(value)
+    raise TokenCarrier(token)

--- a/wool/tests/integration/test_token_parity_caller_mints.py
+++ b/wool/tests/integration/test_token_parity_caller_mints.py
@@ -192,6 +192,44 @@ class TestCallerMintedTokenLocalReset:
 
         await retry_grpc_internal(body)
 
+    @pytest.mark.asyncio
+    async def test_returned_clone_should_equal_the_original(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token carried to a worker and back equals the original.
+
+        Given:
+            TENANT_ID set on the caller, with the token carried to a worker
+            and returned unreset while the original is still held.
+        When:
+            The returned token is compared with the original.
+        Then:
+            It should compare equal to and hash alike the original — the two
+            handles denote one token, so a round-tripped token is equal to the
+            one the caller still holds, as stdlib's single token object would
+            be.
+        """
+
+        async def body():
+            # Arrange
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                prior = routines.TENANT_ID.set("a")
+                try:
+                    token = routines.TENANT_ID.set("b")
+
+                    # Act
+                    returned, _ = await routines.describe_tenant_id_token(token)
+
+                    # Assert
+                    assert returned == token
+                    assert hash(returned) == hash(token)
+                    routines.TENANT_ID.reset(token)
+                finally:
+                    routines.TENANT_ID.reset(prior)
+
+        await retry_grpc_internal(body)
+
 
 @pytest.mark.integration
 class TestCallerMintedTokenRemoteReset:

--- a/wool/tests/integration/test_token_parity_errors.py
+++ b/wool/tests/integration/test_token_parity_errors.py
@@ -594,3 +594,47 @@ class TestStdlibMessageShapeParity:
                 assert _trailing_phrase(message) == "was created in a different Context"
 
         await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestTokenCarriedInException:
+    @pytest.mark.asyncio
+    async def test_token_carried_in_exception_should_transport_and_stay_single_use(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a token raised inside an exception transports and stays single-use.
+
+        Given:
+            A DEFAULT pool whose worker sets a fresh wool.ContextVar, captures
+            the minted token, and raises a TokenCarrier exception carrying it, so
+            the token rides home on the exception frame rather than a return
+            value.
+        When:
+            The caller catches the exception, extracts the token, resets it, then
+            attempts to reset it a second time.
+        Then:
+            The extracted token should be a live wool.Token whose first reset is
+            honored — anchored home exactly as a returned token would be — and a
+            second reset should raise the single-use RuntimeError, proving token
+            transport and single-use hold uniformly across the exception channel.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                # Act
+                with pytest.raises(routines.TokenCarrier) as exc_info:
+                    await routines.set_var_and_raise_with_token(
+                        var.namespace, var.name, "exc-value"
+                    )
+                token = exc_info.value.token
+
+                # Assert
+                assert isinstance(token, wool.Token)
+                var.reset(token)
+                with pytest.raises(RuntimeError, match="has already been used once"):
+                    var.reset(token)
+
+        await retry_grpc_internal(body)

--- a/wool/tests/integration/test_token_parity_streaming.py
+++ b/wool/tests/integration/test_token_parity_streaming.py
@@ -77,6 +77,95 @@ async def streaming_pool(credentials_map):
 @pytest.mark.integration
 class TestStreamingTokenParity:
     @pytest.mark.asyncio
+    async def test_streaming_should_keep_worker_and_caller_ledgers_bounded(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a streaming set/reset routine bounds both worker and caller ledgers.
+
+        Given:
+            A worker pool driving a streaming routine that performs many
+            set-then-reset cycles on a fresh per-test wool.ContextVar, one per
+            yield, reporting the worker-side spent-token ledger size after each
+            cycle and back-propagating each consumed id to the caller's chain.
+        When:
+            The caller drives the async-generator dispatch to exhaustion, then
+            reads its own chain's spent-token ledger for that var's key.
+        Then:
+            Every reported worker-side size should stay at most one — the single
+            in-flight consumed id — and the caller's own ledger should stay a
+            small constant, not growing with the cycle count, so a long-lived
+            streaming chain reaps each collected token on both sides instead of
+            accumulating one entry per cycle for the chain's lifetime.
+        """
+
+        async def body():
+            # Arrange
+            var = wool.ContextVar(f"a5_{uuid.uuid4().hex}")
+            key = (var.namespace, var.name)
+            n = 128
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                # Act
+                sizes = [
+                    size async for size in routines.stream_spent_ledger_size_for(*key, n)
+                ]
+                caller_spent = wool.__chain__.get().spent_tokens.get(key, frozenset())
+
+                # Assert
+                assert len(sizes) == n
+                assert max(sizes) <= 1, f"worker ledger grew unbounded: {sizes}"
+                assert len(caller_spent) <= 2, (
+                    f"caller ledger grew across {n} cycles: {len(caller_spent)}"
+                )
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_interleaved_streams_should_each_keep_the_ledger_bounded(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test two interleaved streams on one chain each keep the ledger bounded.
+
+        Given:
+            Two async-generator dispatches open concurrently on one armed caller
+            chain, each performing per-yield set-then-reset-then-drop cycles on
+            its own distinct variable and reporting its per-key spent size.
+        When:
+            The caller advances both generators in strict alternation to
+            exhaustion.
+        Then:
+            Each stream's reported per-key size should stay at most one, and the
+            caller's own ledger for each key stays bounded — the reap keeps each
+            key O(1) even as two runners fold consumed ids into one shared chain
+            across alternating re-mounts.
+        """
+
+        # Arrange, act, & assert
+        async def body():
+            n = 40
+            var_a = wool.ContextVar(f"a5_{uuid.uuid4().hex}")
+            var_b = wool.ContextVar(f"a5_{uuid.uuid4().hex}")
+            key_a = (var_a.namespace, var_a.name)
+            key_b = (var_b.namespace, var_b.name)
+            scenario = default_scenario(shape=RoutineShape.ASYNC_GEN_ANEXT)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                gen_a = routines.stream_spent_ledger_size_for(*key_a, n)
+                gen_b = routines.stream_spent_ledger_size_for(*key_b, n)
+                sizes_a: list[int] = []
+                sizes_b: list[int] = []
+                for _ in range(n):
+                    sizes_a.append(await anext(gen_a))
+                    sizes_b.append(await anext(gen_b))
+                assert len(sizes_a) == n and len(sizes_b) == n
+                assert max(sizes_a) <= 1, f"stream A grew unbounded: {sizes_a}"
+                assert max(sizes_b) <= 1, f"stream B grew unbounded: {sizes_b}"
+                caller = wool.__chain__.get()
+                assert len(caller.spent_tokens.get(key_a, frozenset())) <= 2
+                assert len(caller.spent_tokens.get(key_b, frozenset())) <= 2
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
     async def test_caller_reset_mid_stream_should_forward_propagate_to_later_yields(
         self, credentials_map, retry_grpc_internal
     ):

--- a/wool/tests/integration/test_token_parity_worker_mints.py
+++ b/wool/tests/integration/test_token_parity_worker_mints.py
@@ -24,6 +24,7 @@ sibling lane files:
   to reset (``nested_oracle_set_report``).
 """
 
+import gc
 import os
 import uuid
 
@@ -441,6 +442,114 @@ class TestWorkerMintedTokenLedgerRelay:
                 with pytest.raises(RuntimeError, match="has already been used once"):
                     var.reset(token)
                 assert var.get(UNSET) == UNSET
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_consumed_token_forwarded_onward_should_be_rejected_downstream(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a consumed token forwarded onward is rejected by the ledger.
+
+        Given:
+            An EPHEMERAL two-worker pool and a worker-minted token returned
+            home, dispatched to a routine that consumes it via a nested reset
+            and then forwards the still-unused token onward through a further
+            reset dispatch.
+        When:
+            The caller drives that relay, retrying with a fresh token until the
+            consuming reset and the onward forward provably land on different
+            worker processes.
+        Then:
+            On every attempt the nested reset should report ok and the onward
+            reset should report the single-use RuntimeError; and at least one
+            attempt should forward to a process distinct from the one that
+            consumed the token — proving the consumed-token signal rode the
+            request frame across the process boundary rather than being served
+            by an intra-process ledger, so the reap never dropped the entry
+            while a downstream dispatch still needed it.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            scenario = default_scenario(
+                pool_mode=PoolMode.EPHEMERAL,
+                lazy=LazyMode.EAGER,
+                quorum=QuorumMode.ABOVE_DEFAULT,
+            )
+            async with build_pool_from_scenario(scenario, credentials_map):
+                # Act — a fresh token each attempt; single-use must hold every
+                # time, and round-robin reaches a distinct onward process within
+                # a few attempts.
+                crossed = False
+                for i in range(8):
+                    _, token = await routines.oracle_set_report(
+                        var.namespace, var.name, f"onward-{i}"
+                    )
+                    inner, downstream = await routines.relay_consume_then_forward_report(
+                        var.namespace, var.name, token
+                    )
+
+                    # Assert — the nested reset consumes; the onward reset is
+                    # rejected by the consumed-token ledger on the request frame.
+                    assert inner[1] == "ok"
+                    assert downstream[1] == "RuntimeError"
+                    assert "has already been used once" in downstream[2]
+                    if inner[0] != downstream[0]:
+                        crossed = True
+                        break
+
+                # Assert — the onward hop reached a distinct process at least
+                # once, so the consumed signal provably rode the wire.
+                assert crossed, (
+                    "the onward hop never reached a process distinct from the "
+                    "consuming reset, so cross-process forwarding was not "
+                    "exercised"
+                )
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_caller_ledger_should_stay_bounded_across_a_worker_mint_reset_loop(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test the caller's ledger stays bounded across many worker-mint resets.
+
+        Given:
+            A DEFAULT pool and a single caller context in which the caller
+            repeatedly has a worker mint a token, resets it, and drops it.
+        When:
+            The loop runs many times, each minting a fresh worker token,
+            resetting it, then dropping the instance and collecting.
+        Then:
+            The caller's own spent-token ledger for the variable's key should
+            stay bounded — a small constant, not growing with the loop count —
+            since the caller reaps each consumed token it no longer holds an
+            instance of rather than accumulating one entry per iteration.
+        """
+
+        async def body():
+            # Arrange
+            var = _fresh_var()
+            key = (var.namespace, var.name)
+            k = 64
+            scenario = default_scenario()
+            async with build_pool_from_scenario(scenario, credentials_map):
+                # Act
+                for i in range(k):
+                    _, token = await routines.oracle_set_report(
+                        var.namespace, var.name, f"loop-{i}"
+                    )
+                    var.reset(token)
+                    del token
+                    gc.collect()
+
+                # Assert
+                caller_spent = wool.__chain__.get().spent_tokens.get(key, frozenset())
+                assert len(caller_spent) <= 2, (
+                    f"caller ledger grew across {k} iterations: {len(caller_spent)}"
+                )
 
         await retry_grpc_internal(body)
 

--- a/wool/tests/runtime/context/test_chain.py
+++ b/wool/tests/runtime/context/test_chain.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextvars
+import gc
 import threading
 from uuid import uuid4
 
@@ -16,6 +17,7 @@ from tests.helpers import _unique
 from tests.helpers import scoped_context
 from wool.runtime.context.chain import Chain
 from wool.runtime.context.manifest import ChainManifest
+from wool.runtime.context.token import Token
 from wool.runtime.context.token import token_sink
 from wool.runtime.context.var import ContextVar
 
@@ -616,23 +618,25 @@ class TestChain:
         """Test from_manifest seeds the manifest's spent ids on a fresh receiver.
 
         Given:
-            A manifest snapshotted from a sender scope that set a variable
-            and reset its token, recording a spent id, and a fresh unarmed
-            receiver context.
+            A manifest snapshotted from a sender scope that set a variable and
+            reset its token — recording a spent id whose token instance is kept
+            alive — and a fresh unarmed receiver context.
         When:
             Chain.from_manifest installs the manifest with no merge target.
         Then:
             The receiver chain's snapshot should carry exactly the sender's
-            per-var spent token ids — the seed branch mirrors the unspent one.
+            per-var spent token ids — the seed branch mirrors the unspent one,
+            and the live instance keeps the id from being reaped on ingress.
         """
         # Arrange
         var = ContextVar(_unique("seed_spent"))
 
-        def _sender() -> ChainManifest:
-            var.reset(var.set("v"))
-            return wool.__chain__.get().to_manifest()
+        def _sender() -> tuple[ChainManifest, Token]:
+            token = var.set("v")
+            var.reset(token)
+            return wool.__chain__.get().to_manifest(), token
 
-        manifest = contextvars.Context().run(_sender)
+        manifest, token = contextvars.Context().run(_sender)
         assert manifest.spent_tokens
 
         def _receiver() -> dict[tuple[str, str], frozenset[str]]:
@@ -645,6 +649,7 @@ class TestChain:
 
         # Assert
         assert received == manifest.spent_tokens
+        assert isinstance(token, Token)  # hold the instance so the seed is not reaped
 
     def test_from_manifest_should_block_local_reset_when_ledger_ingested(self):
         """Test an ingested consumed-token ledger blocks the local reset.
@@ -684,20 +689,21 @@ class TestChain:
             with pytest.raises(RuntimeError, match="has already been used once"):
                 var.reset(token)
 
-    def test_to_manifest_should_retain_spent_tokens_when_var_re_set(self):
-        """Test re-setting a variable retains its spent-token ledger entry.
+    def test_to_manifest_should_retain_spent_tokens_when_instance_held(self):
+        """Test a re-set retains the spent entry while its instance is held.
 
         Given:
             A variable whose token has been consumed by reset, leaving its
-            id in the chain snapshot's spent_tokens for that key.
+            id in the chain snapshot's spent_tokens for that key, with the
+            consumed token still referenced.
         When:
             The variable is set again, minting a fresh token.
         Then:
             The new snapshot's spent_tokens should still carry the consumed
             id under the key — a copy of the consumed token may live on any
             process the id reached with its used flag unset, so this ledger
-            is the only witness rejecting a cross-process double reset.
-            (Bounding the ledger to token lifespan is issue #226.)
+            is the only witness rejecting a cross-process double reset, and
+            the reap holds off while an instance is alive.
         """
         # Arrange
         var = ContextVar(_unique("retain_spent_tokens"))
@@ -714,6 +720,513 @@ class TestChain:
             # Assert
             spent = wool.__chain__.get().to_manifest().spent_tokens
             assert token_id in spent[key]
+            assert isinstance(token, Token)  # keep the instance alive to the assertion
+
+    def test_mount_should_keep_spent_ledger_bounded_across_a_set_reset_loop(self):
+        """Test the spent ledger stays bounded across many set/reset cycles.
+
+        Given:
+            A single long-lived chain driving many set-then-reset cycles,
+            each discarding the consumed token — the streaming routine's
+            growth pattern.
+        When:
+            The cycle repeats N times and the per-key spent-token count is
+            sampled each iteration.
+        Then:
+            The count should stay pinned at the single in-flight consumed id
+            rather than growing with N — each cycle's collected token is reaped
+            instead of accumulating one entry per cycle for the chain's life.
+        """
+        # Arrange
+        n = 64
+        var = ContextVar(_unique("loop_bound"))
+        key = (var.namespace, var.name)
+        sizes: list[int] = []
+
+        def _loop() -> None:
+            for i in range(n):
+                token = var.set(i)
+                var.reset(token)
+                del token
+                gc.collect()
+                chain = wool.__chain__.get()
+                sizes.append(len(chain.spent_tokens.get(key, frozenset())))
+
+        # Act
+        contextvars.Context().run(_loop)
+
+        # Assert — one in-flight consumed id per iteration, independent of N.
+        assert max(sizes) <= 1
+
+    @given(
+        cycles=st.lists(
+            st.tuples(st.integers(), st.booleans()),
+            max_size=16,
+        )
+    )
+    @settings(max_examples=30, deadline=None)
+    def test_mount_should_keep_spent_ledger_bounded_when_arbitrary_set_reset_cycles(
+        self, cycles
+    ):
+        """Test the spent ledger stays bounded across arbitrary set/reset cycles.
+
+        Given:
+            A single var in an isolated context and an arbitrary-length
+            sequence of cycles, each carrying a value to set and a flag for
+            whether to reset the token it mints, with the token
+            deterministically dropped and collected after every cycle.
+        When:
+            Each cycle sets the var, optionally resets the minted token, then
+            drops and collects it, sampling the per-key spent-token count.
+        Then:
+            The count should never exceed one however many cycles run — each
+            cycle's collected consumed id is reaped on the next mount instead
+            of accumulating one entry per cycle for the chain's life.
+        """
+        # Arrange
+        var = ContextVar(_unique("loop_bound_prop"))
+        key = (var.namespace, var.name)
+        sizes: list[int] = []
+
+        def _drive() -> None:
+            for value, do_reset in cycles:
+                token = var.set(value)
+                if do_reset:
+                    var.reset(token)
+                del token
+                gc.collect()
+                chain = wool.__chain__.get()
+                sizes.append(len(chain.spent_tokens.get(key, frozenset())))
+
+        # Act
+        contextvars.Context().run(_drive)
+
+        # Assert — at most one in-flight consumed id, independent of length.
+        assert all(size <= 1 for size in sizes)
+
+    def test_mount_should_reap_a_reconstituted_token_when_dropped(self):
+        """Test a wire-reconstituted token's consumed id is reaped once dropped.
+
+        Given:
+            A live token minted in an origin scope and shipped home, its origin
+            instance then collected, and a receiver that reconstitutes it,
+            anchors it, resets it — recording the id in spent_tokens — then
+            drops it and re-arms the chain.
+        When:
+            The re-arm transits the reap.
+        Then:
+            The consumed id should be reaped once the receiver holds no
+            instance of it — the ledger is bounded by token lifespan, not the
+            chain's.
+        """
+        # Arrange
+        var = ContextVar(_unique("reconstituted_reap"))
+        key = (var.namespace, var.name)
+
+        def _origin() -> tuple[ChainManifest, bytes]:
+            token = var.set("v")
+            return wool.__chain__.get().to_manifest(), wool.__serializer__.dumps(token)
+
+        manifest, payload = contextvars.Context().run(_origin)
+        tok_id = next(iter(manifest.unspent_tokens[key]))
+        gc.collect()  # drop the origin-side instance
+
+        def _receiver() -> frozenset[str]:
+            with token_sink() as pending:
+                wire = cloudpickle.loads(payload)
+            Chain.from_manifest(manifest, owned=True, wire_tokens=pending)
+            var.reset(wire)
+            assert tok_id in wool.__chain__.get().spent_tokens.get(key, frozenset())
+            # Drop every reference to the instance — the sink list still holds it.
+            del wire
+            del pending
+            gc.collect()
+            var.set("bump")
+            return wool.__chain__.get().spent_tokens.get(key, frozenset())
+
+        # Act
+        spent_after = contextvars.Context().run(_receiver)
+
+        # Assert
+        assert tok_id not in spent_after
+
+    def test_from_manifest_should_reap_a_spent_id_without_a_live_instance(self):
+        """Test a wire-arrived spent id with no live instance is reaped on ingress.
+
+        Given:
+            A fresh receiver that ingests a manifest carrying a consumed id in
+            spent_tokens for which it holds no token instance.
+        When:
+            Chain.from_manifest installs it, transiting the reap.
+        Then:
+            The id should be reaped — with no instance in this process nothing
+            can reset or forward it, so the ledger need not retain it; it
+            re-arrives with its own instance if the token is ever forwarded
+            here, keeping single-use intact.
+        """
+        # Arrange
+        var = ContextVar(_unique("external_reap"))
+        key = (var.namespace, var.name)
+        external_id = uuid4().hex
+
+        def _receiver() -> frozenset[str]:
+            manifest = ChainManifest(
+                id=uuid4(),
+                vars={},
+                resets=frozenset(),
+                stubs=frozenset(),
+                spent_tokens={key: frozenset({external_id})},
+            )
+            Chain.from_manifest(manifest, owned=True)
+            return wool.__chain__.get().spent_tokens.get(key, frozenset())
+
+        # Act
+        spent = contextvars.Context().run(_receiver)
+
+        # Assert
+        assert external_id not in spent
+
+    def test_mount_should_not_reap_spent_token_while_a_round_trip_clone_lives(self):
+        """Test the reap holds a consumed id while a returned clone still lives.
+
+        Given:
+            A round-trip where a variable is set and the same token rides home
+            as a live, anchored clone, so two instances share one id in this
+            process; the original is then reset and dropped, and the chain is
+            re-armed by a fresh set.
+        When:
+            The still-live returned clone is reset.
+        Then:
+            It should raise RuntimeError reporting the token was already used —
+            the reap must not drop the consumed id while any instance of it
+            survives, so single-use holds and the freshly-set value stays
+            intact.
+        """
+        # Arrange
+        var = ContextVar(_unique("round_trip_reap"))
+
+        with scoped_context():
+            origin = var.set("v1")
+            manifest = wool.__chain__.get().to_manifest()
+            payload = wool.__serializer__.dumps(origin)
+            # The token rides home on a frame — a live, anchored clone.
+            with token_sink() as pending:
+                clone = cloudpickle.loads(payload)
+            Chain.from_manifest(
+                manifest,
+                owned=True,
+                merge_with=wool.__chain__.get(),
+                wire_tokens=pending,
+            )
+            # Consume via the original, then drop it and re-arm the chain.
+            var.reset(origin)
+            del origin
+            gc.collect()
+            var.set("v2")
+
+            # Act & assert — the clone still lives, so the id must not be reaped.
+            with pytest.raises(RuntimeError, match="has already been used once"):
+                var.reset(clone)
+            assert var.get() == "v2"
+
+    def test_from_manifest_should_reap_dropped_but_keep_held_when_merging(self):
+        """Test the merge-path reap discriminates by instance liveness.
+
+        Given:
+            An armed receiver with two consumed ids — one whose token instance
+            has been dropped and collected, one whose instance is still held.
+        When:
+            A manifest is merged onto the receiver via Chain.from_manifest,
+            transiting the reap on the wire-ingress path.
+        Then:
+            The dropped id should be reaped from spent_tokens while the held id
+            is retained — the merge reap bounds only ids with no live instance.
+        """
+        # Arrange
+        var_a = ContextVar(_unique("merge_dropped"))
+        var_b = ContextVar(_unique("merge_held"))
+        key_a = (var_a.namespace, var_a.name)
+        key_b = (var_b.namespace, var_b.name)
+
+        def _receiver() -> tuple[str, str, frozenset[str], frozenset[str], Token]:
+            dropped = var_a.set("a")
+            id_a = next(iter(wool.__chain__.get().to_manifest().unspent_tokens[key_a]))
+            var_a.reset(dropped)
+            del dropped
+            gc.collect()
+            held = var_b.set("b")
+            id_b = next(iter(wool.__chain__.get().to_manifest().unspent_tokens[key_b]))
+            var_b.reset(held)
+            receiver = wool.__chain__.get()
+            manifest = ChainManifest(
+                id=receiver.id,
+                vars={},
+                resets=frozenset(),
+                stubs=frozenset(),
+            )
+            Chain.from_manifest(manifest, owned=True, merge_with=receiver)
+            chain = wool.__chain__.get()
+            return (
+                id_a,
+                id_b,
+                chain.spent_tokens.get(key_a, frozenset()),
+                chain.spent_tokens.get(key_b, frozenset()),
+                held,
+            )
+
+        # Act
+        id_a, id_b, spent_a, spent_b, held = contextvars.Context().run(_receiver)
+
+        # Assert
+        assert id_a not in spent_a  # instance dropped → reaped on merge
+        assert id_b in spent_b  # instance held → retained
+        assert isinstance(held, Token)  # keep the held instance alive
+
+    def test_mount_should_reap_a_consumed_token_when_dropped_on_worker_side(self):
+        """Test a worker-side (owned=False) mount reaps a consumed id on drop.
+
+        Given:
+            A worker-side install (owned=False) of a reconstituted token that
+            is reset, held live, then dropped and collected.
+        When:
+            A second worker-side mount transits the reap.
+        Then:
+            The consumed id should be retained while the instance is held and
+            reaped once it is dropped — the reap runs on the owned=False
+            per-step driver path too.
+        """
+        # Arrange
+        var = ContextVar(_unique("worker_reap"))
+        key = (var.namespace, var.name)
+
+        def _origin() -> tuple[ChainManifest, bytes]:
+            token = var.set("v")
+            return wool.__chain__.get().to_manifest(), wool.__serializer__.dumps(token)
+
+        manifest, payload = contextvars.Context().run(_origin)
+        tok_id = next(iter(manifest.unspent_tokens[key]))
+        gc.collect()
+
+        def _worker() -> tuple[frozenset[str], frozenset[str]]:
+            with token_sink() as pending:
+                wire = cloudpickle.loads(payload)
+            # Worker-side install: owned=False (driven by step-tasks, not a task).
+            Chain.from_manifest(manifest, owned=False, wire_tokens=pending)
+            var.reset(wire)
+            held = wool.__chain__.get().spent_tokens.get(key, frozenset())
+            # Drop the instance, then transit another owned=False mount.
+            del wire
+            del pending
+            gc.collect()
+            live = wool.__chain__.get()
+            empty = ChainManifest(
+                id=live.id, vars={}, resets=frozenset(), stubs=frozenset()
+            )
+            Chain.from_manifest(empty, owned=False, merge_with=live)
+            reaped = wool.__chain__.get().spent_tokens.get(key, frozenset())
+            return held, reaped
+
+        # Act
+        held, reaped = contextvars.Context().run(_worker)
+
+        # Assert
+        assert tok_id in held  # consumed, retained while held
+        assert tok_id not in reaped  # reaped once dropped, on an owned=False mount
+
+    def test_mount_should_never_prune_unspent_ids(self):
+        """Test the reap never removes an id from the anchor (unspent) ledger.
+
+        Given:
+            A variable set once — its id live in unspent_tokens — and never
+            reset, with its token then dropped and collected.
+        When:
+            A different variable is set, transiting the reap.
+        Then:
+            The first id should remain in unspent_tokens — the reap is
+            restricted to spent ids, so it never prunes an unspent (in-flight)
+            token by instance collection.
+        """
+        # Arrange
+        var_a = ContextVar(_unique("unspent_survive_a"))
+        var_b = ContextVar(_unique("unspent_survive_b"))
+        key_a = (var_a.namespace, var_a.name)
+
+        def _run() -> tuple[str, frozenset[str]]:
+            token = var_a.set("a")  # id_a in unspent, never reset
+            id_a = next(iter(wool.__chain__.get().to_manifest().unspent_tokens[key_a]))
+            del token
+            gc.collect()
+            var_b.set("b")  # a mount transiting the reap
+            return id_a, wool.__chain__.get().unspent_tokens.get(key_a, frozenset())
+
+        # Act
+        id_a, unspent_a = contextvars.Context().run(_run)
+
+        # Assert
+        assert id_a in unspent_a
+
+    def test_mount_should_reap_only_the_dead_id_within_a_shared_key(self):
+        """Test a partial reap drops the dead id and keeps the live one per key.
+
+        Given:
+            One variable reset twice under a single key, so spent_tokens[key]
+            holds two consumed ids, with the first token dropped and collected
+            (dead) and the second still held live.
+        When:
+            A fresh set transits mount's reap.
+        Then:
+            spent_tokens[key] should retain exactly the surviving id under the
+            same key — the reap subtracts only the dead id from the key rather
+            than dropping the whole key when any of its ids is dead.
+        """
+        # Arrange
+        var = ContextVar(_unique("partial_reap"))
+        key = (var.namespace, var.name)
+
+        with scoped_context():
+            first = var.set("a")
+            id1 = next(iter(wool.__chain__.get().to_manifest().unspent_tokens[key]))
+            var.reset(first)
+            second = var.set("b")
+            id2 = next(iter(wool.__chain__.get().to_manifest().unspent_tokens[key]))
+            var.reset(second)
+            spent = wool.__chain__.get().spent_tokens.get(key, frozenset())
+            assert spent == frozenset({id1, id2})
+
+            # Act — drop only the first instance, then transit a reaping mount.
+            del first
+            gc.collect()
+            var.set("c")
+
+            # Assert — only the dead id is reaped; the survivor stays under the key.
+            reaped = wool.__chain__.get().spent_tokens.get(key, frozenset())
+            assert reaped == frozenset({id2})
+            assert isinstance(second, Token)  # keep the survivor alive
+
+    def test_mount_should_drop_a_spent_key_entirely_when_all_ids_reaped(self):
+        """Test a fully-reaped key is removed, not left as an empty frozenset.
+
+        Given:
+            A variable set and reset (its key holding one consumed id), then the
+            token dropped and collected so the key's only id is dead.
+        When:
+            A re-arming mount transits the reap.
+        Then:
+            The key should be absent from spent_tokens entirely — a fully reaped
+            key is dropped, not retained as an empty frozenset that would
+            accumulate one dead key per reaped variable over a chain's life.
+        """
+        # Arrange
+        var = ContextVar(_unique("key_drop"))
+        key = (var.namespace, var.name)
+
+        with scoped_context():
+            token = var.set("v")
+            token_id = next(iter(wool.__chain__.get().to_manifest().unspent_tokens[key]))
+            var.reset(token)
+            assert key in wool.__chain__.get().spent_tokens
+
+            # Act
+            del token
+            gc.collect()
+            var.set("again")
+
+            # Assert — the whole key is gone (not an empty frozenset), so the id is too.
+            chain = wool.__chain__.get()
+            assert key not in chain.spent_tokens
+            assert token_id not in chain.spent_tokens.get(key, frozenset())
+
+    def test_mount_should_not_reap_while_token_only_transitively_reachable(self):
+        """Test the reap holds while a token is reachable only transitively.
+
+        Given:
+            A wire-reconstituted token reset (its consumed id in spent_tokens)
+            whose only surviving reference is the token_sink capture list, the
+            direct name having been dropped and collected.
+        When:
+            A mount transits the reap while the sink list still holds the token,
+            then again after the sink list is dropped.
+        Then:
+            The id should stay in spent_tokens while the sink list keeps the
+            token reachable, and be reaped only once that last reference is
+            dropped — liveness counts every reference, not just named ones.
+        """
+        # Arrange
+        var = ContextVar(_unique("transitive_reach"))
+        key = (var.namespace, var.name)
+
+        def _origin() -> tuple[ChainManifest, bytes]:
+            token = var.set("v")
+            return wool.__chain__.get().to_manifest(), wool.__serializer__.dumps(token)
+
+        manifest, payload = contextvars.Context().run(_origin)
+        tok_id = next(iter(manifest.unspent_tokens[key]))
+        gc.collect()  # drop the origin-side instance
+
+        def _receiver() -> tuple[frozenset[str], frozenset[str]]:
+            with token_sink() as pending:
+                wire = cloudpickle.loads(payload)
+            Chain.from_manifest(manifest, owned=True, wire_tokens=pending)
+            var.reset(wire)
+            assert tok_id in wool.__chain__.get().spent_tokens.get(key, frozenset())
+            # Drop the direct name only; the sink list ``pending`` still holds it.
+            del wire
+            gc.collect()
+            var.set("bump")  # a reaping mount while ``pending`` keeps it reachable
+            held = wool.__chain__.get().spent_tokens.get(key, frozenset())
+            # Now drop the last reference and transit another reaping mount.
+            del pending
+            gc.collect()
+            var.set("bump2")
+            reaped = wool.__chain__.get().spent_tokens.get(key, frozenset())
+            return held, reaped
+
+        # Act
+        held, reaped = contextvars.Context().run(_receiver)
+
+        # Assert
+        assert held  # retained while the sink list kept the token reachable
+        assert not reaped  # reaped once the last reference was dropped
+
+    def test_mount_should_reap_a_token_dropped_on_another_thread(self):
+        """Test a token dropped on another thread is still reaped.
+
+        Given:
+            An armed chain with a variable set and reset (its consumed id in
+            spent_tokens), the token handed to a worker thread inside a
+            container.
+        When:
+            The worker thread drops the token and runs a collection, then a
+            mount on the main thread transits the reap.
+        Then:
+            The consumed id should be reaped — a finalizer firing on a different
+            thread than the one that minted the token still releases its count,
+            so the reap sees no live instance.
+        """
+        # Arrange
+        var = ContextVar(_unique("cross_thread_reap"))
+        key = (var.namespace, var.name)
+
+        with scoped_context():
+            token = var.set("v")
+            var.reset(token)
+            assert key in wool.__chain__.get().spent_tokens
+            box = [token]
+            del token
+
+            # Act — drop the token's last reference on a different thread.
+            def _drop() -> None:
+                box.clear()
+                gc.collect()
+
+            worker = threading.Thread(target=_drop)
+            worker.start()
+            worker.join()
+            gc.collect()
+            var.set("again")  # a reaping mount on the main thread
+
+            # Assert
+            assert key not in wool.__chain__.get().spent_tokens
 
     def test_from_manifest_should_restore_prior_value_when_wire_token_anchored(self):
         """Test an anchored wire token restores a real prior value on reset.

--- a/wool/tests/runtime/context/test_token.py
+++ b/wool/tests/runtime/context/test_token.py
@@ -1,4 +1,5 @@
 import copy
+import gc
 import pickle
 import uuid
 
@@ -11,6 +12,7 @@ from hypothesis import strategies as st
 import wool
 from tests.helpers import scoped_context
 from wool.runtime.context.token import Token
+from wool.runtime.context.token import dead_token_ids
 from wool.runtime.context.token import token_sink
 from wool.runtime.context.var import ContextVar
 from wool.runtime.typing import Undefined
@@ -293,7 +295,8 @@ class TestToken:
             The restored token's var should be the original ContextVar
             and its old_value should equal the original token's — with
             the Undefined sentinel preserved by identity when the var
-            was previously unset.
+            was previously unset. The restored token should also compare
+            equal to and hash alike the original token.
         """
         # Arrange
         var = ContextVar(_unique("token_roundtrip_prior"))
@@ -307,6 +310,8 @@ class TestToken:
 
         # Assert
         assert restored.var is var
+        assert restored == token
+        assert hash(restored) == hash(token)
         if prior is _UNSET:
             assert token.old_value is Undefined
             assert restored.old_value is Undefined
@@ -339,6 +344,90 @@ class TestToken:
             with pytest.raises(ValueError, match="was created in a different Context"):
                 var.reset(clone)
 
+    def test___eq___should_hold_when_a_token_round_trips_through_serialization(self):
+        """Test a round-tripped token compares equal to the original.
+
+        Given:
+            A token minted by set() and still held by the caller.
+        When:
+            It is serialized, reconstituted, and compared with the original.
+        Then:
+            The reconstituted token should be a distinct object that compares
+            equal to and hashes alike the original — the held handle and the
+            one that comes back denote one token, as a contextvars.Token
+            compares equal to itself.
+        """
+        # Arrange
+        var = ContextVar(_unique("eq_round_trip"))
+
+        # Act & assert
+        with scoped_context():
+            original = var.set("x")
+            clone = loads(dumps(original))
+            assert clone is not original
+            assert clone == original
+            assert hash(clone) == hash(original)
+
+    def test___eq___should_not_hold_when_tokens_minted_by_distinct_sets(self):
+        """Test tokens minted by distinct set() calls are unequal.
+
+        Given:
+            Two tokens minted by separate set() calls, each with its own id.
+        When:
+            They are compared for equality.
+        Then:
+            They should be unequal — equality is by token id and each set()
+            mints a fresh id.
+        """
+        # Arrange
+        var = ContextVar(_unique("eq_distinct"))
+
+        # Act & assert
+        with scoped_context():
+            first = var.set("a")
+            second = var.set("b")
+            assert first != second
+
+    def test___eq___should_not_hold_when_compared_to_a_non_token(self):
+        """Test a Token is unequal to a non-Token rather than raising.
+
+        Given:
+            A token minted by set().
+        When:
+            It is compared for equality with objects that are not tokens.
+        Then:
+            It should be unequal and not raise — equality is defined only
+            against other tokens.
+        """
+        # Arrange
+        var = ContextVar(_unique("eq_non_token"))
+
+        # Act & assert
+        with scoped_context():
+            token = var.set("x")
+            assert token != object()
+            assert token != "not a token"
+
+    def test___hash___should_collapse_equal_tokens_in_a_set(self):
+        """Test equal tokens hash alike and collapse to one set member.
+
+        Given:
+            A token and its round-tripped counterpart, which compare equal.
+        When:
+            Both are added to a set.
+        Then:
+            The set should hold a single element — equal tokens hash alike,
+            so the returned token is not a distinct member.
+        """
+        # Arrange
+        var = ContextVar(_unique("hash_set"))
+
+        # Act & assert
+        with scoped_context():
+            original = var.set("x")
+            clone = loads(dumps(original))
+            assert {original, clone} == {original}
+
 
 def test_token_should_keep_its_wool_var_reachable():
     """Test a live Token keeps its wool variable reachable.
@@ -352,8 +441,6 @@ def test_token_should_keep_its_wool_var_reachable():
         The token's ``var`` should still resolve to the wool ContextVar with
         the original namespace and name.
     """
-    import gc
-
     # Arrange
     namespace = uuid.uuid4().hex
     with scoped_context():
@@ -377,7 +464,7 @@ def test_token_sink_should_scope_wire_token_capture_to_the_decode():
         outside any scope.
     Then:
         The in-scope reconstitution should be captured for the frame's mount to
-        anchor, while an out-of-scope reconstitution is captured by nothing — a
+        anchor, while an out-of-scope reconstitution appends to no sink — a
         token whose frame never mounts is reclaimed with the frame's list rather
         than accumulating in a process-global registry.
     """
@@ -394,4 +481,57 @@ def test_token_sink_should_scope_wire_token_capture_to_the_decode():
     # Assert
     assert collected == [clone]
     assert isinstance(outside, Token)
-    assert outside not in collected
+    # An out-of-scope decode is captured by no sink: it is a distinct object
+    # (equal to the captured clone by id, but never appended to the closed
+    # sink's list).
+    assert not any(outside is captured for captured in collected)
+
+
+def test_dead_token_ids_should_report_only_ids_with_no_live_instance():
+    """Test dead_token_ids returns exactly the ids whose tokens are gone.
+
+    Given:
+        Two set tokens under distinct keys — one still held, one dropped and
+        collected — with their ids read from the public chain manifest.
+    When:
+        dead_token_ids is queried with both ids.
+    Then:
+        It should return the dropped token's id and not the held one — the reap
+        oracle reports an id dead once no instance of it remains live.
+    """
+    # Arrange
+    var_held = ContextVar(_unique("dead_ids_held"))
+    var_dropped = ContextVar(_unique("dead_ids_dropped"))
+    key_held = (var_held.namespace, var_held.name)
+    key_dropped = (var_dropped.namespace, var_dropped.name)
+    with scoped_context():
+        held = var_held.set("x")
+        dropped = var_dropped.set("y")
+        manifest = wool.__chain__.get().to_manifest()
+        held_id = next(iter(manifest.unspent_tokens[key_held]))
+        dropped_id = next(iter(manifest.unspent_tokens[key_dropped]))
+
+        # Act
+        del dropped
+        gc.collect()
+        result = dead_token_ids({held_id, dropped_id})
+
+        # Assert
+        assert dropped_id in result
+        assert held_id not in result
+        assert isinstance(held, Token)  # keep the held instance alive
+
+
+def test_dead_token_ids_should_return_empty_when_given_no_ids():
+    """Test dead_token_ids over no ids returns an empty set.
+
+    Given:
+        No token ids — the degenerate empty input the reap passes on every
+        mount of a chain that carries no spent tokens.
+    When:
+        dead_token_ids is queried with an empty iterable.
+    Then:
+        It should return an empty frozenset without error.
+    """
+    # Arrange, act, & assert
+    assert dead_token_ids(frozenset()) == frozenset()


### PR DESCRIPTION
## Summary

Bound the per-chain consumed-token ledger (`Chain.spent_tokens`) to token lifespan so it no longer grows for the life of the chain. A long-lived streaming routine cycling `set`/`reset` or a caller relaying a worker's consumed ids back on every request frame previously accumulated one ledger entry per consumed token without bound.

The changes herein implement a **full-liveness** rule: reap a consumed id once no live `wool.Token` instance of it remains in the process. Full-liveness needs no ownership flag or wire machinery, bounds the ledger on both the worker side (re-injected ids) and the caller side (accumulated ids) where an owner-only rule cannot, preserves cross-process single-use unchanged (a reaped id re-arrives with its own instance if the token is ever forwarded back), and additionally closes a round-trip double-reset. No observable single-use behavior changes.

The PR also gives `wool.Token` value equality. A token round-tripped through a dispatch now compares equal to the original and hashes with it, closing a stdlib-parity gap.

Closes #226
Closes #286

## Design rationale

A `wool.Token` reconstitutes as a distinct object on every hop. The token a caller holds and the token a dispatch returns are two objects, so an equality check between them failed — a divergence from `contextvars.Token`, where a variable's `set` yields one token object that stays comparable to itself. Two designs restore parity. Both were rejected before landing on value equality.

**Interning.** A process-local cache holding one canonical instance per id makes a round-trip return the same object. It also breaks per-hop token re-anchoring. A token forwarded into a nested dispatch — including one routed back to the same worker process — must reconstitute to a fresh instance that the receiving context can anchor. Each dispatch is a fresh task with its own context: it mounts chains through its own registry, and one chain is owned by one task, so reset validity is re-established per hop. Interning hands back the origin instance, still bound to the sender's context, and the nested reset raises "different Context." Same-process nested dispatch is the cross-process forwarding path with both ends on one process, and one instance per id cannot serve it.

**Composite-key cache.** Keying the cache on the token id together with a representation of the context or dispatch restores correctness. The performance it exists for does not survive the scoping. Cloudpickle memoization within a payload and wire-token reuse across streaming frames already decode each id at most once per dispatch, so a correctly-scoped cache never hits within a dispatch — it elides no allocations and adds a lock and a lookup to every decode. The repeated decodes are all cross-context: a nested forward, a round-trip return. A correct key resolves those to distinct instances anyway.

Value equality reaches the goal a round-trip needs — the returned token equal to the original — with distinct-but-equal instances, and leaves per-hop re-anchoring and the consumed-token refcount reap untouched. Object identity across a round-trip is the one property the dispatch model cannot provide, and parity never required it.

## Proposed changes

### Bind each spent id to the lifespan of the `wool.Token` instances carrying it

Add a process-wide per-id live-instance count in `runtime/context/token.py` (`_token_counts`, guarded by a lock so a register on one thread and a `weakref.finalize` release on another cannot lose an update). `_register_token` — called from every `Token._mint`, so the minting `ContextVar.set` and every dispatch reconstitution alike — increments the count and attaches a finalizer that decrements it, dropping the id at zero. `dead_token_ids` reports the ids with no surviving instance.

`Chain.mount` in `runtime/context/chain.py` folds a reap into its single evolution: it subtracts the dead ids from `spent_tokens`, dropping any key that empties. The reap only ever shrinks `spent_tokens` — it never touches `unspent_tokens` and never introduces a key — and short-circuits on an empty ledger, so an armed chain with no consumed tokens pays nothing on the arming hot path. `runtime/context/var.py` is unchanged apart from its `set` mint now being counted.

Because every instance is counted rather than a single canonical one, a token and its returned clone (a round-trip) hold the id until both are collected, so resetting and dropping the origin no longer reaps the id while the clone is still live — a second reset stays rejected.

### Give `wool.Token` value equality

Define `Token.__eq__` and `Token.__hash__` on the token id. The handle a caller holds and the handle a dispatch returns then compare equal and hash alike, matching the stdlib model where a variable's `set` yields one comparable token. Instances stay distinct per hop — the dispatch model re-anchors a forwarded token in each receiving context — and equality compares their ids. No source keys tokens by object identity, so the change is inert beyond comparison itself.

### Test the model behavior

Add unit coverage in `tests/runtime/context/` for instance-liveness reaping across `set`/`reset`/`from_manifest`/merge and both the owned and worker-driver mount paths, partial-versus-whole-key reaping, retention while a token is only transitively reachable, cross-thread finalizer release, the round-trip double-reset rejection, the never-prune-`unspent` restriction, ledger boundedness pinned by both an example `set`/`reset` loop and a Hypothesis property, the `dead_token_ids` oracle, and value equality (round-trip equality, distinct-id inequality, non-Token comparison, and hash-by-id set collapse). Coverage observes `spent_tokens` and the public manifest rather than private counts, so it survives an internal refactor of the reap.

Add integration coverage in `tests/integration/` over real worker pools: streaming boundedness on both the worker and caller sides, two interleaved streams on one chain, a non-streaming caller mint/reset loop, a consumed token forwarded onward and rejected on a distinct downstream process, a token carried home inside a raised exception that stays single-use, and a caller-minted token that returns from a worker equal to the original.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestChain` | A consumed token whose last live instance is collected | A fresh set re-arms the chain | The consumed id is dropped from `spent_tokens` | Reap on last-instance collection |
| 2 | `TestChain` | A key holding two consumed ids, one collected and one held | A mount transits the reap | Only the dead id is removed and the survivor stays under the key | Partial reap within a shared key |
| 3 | `TestChain` | A fully reaped key | A re-arming mount runs | The key is absent rather than an empty frozenset | Whole-key removal |
| 4 | `TestChain` | A consumed token reachable only through the decode sink list | A mount runs before the list is dropped | The id is retained until the last reference is gone | Reachability-gated reap |
| 5 | `TestChain` | A consumed token dropped on a different thread | A mount transits the reap on the main thread | The id is reaped | Cross-thread finalizer release |
| 6 | `TestChain` | A round-trip where a returned clone shares one id with the reset origin | The origin is reset and dropped, then the clone is reset | The second reset raises `RuntimeError` and the value stays intact | Round-trip double-reset rejection |
| 7 | `TestChain` | An armed receiver merging a manifest with one dead and one held id | `Chain.from_manifest` merges onto the receiver | The dead id is reaped and the held id retained | Merge-path liveness discrimination |
| 8 | `TestChain` | An in-flight unspent token whose instance is collected | A different variable is set | The unspent id survives | Reap restricted to spent ids |
| 9 | `TestChain` | A long-lived chain running many `set`/`reset` cycles | The cycle repeats N times | The per-key spent count stays at most one | Bounded set/reset loop |
| 10 | `TestChain` | Arbitrary-length sequences of set/reset/drop cycles on one var | Hypothesis drives the generated sequences | The per-key spent ledger stays bounded across every sequence | Property-based reap boundedness |
| 11 | `TestToken` | Two set tokens, one held and one collected | `dead_token_ids` is queried with both ids | Only the collected id is reported dead | Reap oracle |
| 12 | `TestToken` | A token minted by set() and still held | It is serialized, reconstituted, and compared with the original | The reconstituted token is a distinct object that compares equal and hashes alike | Round-trip value equality |
| 13 | `TestToken` | Two tokens minted by separate set() calls | They are compared for equality | They are unequal, since equality is by token id | Distinct-id inequality |
| 14 | `TestToken` | A token minted by set() | It is compared with non-Token objects | It is unequal and does not raise | Non-Token comparison |
| 15 | `TestToken` | A token and its round-tripped counterpart | Both are added to a set | The set holds a single element | Hash-by-id set collapse |
| 16 | `TestStreamingTokenParity` | A streaming routine running many worker-side `set`/`reset` cycles | The caller drives it to exhaustion | The worker-side ledger stays at most one per cycle | Worker-side streaming boundedness |
| 17 | `TestStreamingTokenParity` | A streaming routine back-propagating consumed ids | The caller drives it to exhaustion and reads its own ledger | The caller's ledger stays bounded | Caller-side streaming boundedness |
| 18 | `TestStreamingTokenParity` | Two async-generator dispatches interleaved on one chain | The caller advances both in alternation | Each stream's per-key ledger stays bounded | Interleaved-stream boundedness |
| 19 | `TestWorkerMintedTokenParity` | A caller loop minting, resetting, and dropping worker tokens | The loop runs many times | The caller's ledger stays bounded | Non-streaming caller boundedness |
| 20 | `TestCallerMintedTokenLocalReset` | A caller-minted token carried to a worker and returned unreset | The returned token is compared with the original | It compares equal to and hashes alike the original over a real pool | Round-trip equality across processes |
| 21 | `TestWorkerMintedTokenLedgerRelay` | A token consumed via a nested reset then forwarded onward | The relay runs until the hop crosses a process | The onward reset is rejected on a distinct process | Consume-then-forward-onward single-use |
| 22 | `TestTokenCarriedInException` | A worker that raises an exception carrying its minted token | The caller catches it and resets the token twice | The first reset succeeds and the second raises the single-use error | Token transport over the exception channel |
