### PR TITLE
Prevent LocalDiscovery teardown from crashing on shared-memory double-unlink — Closes #291

### DIFF
--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -5,6 +5,7 @@ import atexit
 import hashlib
 import struct
 import tempfile
+import warnings
 from contextlib import asynccontextmanager
 from contextlib import contextmanager
 from multiprocessing.shared_memory import SharedMemory
@@ -33,6 +34,7 @@ from wool.runtime.discovery.pool import SubscriberMeta
 from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.afilter import afilter
+from wool.utilities.noreentry import noreentry
 
 REF_WIDTH: Final = 16
 NULL_REF: Final = b"\x00" * REF_WIDTH
@@ -161,25 +163,45 @@ class _WorkerReference:
 class LocalDiscovery(Discovery):
     """Shared-memory discovery for single-machine worker pools.
 
-    The default when a
-    :py:class:`~wool.runtime.worker.pool.WorkerPool` is created
+    The default when a `~wool.runtime.worker.pool.WorkerPool` is created
     without an explicit discovery protocol. Workers and subscribers
-    communicate through a shared memory region identified by a
-    namespace string. File-based locking ensures consistency across
-    processes.
+    communicate through a shared-memory segment identified by a namespace
+    string, so unrelated processes on the same host discover each other by
+    agreeing on a namespace alone. File-based locking keeps the segment
+    consistent across those processes.
 
-    .. note::
-        Multiple unrelated processes can share the same namespace,
-        enabling automatic worker discovery across process boundaries.
+    **Ownership.** Entering a context creates the namespace's segment, or
+    attaches to it when it already exists. The first entrant across all
+    processes wins the create race and *owns* the segment; every later
+    entrant on that namespace merely attaches. Ownership falls out of that
+    race — it is not something the caller selects.
+
+    **Lifecycle.** An instance is single-use: it may be entered once, and a
+    second entry raises `RuntimeError` whether or not the first has exited.
+    Use a fresh instance per ``with`` block. The guard binds to the instance,
+    so distinct instances sharing a namespace — which compare equal — are
+    unaffected by each other.
+
+    The owner's exit unlinks the segment out from under every still-attached
+    peer, while a non-owner's exit only closes its own mapping; a non-owner
+    can therefore outlive the segment it is mapped to. An owner that never
+    exits at all — an abandoned context, an interpreter killed mid-block —
+    still reclaims the segment at interpreter shutdown rather than leaking
+    the namespace, via a fallback armed on owner entry and disarmed on owner
+    exit.
+
+    Teardown never raises: unlinking goes through `_unlink_quietly`, which
+    owns the failure semantics. So `__exit__` cannot replace an exception a
+    caller is already unwinding, and a genuine leak stays observable.
 
     :param namespace:
-        Unique identifier for the shared memory region. Publishers
+        Unique identifier for the shared-memory segment. Publishers
         and subscribers using the same namespace will see each
         other's workers.
     :param filter:
         Optional default predicate function to filter workers.
-        Used by :py:attr:`subscriber` and as the default for
-        :py:meth:`subscribe` when no explicit filter is provided.
+        Used by `subscriber` and as the default for `subscribe` when no
+        explicit filter is provided.
     :param capacity:
         Maximum number of workers that can be registered
         simultaneously. Defaults to 128.
@@ -191,17 +213,24 @@ class LocalDiscovery(Discovery):
 
     .. code-block:: python
 
-        publisher = LocalDiscovery.Publisher("my-worker-pool")
-        async with publisher:
-            await publisher.publish("worker-added", metadata)
+        with LocalDiscovery("my-worker-pool") as discovery:
+            async with discovery.publisher as publisher:
+                await publisher.publish("worker-added", metadata)
 
     Example — subscribe to workers:
 
     .. code-block:: python
 
-        subscriber = LocalDiscovery.Subscriber("my-worker-pool")
-        async for event in subscriber:
-            print(f"Discovered worker: {event.metadata}")
+        with LocalDiscovery("my-worker-pool") as discovery:
+            async for event in discovery.subscriber:
+                print(f"Discovered worker: {event.metadata}")
+
+    .. rubric:: Implementation notes
+
+    The shutdown fallback is an `atexit` handler registered on owner entry
+    and unregistered on owner exit, before the unlink runs — a failed unlink
+    must not leave the handler armed to fire a second time at interpreter
+    shutdown.
     """
 
     _filter: Final[PredicateFunction | None]
@@ -220,7 +249,17 @@ class LocalDiscovery(Discovery):
         self._capacity = capacity
         self._block_size = block_size
 
+    @noreentry
     def __enter__(self) -> Self:
+        """Create or attach to the namespace's shared-memory segment.
+
+        See `LocalDiscovery` for the ownership and teardown contract.
+
+        :returns:
+            This instance.
+        :raises RuntimeError:
+            If this instance has already been entered.
+        """
         size = self._capacity * 4
         try:
             self._address_space = SharedMemory(
@@ -238,16 +277,24 @@ class LocalDiscovery(Discovery):
 
         assert self._address_space.buf
         if self._owner:
-            self._cleanup = atexit.register(lambda: self._address_space.unlink())
+
+            def cleanup():  # pragma: no cover
+                _unlink_quietly(self._address_space)
+
+            self._cleanup = atexit.register(cleanup)
             for i in range(size):
                 self._address_space.buf[i] = 0
         return self
 
     def __exit__(self, *_):
+        """Release this instance's hold on the namespace's segment.
+
+        See `LocalDiscovery` for the ownership and teardown contract.
+        """
         if self._owner:
-            self._address_space.close()
-            self._address_space.unlink()
             atexit.unregister(self._cleanup)
+            self._address_space.close()
+            _unlink_quietly(self._address_space)
         else:
             self._address_space.close()
 
@@ -439,7 +486,10 @@ class LocalDiscovery(Discovery):
                         )
                         struct.pack_into("16s", address_space.buf, i, ref.bytes)
                     except Exception:
-                        await self._drop(metadata, address_space)
+                        # Release what this method acquired rather than
+                        # delegating to `_drop`, whose slot scan cannot find a
+                        # ref that only lands on the last line of this block.
+                        await self._shared_memory_pool.release(str(ref))
                         raise
                     break
             else:
@@ -540,10 +590,7 @@ class LocalDiscovery(Discovery):
             )
 
             def cleanup():  # pragma: no cover
-                try:
-                    shared_memory.unlink()
-                except OSError:
-                    pass
+                _unlink_quietly(shared_memory)
 
             self._cleanups[name] = atexit.register(cleanup)
             return shared_memory
@@ -551,19 +598,16 @@ class LocalDiscovery(Discovery):
         def _shared_memory_finalizer(self, shared_memory: SharedMemory):
             """Clean up a shared memory block when released from the pool.
 
-            Unlinks the shared memory region and unregisters the atexit
-            handler. Errors during unlink are silently ignored to handle
-            Windows platforms where unlink may fail if other processes still
-            have the memory file open.
+            Unregisters the atexit handler before unlinking the block, so a
+            failed unlink cannot leave the handler armed to fire again at
+            interpreter shutdown. The unlink goes through `_unlink_quietly`;
+            see it for the failure semantics.
 
             :param shared_memory:
                 The SharedMemory instance to finalize.
             """
-            try:
-                shared_memory.unlink()
-            except OSError:
-                pass  # pragma: no cover
             atexit.unregister(self._cleanups.pop(shared_memory.name))
+            _unlink_quietly(shared_memory)
 
     class Subscriber(
         metaclass=SubscriberMeta,
@@ -746,6 +790,35 @@ class LocalDiscovery(Discovery):
                     "worker-updated", metadata=discovered_workers[uid]
                 )
                 yield event
+
+
+def _unlink_quietly(shared_memory: SharedMemory) -> None:
+    """Unlink a segment without raising, warning if it fails unexpectedly.
+
+    Every teardown path in this module unlinks through here, so no teardown
+    can raise: an exception escaping a ``__exit__`` or an `atexit` handler
+    would replace the exception the caller was already unwinding, or crash
+    the interpreter at shutdown.
+
+    A segment that is already gone is the expected case and passes silently —
+    any process that attached to it may have unlinked it first (bpo-38119).
+    Any other failure leaves the segment allocated, which is a leak the caller
+    cannot act on but an operator can, so it surfaces as a `ResourceWarning`
+    rather than being swallowed.
+
+    :param shared_memory:
+        The segment to unlink.
+    """
+    try:
+        shared_memory.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as error:
+        warnings.warn(
+            f"failed to unlink shared memory {shared_memory.name!r}: {error}",
+            ResourceWarning,
+            stacklevel=2,
+        )
 
 
 def _short_hash(s: str, n: int = 30) -> str:

