### PR TITLE
Fix spurious worker eviction when concurrent fan-out saturates the gRPC stream ceiling — Closes #290

### DIFF
--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -299,13 +299,13 @@ Workers are self-describing: each worker advertises its gRPC transport configura
 
 ### Connection pooling
 
-`WorkerConnection` is a lightweight facade that dispatches tasks over pooled gRPC channels. Channels are cached at the module level in a `ResourcePool` keyed by `(target, credentials, options)`, with a 60-second TTL — idle channels are finalized after the TTL expires. Each channel's concurrency semaphore is sized by the worker's advertised `max_concurrent_streams`.
+`WorkerConnection` is a lightweight facade that dispatches tasks over pooled gRPC channels. Channels are cached at the module level in a `ResourcePool` keyed by `(target, credentials, options)`, with a 60-second TTL — idle channels are finalized after the TTL expires. Each channel's concurrency semaphore is sized by the worker's advertised `max_concurrent_streams` — the client-side dispatch gate. The worker's own HTTP/2 `MAX_CONCURRENT_STREAMS` ceiling is set to twice that value to absorb transient permit-turnover overshoot without faulting the connection. See issue #290.
 
 ### Transport configuration
 
 Transport options are split into two tiers:
 
-- **`ChannelOptions`** — settings that both the server and client apply symmetrically. Workers advertise these via `WorkerMetadata` so clients connect with identical settings. Includes message sizes (`max_receive_message_length`, `max_send_message_length`), keepalive (`keepalive_time_ms`, `keepalive_timeout_ms`, `keepalive_permit_without_calls`, `max_pings_without_data`), flow control (`max_concurrent_streams`), and compression (`compression`).
+- **`ChannelOptions`** — settings workers advertise via `WorkerMetadata` so clients connect with compatible settings. Includes message sizes (`max_receive_message_length`, `max_send_message_length`), keepalive (`keepalive_time_ms`, `keepalive_timeout_ms`, `keepalive_permit_without_calls`, `max_pings_without_data`), flow control (`max_concurrent_streams`), and compression (`compression`). Most apply symmetrically on both ends; the exception is `max_concurrent_streams`, which sizes the client's dispatch gate while the worker's transport ceiling is set to twice it (see [Connection pooling](#connection-pooling) and issue #290).
 
 - **`WorkerOptions`** — composes a `ChannelOptions` instance with server-only settings that are not communicated to clients: `http2_min_recv_ping_interval_without_data_ms` (minimum allowed client ping interval), `max_ping_strikes` (ping violations before GOAWAY), and optional connection lifecycle limits (`max_connection_idle_ms`, `max_connection_age_ms`, `max_connection_age_grace_ms`).
 

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -46,9 +46,13 @@ logger = logging.getLogger(__name__)
 
 _HAS_UDS: Final[bool] = hasattr(socket, "AF_UNIX")
 
+#: Seconds to wait for a terminated worker process to exit
+#: before escalating to SIGKILL in `WorkerProcess.reap`.
 _REAP_GRACE: Final[float] = 5.0
-"""Seconds to wait for a terminated worker process to exit before
-escalating to SIGKILL in `WorkerProcess.reap`."""
+
+# Factor by which the server's HTTP/2 ``MAX_CONCURRENT_STREAMS``
+# ceiling exceeds the advertised client concurrency gate.
+_SERVER_STREAM_CEILING_MULTIPLIER: Final[int] = 2
 
 
 class WorkerProcess(Process):
@@ -304,7 +308,10 @@ class WorkerProcess(Process):
                     int(channel.keepalive_permit_without_calls),
                 ),
                 ("grpc.http2.max_pings_without_data", channel.max_pings_without_data),
-                ("grpc.max_concurrent_streams", channel.max_concurrent_streams),
+                (
+                    "grpc.max_concurrent_streams",
+                    channel.max_concurrent_streams * _SERVER_STREAM_CEILING_MULTIPLIER,
+                ),
                 (
                     "grpc.default_compression_algorithm",
                     channel.compression.value,

--- a/wool/tests/integration/test_pool_composition.py
+++ b/wool/tests/integration/test_pool_composition.py
@@ -1,5 +1,6 @@
 """Tests for pool composition via build_pool_from_scenario."""
 
+import asyncio
 import uuid
 from functools import partial
 
@@ -9,6 +10,8 @@ import wool
 from wool.runtime.discovery.local import LocalDiscovery
 from wool.runtime.loadbalancer.base import NoWorkersAvailable
 from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
+from wool.runtime.worker.base import ChannelOptions
+from wool.runtime.worker.base import WorkerOptions
 from wool.runtime.worker.local import LocalWorker
 from wool.runtime.worker.pool import WorkerPool
 
@@ -711,3 +714,55 @@ class TestBackpressureRejection:
                 await rejecting_worker.stop()
 
         await retry_grpc_internal(body)
+
+
+# Saturating fan-out regression parameters (issue #290). The client gate is
+# small so the test is fast; each burst dispatches well over the gate to force
+# the semaphore permit-turnover overshoot that, before the fix, drove the
+# server's stream ceiling past its limit and faulted the connection with
+# INTERNAL / ExecuteBatchError. Empirically the fault fired within a couple of
+# bursts when the ceiling equalled the gate; these values reproduce it while
+# keeping the run well under a second on the fixed build.
+_FANOUT_GATE = 32
+_FANOUT_SIZE = 128
+_FANOUT_BURSTS = 10
+
+
+@pytest.mark.integration
+class TestSaturatingFanout:
+    @pytest.mark.asyncio
+    async def test_dispatch_should_complete_saturating_fanout_without_spurious_eviction(
+        self,
+    ):
+        """Test sustained saturating fan-out to a one-worker pool.
+
+        Given:
+            A one-worker pool whose worker advertises a small
+            max_concurrent_streams gate, driven by repeated bursts of
+            concurrent dispatches that far exceed the gate.
+        When:
+            Every burst is awaited to completion in turn.
+        Then:
+            It should complete every dispatch without raising
+            NoWorkersAvailable, leaving the healthy worker in the pool —
+            the transient stream-starvation fault neither surfaces nor
+            evicts the live worker.
+        """
+        # Arrange
+        worker = partial(
+            LocalWorker,
+            options=WorkerOptions(
+                channel=ChannelOptions(max_concurrent_streams=_FANOUT_GATE)
+            ),
+        )
+
+        # Act & assert
+        async with WorkerPool(spawn=1, worker=worker):
+            for _ in range(_FANOUT_BURSTS):
+                results = await asyncio.gather(
+                    *(routines.add(1, 2) for _ in range(_FANOUT_SIZE))
+                )
+                assert results == [3] * _FANOUT_SIZE
+            # The worker must still serve after the sustained fan-out —
+            # a spurious eviction would raise NoWorkersAvailable here.
+            assert await routines.add(1, 2) == 3

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -1746,7 +1746,8 @@ class TestWorkerProcess:
             ("grpc.keepalive_timeout_ms", 30000),
             ("grpc.keepalive_permit_without_calls", 1),
             ("grpc.http2.max_pings_without_data", 2),
-            ("grpc.max_concurrent_streams", 100),
+            # Server ceiling is 2x the client gate (100) — see issue #290.
+            ("grpc.max_concurrent_streams", 200),
             ("grpc.default_compression_algorithm", 0),
             ("grpc.http2.min_recv_ping_interval_without_data_ms", 30000),
             ("grpc.http2.max_ping_strikes", 2),
@@ -1806,12 +1807,63 @@ class TestWorkerProcess:
             ("grpc.keepalive_timeout_ms", 30000),
             ("grpc.keepalive_permit_without_calls", 1),
             ("grpc.http2.max_pings_without_data", 2),
-            ("grpc.max_concurrent_streams", 100),
+            # Server ceiling is 2x the client gate (100) — see issue #290.
+            ("grpc.max_concurrent_streams", 200),
             ("grpc.default_compression_algorithm", 0),
             ("grpc.http2.min_recv_ping_interval_without_data_ms", 30000),
             ("grpc.http2.max_ping_strikes", 2),
         ]
         assert call_kwargs["options"] == expected
+
+    def test_run_should_advertise_gate_while_doubling_server_ceiling(self, mocker):
+        """Test the advertised gate stays 1x while the server ceiling doubles.
+
+        Given:
+            A WorkerProcess whose channel options set a custom
+            max_concurrent_streams gate of 40
+        When:
+            run() builds the gRPC server and sends its metadata
+        Then:
+            The server should receive grpc.max_concurrent_streams of 80 (2x the
+            gate) while the advertised metadata still carries the gate of 40
+            (1x), pinning the gate/ceiling decoupling (issue #290)
+        """
+        # Arrange
+        opts = WorkerOptions(channel=ChannelOptions(max_concurrent_streams=40))
+        process = WorkerProcess(options=opts)
+
+        mocker.patch("wool.runtime.worker.process.wool.__proxy_pool__")
+        mocker.patch("wool.runtime.worker.process.ResourcePool")
+
+        mock_server = mocker.MagicMock()
+        mock_server.add_insecure_port = mocker.MagicMock(return_value=50051)
+        mock_server.start = mocker.AsyncMock()
+        mock_server.stop = mocker.AsyncMock()
+        mock_grpc_server = mocker.patch.object(
+            grpc.aio, "server", return_value=mock_server
+        )
+
+        mock_service = mocker.MagicMock()
+        mock_service.stopped.wait = mocker.AsyncMock()
+        mocker.patch(
+            "wool.runtime.worker.process.WorkerService",
+            return_value=mock_service,
+        )
+        mocker.patch("wool.runtime.worker.process._signal_handlers")
+        mock_send = mocker.patch.object(process._set_metadata, "send")
+        mocker.patch.object(process._set_metadata, "close")
+
+        # Act
+        process.run()
+
+        # Assert
+        server_options = dict(mock_grpc_server.call_args.kwargs["options"])
+        assert server_options["grpc.max_concurrent_streams"] == 80
+        sent = mock_send.call_args[0][0]
+        advertised = WorkerMetadata.from_protobuf(
+            protocol.WorkerMetadata.FromString(sent)
+        )
+        assert advertised.options.max_concurrent_streams == 40
 
     def test_run_with_all_keepalive_options(self, mocker):
         """Test run passes all keepalive options to gRPC server.


### PR DESCRIPTION
## Summary

Under sustained high per-worker concurrent fan-out, dispatch raised `wool.NoWorkersAvailable` against a worker whose process was alive and serving, and the failure was permanent — one transient transport fault drained a small pool to empty. The client sizes its per-channel concurrency gate (an `asyncio.Semaphore`) and the worker sizes its HTTP/2 `MAX_CONCURRENT_STREAMS` ceiling from the same `max_concurrent_streams` value. A freed semaphore permit can open a new stream before the previous one finishes closing at the transport, so under churn the concurrent-stream count overshoots the gate; because the ceiling equalled the gate, the overshoot crossed it and grpc-aio faulted the connection with `INTERNAL` / `ExecuteBatchError`, which the dispatch loop treated as worker death and evicted the worker.

Decouple the two: set the worker's stream ceiling to twice the advertised gate. The overshoot is bounded above by ~2× the gate, so it never reaches the ceiling and the fault never fires. The advertised gate and the client semaphore are unchanged, so the client's real concurrency bound and fan-out throughput are unaffected — the change adds no serialization. This PR is the transport-layer prevention only; making eviction robust to any `INTERNAL` that slips through (a health-aware, per-worker circuit breaker) is tracked in #296.

Closes #290

## Proposed changes

### Size the server stream ceiling to twice the client gate

`WorkerProcess` advertises `grpc.max_concurrent_streams` to the transport at twice `ChannelOptions.max_concurrent_streams` through a new `_SERVER_STREAM_CEILING_MULTIPLIER`. The advertised `WorkerMetadata` gate and the client semaphore stay at the configured value, so the client's concurrency bound is unchanged, and 2× is sufficient by construction: at most one gate's worth of permits can turn over at once, bounding transport concurrency at ~2× the gate. This decouples the transport ceiling from the client gate without serializing any dispatch.

### Add an end-to-end regression guard

`TestSaturatingFanout` drives repeated bursts of concurrent dispatches far exceeding a small worker gate against a one-worker pool and asserts every burst completes with the worker retained. It fails if the ceiling is recoupled to the gate and the starvation fault fires.

### Document the gate/ceiling split

The worker README records that `max_concurrent_streams` sizes the client dispatch gate while the worker sets its transport ceiling to twice that value, so the setting no longer applies symmetrically on both ends.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerProcess` | A default WorkerProcess with the gate of 100 | `run` builds the gRPC server | Server `grpc.max_concurrent_streams` is 200 | Server ceiling is twice the default gate |
| 2 | `TestWorkerProcess` | Custom message-size options with the default gate | `run` builds the gRPC server | Server `grpc.max_concurrent_streams` is 200 | Ceiling doubling holds alongside other custom options |
| 3 | `TestWorkerProcess` | A custom gate of 40 | `run` builds the server and sends metadata | Server ceiling is 80 while the advertised gate stays 40 | Gate and ceiling are decoupled |
| 4 | `TestSaturatingFanout` | A one-worker pool with a small gate under repeated bursts far exceeding it | Every burst is awaited to completion | All dispatches complete and the worker is retained with no `NoWorkersAvailable` | End-to-end worker retention under sustained fan-out |