--- a/wool/tests/integration/test_local_discovery_teardown.py
+++ b/wool/tests/integration/test_local_discovery_teardown.py
@@ -48,6 +48,19 @@ with LocalDiscovery(sys.argv[1]):
     pass
 """
 
+_LEAKED_OWNER_SCRIPT = """
+import sys
+from contextlib import ExitStack
+
+from wool.runtime.discovery.local import LocalDiscovery
+
+stack = ExitStack()
+stack.enter_context(LocalDiscovery(sys.argv[1]))
+print("ready", flush=True)
+sys.stdin.readline()
+print("leaking-context", flush=True)
+"""
+
 
 @pytest.mark.integration
 class TestSameNamespaceRespawn:
@@ -347,6 +360,65 @@ class TestCrossProcessTeardown:
             # Assert
             assert owner.returncode == 0
             assert "clean-exit" in stdout
+            assert "Traceback" not in stderr
+        finally:
+            if owner.poll() is None:
+                owner.kill()
+                owner.wait(timeout=10)
+
+    def test___enter___should_arm_fallback_that_survives_shutdown_when_leaked(self):
+        """Test the shutdown fallback tolerates a vanished segment.
+
+        Given:
+            An owner LocalDiscovery entered in its own interpreter
+            and never exited, and an independent attacher interpreter
+            whose resource tracker unlinked the shared segment at
+            exit
+        When:
+            The owner interpreter shuts down with the fallback still
+            armed
+        Then:
+            It should exit with status 0 and no traceback — the armed
+            fallback suppresses the missing segment instead of
+            crashing interpreter shutdown.
+        """
+        # Arrange
+        namespace = f"leaked-{uuid.uuid4().hex[:12]}"
+        owner = subprocess.Popen(
+            [sys.executable, "-c", _LEAKED_OWNER_SCRIPT, namespace],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            assert owner.stdin is not None and owner.stdout is not None
+            assert owner.stdout.readline().strip() == "ready"
+
+            attacher = subprocess.run(
+                [sys.executable, "-c", _ATTACHER_SCRIPT, namespace],
+                capture_output=True,
+                text=True,
+                timeout=_TIMEOUT,
+            )
+            assert attacher.returncode == 0
+            # Vacuity guard — the attacher's tracker really unlinked
+            # the segment before the owner shuts down.
+            assert "leaked shared_memory" in attacher.stderr
+
+            # Act — the owner returns from its script with the
+            # context still open, so atexit fires the armed fallback
+            # against the vanished segment
+            owner.stdin.write("\n")
+            owner.stdin.flush()
+            stdout, stderr = owner.communicate(timeout=_TIMEOUT)
+
+            # Assert — the owner's own tracker warns about its stale
+            # registration on stderr (its unlink raised before the
+            # tracker unregistration), so assert traceback absence
+            # rather than a clean stderr
+            assert owner.returncode == 0
+            assert "leaking-context" in stdout
             assert "Traceback" not in stderr
         finally:
             if owner.poll() is None:

--- a/wool/tests/integration/test_local_discovery_teardown.py
+++ b/wool/tests/integration/test_local_discovery_teardown.py
@@ -1,0 +1,372 @@
+"""End-to-end tests for LocalDiscovery teardown under namespace reuse (#291).
+
+These are targeted standalone tests rather than pairwise scenarios:
+issue #291's reproduction shape — rapid same-namespace teardown and
+respawn with overlapping pool lifecycles — cannot be expressed through
+``build_pool_from_scenario``'s single-yield nested-context contract,
+and the cross-process case needs independent interpreters whose
+multiprocessing resource trackers genuinely unlink the shared segment
+(CPython bpo-38119). Unit-level simulations of the same contracts live
+in ``tests/runtime/discovery/test_local.py``.
+"""
+
+import asyncio
+import contextlib
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+import uuid
+
+import pytest
+
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.worker.pool import WorkerPool
+
+from . import routines
+
+_TIMEOUT = 30
+
+_OWNER_SCRIPT = """
+import sys
+
+from wool.runtime.discovery.local import LocalDiscovery
+
+with LocalDiscovery(sys.argv[1]):
+    print("ready", flush=True)
+    sys.stdin.readline()
+print("clean-exit", flush=True)
+"""
+
+_ATTACHER_SCRIPT = """
+import sys
+
+from wool.runtime.discovery.local import LocalDiscovery
+
+with LocalDiscovery(sys.argv[1]):
+    pass
+"""
+
+
+@pytest.mark.integration
+class TestSameNamespaceRespawn:
+    @pytest.mark.asyncio
+    async def test___aexit___should_unwind_cleanly_when_namespace_respawned_rapidly(
+        self, retry_grpc_internal
+    ):
+        """Test rapid same-namespace pool teardown and respawn cycles.
+
+        Given:
+            One namespace shared by three successive WorkerPool
+            lifecycles, each with a fresh LocalDiscovery instance
+        When:
+            Each pool is entered, dispatches a routine, and exits
+            back-to-back with no delay between cycles
+        Then:
+            It should return the dispatch result every cycle and
+            unwind every teardown cleanly, leaving no live worker
+            process after each exit.
+        """
+        # Arrange
+        namespace = f"respawn-{uuid.uuid4().hex[:12]}"
+        spawned: list[int] = []
+
+        # Act & assert
+        async def body():
+            for _ in range(3):
+                before = {child.pid for child in multiprocessing.active_children()}
+                async with asyncio.timeout(_TIMEOUT):
+                    async with WorkerPool(spawn=1, discovery=LocalDiscovery(namespace)):
+                        cycle_spawned = [
+                            child.pid
+                            for child in multiprocessing.active_children()
+                            if child.pid not in before
+                        ]
+                        spawned.extend(cycle_spawned)
+                        assert await routines.add(1, 2) == 3
+                # Join any finished children so an exited-but-unreaped
+                # worker cannot masquerade as alive under os.kill(pid, 0).
+                multiprocessing.active_children()
+                for pid in cycle_spawned:
+                    assert not _pid_alive(pid)
+
+        try:
+            await retry_grpc_internal(body)
+        finally:
+            for pid in spawned:
+                _ensure_killed(pid)
+
+
+@pytest.mark.integration
+class TestOverlappingNamespaceLifecycles:
+    @pytest.mark.asyncio
+    async def test___aexit___should_unwind_cleanly_when_non_owner_pool_exits_first(
+        self, retry_grpc_internal
+    ):
+        """Test LIFO overlap of two same-namespace pools.
+
+        Given:
+            An owner pool "a" on a namespace with a non-owner pool
+            "b" on the same namespace nested inside it, workers
+            partitioned by tag
+        When:
+            Pool b dispatches and exits while pool a remains entered
+        Then:
+            It should keep pool a fully functional after b's exit
+            and unwind both teardowns cleanly with no leaked worker.
+        """
+        # Arrange
+        namespace = f"overlap-lifo-{uuid.uuid4().hex[:12]}"
+        before = {child.pid for child in multiprocessing.active_children()}
+
+        # Act & assert
+        async def body():
+            async with asyncio.timeout(_TIMEOUT):
+                async with WorkerPool("a", spawn=1, discovery=LocalDiscovery(namespace)):
+                    assert await routines.add(1, 2) == 3
+                    async with WorkerPool(
+                        "b", spawn=1, discovery=LocalDiscovery(namespace)
+                    ):
+                        assert await routines.add(2, 3) == 5
+                    assert await routines.add(3, 4) == 7
+
+        try:
+            await retry_grpc_internal(body)
+
+            # Assert — no worker outlived its pool
+            leaked = [
+                child.pid
+                for child in multiprocessing.active_children()
+                if child.pid not in before
+            ]
+            assert leaked == []
+        finally:
+            for child in multiprocessing.active_children():
+                if child.pid not in before:
+                    _ensure_killed(child.pid)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_unwind_cleanly_when_owner_pool_exits_first(
+        self, retry_grpc_internal
+    ):
+        """Test the issue's repro: the segment owner exits first.
+
+        Given:
+            An owner pool "a" running in a background task and a
+            non-owner pool "b" on the same namespace entered in the
+            test task with a completed dispatch
+        When:
+            Pool a exits first, then pool b dispatches again and
+            exits, and a fresh pool "c" enters the same namespace
+        Then:
+            It should keep pool b functional after the owner's
+            teardown, unwind b's exit cleanly, and serve the
+            respawned pool c.
+        """
+        # Arrange
+        namespace = f"overlap-owner-first-{uuid.uuid4().hex[:12]}"
+        before = {child.pid for child in multiprocessing.active_children()}
+        owner_up = asyncio.Event()
+        release_owner = asyncio.Event()
+
+        async def owner():
+            async with WorkerPool("a", spawn=1, discovery=LocalDiscovery(namespace)):
+                assert await routines.add(1, 2) == 3
+                owner_up.set()
+                await release_owner.wait()
+
+        # Act & assert
+        async def body():
+            async with asyncio.timeout(_TIMEOUT):
+                owner_task = asyncio.create_task(owner())
+                try:
+                    await owner_up.wait()
+                    async with WorkerPool(
+                        "b", spawn=1, discovery=LocalDiscovery(namespace)
+                    ):
+                        assert await routines.add(2, 3) == 5
+                        release_owner.set()
+                        await owner_task
+                        assert await routines.add(3, 4) == 7
+                    async with WorkerPool(
+                        "c", spawn=1, discovery=LocalDiscovery(namespace)
+                    ):
+                        assert await routines.add(4, 5) == 9
+                finally:
+                    release_owner.set()
+                    if not owner_task.done():
+                        owner_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await owner_task
+
+        try:
+            await retry_grpc_internal(body)
+        finally:
+            # Hygiene, not assertion: pool b's worker currently leaks
+            # after an owner-first exit (#298); kill any stragglers so
+            # they cannot pollute the session.
+            for child in multiprocessing.active_children():
+                if child.pid not in before:
+                    _ensure_killed(child.pid)
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(
+        strict=True,
+        raises=AssertionError,
+        reason="surviving pool's worker leaks after owner-first exit (#298)",
+    )
+    async def test___aexit___should_reap_worker_when_owner_pool_exited_first(
+        self, retry_grpc_internal
+    ):
+        """Test a surviving pool reaps its worker despite owner exit.
+
+        Given:
+            An owner pool "a" running in a background task and a
+            non-owner pool "b" on the same namespace with its worker
+            pid captured
+        When:
+            Pool a exits first and pool b then exits
+        Then:
+            It should leave no pool-b worker process alive after b's
+            exit.
+        """
+        # Arrange
+        namespace = f"overlap-reap-{uuid.uuid4().hex[:12]}"
+        before = {child.pid for child in multiprocessing.active_children()}
+        owner_up = asyncio.Event()
+        release_owner = asyncio.Event()
+        b_pids: list[int] = []
+
+        # The strict xfail below pins #298 via ``raises=AssertionError``, so
+        # the reap check must be the only ``assert`` in this test: arrange
+        # and act failures use ``pytest.fail``, which raises ``Failed`` and
+        # therefore cannot satisfy the xfail.
+        async def owner():
+            async with WorkerPool("a", spawn=1, discovery=LocalDiscovery(namespace)):
+                if await routines.add(1, 2) != 3:
+                    pytest.fail("pool a failed to dispatch before the owner was pinned")
+                owner_up.set()
+                await release_owner.wait()
+
+        # Act
+        async def body():
+            async with asyncio.timeout(_TIMEOUT):
+                owner_task = asyncio.create_task(owner())
+                try:
+                    await owner_up.wait()
+                    before_b = {child.pid for child in multiprocessing.active_children()}
+                    async with WorkerPool(
+                        "b", spawn=1, discovery=LocalDiscovery(namespace)
+                    ):
+                        if await routines.add(2, 3) != 5:
+                            pytest.fail("pool b failed to dispatch before owner exit")
+                        b_pids.extend(
+                            child.pid
+                            for child in multiprocessing.active_children()
+                            if child.pid not in before_b
+                        )
+                        release_owner.set()
+                        await owner_task
+                finally:
+                    release_owner.set()
+                    if not owner_task.done():
+                        owner_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await owner_task
+
+        try:
+            await retry_grpc_internal(body)
+
+            # Assert — join any finished children first so an
+            # exited-but-unreaped worker cannot masquerade as alive
+            # under os.kill(pid, 0)
+            multiprocessing.active_children()
+            for pid in b_pids:
+                assert not _pid_alive(pid)
+        finally:
+            for child in multiprocessing.active_children():
+                if child.pid not in before:
+                    _ensure_killed(child.pid)
+            for pid in b_pids:
+                _ensure_killed(pid)
+
+
+@pytest.mark.integration
+class TestCrossProcessTeardown:
+    def test___exit___should_unwind_cleanly_when_tracker_unlinks_segment(self):
+        """Test owner teardown after a genuine external unlink.
+
+        Given:
+            An owner LocalDiscovery entered in its own interpreter,
+            and an independent attacher interpreter that entered and
+            exited the same namespace, whose multiprocessing resource
+            tracker then unlinked the shared segment at exit
+            (CPython bpo-38119)
+        When:
+            The owner is released, exits its context, and its
+            interpreter shuts down
+        Then:
+            It should exit with status 0 and no traceback — the
+            vanished segment aborts neither the context exit nor the
+            atexit fallback at interpreter shutdown.
+        """
+        # Arrange
+        namespace = f"tracker-{uuid.uuid4().hex[:12]}"
+        owner = subprocess.Popen(
+            [sys.executable, "-c", _OWNER_SCRIPT, namespace],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            assert owner.stdin is not None and owner.stdout is not None
+            assert owner.stdout.readline().strip() == "ready"
+
+            attacher = subprocess.run(
+                [sys.executable, "-c", _ATTACHER_SCRIPT, namespace],
+                capture_output=True,
+                text=True,
+                timeout=_TIMEOUT,
+            )
+            assert attacher.returncode == 0
+            # Vacuity guard — the attacher's tracker really unlinked
+            # the segment (warning about the leak) before the owner
+            # exits; if CPython ever stops tracking attaches this
+            # fails loudly instead of passing without exercising the
+            # fix.
+            assert "leaked shared_memory" in attacher.stderr
+
+            # Act — release the owner to exit its context and shut
+            # down its interpreter
+            owner.stdin.write("\n")
+            owner.stdin.flush()
+            stdout, stderr = owner.communicate(timeout=_TIMEOUT)
+
+            # Assert
+            assert owner.returncode == 0
+            assert "clean-exit" in stdout
+            assert "Traceback" not in stderr
+        finally:
+            if owner.poll() is None:
+                owner.kill()
+                owner.wait(timeout=10)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return whether a process with the given pid currently exists."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _ensure_killed(pid: int | None) -> None:
+    """Best-effort SIGKILL so a failing run cannot leak a worker."""
+    if pid is not None and _pid_alive(pid):
+        with contextlib.suppress(OSError):
+            os.kill(pid, signal.SIGKILL)

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -1,6 +1,10 @@
 import asyncio
+import atexit
 import struct
 import uuid
+from collections import Counter
+from contextlib import ExitStack
+from multiprocessing.shared_memory import SharedMemory
 from types import MappingProxyType
 
 import portalocker
@@ -39,6 +43,78 @@ def namespace():
     memory regions don't interfere with each other.
     """
     return f"test-namespace-{uuid.uuid4()}"
+
+
+@pytest.fixture
+def atexit_recorder(mocker):
+    """Wraps atexit registration in recording pass-throughs.
+
+    Returns a (registered, unregistered) tuple of lists capturing every
+    callable that flows through atexit.register and atexit.unregister
+    while the real registry stays consistent.
+
+    Tests built on this fixture deliberately pin the atexit mechanism
+    rather than an observable outcome: the disarm-before-unlink ordering
+    is not observable in-process any other way, and an armed handler
+    only misbehaves at interpreter shutdown. The behavioral contract is
+    covered cross-process in tests/integration/. A refactor away from
+    atexit (to weakref.finalize, say) is expected to rewrite these
+    assertions along with it.
+    """
+    registered = []
+    unregistered = []
+    real_register = atexit.register
+    real_unregister = atexit.unregister
+
+    def register(func, *args, **kwargs):
+        registered.append(func)
+        return real_register(func, *args, **kwargs)
+
+    def unregister(func):
+        unregistered.append(func)
+        return real_unregister(func)
+
+    mocker.patch.object(atexit, "register", register)
+    mocker.patch.object(atexit, "unregister", unregister)
+    return registered, unregistered
+
+
+@pytest.fixture
+def unlink_schedule(mocker):
+    """Patches SharedMemory.unlink with a schedule-driven wrapper and
+    returns the schedule list.
+
+    Each unlink call performs the real unlink — so no segment leaks —
+    then consumes one schedule entry and raises it when the entry is an
+    exception, simulating an external unlinker or a hostile filesystem.
+    An empty or exhausted schedule means the unlink passes through
+    untouched. A one-shot failure is therefore a one-entry schedule, and
+    a generated failure pattern is a longer one. Patching once per test
+    (rather than per failure or per Hypothesis example) avoids stacking
+    wrappers.
+    """
+    schedule: list[Exception | None] = []
+    real_unlink = SharedMemory.unlink
+
+    def unlink(shm):
+        real_unlink(shm)
+        if schedule and (error := schedule.pop(0)) is not None:
+            raise error
+
+    mocker.patch.object(SharedMemory, "unlink", unlink)
+    return schedule
+
+
+#: Same-namespace lifecycle forests: each node is one LocalDiscovery
+#: context; nesting models concurrently overlapping instances and
+#: siblings model teardown+respawn generations reusing the namespace.
+#: Referenced by ``@given`` at class-definition time, so it must precede
+#: the test classes.
+_LIFECYCLE_FORESTS = st.recursive(
+    st.just([]),
+    lambda children: st.lists(children, max_size=3),
+    max_leaves=6,
+)
 
 
 class TestLocalDiscovery:
@@ -377,7 +453,7 @@ class TestLocalDiscovery:
         assert len(events) >= 1
         assert events[0].type == "worker-added"
 
-    def test___enter___and___exit___lifecycle(self):
+    def test___enter___and___exit___lifecycle(self, namespace):
         """Test LocalDiscovery context manager lifecycle.
 
         Given:
@@ -385,11 +461,11 @@ class TestLocalDiscovery:
         When:
             Used as a context manager via with statement
         Then:
-            It should create shared memory on entry and clean up on
-            exit.
+            It should yield the same instance on entry and complete
+            the exit cleanly.
         """
         # Arrange
-        discovery = LocalDiscovery(f"test-cm-{uuid.uuid4()}")
+        discovery = LocalDiscovery(namespace)
 
         # Act & assert
         with discovery as ctx:
@@ -410,6 +486,219 @@ class TestLocalDiscovery:
             # Act & assert
             with LocalDiscovery(namespace) as joiner:
                 assert joiner is not None
+
+    @pytest.mark.asyncio
+    async def test___enter___should_preserve_workers_when_joining_existing_namespace(
+        self, namespace, metadata
+    ):
+        """Test joining an existing namespace preserves its contents.
+
+        Given:
+            An owner's namespace already containing a published worker
+        When:
+            A second LocalDiscovery enters the same namespace and a
+            subscriber obtained from the joiner iterates
+        Then:
+            It should yield the pre-join worker-added event, proving
+            attaching did not reinitialize the segment.
+        """
+        # Arrange
+        events = []
+        event_received = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                events.append(event)
+                event_received.set()
+                break
+
+        with LocalDiscovery(namespace):
+            publisher = LocalDiscovery.Publisher(namespace)
+            async with publisher:
+                await publisher.publish("worker-added", metadata)
+
+                # Act
+                with LocalDiscovery(namespace) as joiner:
+                    subscriber = joiner.subscribe(poll_interval=0.05)
+                    task = asyncio.create_task(collect(subscriber))
+                    try:
+                        await asyncio.wait_for(event_received.wait(), timeout=2.0)
+                    except asyncio.TimeoutError:
+                        pytest.fail("Pre-join worker not discovered within timeout")
+                    finally:
+                        task.cancel()
+                        try:
+                            await task
+                        except asyncio.CancelledError:
+                            pass
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].type == "worker-added"
+        assert events[0].metadata.uid == metadata.uid
+
+    @pytest.mark.asyncio
+    async def test___enter___should_recreate_segment_when_namespace_reused(
+        self, namespace, metadata
+    ):
+        """Test a namespace remains fully usable after rapid teardowns.
+
+        Given:
+            A namespace already cycled through several rapid owner
+            enter/exit lifecycles, leaving no segment behind
+        When:
+            A fresh LocalDiscovery enters the namespace and a worker
+            is published and subscribed to
+        Then:
+            It should yield the worker-added event, proving each
+            teardown freed the segment name for a functional respawn.
+        """
+        # Arrange
+        for _ in range(3):
+            with LocalDiscovery(namespace):
+                pass
+
+        # Arrange — the last teardown really freed the name: with no
+        # owner holding it, a publish finds no segment to attach to.
+        # Without this probe a stale surviving segment would satisfy the
+        # roundtrip below just as well as a recreated one.
+        probe = LocalDiscovery.Publisher(namespace)
+        async with probe:
+            with pytest.raises(FileNotFoundError):
+                await probe.publish("worker-added", metadata)
+
+        events = []
+        event_received = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                events.append(event)
+                event_received.set()
+                break
+
+        # Act
+        with LocalDiscovery(namespace) as discovery:
+            publisher = LocalDiscovery.Publisher(namespace)
+            subscriber = discovery.subscribe(poll_interval=0.05)
+            async with publisher:
+                await publisher.publish("worker-added", metadata)
+
+                task = asyncio.create_task(collect(subscriber))
+                try:
+                    await asyncio.wait_for(event_received.wait(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    pytest.fail("Worker not discovered after namespace reuse")
+                finally:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].type == "worker-added"
+        assert events[0].metadata.uid == metadata.uid
+
+    def test___enter___should_not_register_atexit_fallback_when_namespace_already_owned(
+        self, namespace, atexit_recorder
+    ):
+        """Test the non-owner branch performs no atexit traffic.
+
+        Given:
+            An owner already holding a namespace, with atexit
+            registration wrapped in recording pass-throughs
+        When:
+            A second LocalDiscovery enters and exits the same
+            namespace via with
+        Then:
+            It should neither register nor unregister any atexit
+            fallback.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+
+        with LocalDiscovery(namespace):
+            registrations = len(registered)
+
+            # Act
+            with LocalDiscovery(namespace):
+                pass
+
+            # Assert
+            assert len(registered) == registrations
+            assert unregistered == []
+
+    def test___enter___should_raise_when_the_same_instance_is_reentered(self, namespace):
+        """Test a second entry on one instance is rejected.
+
+        Given:
+            A LocalDiscovery instance already entered via with
+        When:
+            The same instance is entered a second time
+        Then:
+            It should raise RuntimeError.
+        """
+        # Arrange
+        discovery = LocalDiscovery(namespace)
+
+        # Act & assert
+        with discovery:
+            with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+                with discovery:
+                    pass
+
+    def test___enter___should_admit_distinct_instances_sharing_a_namespace(
+        self, namespace
+    ):
+        """Test the single-use guard is per instance, not per namespace.
+
+        Given:
+            A LocalDiscovery instance that has been entered and exited,
+            and a second instance equal to it by namespace
+        When:
+            The second instance is entered
+        Then:
+            It should enter successfully, the guard binding to the
+            instance rather than to the namespace it compares equal on.
+        """
+        # Arrange
+        first = LocalDiscovery(namespace)
+        second = LocalDiscovery(namespace)
+        assert first == second and hash(first) == hash(second)
+        with first:
+            pass
+
+        # Act & assert
+        with second as entered:
+            assert entered is second
+
+    def test___exit___should_disarm_atexit_fallback_when_reentry_is_rejected(
+        self, namespace, atexit_recorder
+    ):
+        """Test a rejected re-entry leaves no fallback armed.
+
+        Given:
+            A LocalDiscovery instance whose second entry was rejected,
+            with atexit registration wrapped in recording pass-throughs
+        When:
+            The instance exits the with block it did enter
+        Then:
+            It should unregister every atexit fallback it registered.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+        discovery = LocalDiscovery(namespace)
+
+        # Act
+        with discovery:
+            with pytest.raises(RuntimeError):
+                with discovery:
+                    pass
+
+        # Assert
+        assert len(registered) == 1
+        assert registered == unregistered
 
     @pytest.mark.asyncio
     async def test___exit___as_non_owner(self, namespace):
@@ -440,6 +729,364 @@ class TestLocalDiscovery:
             publisher = LocalDiscovery.Publisher(namespace)
             async with publisher:
                 await publisher.publish("worker-added", worker)
+
+    @pytest.mark.asyncio
+    async def test___exit___should_unlink_segment_when_owner_exits(
+        self, namespace, metadata
+    ):
+        """Test owner exit removes the shared-memory segment.
+
+        Given:
+            An owner LocalDiscovery that entered a namespace
+        When:
+            The owner exits via with and a Publisher then publishes
+            to that namespace
+        Then:
+            It should raise FileNotFoundError from the publish — the
+            segment no longer exists.
+        """
+        # Arrange
+        with LocalDiscovery(namespace):
+            pass
+        publisher = LocalDiscovery.Publisher(namespace)
+
+        # Act & assert
+        async with publisher:
+            with pytest.raises(FileNotFoundError):
+                await publisher.publish("worker-added", metadata)
+
+    def test___exit___should_disarm_atexit_fallback_when_exit_is_clean(
+        self, namespace, atexit_recorder
+    ):
+        """Test a clean owner exit pairs the atexit fallback exactly.
+
+        Given:
+            An owner LocalDiscovery with atexit registration wrapped
+            in recording pass-throughs and no fault injected
+        When:
+            The owner enters and exits via with
+        Then:
+            It should register exactly one shutdown fallback and
+            unregister that same callable.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+
+        # Act
+        with LocalDiscovery(namespace):
+            pass
+
+        # Assert
+        assert registered == unregistered
+        assert len(registered) == 1
+
+    @pytest.mark.asyncio
+    async def test___exit___should_unlink_segment_when_body_raises(
+        self, namespace, metadata
+    ):
+        """Test exceptional exit still tears the segment down.
+
+        Given:
+            An owner LocalDiscovery whose with body raises ValueError
+        When:
+            The exception unwinds the with statement
+        Then:
+            It should propagate the ValueError unsuppressed while
+            still unlinking the segment, so a subsequent publish
+            raises FileNotFoundError.
+        """
+        # Arrange
+        publisher = LocalDiscovery.Publisher(namespace)
+
+        # Act
+        with pytest.raises(ValueError, match="boom"):
+            with LocalDiscovery(namespace):
+                raise ValueError("boom")
+
+        # Assert — teardown still removed the segment
+        async with publisher:
+            with pytest.raises(FileNotFoundError):
+                await publisher.publish("worker-added", metadata)
+
+    def test___exit___should_unwind_cleanly_when_owner_exits_before_non_owner(
+        self, namespace
+    ):
+        """Test a non-owner outliving the owner still exits cleanly.
+
+        Given:
+            An owner and an attached non-owner sharing a namespace
+        When:
+            The owner exits first, unlinking the segment name, and
+            the non-owner exits afterwards
+        Then:
+            It should raise nothing from either exit and leave the
+            namespace re-creatable.
+        """
+        # Arrange — the ExitStack holds the non-owner open past the
+        # owner's exit and closes it afterwards
+        attached = ExitStack()
+
+        # Act
+        with attached:
+            with LocalDiscovery(namespace):
+                attached.enter_context(LocalDiscovery(namespace))
+
+        # Assert
+        with LocalDiscovery(namespace) as respawned:
+            assert respawned.namespace == namespace
+
+    @pytest.mark.asyncio
+    async def test___exit___should_unwind_cleanly_when_overlapping_lifecycles_interleave(
+        self, namespace, metadata
+    ):
+        """Test overlapping same-namespace generations unwind cleanly.
+
+        Given:
+            Owner A and attached non-owner B sharing a namespace
+        When:
+            A exits, C enters the freed namespace, B exits inside
+            C's epoch, and a worker is published in C's epoch
+        Then:
+            It should raise nothing at any step and the worker should
+            be discoverable through C's fresh segment.
+        """
+        # Arrange
+        events = []
+        event_received = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                events.append(event)
+                event_received.set()
+                break
+
+        attached = ExitStack()
+
+        # Act — A-enter/B-enter/A-exit/C-enter/B-exit/publish/C-exit
+        with attached:
+            with LocalDiscovery(namespace):
+                attached.enter_context(LocalDiscovery(namespace))
+            with LocalDiscovery(namespace) as c:
+                attached.close()
+                publisher = LocalDiscovery.Publisher(namespace)
+                async with publisher:
+                    await publisher.publish("worker-added", metadata)
+
+                    subscriber = c.subscribe(poll_interval=0.05)
+                    task = asyncio.create_task(collect(subscriber))
+                    try:
+                        await asyncio.wait_for(event_received.wait(), timeout=2.0)
+                    except asyncio.TimeoutError:
+                        pytest.fail("Worker not discovered in C's epoch")
+                    finally:
+                        task.cancel()
+                        try:
+                            await task
+                        except asyncio.CancelledError:
+                            pass
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].type == "worker-added"
+        assert events[0].metadata.uid == metadata.uid
+
+    def test___exit___should_not_raise_when_segment_already_unlinked(
+        self, namespace, unlink_schedule
+    ):
+        """Test owner exit tolerates an externally unlinked segment.
+
+        Given:
+            An owner LocalDiscovery whose shared-memory segment is
+            unlinked out from under it, as by another process's
+            resource tracker
+        When:
+            The owner exits via with
+        Then:
+            It should exit cleanly without raising FileNotFoundError.
+        """
+        # Arrange
+        unlink_schedule.append(FileNotFoundError(2, "No such file or directory"))
+
+        # Act & assert — exits cleanly despite the vanished segment
+        with LocalDiscovery(namespace):
+            pass
+
+    def test___exit___should_disarm_atexit_fallback_when_unlink_raises(
+        self, namespace, atexit_recorder, unlink_schedule
+    ):
+        """Test owner exit disarms the atexit fallback when unlink raises.
+
+        Given:
+            An owner LocalDiscovery whose shared-memory segment is
+            unlinked out from under it, as by another process's
+            resource tracker
+        When:
+            The owner exits via with
+        Then:
+            It should unregister the atexit-registered fallback so it
+            cannot fire a second unlink at interpreter shutdown.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+        unlink_schedule.append(FileNotFoundError(2, "No such file or directory"))
+
+        # Act
+        with LocalDiscovery(namespace):
+            pass
+
+        # Assert
+        assert registered == unregistered
+        assert len(registered) == 1
+
+    def test___exit___should_disarm_atexit_fallback_when_unlink_raises_permission_error(
+        self, namespace, atexit_recorder, unlink_schedule
+    ):
+        """Test the fallback is disarmed before the unlink can fail.
+
+        Given:
+            An owner LocalDiscovery whose segment unlink raises
+            PermissionError, with atexit registration wrapped in
+            recording pass-throughs
+        When:
+            The owner exits via with
+        Then:
+            It should have unregistered the fallback, proving the
+            disarm precedes the unlink.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+        unlink_schedule.append(PermissionError(13, "Permission denied"))
+
+        # Act
+        with pytest.warns(ResourceWarning):
+            with LocalDiscovery(namespace):
+                pass
+
+        # Assert
+        assert registered == unregistered
+        assert len(registered) == 1
+
+    def test___exit___should_warn_when_unlink_fails_unexpectedly(
+        self, namespace, unlink_schedule
+    ):
+        """Test an unexpected unlink failure surfaces as a warning.
+
+        Given:
+            An owner LocalDiscovery whose segment unlink raises
+            PermissionError, a failure with no benign explanation
+        When:
+            The owner exits via with
+        Then:
+            It should emit a ResourceWarning naming the segment it
+            could not reclaim.
+        """
+        # Arrange
+        unlink_schedule.append(PermissionError(13, "Permission denied"))
+
+        # Act & assert
+        with pytest.warns(ResourceWarning, match="failed to unlink shared memory"):
+            with LocalDiscovery(namespace):
+                pass
+
+    def test___exit___should_propagate_body_error_when_unlink_fails_unexpectedly(
+        self, namespace, unlink_schedule
+    ):
+        """Test a failing teardown does not mask the caller's exception.
+
+        Given:
+            An owner LocalDiscovery whose segment unlink raises
+            PermissionError
+        When:
+            The body raises ValueError and the owner exits via with
+        Then:
+            It should surface the body's ValueError rather than
+            replacing it with the teardown failure.
+        """
+        # Arrange
+        unlink_schedule.append(PermissionError(13, "Permission denied"))
+
+        # Act & assert
+        with pytest.warns(ResourceWarning):
+            with pytest.raises(ValueError, match="boom"):
+                with LocalDiscovery(namespace):
+                    raise ValueError("boom")
+
+    @given(forest=_LIFECYCLE_FORESTS)
+    @settings(
+        max_examples=25,
+        deadline=5000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test___exit___should_unwind_arbitrary_lifecycle_interleavings(
+        self, namespace, forest
+    ):
+        """Test arbitrary same-namespace lifecycles unwind cleanly.
+
+        Given:
+            An arbitrary forest of same-namespace LocalDiscovery
+            contexts, where nesting models overlapping instances and
+            siblings model teardown+respawn generations
+        When:
+            Every context is entered and exited via nested with
+            statements and a final fresh context enters the namespace
+        Then:
+            It should raise nothing for any interleaving and leave
+            the namespace re-creatable.
+        """
+        # Arrange — per-example namespace so a leaked segment in one
+        # example cannot demote the next example's first context
+        example_ns = f"{namespace}-{uuid.uuid4().hex[:8]}"
+
+        # Act
+        _enter_lifecycle_forest(example_ns, forest)
+
+        # Assert — the namespace remains re-creatable
+        with LocalDiscovery(example_ns):
+            pass
+
+    @given(forest=_LIFECYCLE_FORESTS, mask=st.lists(st.booleans(), max_size=10))
+    @settings(
+        max_examples=25,
+        deadline=5000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test___exit___should_unwind_interleavings_when_segments_vanish(
+        self, namespace, atexit_recorder, unlink_schedule, forest, mask
+    ):
+        """Test vanishing segments never break lifecycle unwinding.
+
+        Given:
+            An arbitrary forest of same-namespace LocalDiscovery
+            contexts and an arbitrary subset of unlink calls that
+            observe the segment already removed by an external
+            unlinker, with atexit registration wrapped in recording
+            pass-throughs
+        When:
+            Every context is entered and exited via nested with
+            statements
+        Then:
+            It should raise nothing for any forest and mask
+            combination, pair every registered fallback with exactly
+            one unregistration, and leave the namespace re-creatable.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+        registered.clear()
+        unregistered.clear()
+        unlink_schedule.clear()
+        unlink_schedule.extend(
+            FileNotFoundError(2, "No such file or directory") if vanished else None
+            for vanished in mask
+        )
+        example_ns = f"{namespace}-{uuid.uuid4().hex[:8]}"
+
+        # Act
+        _enter_lifecycle_forest(example_ns, forest)
+
+        # Assert
+        assert registered == unregistered
+        with LocalDiscovery(example_ns):
+            pass
 
     @pytest.mark.asyncio
     async def test_subscribe_with_non_owner_discovery(self, namespace):
@@ -673,6 +1320,186 @@ class TestLocalDiscoveryPublisher:
         assert dropped[0].metadata.uid == metadata.uid
 
     @pytest.mark.asyncio
+    async def test_publish_should_complete_silently_when_dropping_unknown_worker(
+        self, namespace, metadata
+    ):
+        """Test dropping a never-added worker is a public no-op.
+
+        Given:
+            An initialized Publisher on an empty namespace
+        When:
+            publish("worker-dropped", metadata) is called for a
+            worker that was never added
+        Then:
+            It should complete without raising and emit no
+            subscriber-visible event.
+        """
+        # Arrange
+        events = []
+        event_received = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                events.append(event)
+                event_received.set()
+                break
+
+        with LocalDiscovery(namespace):
+            publisher = LocalDiscovery.Publisher(namespace)
+            async with publisher:
+                # Act
+                await publisher.publish("worker-dropped", metadata)
+
+                # Assert — no event lands within the observation window
+                subscriber = LocalDiscovery.Subscriber(namespace, poll_interval=0.05)
+                task = asyncio.create_task(collect(subscriber))
+                with pytest.raises(asyncio.TimeoutError):
+                    await asyncio.wait_for(event_received.wait(), timeout=0.25)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_publish_should_disarm_block_atexit_fallback_when_worker_dropped(
+        self, namespace, metadata, atexit_recorder
+    ):
+        """Test drop disarms the per-block atexit fallback.
+
+        Given:
+            A Publisher in an owner discovery context, with atexit
+            registration wrapped in recording pass-throughs
+        When:
+            A worker is published and then dropped
+        Then:
+            It should register exactly one per-block fallback and
+            unregister that same callable at the drop.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+
+        with LocalDiscovery(namespace):
+            baseline = len(registered)
+            publisher = LocalDiscovery.Publisher(namespace)
+            async with publisher:
+                # Act
+                await publisher.publish("worker-added", metadata)
+                await publisher.publish("worker-dropped", metadata)
+
+                # Assert
+                block_registered = registered[baseline:]
+                assert block_registered == unregistered
+                assert len(block_registered) == 1
+
+    @pytest.mark.asyncio
+    async def test_publish_should_pair_atexit_fallbacks_when_worker_cycles_repeatedly(
+        self, namespace, metadata, atexit_recorder
+    ):
+        """Test repeated add/drop cycles never accumulate fallbacks.
+
+        Given:
+            A Publisher in an owner discovery context, with atexit
+            registration wrapped in recording pass-throughs
+        When:
+            The same worker is added, dropped, added, and dropped
+        Then:
+            It should record two registrations paired one-to-one in
+            order with two unregistrations, the second add succeeding
+            because the drop unlinked the block's segment name.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+
+        with LocalDiscovery(namespace):
+            baseline = len(registered)
+            publisher = LocalDiscovery.Publisher(namespace)
+            async with publisher:
+                # Act
+                await publisher.publish("worker-added", metadata)
+                await publisher.publish("worker-dropped", metadata)
+                await publisher.publish("worker-added", metadata)
+                await publisher.publish("worker-dropped", metadata)
+
+                # Assert
+                block_registered = registered[baseline:]
+                assert block_registered == unregistered
+                assert len(block_registered) == 2
+
+    @pytest.mark.asyncio
+    async def test_publish_should_complete_drop_when_block_already_unlinked(
+        self, namespace, metadata, atexit_recorder, unlink_schedule
+    ):
+        """Test drop tolerates an externally unlinked worker block.
+
+        Given:
+            A published worker whose per-block segment is unlinked
+            out from under the publisher, with atexit registration
+            wrapped in recording pass-throughs
+        When:
+            publish("worker-dropped", metadata) is called
+        Then:
+            It should complete without raising and still pair the
+            block's fallback registration with its unregistration.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+
+        with LocalDiscovery(namespace):
+            baseline = len(registered)
+            publisher = LocalDiscovery.Publisher(namespace)
+            async with publisher:
+                await publisher.publish("worker-added", metadata)
+                unlink_schedule.append(FileNotFoundError(2, "No such file or directory"))
+
+                # Act
+                await publisher.publish("worker-dropped", metadata)
+
+                # Assert
+                block_registered = registered[baseline:]
+                assert block_registered == unregistered
+                assert len(block_registered) == 1
+
+    @pytest.mark.asyncio
+    async def test_publish_should_disarm_atexit_fallback_when_unlink_fails(
+        self, namespace, metadata, atexit_recorder, unlink_schedule
+    ):
+        """Test the block fallback is disarmed before the unlink runs.
+
+        Given:
+            A published worker whose next block unlink raises
+            RuntimeError, an error the block finalizer does not
+            suppress, with atexit registration wrapped in recording
+            pass-throughs
+        When:
+            publish("worker-dropped", metadata) is called
+        Then:
+            It should complete without raising, the pool swallowing
+            the finalizer error, and the block's fallback should
+            already be unregistered — proving the disarm precedes the
+            unlink.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+
+        with LocalDiscovery(namespace):
+            baseline = len(registered)
+            publisher = LocalDiscovery.Publisher(namespace)
+            async with publisher:
+                await publisher.publish("worker-added", metadata)
+                unlink_schedule.append(RuntimeError("unlink failed"))
+
+                # Act
+                await publisher.publish("worker-dropped", metadata)
+
+                # Assert
+                block_registered = registered[baseline:]
+                assert block_registered == unregistered
+                assert len(block_registered) == 1
+
+    @pytest.mark.asyncio
     async def test_publish_worker_updated(self, namespace, metadata):
         """Test publish("worker-updated") updates worker metadata.
 
@@ -863,38 +1690,47 @@ class TestLocalDiscoveryPublisher:
                 with pytest.raises(KeyError, match=str(metadata.uid)):
                     await publisher.publish("worker-updated", metadata)
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "capacity is not enforced until #299 — page rounding inflates "
+            "the segment to a full page"
+        ),
+    )
     @pytest.mark.asyncio
     async def test_publish_to_full_address_space_raises_runtime_error(self, namespace):
         """Test publish to full address space raises RuntimeError.
 
         Given:
-            A LocalDiscovery whose address space is completely
-            filled with non-null references
+            A LocalDiscovery whose declared capacity has been filled
+            with published workers
         When:
-            A new worker is published
+            One worker beyond capacity is published
         Then:
             It should raise RuntimeError with "No available slots".
         """
         # Arrange
-        worker = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="localhost:50051",
-            pid=123,
-            version="1.0",
-        )
+        capacity = 8
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:{50051 + i}",
+                pid=123 + i,
+                version="1.0",
+            )
+            for i in range(capacity + 1)
+        ]
 
-        with LocalDiscovery(namespace, capacity=4) as discovery:
+        with LocalDiscovery(namespace, capacity=capacity):
             publisher = LocalDiscovery.Publisher(namespace)
 
-            # Fill all slots with non-null references
-            buf = discovery._address_space.buf
-            for i in range(0, len(buf), 16):
-                struct.pack_into("16s", buf, i, b"\xff" * 16)
-
-            # Act & assert
             async with publisher:
-                with pytest.raises(RuntimeError, match="No available slots"):
+                for worker in workers[:capacity]:
                     await publisher.publish("worker-added", worker)
+
+                # Act & assert
+                with pytest.raises(RuntimeError, match="No available slots"):
+                    await publisher.publish("worker-added", workers[capacity])
 
     @pytest.mark.asyncio
     async def test_publish_update_overflow_preserves_prior_state(self, namespace):
@@ -963,6 +1799,112 @@ class TestLocalDiscoveryPublisher:
         assert events[0].metadata.version == "1.0"
 
     @pytest.mark.asyncio
+    async def test_publish_should_release_block_when_add_overflows(
+        self, namespace, atexit_recorder
+    ):
+        """Test a failed add releases the block it acquired.
+
+        Given:
+            A Publisher with a small block size and a worker whose
+            metadata exceeds the block, with atexit registration
+            wrapped in recording pass-throughs
+        When:
+            The oversized worker is published and the add fails
+        Then:
+            It should release the block it acquired, pairing the
+            block's fallback registration with its unregistration.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+        oversized = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="localhost:50051",
+            pid=123,
+            version="1.0",
+            extra=MappingProxyType({"data": "x" * 20000}),
+        )
+
+        with LocalDiscovery(namespace):
+            baseline = len(registered)
+            publisher = LocalDiscovery.Publisher(namespace, block_size=100)
+            async with publisher:
+                # Act
+                with pytest.raises(struct.error):
+                    await publisher.publish("worker-added", oversized)
+
+                # Assert
+                block_registered = registered[baseline:]
+                assert len(block_registered) == 1
+                assert block_registered == unregistered
+
+    @pytest.mark.asyncio
+    async def test_publish_should_leave_worker_undiscoverable_when_add_overflows(
+        self, namespace
+    ):
+        """Test a failed add leaves no trace of the worker behind.
+
+        Given:
+            A Publisher with a small block size, a worker whose
+            metadata exceeds the block, and a worker that fits
+        When:
+            The oversized worker is published and then the fitting
+            worker is published
+        Then:
+            It should raise struct.error for the oversized worker,
+            discover only the fitting worker, and tear both contexts
+            down cleanly.
+        """
+        # Arrange
+        oversized = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="localhost:50051",
+            pid=123,
+            version="1.0",
+            extra=MappingProxyType({"data": "x" * 20000}),
+        )
+        fitting = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="localhost:50052",
+            pid=124,
+            version="1.0",
+        )
+
+        events = []
+        event_received = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                events.append(event)
+                event_received.set()
+
+        with LocalDiscovery(namespace):
+            publisher = LocalDiscovery.Publisher(namespace, block_size=100)
+            async with publisher:
+                # Act
+                with pytest.raises(struct.error):
+                    await publisher.publish("worker-added", oversized)
+                await publisher.publish("worker-added", fitting)
+
+                # Assert — drain a bounded window rather than stopping at
+                # the first event, so a leaked oversized worker surfaces
+                # whatever order the two would arrive in
+                subscriber = LocalDiscovery.Subscriber(namespace, poll_interval=0.05)
+                task = asyncio.create_task(collect(subscriber))
+                try:
+                    await asyncio.wait_for(event_received.wait(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    pytest.fail("Fitting worker not discovered within timeout")
+                await asyncio.sleep(0.25)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        assert events[0].type == "worker-added"
+        assert {e.metadata.uid for e in events} == {fitting.uid}
+
+    @pytest.mark.asyncio
     async def test_publish_with_concurrent_lock_contention(
         self, namespace, metadata, mocker
     ):
@@ -1002,6 +1944,149 @@ class TestLocalDiscoveryPublisher:
 
         # Assert
         assert attempt == 2
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_disarm_atexit_fallbacks_when_workers_still_published(
+        self, namespace, atexit_recorder
+    ):
+        """Test publisher exit finalizes blocks of residual workers.
+
+        Given:
+            A Publisher with two published workers that were never
+            dropped, with atexit registration wrapped in recording
+            pass-throughs
+        When:
+            The publisher's async with block exits
+        Then:
+            It should exit cleanly and unregister every per-block
+            fallback it registered.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:5005{i}",
+                pid=123 + i,
+                version="1.0",
+            )
+            for i in range(2)
+        ]
+
+        with LocalDiscovery(namespace):
+            baseline = len(registered)
+            publisher = LocalDiscovery.Publisher(namespace)
+
+            # Act
+            async with publisher:
+                for worker in workers:
+                    await publisher.publish("worker-added", worker)
+
+            # Assert
+            block_registered = registered[baseline:]
+            assert len(block_registered) == 2
+            assert Counter(block_registered) == Counter(unregistered)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_exit_cleanly_when_worker_segments_already_unlinked(
+        self, namespace, metadata, atexit_recorder, unlink_schedule
+    ):
+        """Test publisher exit tolerates vanished worker blocks.
+
+        Given:
+            A Publisher with a published worker whose per-block
+            segment is unlinked out from under it, with atexit
+            registration wrapped in recording pass-throughs
+        When:
+            The publisher's async with block exits
+        Then:
+            It should exit without raising and pair the block's
+            fallback registration with its unregistration.
+        """
+        # Arrange
+        registered, unregistered = atexit_recorder
+
+        with LocalDiscovery(namespace):
+            baseline = len(registered)
+            publisher = LocalDiscovery.Publisher(namespace)
+
+            # Act
+            async with publisher:
+                await publisher.publish("worker-added", metadata)
+                unlink_schedule.append(FileNotFoundError(2, "No such file or directory"))
+
+            # Assert
+            block_registered = registered[baseline:]
+            assert block_registered == unregistered
+            assert len(block_registered) == 1
+
+    @given(
+        ops=st.lists(
+            st.tuples(
+                st.sampled_from(["add", "drop"]),
+                st.integers(min_value=0, max_value=4),
+            ),
+            max_size=8,
+        )
+    )
+    @settings(
+        max_examples=15,
+        deadline=5000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @pytest.mark.asyncio
+    async def test_publish_should_pair_atexit_fallbacks_across_add_drop_sequences(
+        self, namespace, atexit_recorder, ops
+    ):
+        """Test arbitrary add/drop sequences never leave armed fallbacks.
+
+        Given:
+            An arbitrary sequence of add and drop operations over a
+            small worker roster, where drops may target workers that
+            were never added, with atexit registration wrapped in
+            recording pass-throughs
+        When:
+            The sequence is published and the publisher then exits
+            with any residual workers still registered
+        Then:
+            It should unwind cleanly and pair every per-block
+            fallback registration with exactly one unregistration.
+        """
+        # Arrange — per-example namespace and recorder state so
+        # Hypothesis examples stay independent
+        registered, unregistered = atexit_recorder
+        registered.clear()
+        unregistered.clear()
+        example_ns = f"{namespace}-{uuid.uuid4().hex[:8]}"
+        roster = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:5005{i}",
+                pid=123 + i,
+                version="1.0",
+            )
+            for i in range(5)
+        ]
+        added = set()
+
+        # Act
+        with LocalDiscovery(example_ns):
+            baseline = len(registered)
+            publisher = LocalDiscovery.Publisher(example_ns)
+            async with publisher:
+                for op, index in ops:
+                    if op == "add":
+                        if index in added:
+                            continue
+                        await publisher.publish("worker-added", roster[index])
+                        added.add(index)
+                    else:
+                        await publisher.publish("worker-dropped", roster[index])
+                        added.discard(index)
+
+            # Assert
+            block_registered = registered[baseline:]
+            assert Counter(block_registered) == Counter(unregistered)
 
 
 class TestWorkerReference:
@@ -1494,3 +2579,10 @@ class TestLocalDiscoverySubscriber:
         assert len(events_2) == 1
         assert events_2[0].type == "worker-added"
         assert events_2[0].metadata.uid == metadata.uid
+
+
+def _enter_lifecycle_forest(namespace, forest):
+    """Enter one same-namespace context per node, nesting children."""
+    for children in forest:
+        with LocalDiscovery(namespace):
+            _enter_lifecycle_forest(namespace, children)


### PR DESCRIPTION
## Summary

Prevent `LocalDiscovery` teardown from crashing the interpreter when a shared-memory segment is unlinked twice.

The owner's `__exit__` unlinked its segment unguarded, so a segment already reclaimed by another process's resource tracker raised `FileNotFoundError` out of teardown — and because `atexit.unregister` ran *after* that raising unlink, the shutdown fallback stayed armed and fired a second unlink at interpreter exit. Two bugs compounding: the first crashed the caller's teardown, the second crashed the interpreter.

Fix the ordering (disarm the fallback before unlinking, so a failed unlink can never leave it armed) and route every unlink in the module through a single `_unlink_quietly` helper. The module previously carried four "unlink and tolerate failure" sites under two different policies — the address-space paths suppressed only `FileNotFoundError` while the block paths swallowed every `OSError`, justified by a Windows rationale that does not hold (`SharedMemory.unlink` is a documented no-op on Windows). The real reason suppression is needed is narrower and verifiable: any process that attached to a segment may have unlinked it first (bpo-38119), which surfaces as `ENOENT`. `_unlink_quietly` therefore swallows `FileNotFoundError` silently and downgrades every other `OSError` to a `ResourceWarning` rather than raising it. Teardown can no longer replace an exception the caller is already unwinding, and a genuine leak stays observable instead of being silently swallowed.

Two adjacent reclamation paths that could not fire are fixed alongside it. `Publisher._add` delegated failure cleanup to `_drop`, which scans the address space for a ref that `_add` only writes on the last line of its `try` — so on any failure the ref was never there, `_drop` found nothing, and the block leaked with its `atexit` handler armed for the pool's lifetime. And re-entering one `LocalDiscovery` instance silently demoted it to non-owner while stranding the first entry's fallback; instances are now single-use.

### Trade-offs

**`LocalDiscovery` instances are now single-use.** A second `__enter__` raises `RuntimeError` whether or not the first has exited, so sequentially reusing an instance — which worked before — now fails. Nothing in the codebase relied on it, every internal caller already constructs a fresh instance per `with`, and failing loudly is the point: the silent alternative corrupted ownership state and leaked the namespace.

**An unexpected unlink failure now warns instead of raising.** A non-`ENOENT` `OSError` during teardown emits a `ResourceWarning` rather than propagating. This is deliberate — a raising teardown replaces the caller's in-flight exception — but it means a genuinely unreclaimable segment no longer stops the program. `ResourceWarning` is in Python's default ignore filter, so it is silent in a normal run and visible under `-X dev`, `-W`, or pytest, matching how CPython treats an unclosed socket.

**Two known bugs are pinned as strict xfails rather than fixed here.** `capacity` is not enforced (POSIX page-rounding inflates the segment to a full page regardless, #299), and a surviving pool's worker leaks after an owner-first exit (#298). Both tests flip to `XPASS` — and, being strict, to hard failures — the moment those issues land, forcing the markers to be removed.

Closes #291

## Proposed changes

### Order teardown so a failed unlink cannot leave the fallback armed

`__exit__` now unregisters the `atexit` fallback *before* closing and unlinking. Previously the unregister sat after the unlink, so any unlink failure skipped it and left the handler armed to fire a second time at shutdown — the crash #291 reports.

### Route every unlink through one policy

Add the module-private `_unlink_quietly(shared_memory)` and call it from all four teardown sites: `__enter__`'s fallback closure, `__exit__`, `Publisher._shared_memory_factory`'s fallback closure, and `Publisher._shared_memory_finalizer`. It swallows `FileNotFoundError` — the segment is already gone, which is the expected outcome under bpo-38119 — and emits a `ResourceWarning` for any other `OSError`.

This replaces the two divergent policies with one, and it is what makes teardown non-raising: an exception escaping `__exit__` or an `atexit` handler would otherwise replace the exception the caller was unwinding, or crash the interpreter at shutdown. Swallowing everything would have traded that bug for a silent leak, so an unexpected failure warns instead.

### Release the block a failed publish acquired

`Publisher._add` acquires a per-worker block, packs the metadata into it, and only then writes the worker's ref into the address space. On any failure it called `_drop`, which reclaims a block by scanning the address space for that ref — but the ref lands on the last line of the `try`, so on every failure path it was never written. `_drop` could not find it, `release` never ran, and the block survived with its `atexit` handler armed until the publisher closed. Worse, the leak was sticky: a later successful add of the same uid took the refcount to 2, so its matching drop returned it to 1 and the block was never unlinked even on a clean drop.

Release what `_add` itself acquired instead of inferring it from address-space state. `ResourcePool.release` is a documented no-op for a key that was never cached, so it is also correct when `acquire` is what raised.

### Guard `LocalDiscovery` against re-entry

Entering the same instance twice overwrote `_address_space` and `_owner` while leaving `_cleanup` pointing at the first entry's closure, so both exits took the non-owner branch, the fallback was never disarmed, and the namespace stayed occupied for the process lifetime. Decorate `__enter__` with the existing `@noreentry` utility so a second entry raises `RuntimeError` instead of silently corrupting the instance's ownership state. The guard binds to the instance, not the namespace — distinct instances sharing a namespace compare equal but guard independently.

### Document the teardown contract on the public surface

`LocalDiscovery` is public but carried no statement of the behavior this change is built around. Its class docstring now states the contract once: create-or-attach ownership, the owner's exit unlinking the segment for every still-attached peer, the shutdown fallback for a context never exited, the single-use guard, and a pointer to `_unlink_quietly` for the failure semantics. The `Publisher`/`Subscriber` examples were also corrected — as written they raised `FileNotFoundError`, because they showed no owning context.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestLocalDiscovery` | An owner and a non-owner sharing a namespace | Both enter and exit | Workers are preserved for the peer that joined an existing namespace | Create-or-attach ownership |
| 2 | `TestLocalDiscovery` | A namespace entered and exited three times | A fresh instance enters again | The segment is recreated, proven by a publish raising `FileNotFoundError` between cycles | Segment name is freed on teardown |
| 3 | `TestLocalDiscovery` | An owner already holding a namespace | A second `LocalDiscovery` enters and exits the same namespace | No `atexit` fallback is registered or unregistered | Non-owner performs no fallback traffic |
| 4 | `TestLocalDiscovery` | A `LocalDiscovery` instance already entered | The same instance is entered again | It raises `RuntimeError` | Single-use guard |
| 5 | `TestLocalDiscovery` | Two instances that compare and hash equal by namespace | Each is entered in turn | Both enter successfully | Guard binds to the instance, not the namespace |
| 6 | `TestLocalDiscovery` | An instance whose second entry was rejected | The instance exits the block it did enter | Every registered fallback is unregistered | Rejected re-entry strands nothing |
| 7 | `TestLocalDiscovery` | An owner holding a namespace | The owner exits | The segment is unlinked, proven by a subsequent publish raising `FileNotFoundError` | Owner exit unlinks for all peers |
| 8 | `TestLocalDiscovery` | An owner with a clean exit | The owner exits | The `atexit` fallback is disarmed | Fallback pairing |
| 9 | `TestLocalDiscovery` | An owner whose body raises | The owner exits by exception | The segment is still unlinked | Teardown runs on the exceptional path |
| 10 | `TestLocalDiscovery` | An owner and a non-owner with overlapping lifetimes | The owner exits before the non-owner | Both unwind cleanly and the namespace is re-creatable | Owner-first unwind |
| 11 | `TestLocalDiscovery` | Three interleaved discovery lifecycles | The contexts unwind in overlapping order | A publish through the last epoch is discovered by a subscriber | Interleaved lifecycles |
| 12 | `TestLocalDiscovery` | An owner whose segment vanished before exit | The owner exits | It exits cleanly without raising | `ENOENT` is the expected case |
| 13 | `TestLocalDiscovery` | An owner whose unlink raises `FileNotFoundError` | The owner exits | The fallback is unregistered | Disarm precedes unlink |
| 14 | `TestLocalDiscovery` | An owner whose unlink raises `PermissionError` | The owner exits | The fallback is still unregistered | Disarm precedes unlink on unexpected failure |
| 15 | `TestLocalDiscovery` | An owner whose unlink raises `PermissionError` | The owner exits | It emits a `ResourceWarning` naming the segment | Unexpected failure is observable |
| 16 | `TestLocalDiscovery` | An owner whose unlink raises `PermissionError` | The body raises `ValueError` and the owner exits | The body's `ValueError` propagates, not the teardown failure | Teardown never masks the caller's exception |
| 17 | `TestLocalDiscovery` | Any tree of nested and sequential lifecycles (Hypothesis) | The tree is entered and unwound | Every registered fallback is unregistered | Fallback pairing under arbitrary interleavings |
| 18 | `TestLocalDiscovery` | Any tree of lifecycles with segments vanishing at arbitrary points (Hypothesis) | The tree is entered and unwound | It unwinds cleanly and every fallback is paired | Pairing survives vanished segments |
| 19 | `TestLocalDiscoveryPublisher` | A publisher and an unknown worker | `publish("worker-dropped", …)` is called | It completes silently and emits no event | Dropping an unknown worker is a no-op |
| 20 | `TestLocalDiscoveryPublisher` | A published worker | The worker is dropped | The block's `atexit` fallback is disarmed | Block reclamation on drop |
| 21 | `TestLocalDiscoveryPublisher` | A worker added and dropped repeatedly | The cycle repeats | Fallback registrations and unregistrations stay paired | Block pairing across cycles |
| 22 | `TestLocalDiscoveryPublisher` | A published worker whose block was unlinked externally | The worker is dropped | The drop completes and the fallback is still paired | Drop tolerates a vanished block |
| 23 | `TestLocalDiscoveryPublisher` | A published worker whose block unlink raises `RuntimeError` | The worker is dropped | The fallback was already disarmed | Disarm precedes unlink for blocks |
| 24 | `TestLocalDiscoveryPublisher` | A publisher and a worker whose metadata exceeds the block | The oversized worker is published and the add fails | The acquired block is released and its fallback paired | Failed add reclaims its block |
| 25 | `TestLocalDiscoveryPublisher` | An oversized worker and a fitting worker | Both are published | Only the fitting worker is discoverable | Failed add leaves no trace |
| 26 | `TestLocalDiscoveryPublisher` | A publisher with workers still published | The publisher exits | Every block fallback is disarmed | Publisher teardown reclaims blocks |
| 27 | `TestLocalDiscoveryPublisher` | A publisher whose worker segments were already unlinked | The publisher exits | It exits cleanly | Teardown tolerates vanished blocks |
| 28 | `TestLocalDiscoveryPublisher` | Any sequence of adds and drops (Hypothesis) | The sequence is applied | Fallback registrations and unregistrations stay paired | Block pairing under arbitrary sequences |
| 29 | `TestLocalDiscoveryPublisher` | A discovery with `capacity=8` | Nine workers are published | The ninth raises `RuntimeError` | Address-space exhaustion (`xfail(strict)` pending #299) |
| 30 | `TestSameNamespaceRespawn` | A worker pool repeatedly created and torn down on one namespace | The pools respawn rapidly | Each unwinds cleanly and every worker is reaped | Rapid namespace respawn |
| 31 | `TestOverlappingNamespaceLifecycles` | Two pools sharing a namespace | The non-owner pool exits first | Both unwind cleanly | Non-owner-first teardown |
| 32 | `TestOverlappingNamespaceLifecycles` | Two pools sharing a namespace | The owner pool exits first | Both unwind cleanly with no leaked worker | Owner-first teardown |
| 33 | `TestOverlappingNamespaceLifecycles` | Two pools sharing a namespace | The owner pool exits first | The surviving pool's worker is reaped | Worker reaping (`xfail(strict)` pending #298) |
| 34 | `TestCrossProcessTeardown` | An owner process whose segment is unlinked by another process's resource tracker | The owner exits | It exits with returncode 0 and no traceback | Real double-unlink across processes |
| 35 | `TestCrossProcessTeardown` | An owner process that never exits its context | The interpreter shuts down | The armed fallback reclaims the segment without crashing | Fallback survives real interpreter shutdown |
