### PR TITLE
Discovery sentinel drops worker-updated events carrying changed metadata — Closes #292

### DIFF
--- a/wool/src/wool/runtime/loadbalancer/README.md
+++ b/wool/src/wool/runtime/loadbalancer/README.md
@@ -22,26 +22,15 @@ Wool supports custom load balancers via structural subtyping.
 
 ### `LoadBalancerLike` protocol
 
-Custom load balancers implement a single method:
-
-```python
-class LoadBalancerLike(Protocol):
-    def delegate(
-        self,
-        task: Task,
-        *,
-        context: LoadBalancerContextView,
-    ) -> AsyncGenerator[
-        tuple[WorkerMetadata, WorkerConnection],
-        WorkerMetadata | None,
-    ]: ...
-```
+Custom load balancers implement a single method, `delegate` — an async generator that yields the uid of each worker it wants tried, in preference order. See the `LoadBalancerLike` docstring for the signature and the driver contract.
 
 `task` is the `Task` being routed, passed read-only as the first positional argument. A balancer MAY key its routing on it — hashing `task.tag` for sticky routing, or dispatching by `task.callable` for task-type specialization — or ignore it entirely, as `RoundRobinLoadBalancer` does.
 
 ### Contract
 
 The proxy drives the `delegate` generator: the balancer selects and orders worker candidates, and the proxy dispatches to each, retries on failure, and evicts unhealthy workers. Selection lives in the balancer; dispatch, retry, and eviction live in the proxy. The proxy reports each candidate's outcome back through the generator's `anext`, `athrow`, and `asend` signals — the `LoadBalancerLike` docstring documents them signal by signal and is the single source of truth for the handshake.
+
+A balancer yields worker **uids**, not connections: it names a worker, and the proxy resolves that name against the live pool when it dispatches, so a selection can never carry a stale address. Yielding a uid that has since left the pool is not an error — the proxy skips it and asks for the next candidate, resuming the generator with `None` instead of a success echo. Only a non-`None` resume means the task was dispatched, so a balancer must capture the value the `yield` returns and terminate only on a non-`None` one. See the `LoadBalancerLike` docstring for the full handshake.
 
 ### Implementing a custom load balancer
 
@@ -60,7 +49,7 @@ class StickyTagBalancer:
         *,
         context: wool.LoadBalancerContextView,
     ):
-        workers = list(context.workers.values())
+        workers = list(context.workers)
         if not workers:
             return
 
@@ -73,24 +62,29 @@ class StickyTagBalancer:
         # Probe the hashed worker first, then walk the ring so a single
         # unhealthy worker does not strand the task.
         for offset in range(len(workers)):
-            metadata, connection = workers[(start + offset) % len(workers)]
+            uid = workers[(start + offset) % len(workers)]
             try:
-                yield metadata, connection
+                sent = yield uid
             except Exception:
                 # Dispatch failed (reported via athrow). Advance to the
                 # next worker on the ring. Catch Exception (not
                 # BaseException) so GeneratorExit and CancelledError
                 # propagate correctly.
                 continue
-            # Control returns here only when the proxy signals success
-            # via asend; the contract requires the generator to
-            # terminate after a success.
-            return
+            if sent is not None:
+                # Success echo (asend). The contract requires the
+                # generator to terminate after a success.
+                return
+            # The proxy resumed us with None (anext): the worker left
+            # the pool before dispatch, so nothing was tried. Walk on to
+            # the next worker on the ring.
 ```
 
 A worker-keyed balancer ignores `task` and ranks by worker state instead — here, by in-flight task count, yielding the least-loaded worker first:
 
 ```python
+import uuid
+
 import wool
 
 
@@ -98,7 +92,7 @@ class LeastLoadedBalancer:
     """Yield workers in ascending order of in-flight task count."""
 
     def __init__(self):
-        self._in_flight: dict[str, int] = {}
+        self._in_flight: dict[uuid.UUID, int] = {}
 
     async def delegate(
         self,
@@ -108,28 +102,31 @@ class LeastLoadedBalancer:
     ):
         # Rank workers by current in-flight count (ascending).
         ranked = sorted(
-            context.workers.values(),
-            key=lambda item: self._in_flight.get(item[0].uid, 0),
+            context.workers,
+            key=lambda uid: self._in_flight.get(uid, 0),
         )
 
-        for metadata, connection in ranked:
-            self._in_flight[metadata.uid] = (
-                self._in_flight.get(metadata.uid, 0) + 1
-            )
+        for uid in ranked:
+            self._in_flight[uid] = self._in_flight.get(uid, 0) + 1
             try:
-                yield metadata, connection
+                sent = yield uid
             except Exception:
                 # Dispatch failed. Decrement and try the next candidate.
                 # Catch Exception (not BaseException) so GeneratorExit
                 # and CancelledError propagate correctly.
-                self._in_flight[metadata.uid] -= 1
+                self._in_flight[uid] -= 1
                 continue
-            # Success signaled via asend; the contract requires the
-            # generator to terminate here. The in-flight count stays
-            # incremented for the life of this dispatch; the matching
-            # decrement happens out-of-band when the stream drains (not
-            # shown — requires a lifecycle hook beyond this protocol).
-            return
+            if sent is not None:
+                # Success echo (asend); the contract requires the
+                # generator to terminate here. The in-flight count stays
+                # incremented for the life of this dispatch; the matching
+                # decrement happens out-of-band when the stream drains (not
+                # shown — requires a lifecycle hook beyond this protocol).
+                return
+            # The proxy resumed us with None (anext): the worker left the
+            # pool before dispatch. Nothing was tried, so release the
+            # reservation and rank on.
+            self._in_flight[uid] -= 1
 ```
 
 ## Usage examples

--- a/wool/src/wool/runtime/loadbalancer/README.md
+++ b/wool/src/wool/runtime/loadbalancer/README.md
@@ -60,7 +60,7 @@ class StickyTagBalancer:
         *,
         context: wool.LoadBalancerContextView,
     ):
-        workers = list(context.workers.items())
+        workers = list(context.workers.values())
         if not workers:
             return
 
@@ -108,7 +108,7 @@ class LeastLoadedBalancer:
     ):
         # Rank workers by current in-flight count (ascending).
         ranked = sorted(
-            context.workers.items(),
+            context.workers.values(),
             key=lambda item: self._in_flight.get(item[0].uid, 0),
         )
 

--- a/wool/src/wool/runtime/loadbalancer/base.py
+++ b/wool/src/wool/runtime/loadbalancer/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import uuid
 import warnings
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -40,6 +41,14 @@ class LoadBalancerContextView(Protocol):
     mutation are the `WorkerProxy`'s responsibility; load balancers
     observe the pool but cannot mutate it.
 
+    A worker is identified by its `WorkerMetadata.uid`, which is
+    stable for the life of the worker process while the rest of its
+    record (e.g., address, tags, transport options) is not: discovery
+    republishes a changed record under the same uid, and the pool
+    refreshes the entry in place. A uid observed at any time therefore
+    still names the same worker, and always resolves to that worker's
+    latest record.
+
     By convention across this package, a ``*View`` suffix marks a
     read-only protocol view of an otherwise mutable object.
     """
@@ -47,11 +56,13 @@ class LoadBalancerContextView(Protocol):
     @property
     def workers(
         self,
-    ) -> MappingProxyType[WorkerMetadata, WorkerConnection]:
+    ) -> MappingProxyType[uuid.UUID, tuple[WorkerMetadata, WorkerConnection]]:
         """Read-only view of workers in this context.
 
         :returns:
-            Immutable mapping of worker metadata to connections.
+            A live view of pool membership. The proxy's mutations are
+            visible through it without re-reading the property, and the
+            entry under a uid is always that worker's latest record.
         """
         ...
 
@@ -70,7 +81,19 @@ class LoadBalancerContextLike(LoadBalancerContextView, Protocol):
 
     This is the mutable superset of `LoadBalancerContextView` used by
     the legacy `DispatchingLoadBalancerLike` protocol and by the
-    `WorkerProxy` itself for its internal pool bookkeeping.
+    `WorkerProxy` itself for its internal pool bookkeeping. Worker
+    identity — and with it the semantics every mutator below follows —
+    is defined on `LoadBalancerContextView`.
+
+    Every mutator addresses a worker by ``metadata.uid``, so a record
+    whose other fields have changed still names the worker it was read
+    from. Writes are last-writer-wins: the stored entry is replaced
+    with the given record wholesale, so a caller writing a record it
+    captured earlier regresses a fresher one for the same uid.
+    A displaced `WorkerConnection` is *not* closed — see
+    `wool.runtime.worker.connection.WorkerConnection` for why channel
+    lifetime belongs to the pooling layer rather than to the holder of
+    a connection handle.
     """
 
     def add_worker(
@@ -78,12 +101,12 @@ class LoadBalancerContextLike(LoadBalancerContextView, Protocol):
         metadata: WorkerMetadata,
         connection: WorkerConnection,
     ) -> None:
-        """Add a worker to this context.
+        """Admit a worker to this context, replacing any entry it has.
 
         :param metadata:
-            Information about the worker to add.
+            Information about the worker to admit.
         :param connection:
-            The :py:class:`WorkerConnection` for this worker.
+            The `WorkerConnection` for this worker.
         """
         ...
 
@@ -91,26 +114,26 @@ class LoadBalancerContextLike(LoadBalancerContextView, Protocol):
         self,
         metadata: WorkerMetadata,
         connection: WorkerConnection,
-        *,
-        upsert: bool = False,
     ) -> None:
-        """Update an existing worker's connection.
+        """Refresh an admitted worker's metadata record and connection.
+
+        Does nothing when the worker is not in the context; use
+        `add_worker` to admit one.
 
         :param metadata:
-            Information about the worker to update.
+            Information about the worker to refresh.
         :param connection:
-            New :py:class:`WorkerConnection` for this worker.
-        :param upsert:
-            Flag indicating whether or not to add the worker if
-            it's not already in the context.
+            New `WorkerConnection` for this worker.
         """
         ...
 
     def remove_worker(self, metadata: WorkerMetadata) -> None:
-        """Remove a worker from this context.
+        """Evict a worker from this context.
+
+        Does nothing when the worker is not in the context.
 
         :param metadata:
-            Information about the worker to remove.
+            Information about the worker to evict.
         """
         ...
 
@@ -251,6 +274,13 @@ class LoadBalancerLike(Protocol):
     When the generator ends (via ``return`` or `StopAsyncIteration`
     in response to an ``athrow`` or the initial ``anext``), the proxy
     raises `NoWorkersAvailable`.
+
+    .. rubric:: Implementation notes
+
+    The staleness guarantee is structural rather than enforced: a
+    candidate names a worker, and the proxy resolves that name against
+    the pool it owns at the moment it dispatches, so the record a
+    balancer read is never the record dispatched through.
     """
 
     def delegate(
@@ -274,14 +304,15 @@ class LoadBalancerLike(Protocol):
             its routing decisions on it (for example, hashing
             ``task.tag`` to a worker) or ignore it entirely.
         :param context:
-            Read-only view of the worker pool. Only its ``workers``
-            mapping is exposed; eviction and pool mutation are the
-            proxy's responsibility.
+            Read-only view of the worker pool; see
+            `LoadBalancerContextView` for the surface it exposes.
+            Eviction and pool mutation are the proxy's responsibility.
         :yields:
             ``(metadata, connection)`` candidates in the balancer's
             preferred order. See the class docstring for the
             ``anext``/``athrow``/``asend`` protocol that drives this
             generator.
+
         """
         ...
 
@@ -291,23 +322,21 @@ class LoadBalancerContext:
 
     Manages workers and their connections for a specific worker pool,
     enabling load balancer instances to service multiple pools with
-    independent state and worker lists.
+    independent state and worker lists. The pool's identity model and
+    mutation semantics are the ones `LoadBalancerContextView` and
+    `LoadBalancerContextLike` define.
     """
 
-    _workers: Final[dict[WorkerMetadata, WorkerConnection]]
+    _workers: Final[dict[uuid.UUID, tuple[WorkerMetadata, WorkerConnection]]]
 
     def __init__(self):
         self._workers = {}
 
     @property
-    def workers(self) -> MappingProxyType[WorkerMetadata, WorkerConnection]:
-        """Read-only view of workers in this context.
-
-        :returns:
-            Immutable mapping of worker metadata to connections.
-            Changes to the underlying context are reflected in
-            the returned proxy.
-        """
+    def workers(
+        self,
+    ) -> MappingProxyType[uuid.UUID, tuple[WorkerMetadata, WorkerConnection]]:
+        """Read-only view of workers in this context."""
         return MappingProxyType(self._workers)
 
     def add_worker(
@@ -315,42 +344,18 @@ class LoadBalancerContext:
         metadata: WorkerMetadata,
         connection: WorkerConnection,
     ):
-        """Add a worker to this context.
-
-        :param metadata:
-            Information about the worker to add.
-        :param connection:
-            The :py:class:`WorkerConnection` for this worker.
-        """
-        self._workers[metadata] = connection
+        """Admit a worker to this context, replacing any entry it has."""
+        self._workers[metadata.uid] = (metadata, connection)
 
     def update_worker(
         self,
         metadata: WorkerMetadata,
         connection: WorkerConnection,
-        *,
-        upsert: bool = False,
     ):
-        """Update an existing worker's connection.
-
-        :param metadata:
-            Information about the worker to update. If the worker is not
-            present in the context, this method does nothing.
-        :param connection:
-            New :py:class:`WorkerConnection` for this worker.
-        :param upsert:
-            Flag indicating whether or not to add the worker if it's not
-            already in the context.
-        """
-        if upsert or metadata in self._workers:
-            self._workers[metadata] = connection
+        """Refresh an admitted worker's metadata record and connection."""
+        if metadata.uid in self._workers:
+            self._workers[metadata.uid] = (metadata, connection)
 
     def remove_worker(self, metadata: WorkerMetadata):
-        """Remove a worker from this context.
-
-        :param metadata:
-            Information about the worker to remove. If the worker is not
-            present in the context, this method does nothing.
-        """
-        if metadata in self._workers:
-            del self._workers[metadata]
+        """Evict a worker from this context."""
+        self._workers.pop(metadata.uid, None)

--- a/wool/src/wool/runtime/loadbalancer/base.py
+++ b/wool/src/wool/runtime/loadbalancer/base.py
@@ -253,6 +253,17 @@ class LoadBalancerLike(Protocol):
     non-transient errors, and reports each outcome back to the
     balancer's generator.
 
+    A balancer cannot route a task to a superseded address, however
+    long it holds a candidate or however stale the view it chose from.
+    Balancers that need a worker's record or connection to decide
+    (e.g., to match tags, pin a version, or weigh a connection) read
+    them from ``context.workers``, but do not carry what they read back
+    across this boundary.
+
+    Selecting a worker that has left the pool is not an error. The
+    proxy finds no entry for the uid, asks for the next candidate, and
+    reports nothing back — a departed worker has not failed a dispatch.
+
     The generator supports three signals:
 
     - ``anext()`` — request the next worker candidate.
@@ -262,14 +273,14 @@ class LoadBalancerLike(Protocol):
       the context *before* throwing into the generator, so the
       balancer observes the capacity change before choosing the next
       candidate.
-    - ``asend(metadata)`` — report that the previous candidate's
-      dispatch succeeded. The value sent back is an opaque success
-      echo — the proxy sends back the metadata it just yielded, and
-      only its not-None-ness is meaningful. **The generator MUST
-      terminate after receiving a success signal** — either by
-      ``return`` or by letting control fall off the end. Yielding
-      another candidate after ``asend`` is a protocol violation; the
-      proxy raises `RuntimeError` at the call site.
+    - ``asend(uid)`` — report that the previous candidate's dispatch
+      succeeded. The value sent back is an opaque success echo — the
+      proxy sends back the uid it just yielded, and only its
+      not-None-ness is meaningful. **The generator MUST terminate
+      after receiving a success signal** — either by ``return`` or by
+      letting control fall off the end. Yielding another candidate
+      after ``asend`` is a protocol violation; the proxy raises
+      `RuntimeError` at the call site.
 
     When the generator ends (via ``return`` or `StopAsyncIteration`
     in response to an ``athrow`` or the initial ``anext``), the proxy
@@ -288,16 +299,8 @@ class LoadBalancerLike(Protocol):
         task: Task,
         *,
         context: LoadBalancerContextView,
-    ) -> AsyncGenerator[
-        tuple[WorkerMetadata, WorkerConnection],
-        WorkerMetadata | None,
-    ]:
+    ) -> AsyncGenerator[uuid.UUID, uuid.UUID | None]:
         """Yield worker candidates for the proxy to dispatch to.
-
-        The `WorkerProxy` delegates candidate selection to this
-        generator: the balancer selects and orders candidates, and the
-        proxy drives the generator and dispatches to each yielded
-        worker.
 
         :param task:
             The `Task` being routed. Read-only — the balancer MAY key
@@ -308,11 +311,9 @@ class LoadBalancerLike(Protocol):
             `LoadBalancerContextView` for the surface it exposes.
             Eviction and pool mutation are the proxy's responsibility.
         :yields:
-            ``(metadata, connection)`` candidates in the balancer's
-            preferred order. See the class docstring for the
-            ``anext``/``athrow``/``asend`` protocol that drives this
-            generator.
-
+            Worker uids in the balancer's preferred order. See the
+            class docstring for the ``anext``/``athrow``/``asend``
+            protocol that drives this generator.
         """
         ...
 

--- a/wool/src/wool/runtime/loadbalancer/roundrobin.py
+++ b/wool/src/wool/runtime/loadbalancer/roundrobin.py
@@ -6,9 +6,6 @@ from typing import AsyncGenerator
 from typing import Final
 from weakref import WeakKeyDictionary
 
-from wool.runtime.worker.connection import WorkerConnection
-from wool.runtime.worker.metadata import WorkerMetadata
-
 from .base import LoadBalancerContextView
 
 if TYPE_CHECKING:
@@ -30,14 +27,13 @@ class RoundRobinLoadBalancer:
     .. rubric:: Implementation notes
 
     The rotation snapshots the pool's uids once per wrap and indexes
-    them in O(1); each candidate's record and connection are read from
-    the live pool at yield time, so a worker refreshed mid-cycle is
-    offered under its current entry rather than a stale one. The cycle
-    boundary is the uid of the first yielded candidate and survives
-    such refreshes — the cycle terminates when that uid recurs. Only
-    when the boundary uid leaves the pool is the boundary reseeded from
-    the next surviving candidate, since a uid that has left can never
-    recur and would otherwise never close the cycle.
+    them in O(1). A refresh mid-cycle needs no handling here —
+    candidates are uids (see `LoadBalancerLike`). The cycle boundary is
+    the uid of the first yielded candidate and survives such refreshes:
+    the cycle terminates when that uid recurs. Only when the boundary
+    uid leaves the pool is the boundary reseeded from the next
+    surviving candidate, since a uid that has left can never recur and
+    would otherwise never close the cycle.
 
     Per-context rotation state lives in a `WeakKeyDictionary` keyed on
     the context, so a retired pool's cursor is reclaimed with the
@@ -57,10 +53,7 @@ class RoundRobinLoadBalancer:
         task: Task,
         *,
         context: LoadBalancerContextView,
-    ) -> AsyncGenerator[
-        tuple[WorkerMetadata, WorkerConnection],
-        WorkerMetadata | None,
-    ]:
+    ) -> AsyncGenerator[uuid.UUID, uuid.UUID | None]:
         """Yield worker candidates in round-robin order.
 
         :param task:
@@ -73,8 +66,8 @@ class RoundRobinLoadBalancer:
             proxy's responsibility; the balancer only reads
             ``context.workers`` to pick the next candidate.
         :yields:
-            ``(metadata, connection)`` pairs. The generator is driven
-            by the proxy via ``anext``/``athrow``/``asend``.
+            Worker uids. The generator is driven by the proxy via
+            ``anext``/``athrow``/``asend``.
         """
         checkpoint: uuid.UUID | None = None
         snapshot: list[uuid.UUID] = []
@@ -107,11 +100,11 @@ class RoundRobinLoadBalancer:
                 # See the rubric: a boundary uid that has left the pool
                 # can never recur, so reseed from the next survivor.
                 checkpoint = None
-            current = workers.get(uid)
-            if current is None:
-                # Evicted since the snapshot was taken — skip it.
+            if uid not in workers:
+                # Evicted since the snapshot was taken. The proxy would
+                # skip it anyway; not yielding it keeps the cycle
+                # boundary anchored to a worker that still exists.
                 continue
-            metadata, connection = current
             if checkpoint is None:
                 checkpoint = uid
             elif uid == checkpoint:
@@ -120,7 +113,7 @@ class RoundRobinLoadBalancer:
                 return
 
             try:
-                yield (metadata, connection)
+                yield uid
             except Exception:
                 # Proxy reports failure (transient or non-transient).
                 # Advance to the next worker; eviction, if any, has
@@ -129,8 +122,11 @@ class RoundRobinLoadBalancer:
                 # aclose() and task cancellation work correctly.
                 continue
             else:
-                # Resumed without an exception: the proxy signaled
-                # success. Round-robin has no per-dispatch state to
-                # record, so terminate. See LoadBalancerLike for the
-                # driver contract.
+                # A non-exception resume means success *here* only
+                # because the ``uid not in workers`` guard above never
+                # offers a candidate the proxy would skip, so the
+                # ``None`` resume `LoadBalancerLike` documents cannot
+                # reach this branch. A balancer without that guard must
+                # test the value the yield returns instead. Round-robin
+                # has no per-dispatch state to record, so terminate.
                 return

--- a/wool/src/wool/runtime/loadbalancer/roundrobin.py
+++ b/wool/src/wool/runtime/loadbalancer/roundrobin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING
 from typing import AsyncGenerator
 from typing import Final
@@ -28,15 +29,19 @@ class RoundRobinLoadBalancer:
 
     .. rubric:: Implementation notes
 
-    The cycle boundary is identified by the UID of the first yielded
-    candidate. If that first candidate is evicted mid-cycle its UID can
-    never recur, so the boundary is reseeded from the next surviving
-    candidate.
+    The rotation snapshots the pool's uids once per wrap and indexes
+    them in O(1); each candidate's record and connection are read from
+    the live pool at yield time, so a worker refreshed mid-cycle is
+    offered under its current entry rather than a stale one. The cycle
+    boundary is the uid of the first yielded candidate and survives
+    such refreshes — the cycle terminates when that uid recurs. Only
+    when the boundary uid leaves the pool is the boundary reseeded from
+    the next surviving candidate, since a uid that has left can never
+    recur and would otherwise never close the cycle.
 
     Per-context rotation state lives in a `WeakKeyDictionary` keyed on
-    the context, so a retired pool's cursor — and the connections it
-    references — are reclaimed with the context instead of pinned for
-    the balancer's lifetime.
+    the context, so a retired pool's cursor is reclaimed with the
+    context instead of pinned for the balancer's lifetime.
     """
 
     _index: Final[WeakKeyDictionary[LoadBalancerContextView, int]]
@@ -71,11 +76,14 @@ class RoundRobinLoadBalancer:
             ``(metadata, connection)`` pairs. The generator is driven
             by the proxy via ``anext``/``athrow``/``asend``.
         """
-        checkpoint: WorkerMetadata | None = None
-        snapshot: list[tuple[WorkerMetadata, WorkerConnection]] = []
+        checkpoint: uuid.UUID | None = None
+        snapshot: list[uuid.UUID] = []
         cursor = 0
+        # Hoisted: ``workers`` is a live view (see
+        # LoadBalancerContextView), so re-reading it per candidate would
+        # buy nothing.
+        workers = context.workers
         while True:
-            workers = context.workers
             if not workers:
                 return
             # Select the candidate and advance the shared per-context index
@@ -89,22 +97,24 @@ class RoundRobinLoadBalancer:
                 # Re-observe membership once per wrap and index the ordered
                 # workers in O(1). Rebuilding the snapshot is the only O(n)
                 # step and amortizes to O(1) per candidate over a cycle.
-                snapshot = list(workers.items())
+                snapshot = list(workers)
                 cursor = index % len(snapshot)
-            metadata, connection = snapshot[cursor]
+            uid = snapshot[cursor]
             cursor += 1
             self._index[context] = index + 1
 
             if checkpoint is not None and checkpoint not in workers:
-                # The cycle boundary was evicted; its UID can never recur,
-                # so drop it and let the next survivor reseed the boundary.
+                # See the rubric: a boundary uid that has left the pool
+                # can never recur, so reseed from the next survivor.
                 checkpoint = None
-            if metadata not in workers:
+            current = workers.get(uid)
+            if current is None:
                 # Evicted since the snapshot was taken — skip it.
                 continue
+            metadata, connection = current
             if checkpoint is None:
-                checkpoint = metadata
-            elif metadata.uid == checkpoint.uid:
+                checkpoint = uid
+            elif uid == checkpoint:
                 # One full cycle completed without a successful
                 # dispatch — signal exhaustion.
                 return

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -132,6 +132,12 @@ class WorkerConnection:
     The channel stays alive until the caller finishes consuming the
     result stream.
 
+    A connection is a lazy handle, not a channel owner: channel lifetime
+    belongs to the pool, which reaps a channel by refcount and TTL once
+    no handle is using it. Discarding a connection therefore does not
+    close its channel, and closing a connection whose channel another
+    handle still shares would evict that channel out from under it.
+
     **Cleanup semantics on cancellation.** Every code path that owns
     an in-flight gRPC call wraps its body in
     ``try / except BaseException`` so that ``asyncio.CancelledError``

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -140,10 +140,10 @@ class WorkerPool:
 
         class PriorityBalancer:
             async def delegate(self, task, *, context):
-                # Yield workers in priority order.
-                for metadata, connection in context.workers.values():
+                # Yield worker uids in priority order.
+                for uid in context.workers:
                     try:
-                        sent = yield metadata, connection
+                        sent = yield uid
                     except Exception:
                         continue
                     if sent is not None:

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -141,7 +141,7 @@ class WorkerPool:
         class PriorityBalancer:
             async def delegate(self, task, *, context):
                 # Yield workers in priority order.
-                for metadata, connection in context.workers.items():
+                for metadata, connection in context.workers.values():
                     try:
                         sent = yield metadata, connection
                     except Exception:
@@ -195,7 +195,8 @@ class WorkerPool:
         (unbounded). Only meaningful when a ``discovery`` service is
         configured; supplying ``lease`` without ``discovery`` records
         the value but never consults it, accompanied by an
-        `IneffectiveLeaseWarning`.
+        `IneffectiveLeaseWarning`. Admission semantics are
+        `WorkerProxy`'s — see its ``lease`` parameter.
     :param worker:
         Worker factory callable. A `WorkerFactory` declares a ``host``
         keyword and receives the discovery publisher's prescribed bind

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -252,9 +252,9 @@ class WorkerProxy:
         class StickyBalancer:
             async def delegate(self, task, *, context):
                 # Yield a preferred worker first, then fall back.
-                for metadata, connection in context.workers.values():
+                for uid in context.workers:
                     try:
-                        sent = yield metadata, connection
+                        sent = yield uid
                     except Exception:
                         continue
                     if sent is not None:
@@ -926,9 +926,8 @@ class WorkerProxy:
     ) -> AsyncGenerator:
         """Drive a delegating load balancer through one dispatch.
 
-        Pulls candidates from ``loadbalancer.delegate(task, context=...)``,
-        calls `WorkerConnection.dispatch` on each, and reports the
-        outcome back via ``asend`` on success or ``athrow`` on failure.
+        Implements the driver side of the `LoadBalancerLike` handshake.
+
         Only `RpcError` is treated as a worker-health signal:
         a non-transient `RpcError` triggers eviction from the
         context before the balancer is notified, so it observes the
@@ -962,11 +961,22 @@ class WorkerProxy:
         generator = loadbalancer.delegate(task, context=ctx)
         try:
             try:
-                metadata, connection = await generator.__anext__()
+                uid = await anext(generator)
             except StopAsyncIteration:
                 raise NoWorkersAvailable()
 
             while True:
+                current = ctx.workers.get(uid)
+                if current is None:
+                    # Departed worker: not a dispatch failure — see
+                    # LoadBalancerLike.
+                    try:
+                        uid = await anext(generator)
+                    except StopAsyncIteration:
+                        raise NoWorkersAvailable()
+                    continue
+
+                metadata, connection = current
                 try:
                     stream = await connection.dispatch(task, timeout=timeout)
                 except RpcError as exc:
@@ -976,7 +986,7 @@ class WorkerProxy:
                     if not isinstance(exc, TransientRpcError):
                         ctx.remove_worker(metadata)
                     try:
-                        metadata, connection = await generator.athrow(exc)
+                        uid = await generator.athrow(exc)
                     except StopAsyncIteration:
                         raise NoWorkersAvailable() from exc
                     continue
@@ -990,7 +1000,7 @@ class WorkerProxy:
                 # handoff.
                 try:
                     try:
-                        trailing = await generator.asend(metadata)
+                        trailing = await generator.asend(uid)
                     except StopAsyncIteration:
                         result, stream = stream, None
                         return result

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -210,8 +210,8 @@ class WorkerProxy:
     """Client-side proxy for dispatching tasks to distributed workers.
 
     Manages worker discovery, connection pooling, and load-balanced task
-    routing. The bridge between :func:`@wool.routine <wool.routine>` decorated
-    functions and the worker pool.
+    routing. The bridge between `wool.routine`-decorated functions and
+    the worker pool.
 
     Connects to workers through discovery services, pool URIs, or static
     worker lists. Handles connection lifecycle and fault tolerance
@@ -252,7 +252,7 @@ class WorkerProxy:
         class StickyBalancer:
             async def delegate(self, task, *, context):
                 # Yield a preferred worker first, then fall back.
-                for metadata, connection in context.workers.items():
+                for metadata, connection in context.workers.values():
                     try:
                         sent = yield metadata, connection
                     except Exception:
@@ -294,7 +294,10 @@ class WorkerProxy:
         Optional channel credentials for TLS/mTLS connections to workers.
     :param lease:
         Maximum number of workers this proxy will admit from discovery.
-        Defaults to ``None`` (unbounded).
+        Defaults to ``None`` (unbounded).  The cap counts distinct
+        worker uids, so a worker re-announcing itself refreshes its
+        entry without consuming a slot; only a worker the proxy has
+        not admitted can be turned away.
     :param quorum:
         Minimum number of workers that must be discovered before the proxy
         considers itself ready. Defaults to ``1`` — block until at least
@@ -306,11 +309,11 @@ class WorkerProxy:
         first dispatch; with ``lazy=False`` it blocks at context entry.
     :param quorum_timeout:
         Seconds to wait for ``quorum`` workers to be discovered before
-        raising :class:`asyncio.TimeoutError`. Only meaningful when
+        raising `asyncio.TimeoutError`. Only meaningful when
         ``quorum`` is a positive integer; supplying it with
         ``quorum=None`` or ``quorum=0`` records the value but never
         consults it, accompanied by an
-        :class:`IneffectiveQuorumTimeoutWarning`. Defaults to ``60``;
+        `IneffectiveQuorumTimeoutWarning`. Defaults to ``60``;
         pass ``None`` to wait indefinitely.
 
     :raises ValueError:
@@ -321,7 +324,7 @@ class WorkerProxy:
         positive ``quorum``.
     :raises asyncio.TimeoutError:
         Raised at context entry (``lazy=False``) or first
-        :meth:`dispatch` (``lazy=True``) if ``quorum`` workers are not
+        `dispatch` (``lazy=True``) if ``quorum`` workers are not
         admitted within ``quorum_timeout`` seconds.
 
     .. caution::
@@ -329,7 +332,7 @@ class WorkerProxy:
        Pre-called context manager instances passed as ``loadbalancer``
        or ``discovery`` are not picklable and will cause nested routine
        dispatch to fail.  Pass a callable returning the context manager
-       instead.  See :data:`Factory`.
+       instead.  See `Factory`.
     """
 
     _discovery: DiscoverySubscriberLike | Factory[DiscoverySubscriberLike]
@@ -668,9 +671,16 @@ class WorkerProxy:
 
     @property
     def workers(self) -> list[WorkerMetadata]:
-        """A list of the currently discovered worker gRPC stubs."""
+        """Return the current metadata record of every discovered worker.
+
+        A worker's record is replaced in place when discovery
+        republishes it, so correlate entries across calls by
+        `WorkerMetadata.uid` rather than by holding a record.
+        """
         if self._loadbalancer_context:
-            return list(self._loadbalancer_context.workers.keys())
+            return [
+                metadata for metadata, _ in self._loadbalancer_context.workers.values()
+            ]
         else:
             return []
 
@@ -1103,27 +1113,41 @@ class WorkerProxy:
             if self._credentials is not None
             else None
         )
+
+        def connect(metadata: WorkerMetadata) -> WorkerConnection:
+            return WorkerConnection(
+                metadata.address,
+                credentials=client_credentials,
+                options=metadata.options,
+            )
+
         async for event in self._discovery_stream:
             match event.type:
-                case "worker-added" | "worker-updated":
+                case "worker-added":
                     if (
-                        event.type == "worker-added"
-                        and self._lease is not None
+                        self._lease is not None
+                        and event.metadata.uid not in self._loadbalancer_context.workers
                         and len(self._loadbalancer_context.workers) >= self._lease
                     ):
+                        # Admission is per uid — see the ``lease``
+                        # parameter on this class.
                         continue
-                    connection = WorkerConnection(
-                        event.metadata.address,
-                        credentials=client_credentials,
-                        options=event.metadata.options,
+                    # Displaced connections are not closed — see
+                    # LoadBalancerContextLike.
+                    self._loadbalancer_context.add_worker(
+                        event.metadata, connect(event.metadata)
                     )
-                    if event.type == "worker-added":
-                        self._loadbalancer_context.add_worker(event.metadata, connection)
-                        self._workers_changed.set()
-                    elif event.metadata in self._loadbalancer_context.workers:
-                        self._loadbalancer_context.update_worker(
-                            event.metadata, connection
-                        )
+                    self._workers_changed.set()
+                case "worker-updated":
+                    if event.metadata.uid not in self._loadbalancer_context.workers:
+                        # A refresh never admits a worker; skip before
+                        # minting a connection this event cannot use.
+                        continue
+                    # Displaced connections are not closed — see
+                    # LoadBalancerContextLike.
+                    self._loadbalancer_context.update_worker(
+                        event.metadata, connect(event.metadata)
+                    )
                 case "worker-dropped":
                     self._loadbalancer_context.remove_worker(event.metadata)
                     self._workers_changed.set()

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -12,6 +12,7 @@ import ipaddress
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from contextlib import suppress
 from dataclasses import dataclass
 from dataclasses import fields
 from enum import Enum
@@ -1510,6 +1511,57 @@ async def _clear_channel_pool():
 # autouse cleanup. (The previous sync ``_clear_proxy_context``
 # autouse fixture mutated the pytest main Chain, which async test
 # tasks never observe; it was load-bearing in appearance only.)
+
+
+@pytest_asyncio.fixture
+async def worker_update_pool(request) -> AsyncIterator[tuple]:
+    """Yield a live pool over one announced worker plus a live spare.
+
+    Starts two ``LocalWorker`` processes against a per-test
+    ``LocalDiscovery`` namespace, announces only the first, and enters a
+    ``WorkerPool`` bound to that discovery through the ``_DIRECT``
+    factory form. Yields ``(pool, publisher, worker_a, worker_b)``: the
+    publisher so a test can drive worker-added/updated/dropped events,
+    and both workers so a test can name their uids, addresses, and pids.
+
+    The pool's ``lease`` is taken from an indirect parameter and
+    defaults to ``None`` (uncapped); parametrize the fixture indirectly
+    to cap admission.
+
+    The pool is entered inside the caller's task so the ambient proxy
+    ``ContextVar`` is visible to the dispatches the test makes. On exit
+    the announced uid is dropped and both worker processes are stopped,
+    whether or not the test already stopped one of them.
+    """
+    lease = getattr(request, "param", None)
+    namespace = f"worker-update-{uuid.uuid4().hex[:12]}"
+    worker_a = LocalWorker()
+    worker_b = LocalWorker()
+    await worker_a.start()
+    await worker_b.start()
+    try:
+        with LocalDiscovery(namespace) as discovery:
+            publisher = discovery.publisher
+            async with publisher:
+                await publisher.publish("worker-added", worker_a.metadata)
+                pool = WorkerPool(
+                    discovery=_DirectDiscovery(discovery),
+                    loadbalancer=RoundRobinLoadBalancer,
+                    lease=lease,
+                )
+                try:
+                    async with pool:
+                        yield pool, publisher, worker_a, worker_b
+                finally:
+                    with suppress(KeyError):
+                        await publisher.publish("worker-dropped", worker_a.metadata)
+    finally:
+        # ``LocalWorker.stop`` raises on an already-stopped worker, so
+        # the teardown absorbs that here rather than making every test
+        # carry a "did I stop it?" flag.
+        for worker in (worker_b, worker_a):
+            with suppress(RuntimeError):
+                await worker.stop()
 
 
 @pytest.fixture

--- a/wool/tests/integration/test_worker_update.py
+++ b/wool/tests/integration/test_worker_update.py
@@ -1,0 +1,223 @@
+"""End-to-end tests for live worker-metadata updates (#292).
+
+These are targeted standalone tests rather than pairwise scenarios: the
+scenario matrix's dimensions are static composition axes resolved once
+at build time, and worker metadata never changes mid-scenario there —
+the update flow is a temporal lifecycle behavior against one live pool.
+The full pipeline is proved with real components: a ``LocalDiscovery``
+publish flows through the shared-memory rescan, the subscriber diff,
+the proxy's worker sentinel, and the uid-keyed load-balancer context
+into real gRPC dispatch. LAN discovery is deliberately not exercised:
+its updates never re-resolve the advertised address, so a connection
+refresh to a new address cannot occur on that transport.
+"""
+
+import asyncio
+from dataclasses import replace
+
+import pytest
+
+from wool.runtime.loadbalancer.base import NoWorkersAvailable
+
+from . import routines
+
+_TIMEOUT = 30
+_PROPAGATION_TIMEOUT = 15.0
+# Long enough for the publish to traverse the rescan and the subscriber
+# diff, so a sentinel that wrongly admitted the worker would have done
+# so before the assertion reads the pool.
+_SETTLE = 2.0
+
+
+async def _poll_until(predicate, message):
+    """Dispatch get_pid until the predicate holds, or fail.
+
+    Discovery propagation is asynchronous, so the pool observes an
+    event some bounded time after it is published; dispatching is the
+    only public window onto which worker is pooled.
+    """
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + _PROPAGATION_TIMEOUT
+    while not predicate(pid := await routines.get_pid()):
+        assert loop.time() < deadline, f"dispatch still reaches pid {pid}; {message}"
+        await asyncio.sleep(0.1)
+
+
+async def _poll_until_unavailable(message):
+    """Dispatch get_pid until the pool has no workers left, or fail.
+
+    The eviction counterpart of :func:`_poll_until`: an evicted worker
+    is observable only as a dispatch that can no longer be routed.
+    """
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + _PROPAGATION_TIMEOUT
+    while True:
+        try:
+            await routines.get_pid()
+        except NoWorkersAvailable:
+            return
+        assert loop.time() < deadline, message
+        await asyncio.sleep(0.1)
+
+
+@pytest.mark.integration
+class TestWorkerUpdatePropagation:
+    @pytest.mark.asyncio
+    async def test_dispatch_should_follow_update_when_metadata_changes(
+        self, worker_update_pool, retry_grpc_internal
+    ):
+        """Test a worker-updated event redirects dispatch end to end.
+
+        Given:
+            A pool over a real LocalDiscovery with one announced worker
+            and a second live but unannounced worker
+        When:
+            The publisher publishes worker-updated carrying the
+            announced worker's uid with the unannounced worker's
+            address and pid
+        Then:
+            It should redirect dispatch to the second worker within a
+            bounded deadline
+        """
+        _, publisher, worker_a, worker_b = worker_update_pool
+
+        async def body():
+            async with asyncio.timeout(_TIMEOUT):
+                # Arrange
+                assert await routines.get_pid() == worker_a.metadata.pid
+                updated = replace(worker_b.metadata, uid=worker_a.metadata.uid)
+
+                # Act
+                await publisher.publish("worker-updated", updated)
+
+                # Assert
+                await _poll_until(
+                    lambda pid: pid == worker_b.metadata.pid,
+                    "the worker-updated event never propagated",
+                )
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_keep_routing_when_stale_worker_stops(
+        self, worker_update_pool, retry_grpc_internal
+    ):
+        """Test the redirected pool holds no reference to the old worker.
+
+        Given:
+            A pool whose sole worker's metadata was refreshed onto a
+            second live worker's address, with dispatch already
+            observed to follow the refresh
+        When:
+            The original worker's process is stopped
+        Then:
+            It should keep dispatching to the second worker — the
+            refresh replaced the pooled connection rather than adding
+            to it
+        """
+        _, publisher, worker_a, worker_b = worker_update_pool
+
+        async def body():
+            async with asyncio.timeout(_TIMEOUT):
+                # Arrange
+                updated = replace(worker_b.metadata, uid=worker_a.metadata.uid)
+                await publisher.publish("worker-updated", updated)
+                await _poll_until(
+                    lambda pid: pid == worker_b.metadata.pid,
+                    "the worker-updated event never propagated",
+                )
+
+                # Act
+                await worker_a.stop()
+
+                # Assert
+                assert await routines.get_pid() == worker_b.metadata.pid
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_raise_when_worker_dropped_after_update(
+        self, worker_update_pool, retry_grpc_internal
+    ):
+        """Test a drop following an applied update evicts the worker.
+
+        Given:
+            A pool over a real LocalDiscovery whose sole worker's
+            metadata was refreshed by an applied worker-updated event,
+            with both worker processes alive throughout
+        When:
+            The publisher publishes worker-dropped for that uid
+        Then:
+            It should evict the worker — dispatch raises
+            NoWorkersAvailable within a bounded deadline instead of a
+            ghost entry serving dispatches forever
+        """
+        _, publisher, worker_a, worker_b = worker_update_pool
+
+        async def body():
+            async with asyncio.timeout(_TIMEOUT):
+                # Arrange
+                updated = replace(worker_b.metadata, uid=worker_a.metadata.uid)
+                await publisher.publish("worker-updated", updated)
+                await _poll_until(
+                    lambda pid: pid == worker_b.metadata.pid,
+                    "the worker-updated event never propagated",
+                )
+
+                # Act
+                await publisher.publish("worker-dropped", updated)
+
+                # Assert
+                await _poll_until_unavailable(
+                    "worker-dropped never evicted the refreshed entry"
+                )
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.parametrize("worker_update_pool", [1], indirect=True)
+    @pytest.mark.asyncio
+    async def test_dispatch_should_raise_when_update_precedes_add(
+        self, worker_update_pool, retry_grpc_internal
+    ):
+        """Test a worker-updated event never admits an unadmitted worker.
+
+        Given:
+            A pool over a real LocalDiscovery with lease=1, holding its
+            one announced worker, and a second announced worker the cap
+            rejected, after which the admitted worker is dropped and the
+            pool is empty
+        When:
+            The publisher publishes worker-updated for the rejected
+            worker's uid
+        Then:
+            It should leave the pool empty — dispatch keeps raising
+            NoWorkersAvailable, because a refresh never admits a worker
+        """
+        _, publisher, worker_a, worker_b = worker_update_pool
+
+        async def body():
+            async with asyncio.timeout(_TIMEOUT):
+                # Arrange — discovery's registrar refuses to publish
+                # worker-updated for a uid it has never registered, so
+                # the only worker a refresh can name that the pool does
+                # not hold is one the pool never admitted: one the lease
+                # cap rejected. Dispatch once so the lazy pool starts and
+                # admits worker_a against the cap, announce worker_b so
+                # the cap rejects it, then retire worker_a so only an
+                # admission could repopulate the pool.
+                assert await routines.get_pid() == worker_a.metadata.pid
+                await publisher.publish("worker-added", worker_b.metadata)
+                await publisher.publish("worker-dropped", worker_a.metadata)
+                await _poll_until_unavailable(
+                    "the cap-rejected worker was admitted, or worker_a was never evicted"
+                )
+
+                # Act
+                await publisher.publish("worker-updated", worker_b.metadata)
+                await asyncio.sleep(_SETTLE)
+
+                # Assert
+                with pytest.raises(NoWorkersAvailable):
+                    await routines.get_pid()
+
+        await retry_grpc_internal(body)

--- a/wool/tests/runtime/loadbalancer/test_base.py
+++ b/wool/tests/runtime/loadbalancer/test_base.py
@@ -1,7 +1,10 @@
+from dataclasses import replace
 from types import MappingProxyType
 from uuid import uuid4
 
+import pytest
 from hypothesis import given
+from hypothesis import settings
 from hypothesis import strategies as st
 
 from wool.runtime.loadbalancer.base import DispatchingLoadBalancerLike
@@ -12,33 +15,102 @@ from wool.runtime.loadbalancer.base import LoadBalancerLike
 from wool.runtime.worker.connection import WorkerConnection
 from wool.runtime.worker.metadata import WorkerMetadata
 
+_MUTABLE_FIELDS = ("address", "pid", "version", "tags", "extra", "secure", "options")
+
 
 @st.composite
-def loadbalancer_context(draw):
-    """Generate a LoadBalancerContext seeded with 1-8 workers.
+def worker_metadata(draw):
+    """Generate a WorkerMetadata with varied non-uid fields.
 
-    Creates a LoadBalancerContext populated with randomly generated workers.
-    Each worker has unique identifying information and a connection.
+    Generated ports and pids deliberately exclude the sentinel values
+    used by example-based tests (ports 60000/61000, pid 9999) so a
+    record replaced with those sentinels always differs from any
+    generated record.
 
     :param draw:
         Hypothesis draw function
 
     :returns:
-        LoadBalancerContext instance with 1-8 workers
+        WorkerMetadata instance with randomized fields
     """
-    worker_count = draw(st.integers(min_value=1, max_value=8))
+    port = draw(st.integers(min_value=50000, max_value=59999))
+    return WorkerMetadata(
+        uid=uuid4(),
+        address=f"localhost:{port}",
+        pid=draw(st.integers(min_value=1, max_value=9998)),
+        version=draw(st.sampled_from(["1.0.0", "1.2.3", "2.0.1"])),
+        tags=frozenset(
+            draw(st.sets(st.sampled_from(["cpu", "gpu", "arm", "x86"]), max_size=3))
+        ),
+        extra=MappingProxyType(
+            draw(
+                st.dictionaries(
+                    st.sampled_from(["zone", "rack", "tier"]),
+                    st.text(alphabet="abcdef", min_size=1, max_size=4),
+                    max_size=2,
+                )
+            )
+        ),
+        secure=draw(st.booleans()),
+    )
+
+
+@st.composite
+def loadbalancer_context(draw, min_workers: int = 1):
+    """Generate a LoadBalancerContext seeded with workers.
+
+    Creates a LoadBalancerContext populated with randomly generated workers.
+    Each worker has a unique uid, varied metadata fields, and a connection.
+
+    :param draw:
+        Hypothesis draw function
+
+    :param min_workers:
+        Minimum number of workers to seed; the maximum is always 8.
+
+    :returns:
+        LoadBalancerContext instance with ``min_workers``-8 workers
+    """
+    worker_count = draw(st.integers(min_value=min_workers, max_value=8))
     ctx = LoadBalancerContext()
 
-    for i in range(worker_count):
-        metadata = WorkerMetadata(
-            uid=uuid4(),
-            address=f"localhost:{50051 + i}",
-            pid=1000 + i,
-            version="1.0.0",
-        )
-        ctx.add_worker(metadata, WorkerConnection(f"localhost:{50051 + i}"))
+    for _ in range(worker_count):
+        metadata = draw(worker_metadata())
+        ctx.add_worker(metadata, WorkerConnection(metadata.address))
 
     return ctx
+
+
+def _mutate(metadata: WorkerMetadata, fields) -> WorkerMetadata:
+    """Return a same-uid copy of metadata with the given fields changed.
+
+    Every mutation differs from the original value by construction, so
+    the returned record is never equal to the original.
+    """
+    mutations = {}
+    for field in fields:
+        match field:
+            case "address":
+                host, _, port = metadata.address.rpartition(":")
+                mutations["address"] = f"{host}:{int(port) + 1}"
+            case "pid":
+                mutations["pid"] = metadata.pid + 1
+            case "version":
+                mutations["version"] = f"{metadata.version}.post1"
+            case "tags":
+                mutations["tags"] = metadata.tags | {"mutated"}
+            case "extra":
+                mutations["extra"] = MappingProxyType(
+                    {**metadata.extra, "mutated": "true"}
+                )
+            case "secure":
+                mutations["secure"] = not metadata.secure
+            case "options":
+                mutations["options"] = replace(
+                    metadata.options,
+                    max_concurrent_streams=metadata.options.max_concurrent_streams + 1,
+                )
+    return replace(metadata, **mutations)
 
 
 class TestLoadBalancerContextLike:
@@ -62,7 +134,7 @@ class TestLoadBalancerContextLike:
             def add_worker(self, metadata, connection):
                 pass
 
-            def update_worker(self, metadata, connection, *, upsert=False):
+            def update_worker(self, metadata, connection):
                 pass
 
             def remove_worker(self, metadata):
@@ -101,7 +173,8 @@ class TestLoadBalancerContextView:
         """Test a conforming class satisfies the protocol.
 
         Given:
-            A class exposing only a read-only ``workers`` property
+            A class exposing the read-only view surface — a ``workers``
+            property
         When:
             Checked against the LoadBalancerContextView protocol
         Then:
@@ -294,212 +367,424 @@ class TestLoadBalancerContext:
         assert isinstance(LoadBalancerContext(), LoadBalancerContextLike)
 
     @given(loadbalancer_context())
-    def test_workers_property_immutability(self, context: LoadBalancerContext):
-        """Test that the ``workers`` property is immutable.
+    @settings(max_examples=50)
+    def test_workers_should_reject_mutation(self, context: LoadBalancerContext):
+        """Test that the workers mapping cannot be mutated by a caller.
 
         Given:
             A load balancer context with one or more workers
             registered
         When:
-            The workers property is accessed
+            A caller attempts to assign through the workers mapping
         Then:
-            The returned value is an immutable mapping proxy
-        """
-        # Act & assert
-        assert isinstance(context.workers, MappingProxyType)
-
-    @given(loadbalancer_context())
-    def test_add_worker_with_new_worker(self, context: LoadBalancerContext):
-        """Test that a worker can be added to the context.
-
-        Given:
-            A load balancer context with one or more workers
-            registered
-        When:
-            A worker is added to the context
-        Then:
-            The new worker is present and the existing workers in
-            the context are unchanged
+            It should raise TypeError — the pool is mutated only
+            through the context's own methods
         """
         # Arrange
-        original_workers = dict(context.workers)
-        worker = WorkerMetadata(
+        uid = next(iter(context.workers))
+
+        # Act & assert
+        with pytest.raises(TypeError):
+            context.workers[uid] = None  # type: ignore[index]
+
+    @given(loadbalancer_context(min_workers=2))
+    @settings(max_examples=50)
+    def test_workers_should_reflect_mutations_when_view_captured_earlier(
+        self, context: LoadBalancerContext
+    ):
+        """Test that a captured workers view stays live across mutations.
+
+        Given:
+            A load balancer context holding two or more workers, whose
+            workers view was captured before any mutation
+        When:
+            A worker is admitted, a second refreshed, and a third
+            evicted
+        Then:
+            It should reflect all three mutations through the
+            previously captured view
+        """
+        # Arrange
+        view = context.workers
+        (stale, _), (evicted, _) = list(context.workers.values())[:2]
+        refreshed = _mutate(stale, ["address", "pid"])
+        refreshed_connection = WorkerConnection(refreshed.address)
+        admitted = WorkerMetadata(
             uid=uuid4(),
-            address="localhost:60000",
+            address="localhost:61000",
             pid=9999,
             version="1.0.0",
         )
-        connection = WorkerConnection("localhost:60000")
+        admitted_connection = WorkerConnection(admitted.address)
+
+        # Act
+        context.add_worker(admitted, admitted_connection)
+        context.update_worker(refreshed, refreshed_connection)
+        context.remove_worker(evicted)
+
+        # Assert
+        assert view[admitted.uid] == (admitted, admitted_connection)
+        assert view[refreshed.uid] == (refreshed, refreshed_connection)
+        assert evicted.uid not in view
+
+    @given(loadbalancer_context())
+    @settings(max_examples=50)
+    def test_add_worker_should_admit_worker_when_uid_absent(
+        self, context: LoadBalancerContext
+    ):
+        """Test that a worker can be admitted to the context.
+
+        Given:
+            A load balancer context with one or more workers
+            registered
+        When:
+            A worker with an unseen uid is admitted
+        Then:
+            It should be present under its uid, mapped to its record
+            and connection, leaving the existing workers unchanged
+        """
+        # Arrange
+        original = dict(context.workers)
+        worker = WorkerMetadata(
+            uid=uuid4(),
+            address="localhost:61000",
+            pid=9999,
+            version="1.0.0",
+        )
+        connection = WorkerConnection(worker.address)
 
         # Act
         context.add_worker(worker, connection)
 
         # Assert
-        assert worker in context.workers
-        assert context.workers[worker] == connection
-        for metadata in original_workers:
-            assert metadata in context.workers
-            assert context.workers[metadata] == original_workers[metadata]
+        assert context.workers[worker.uid] == (worker, connection)
+        assert len(context.workers) == len(original) + 1
+        for uid, entry in original.items():
+            assert context.workers[uid] == entry
 
     @given(loadbalancer_context())
-    def test_update_worker_with_existing_worker(self, context: LoadBalancerContext):
-        """Test that a worker already in the context can be updated.
+    @settings(max_examples=50)
+    def test_add_worker_should_replace_entry_when_uid_present(
+        self, context: LoadBalancerContext
+    ):
+        """Test that re-admitting a uid replaces its entry.
 
         Given:
             A load balancer context with one or more workers
             registered
         When:
-            One of the workers in the context is updated
+            A worker is re-admitted under the same uid with changed
+            metadata and a new connection
         Then:
-            The updated worker reflects the updates accurately and
-            the other existing workers in the context are unchanged
+            It should replace that worker's entry without changing the
+            pool size or disturbing the other workers
         """
         # Arrange
-        original_workers = dict(context.workers)
-        worker_to_update = next(iter(context.workers.keys()))
-        connection = WorkerConnection("localhost:60000")
+        original = dict(context.workers)
+        stale, _ = next(iter(context.workers.values()))
+        changed = _mutate(stale, ["address", "pid"])
+        connection = WorkerConnection(changed.address)
 
         # Act
-        context.update_worker(worker_to_update, connection)
+        context.add_worker(changed, connection)
 
         # Assert
-        assert context.workers[worker_to_update] == connection
-        for metadata in original_workers:
-            if metadata != worker_to_update:
-                assert context.workers[metadata] == original_workers[metadata]
+        assert context.workers[stale.uid] == (changed, connection)
+        assert len(context.workers) == len(original)
+        for uid, entry in original.items():
+            if uid != stale.uid:
+                assert context.workers[uid] == entry
 
     @given(loadbalancer_context())
-    def test_update_worker_with_upsert_existing(self, context: LoadBalancerContext):
-        """Test that a worker already in the context can be updated
-        with the ``upsert`` flag.
+    @settings(max_examples=50)
+    def test_add_worker_should_readmit_worker_when_uid_previously_removed(
+        self, context: LoadBalancerContext
+    ):
+        """Test that a previously evicted uid can be re-admitted.
 
         Given:
-            A load balancer context with one or more workers
-            registered
+            A load balancer context from which one worker was evicted
         When:
-            One of the workers in the context is updated with the
-            ``upsert`` flag
+            A changed record carrying that uid is admitted again
         Then:
-            The updated worker reflects the updates accurately and
-            the other existing workers in the context are unchanged
+            It should hold exactly one entry for that uid, carrying the
+            new record and connection
         """
         # Arrange
-        original_workers = dict(context.workers)
-        worker_to_update = next(iter(context.workers.keys()))
-        connection = WorkerConnection("localhost:60000")
+        original = dict(context.workers)
+        evicted, _ = next(iter(context.workers.values()))
+        context.remove_worker(evicted)
+        readmitted = _mutate(evicted, ["address", "pid"])
+        connection = WorkerConnection(readmitted.address)
 
         # Act
-        context.update_worker(worker_to_update, connection, upsert=True)
+        context.add_worker(readmitted, connection)
 
         # Assert
-        assert context.workers[worker_to_update] == connection
-        for metadata in original_workers:
-            if metadata != worker_to_update:
-                assert context.workers[metadata] == original_workers[metadata]
+        assert context.workers[evicted.uid] == (readmitted, connection)
+        assert len(context.workers) == len(original)
+
+    @given(
+        loadbalancer_context(),
+        st.sets(st.sampled_from(_MUTABLE_FIELDS), min_size=1),
+    )
+    @settings(max_examples=50)
+    def test_update_worker_should_refresh_entry_when_any_field_subset_changes(
+        self, context: LoadBalancerContext, fields: set[str]
+    ):
+        """Test that updates address a worker by uid across every field.
+
+        Given:
+            A load balancer context and a same-uid record mutated in
+            any non-empty subset of the non-uid metadata fields
+        When:
+            The worker is refreshed with the mutated record and a new
+            connection
+        Then:
+            It should carry the mutated record and the new connection
+            under the worker's uid, leaving the other workers unchanged
+        """
+        # Arrange
+        original = dict(context.workers)
+        stale, _ = next(iter(context.workers.values()))
+        changed = _mutate(stale, fields)
+        connection = WorkerConnection(changed.address)
+
+        # Act
+        context.update_worker(changed, connection)
+
+        # Assert
+        assert context.workers[stale.uid] == (changed, connection)
+        assert len(context.workers) == len(original)
+        for uid, entry in original.items():
+            if uid != stale.uid:
+                assert context.workers[uid] == entry
+
+    @given(loadbalancer_context(), st.integers(min_value=2, max_value=5))
+    @settings(max_examples=50)
+    def test_update_worker_should_retain_single_entry_when_refreshed_repeatedly(
+        self, context: LoadBalancerContext, refreshes: int
+    ):
+        """Test that successive refreshes never accumulate entries.
+
+        Given:
+            A load balancer context and a chain of 2-5 successive
+            pairwise-distinct variants of one worker's record, each
+            paired with a fresh connection
+        When:
+            The worker is refreshed with each variant in order
+        Then:
+            It should hold exactly one entry for that uid, carrying the
+            final variant and the final connection
+        """
+        # Arrange
+        original = dict(context.workers)
+        base, _ = next(iter(context.workers.values()))
+        host, _, port = base.address.rpartition(":")
+        variants = [
+            replace(base, pid=base.pid + i, address=f"{host}:{int(port) + i}")
+            for i in range(1, refreshes + 1)
+        ]
+        connections = [WorkerConnection(variant.address) for variant in variants]
+
+        # Act
+        for variant, connection in zip(variants, connections):
+            context.update_worker(variant, connection)
+
+        # Assert
+        assert context.workers[base.uid] == (variants[-1], connections[-1])
+        assert len(context.workers) == len(original)
 
     @given(loadbalancer_context())
-    def test_update_worker_with_upsert_new(self, context: LoadBalancerContext):
-        """Test that updating a non-existent worker with the
-        ``upsert`` flag adds the worker to the context.
+    @settings(max_examples=50)
+    def test_update_worker_should_regress_entry_when_record_stale(
+        self, context: LoadBalancerContext
+    ):
+        """Test that writes are last-writer-wins, even with a stale record.
 
         Given:
-            A load balancer context with one or more workers
-            registered
+            A load balancer context whose worker has been refreshed, so
+            an earlier record of it is now stale
         When:
-            A non-existent worker is updated with the ``upsert``
-            flag
+            The worker is refreshed again using the stale record
         Then:
-            The upserted worker is present and the existing workers
-            in the context are unchanged
+            It should regress the entry to the stale record — the
+            context does not order writes, so the last writer wins
         """
         # Arrange
-        original_workers = dict(context.workers)
-        new_worker = WorkerMetadata(
-            uid=uuid4(),
-            address="localhost:60000",
-            pid=9999,
-            version="1.0.0",
-        )
-        connection = WorkerConnection("localhost:60000")
+        captured, _ = next(iter(context.workers.values()))
+        captured_connection = WorkerConnection(captured.address)
+        fresher = _mutate(captured, ["address", "pid"])
+        context.update_worker(fresher, WorkerConnection(fresher.address))
 
         # Act
-        context.update_worker(new_worker, connection, upsert=True)
+        context.update_worker(captured, captured_connection)
 
         # Assert
-        assert new_worker in context.workers
-        assert context.workers[new_worker] == connection
-        for metadata in original_workers:
-            assert metadata in context.workers
-            assert context.workers[metadata] == original_workers[metadata]
+        assert context.workers[captured.uid] == (captured, captured_connection)
 
-    def test_update_worker_noop_without_upsert(self):
-        """Test that updating an absent worker without upsert is a
-        no-op.
+    def test_update_worker_should_preserve_order_when_entry_refreshed(self):
+        """Test that refreshing a worker does not perturb rotation order.
+
+        Given:
+            A load balancer context holding three workers in a known
+            order
+        When:
+            The middle worker is refreshed with a changed record
+        Then:
+            It should preserve the workers mapping's iteration order —
+            the order round-robin rotates through
+        """
+        # Arrange
+        context = LoadBalancerContext()
+        workers = [
+            WorkerMetadata(
+                uid=uuid4(),
+                address=f"localhost:{60001 + i}",
+                pid=8001 + i,
+                version="1.0.0",
+            )
+            for i in range(3)
+        ]
+        for worker in workers:
+            context.add_worker(worker, WorkerConnection(worker.address))
+        refreshed = _mutate(workers[1], ["address", "pid"])
+
+        # Act
+        context.update_worker(refreshed, WorkerConnection(refreshed.address))
+
+        # Assert
+        assert list(context.workers) == [worker.uid for worker in workers]
+
+    @given(loadbalancer_context())
+    @settings(max_examples=50)
+    def test_update_worker_should_ignore_record_when_uid_absent(
+        self, context: LoadBalancerContext
+    ):
+        """Test that refreshing an unadmitted worker does nothing.
+
+        Given:
+            A load balancer context and a clone of an existing worker's
+            fields carrying a fresh uid
+        When:
+            The clone is passed to update_worker
+        Then:
+            It should do nothing — refreshing never admits a worker,
+            and matching is by uid rather than by field equality
+        """
+        # Arrange
+        original = dict(context.workers)
+        existing, _ = next(iter(context.workers.values()))
+        clone = replace(existing, uid=uuid4())
+
+        # Act
+        context.update_worker(clone, WorkerConnection(clone.address))
+
+        # Assert
+        assert clone.uid not in context.workers
+        assert dict(context.workers) == original
+
+    @given(loadbalancer_context())
+    @settings(max_examples=50)
+    def test_update_worker_should_not_resurrect_worker_when_evicted(
+        self, context: LoadBalancerContext
+    ):
+        """Test that eviction fully retires a uid against later refreshes.
+
+        Given:
+            A load balancer context from which one worker was evicted
+        When:
+            A changed record carrying that uid is passed to
+            update_worker
+        Then:
+            It should not resurrect the worker — the uid stays absent
+        """
+        # Arrange
+        original = dict(context.workers)
+        evicted, _ = next(iter(context.workers.values()))
+        context.remove_worker(evicted)
+        changed = _mutate(evicted, ["address", "pid"])
+
+        # Act
+        context.update_worker(changed, WorkerConnection(changed.address))
+
+        # Assert
+        assert evicted.uid not in context.workers
+        assert len(context.workers) == len(original) - 1
+
+    @given(
+        loadbalancer_context(),
+        st.sets(st.sampled_from(_MUTABLE_FIELDS), min_size=1),
+    )
+    @settings(max_examples=50)
+    def test_remove_worker_should_evict_entry_when_any_field_subset_changes(
+        self, context: LoadBalancerContext, fields: set[str]
+    ):
+        """Test that eviction addresses a worker by uid across every field.
+
+        Given:
+            A load balancer context and a same-uid record mutated in
+            any non-empty subset of the non-uid metadata fields
+        When:
+            The worker is evicted using the mutated record
+        Then:
+            It should evict the worker, leaving the other workers
+            unchanged
+        """
+        # Arrange
+        original = dict(context.workers)
+        stale, _ = next(iter(context.workers.values()))
+        changed = _mutate(stale, fields)
+
+        # Act
+        context.remove_worker(changed)
+
+        # Assert
+        assert stale.uid not in context.workers
+        assert len(context.workers) == len(original) - 1
+        for uid, entry in original.items():
+            if uid != stale.uid:
+                assert context.workers[uid] == entry
+
+    @given(loadbalancer_context())
+    @settings(max_examples=50)
+    def test_remove_worker_should_ignore_record_when_uid_absent(
+        self, context: LoadBalancerContext
+    ):
+        """Test that eviction matches by uid, never by field equality.
+
+        Given:
+            A load balancer context and a clone of an existing worker's
+            fields carrying a fresh uid
+        When:
+            The clone is passed to remove_worker
+        Then:
+            It should do nothing — the existing worker keeps its entry
+        """
+        # Arrange
+        original = dict(context.workers)
+        existing, _ = next(iter(context.workers.values()))
+        clone = replace(existing, uid=uuid4())
+
+        # Act
+        context.remove_worker(clone)
+
+        # Assert
+        assert dict(context.workers) == original
+
+    def test_remove_worker_should_ignore_record_when_context_empty(self):
+        """Test that evicting from an empty context does nothing.
 
         Given:
             A load balancer context with no workers registered
         When:
-            A non-existent worker is updated without the ``upsert``
-            flag
+            A worker is passed to remove_worker
         Then:
-            The context remains unchanged
+            It should do nothing and raise nothing
         """
         # Arrange
-        ctx = LoadBalancerContext()
-        absent_worker = WorkerMetadata(
-            uid=uuid4(),
-            address="localhost:60000",
-            pid=9999,
-            version="1.0.0",
-        )
-        connection = WorkerConnection("localhost:60000")
-
-        # Act
-        ctx.update_worker(absent_worker, connection)
-
-        # Assert
-        assert len(ctx.workers) == 0
-
-    @given(loadbalancer_context())
-    def test_remove_worker_with_existing_worker(self, context: LoadBalancerContext):
-        """Test that a worker can be removed from the context.
-
-        Given:
-            A load balancer context with one or more workers
-            registered
-        When:
-            A worker is removed from the context
-        Then:
-            The removed worker is no longer present and the existing
-            workers in the context are unchanged
-        """
-        # Arrange
-        original_workers = dict(context.workers)
-        worker_to_remove = next(iter(context.workers.keys()))
-
-        # Act
-        context.remove_worker(worker_to_remove)
-
-        # Assert
-        assert worker_to_remove not in context.workers
-        for metadata in original_workers:
-            if metadata != worker_to_remove:
-                assert metadata in context.workers
-                assert context.workers[metadata] == original_workers[metadata]
-
-    def test_remove_worker_noop_when_absent(self):
-        """Test that removing an absent worker is a no-op.
-
-        Given:
-            A load balancer context with no workers registered
-        When:
-            A non-existent worker is removed from the context
-        Then:
-            The context remains unchanged
-        """
-        # Arrange
-        ctx = LoadBalancerContext()
-        absent_worker = WorkerMetadata(
+        context = LoadBalancerContext()
+        absent = WorkerMetadata(
             uid=uuid4(),
             address="localhost:60000",
             pid=9999,
@@ -507,7 +792,70 @@ class TestLoadBalancerContext:
         )
 
         # Act
-        ctx.remove_worker(absent_worker)
+        context.remove_worker(absent)
 
         # Assert
-        assert len(ctx.workers) == 0
+        assert len(context.workers) == 0
+
+    @given(
+        loadbalancer_context(),
+        st.lists(
+            st.tuples(
+                st.sampled_from(("add", "update", "remove")),
+                st.integers(min_value=0, max_value=2),
+                st.booleans(),
+            ),
+            max_size=20,
+        ),
+    )
+    @settings(max_examples=50)
+    def test_workers_should_mirror_uid_keyed_model_when_operations_interleave(
+        self,
+        context: LoadBalancerContext,
+        operations: list[tuple[str, int, bool]],
+    ):
+        """Test the workers mapping against a uid-keyed reference model.
+
+        Given:
+            A seeded load balancer context and a generated sequence of
+            admit, refresh, and evict operations over a pool of three
+            uids, each write drawing either a mutated record or an
+            equal copy of that uid's last record
+        When:
+            The operations are applied in order alongside a plain
+            uid-keyed dict model with the documented semantics
+        Then:
+            After every operation the workers mapping should equal the
+            model exactly — one entry per live uid, each carrying that
+            uid's last-written record and connection
+        """
+        # Arrange
+        model = dict(context.workers)
+        bases = [
+            WorkerMetadata(
+                uid=uuid4(),
+                address=f"localhost:{40000 + slot}",
+                pid=100 + slot,
+                version="1.0.0",
+            )
+            for slot in range(3)
+        ]
+
+        # Act & assert
+        for operation, slot, mutate in operations:
+            last = model.get(bases[slot].uid)
+            base = bases[slot] if last is None else last[0]
+            record = replace(base, pid=base.pid + 1) if mutate else replace(base)
+            connection = WorkerConnection(record.address)
+            if operation == "add":
+                context.add_worker(record, connection)
+                model[record.uid] = (record, connection)
+            elif operation == "update":
+                context.update_worker(record, connection)
+                if record.uid in model:
+                    model[record.uid] = (record, connection)
+            else:
+                context.remove_worker(record)
+                model.pop(record.uid, None)
+
+            assert dict(context.workers) == model

--- a/wool/tests/runtime/loadbalancer/test_roundrobin.py
+++ b/wool/tests/runtime/loadbalancer/test_roundrobin.py
@@ -5,6 +5,7 @@ import weakref
 from uuid import uuid4
 
 import pytest
+from hypothesis import HealthCheck
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
@@ -44,18 +45,18 @@ def _make_context(worker_count: int) -> tuple[LoadBalancerContext, list[WorkerMe
     return ctx, ordered
 
 
-class _ItemsCountingContext:
-    """LoadBalancerContextView that counts workers.items() materializations.
+class _SnapshotCountingContext:
+    """LoadBalancerContextView that counts snapshot materializations.
 
-    Wraps a real `LoadBalancerContext` and records how many times
-    the ordered worker mapping is materialized via ``items()``, so a test
-    can prove the balancer snapshots once per wrap rather than rescanning
-    the mapping per candidate.
+    Wraps a real `LoadBalancerContext` and records how many times the
+    worker mapping is materialized by iteration, so a test can prove
+    the balancer snapshots once per wrap rather than rescanning the
+    mapping per candidate.
     """
 
     def __init__(self, context: LoadBalancerContext):
         self._context = context
-        self.items_calls = 0
+        self.snapshot_calls = 0
 
     @property
     def workers(self):
@@ -69,9 +70,12 @@ class _ItemsCountingContext:
             def __contains__(self, key):
                 return key in real
 
-            def items(self):
-                outer.items_calls += 1
-                return real.items()
+            def __iter__(self):
+                outer.snapshot_calls += 1
+                return iter(real)
+
+            def get(self, key):
+                return real.get(key)
 
         return _CountingMapping()
 
@@ -167,7 +171,7 @@ class TestRoundRobinLoadBalancer:
 
         # Assert
         assert metadata == worker
-        assert connection is ctx.workers[worker]
+        assert connection is ctx.workers[worker.uid][1]
         await generator.aclose()
 
     @pytest.mark.asyncio
@@ -287,7 +291,7 @@ class TestRoundRobinLoadBalancer:
         assert first_metadata == workers[0]
         assert second_metadata != first_metadata
         assert second_metadata in workers
-        assert first_metadata not in ctx.workers
+        assert first_metadata.uid not in ctx.workers
         await generator.aclose()
 
     @pytest.mark.asyncio
@@ -459,7 +463,7 @@ class TestRoundRobinLoadBalancer:
 
         # Assert
         assert terminated, "delegate did not terminate after checkpoint eviction"
-        assert first not in ctx.workers
+        assert first.uid not in ctx.workers
         assert first not in yielded[1:]
 
     @pytest.mark.asyncio
@@ -495,8 +499,226 @@ class TestRoundRobinLoadBalancer:
 
         # Assert
         assert terminated, "delegate did not terminate after mid-cycle eviction"
-        assert workers[2] not in ctx.workers
+        assert workers[2].uid not in ctx.workers
         assert workers[2] not in yielded
+
+    @pytest.mark.asyncio
+    async def test_delegate_should_yield_fresh_record_when_sole_worker_updated(self):
+        """Test a refreshed sole worker is served fresh on the next call.
+
+        Given:
+            A single-worker context whose worker is refreshed with a
+            same-uid changed record and a new connection after its
+            first yield
+        When:
+            The proxy reports the failure via athrow and then starts a
+            new delegate call
+        Then:
+            It should exhaust the current cycle — the worker's one
+            attempt was already consumed — and yield the fresh record
+            paired with the new connection on the next call
+        """
+        # Arrange
+        loadbalancer = RoundRobinLoadBalancer()
+        ctx, workers = _make_context(1)
+        stale = workers[0]
+        fresh = WorkerMetadata(
+            uid=stale.uid,
+            address="localhost:60000",
+            pid=9999,
+            version="1.0.0",
+        )
+        fresh_connection = WorkerConnection(fresh.address)
+        generator = loadbalancer.delegate(_TASK, context=ctx)
+        first, _ = await anext(generator)
+        ctx.update_worker(fresh, fresh_connection)
+
+        # Act
+        with pytest.raises(StopAsyncIteration):
+            await generator.athrow(TransientRpcError())
+        retry = loadbalancer.delegate(_TASK, context=ctx)
+        metadata, connection = await anext(retry)
+        await retry.aclose()
+
+        # Assert
+        assert first == stale
+        assert metadata == fresh
+        assert connection is fresh_connection
+
+    @pytest.mark.asyncio
+    async def test_delegate_should_resolve_candidate_when_worker_updated_mid_cycle(
+        self,
+    ):
+        """Test a mid-cycle refresh is offered under its current entry.
+
+        Given:
+            A three-worker context in which a not-yet-reached worker is
+            refreshed with a same-uid changed record and a new
+            connection after the first yield, leaving a same-hash
+            unequal fresh key in the pool
+        When:
+            The proxy drives the generator to exhaustion via athrow
+        Then:
+            It should never yield the stale snapshot pair — the
+            refreshed worker is offered under its fresh record and new
+            connection within the same cycle — and should terminate
+        """
+        # Arrange
+        loadbalancer = RoundRobinLoadBalancer()
+        ctx, workers = _make_context(3)
+        stale = workers[2]
+        fresh = WorkerMetadata(
+            uid=stale.uid,
+            address="localhost:60000",
+            pid=9999,
+            version="1.0.0",
+        )
+        fresh_connection = WorkerConnection(fresh.address)
+        generator = loadbalancer.delegate(_TASK, context=ctx)
+        first, first_connection = await anext(generator)
+        ctx.update_worker(fresh, fresh_connection)
+
+        # Act
+        yielded: list[tuple[WorkerMetadata, WorkerConnection]] = [
+            (first, first_connection)
+        ]
+        terminated = False
+        for _ in range(100):
+            try:
+                metadata, connection = await generator.athrow(TransientRpcError())
+            except StopAsyncIteration:
+                terminated = True
+                break
+            yielded.append((metadata, connection))
+
+        # Assert
+        assert terminated, "delegate did not terminate after mid-cycle update"
+        candidates = [metadata for metadata, _ in yielded]
+        assert stale not in candidates
+        assert candidates == [workers[0], workers[1], fresh]
+        assert yielded[2][1] is fresh_connection
+
+    @pytest.mark.asyncio
+    async def test_delegate_should_keep_boundary_when_checkpoint_updated(self):
+        """Test the cycle boundary survives a checkpoint refresh.
+
+        Given:
+            A three-worker context whose first-yielded (checkpoint)
+            worker is refreshed with a same-uid changed record
+            immediately after its yield, so its uid remains in the pool
+            under the fresh record
+        When:
+            The proxy drives the generator to termination via athrow
+        Then:
+            It should terminate without livelock when the boundary uid
+            recurs, never re-yielding the stale checkpoint record or
+            offering the fresh record, and yielding each candidate at
+            most twice
+        """
+        # Arrange
+        loadbalancer = RoundRobinLoadBalancer()
+        ctx, workers = _make_context(3)
+        checkpoint = workers[0]
+        fresh = WorkerMetadata(
+            uid=checkpoint.uid,
+            address="localhost:60000",
+            pid=9999,
+            version="1.0.0",
+        )
+        generator = loadbalancer.delegate(_TASK, context=ctx)
+        first, _ = await anext(generator)
+        ctx.update_worker(fresh, WorkerConnection(fresh.address))
+
+        # Act
+        yielded: list[WorkerMetadata] = [first]
+        terminated = False
+        for _ in range(100):
+            try:
+                metadata, _ = await generator.athrow(TransientRpcError())
+            except StopAsyncIteration:
+                terminated = True
+                break
+            yielded.append(metadata)
+
+        # Assert
+        assert terminated, "delegate did not terminate after checkpoint update"
+        assert yielded.count(workers[0]) == 1
+        assert fresh not in yielded
+        assert len(yielded) <= 2 * len(workers)
+        uid_counts: dict = {}
+        for metadata in yielded:
+            uid_counts[metadata.uid] = uid_counts.get(metadata.uid, 0) + 1
+        assert all(count <= 2 for count in uid_counts.values())
+
+    @pytest.mark.asyncio
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        worker_count=st.integers(min_value=2, max_value=6),
+        position=st.integers(min_value=0, max_value=5),
+        step=st.integers(min_value=0, max_value=5),
+    )
+    async def test_delegate_should_terminate_when_update_lands_at_any_step(
+        self, worker_count: int, position: int, step: int
+    ):
+        """Test refresh timing and position never break cycle termination.
+
+        Given:
+            A context of 2-6 workers, a drawn worker position to
+            refresh, and a drawn injection step, with every dispatch
+            failing transiently
+        When:
+            The refresh is injected after the drawn yield while athrow
+            drives the generator to termination
+        Then:
+            It should always terminate, yield at most two candidates
+            per uid and at most two full cycles in total, and never
+            yield the stale record after the injection
+        """
+        # Arrange
+        loadbalancer = RoundRobinLoadBalancer()
+        ctx, workers = _make_context(worker_count)
+        target = workers[position % worker_count]
+        fresh = WorkerMetadata(
+            uid=target.uid,
+            address="localhost:60000",
+            pid=9999,
+            version="1.0.0",
+        )
+        injection_step = step % worker_count
+        generator = loadbalancer.delegate(_TASK, context=ctx)
+
+        # Act & assert
+        yielded: list[WorkerMetadata] = []
+        terminated = False
+        injected = False
+        metadata, _ = await anext(generator)
+        yielded.append(metadata)
+        if injection_step == 0:
+            ctx.update_worker(fresh, WorkerConnection(fresh.address))
+            injected = True
+        for current in range(1, 3 * worker_count + 4):
+            try:
+                metadata, _ = await generator.athrow(TransientRpcError())
+            except StopAsyncIteration:
+                terminated = True
+                break
+            yielded.append(metadata)
+            if injected:
+                assert metadata != target
+            if current == injection_step:
+                ctx.update_worker(fresh, WorkerConnection(fresh.address))
+                injected = True
+
+        assert terminated, "delegate did not terminate within the bound"
+        assert len(yielded) <= 2 * worker_count
+        uid_counts: dict = {}
+        for metadata in yielded:
+            uid_counts[metadata.uid] = uid_counts.get(metadata.uid, 0) + 1
+        assert all(count <= 2 for count in uid_counts.values())
 
     @pytest.mark.asyncio
     async def test_delegate_snapshots_once_per_wrap(self):
@@ -505,7 +727,7 @@ class TestRoundRobinLoadBalancer:
         Given:
             A balancer cycling a 16-worker pool through one full cycle of
             transient failures, observed through a context view that
-            counts ``workers.items()`` materializations
+            counts snapshot materializations
         When:
             The generator is driven to exhaustion via athrow
         Then:
@@ -515,7 +737,7 @@ class TestRoundRobinLoadBalancer:
         """
         # Arrange
         ctx, workers = _make_context(16)
-        counting = _ItemsCountingContext(ctx)
+        counting = _SnapshotCountingContext(ctx)
         loadbalancer = RoundRobinLoadBalancer()
 
         # Act
@@ -532,7 +754,7 @@ class TestRoundRobinLoadBalancer:
 
         # Assert
         assert len(yielded) == len(workers)
-        assert counting.items_calls <= 2
+        assert counting.snapshot_calls <= 2
 
     @pytest.mark.asyncio
     async def test_delegate_does_not_pin_retired_contexts(self):

--- a/wool/tests/runtime/loadbalancer/test_roundrobin.py
+++ b/wool/tests/runtime/loadbalancer/test_roundrobin.py
@@ -1,11 +1,11 @@
 import asyncio
 import gc
 import pickle
+import uuid
 import weakref
 from uuid import uuid4
 
 import pytest
-from hypothesis import HealthCheck
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
@@ -28,7 +28,7 @@ def _make_context(worker_count: int) -> tuple[LoadBalancerContext, list[WorkerMe
 
     :returns:
         Tuple of ``(context, ordered_metadata_list)`` so tests can
-        assert yielded candidates against insertion order.
+        assert yielded uids against insertion order.
     """
     ctx = LoadBalancerContext()
     ordered: list[WorkerMetadata] = []
@@ -45,14 +45,67 @@ def _make_context(worker_count: int) -> tuple[LoadBalancerContext, list[WorkerMe
     return ctx, ordered
 
 
+def _evict(ctx: LoadBalancerContext, uid: uuid.UUID) -> None:
+    """Evict a pooled worker by uid, as the proxy would."""
+    ctx.remove_worker(ctx.workers[uid][0])
+
+
+async def _advance_cursor(
+    loadbalancer: RoundRobinLoadBalancer, ctx: LoadBalancerContext, dispatches: int
+) -> None:
+    """Drive ``dispatches`` successful delegate calls to warm the cursor.
+
+    Each completed call advances the balancer's rotation cursor by one,
+    so the next cycle starts mid-pool and wraps past the end of the
+    snapshot before it exhausts.
+    """
+    for _ in range(dispatches):
+        generator = loadbalancer.delegate(_TASK, context=ctx)
+        uid = await anext(generator)
+        with pytest.raises(StopAsyncIteration):
+            await generator.asend(uid)
+
+
+@st.composite
+def refresh_injection(draw):
+    """Generate a self-consistent refresh-injection scenario.
+
+    Draws the dependent values in order so every drawn value lies in
+    its own reachable domain: ``worker_count`` first, then the number
+    of prior successful dispatches (which positions the balancer's
+    cursor), then the position of the worker to refresh, then the yield
+    after which the refresh lands. The injection step spans the whole
+    cycle, so a refresh can land after the cursor wraps past the end of
+    the snapshot — the case the checkpoint/boundary logic exists to
+    handle.
+
+    :param draw:
+        Hypothesis draw function
+
+    :returns:
+        Tuple of ``(worker_count, warmup, position, injection_step)``
+    """
+    worker_count = draw(st.integers(min_value=2, max_value=6))
+    warmup = draw(st.integers(min_value=0, max_value=worker_count - 1))
+    position = draw(st.integers(min_value=0, max_value=worker_count - 1))
+    injection_step = draw(st.integers(min_value=0, max_value=worker_count - 1))
+    return worker_count, warmup, position, injection_step
+
+
 class _SnapshotCountingContext:
     """LoadBalancerContextView that counts snapshot materializations.
 
     Wraps a real `LoadBalancerContext` and records how many times the
-    worker mapping is materialized by iteration, so a test can prove
-    the balancer snapshots once per wrap rather than rescanning the
-    mapping per candidate.
+    worker mapping is materialized — by ``__iter__``, ``keys``,
+    ``items``, or ``values`` — so a test can prove the balancer
+    snapshots once per wrap rather than rescanning the mapping per
+    candidate. Every other attribute delegates to the real
+    `MappingProxyType`, so a balancer that materializes the mapping a
+    different way fails the count assertion rather than crashing the
+    double.
     """
+
+    _MATERIALIZERS = frozenset({"keys", "items", "values"})
 
     def __init__(self, context: LoadBalancerContext):
         self._context = context
@@ -70,12 +123,17 @@ class _SnapshotCountingContext:
             def __contains__(self, key):
                 return key in real
 
+            def __getitem__(self, key):
+                return real[key]
+
             def __iter__(self):
                 outer.snapshot_calls += 1
                 return iter(real)
 
-            def get(self, key):
-                return real.get(key)
+            def __getattr__(self, name):
+                if name in outer._MATERIALIZERS:
+                    outer.snapshot_calls += 1
+                return getattr(real, name)
 
         return _CountingMapping()
 
@@ -113,7 +171,7 @@ class TestRoundRobinLoadBalancer:
         ctx, workers = _make_context(3)
 
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        first_used, _ = await anext(generator)
+        first_used = await anext(generator)
         with pytest.raises(StopAsyncIteration):
             await generator.asend(first_used)
         # Original has now advanced past workers[0] on ctx.
@@ -124,12 +182,12 @@ class TestRoundRobinLoadBalancer:
         # Assert
         assert isinstance(restored, RoundRobinLoadBalancer)
         restored_generator = restored.delegate(_TASK, context=ctx)
-        first_after_restore, _ = await anext(restored_generator)
+        first_after_restore = await anext(restored_generator)
         await restored_generator.aclose()
-        assert first_after_restore == workers[0]
+        assert first_after_restore == workers[0].uid
 
     @pytest.mark.asyncio
-    async def test_delegate_with_empty_context(self):
+    async def test_delegate_should_yield_nothing_when_context_empty(self):
         """Test delegate ends immediately on an empty context.
 
         Given:
@@ -151,7 +209,7 @@ class TestRoundRobinLoadBalancer:
         await generator.aclose()
 
     @pytest.mark.asyncio
-    async def test_delegate_with_single_worker(self):
+    async def test_delegate_should_yield_sole_uid_when_one_worker_pooled(self):
         """Test delegate yields the first worker on initial anext.
 
         Given:
@@ -159,7 +217,8 @@ class TestRoundRobinLoadBalancer:
         When:
             delegate() is driven with anext
         Then:
-            The first yielded candidate is the worker in the context.
+            The first yielded candidate is the uid of the worker in the
+            context, and it resolves against the pool to that worker.
         """
         # Arrange
         loadbalancer = RoundRobinLoadBalancer()
@@ -167,15 +226,15 @@ class TestRoundRobinLoadBalancer:
 
         # Act
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        metadata, connection = await anext(generator)
+        uid = await anext(generator)
 
         # Assert
-        assert metadata == worker
-        assert connection is ctx.workers[worker.uid][1]
+        assert uid == worker.uid
+        assert ctx.workers[uid][0] == worker
         await generator.aclose()
 
     @pytest.mark.asyncio
-    async def test_delegate_after_prior_success(self):
+    async def test_delegate_should_advance_cursor_when_prior_dispatch_succeeded(self):
         """Test delegate advances the round-robin index after asend.
 
         Given:
@@ -193,20 +252,20 @@ class TestRoundRobinLoadBalancer:
 
         # Act
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        first_metadata, _ = await anext(generator)
+        first_uid = await anext(generator)
         with pytest.raises(StopAsyncIteration):
-            await generator.asend(first_metadata)
+            await generator.asend(first_uid)
 
         second_generator = loadbalancer.delegate(_TASK, context=ctx)
-        second_metadata, _ = await anext(second_generator)
+        second_uid = await anext(second_generator)
 
         # Assert
-        assert first_metadata == workers[0]
-        assert second_metadata == workers[1]
+        assert first_uid == workers[0].uid
+        assert second_uid == workers[1].uid
         await second_generator.aclose()
 
     @pytest.mark.asyncio
-    async def test_delegate_after_athrow(self):
+    async def test_delegate_should_advance_cursor_when_candidate_fails(self):
         """Test delegate advances the index on athrow (failure).
 
         Given:
@@ -223,16 +282,16 @@ class TestRoundRobinLoadBalancer:
 
         # Act
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        first_metadata, _ = await anext(generator)
-        second_metadata, _ = await generator.athrow(TransientRpcError())
+        first_uid = await anext(generator)
+        second_uid = await generator.athrow(TransientRpcError())
 
         # Assert
-        assert first_metadata == workers[0]
-        assert second_metadata == workers[1]
+        assert first_uid == workers[0].uid
+        assert second_uid == workers[1].uid
         await generator.aclose()
 
     @pytest.mark.asyncio
-    async def test_delegate_with_all_workers_failing(self):
+    async def test_delegate_should_end_cycle_when_every_worker_fails(self):
         """Test delegate ends after a full cycle of failures.
 
         Given:
@@ -248,23 +307,23 @@ class TestRoundRobinLoadBalancer:
         ctx, workers = _make_context(5)
 
         # Act
-        yielded: list[WorkerMetadata] = []
+        yielded: list[uuid.UUID] = []
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        metadata, _ = await anext(generator)
-        yielded.append(metadata)
+        uid = await anext(generator)
+        yielded.append(uid)
         while True:
             try:
-                metadata, _ = await generator.athrow(TransientRpcError())
+                uid = await generator.athrow(TransientRpcError())
             except StopAsyncIteration:
                 break
-            yielded.append(metadata)
+            yielded.append(uid)
 
         # Assert
         assert len(yielded) == len(workers)
-        assert set(yielded) == set(workers)
+        assert set(yielded) == {worker.uid for worker in workers}
 
     @pytest.mark.asyncio
-    async def test_delegate_with_context_eviction(self):
+    async def test_delegate_should_skip_evicted_worker_when_pool_mutates_mid_cycle(self):
         """Test delegate observes pool mutations between yields.
 
         Given:
@@ -283,26 +342,26 @@ class TestRoundRobinLoadBalancer:
 
         # Act
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        first_metadata, _ = await anext(generator)
-        ctx.remove_worker(first_metadata)  # simulate proxy eviction
-        second_metadata, _ = await generator.athrow(Exception("fatal"))
+        first_uid = await anext(generator)
+        _evict(ctx, first_uid)  # simulate proxy eviction
+        second_uid = await generator.athrow(Exception("fatal"))
 
         # Assert
-        assert first_metadata == workers[0]
-        assert second_metadata != first_metadata
-        assert second_metadata in workers
-        assert first_metadata.uid not in ctx.workers
+        assert first_uid == workers[0].uid
+        assert second_uid != first_uid
+        assert second_uid in {worker.uid for worker in workers}
+        assert first_uid not in ctx.workers
         await generator.aclose()
 
     @pytest.mark.asyncio
-    async def test_delegate_with_asend_success(self):
+    async def test_delegate_should_terminate_when_success_reported(self):
         """Test delegate terminates after asend signals success.
 
         Given:
             A load balancer with multiple workers, the first
             candidate has just been yielded
         When:
-            The proxy reports success via asend(metadata)
+            The proxy reports success via asend(uid)
         Then:
             The generator raises StopAsyncIteration — honoring the
             contract that asend is terminal.
@@ -313,11 +372,11 @@ class TestRoundRobinLoadBalancer:
 
         # Act
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        metadata, _ = await anext(generator)
+        uid = await anext(generator)
 
         # Assert
         with pytest.raises(StopAsyncIteration):
-            await generator.asend(metadata)
+            await generator.asend(uid)
 
     @pytest.mark.asyncio
     @settings(max_examples=32)
@@ -325,7 +384,7 @@ class TestRoundRobinLoadBalancer:
         worker_count=st.integers(min_value=2, max_value=8),
         failure_count=st.integers(min_value=0, max_value=7),
     )
-    async def test_delegate_with_failures_then_success(
+    async def test_delegate_should_offer_workers_in_order_when_failures_precede_success(
         self, worker_count: int, failure_count: int
     ):
         """Test delegate respects round-robin fairness across failures.
@@ -346,17 +405,17 @@ class TestRoundRobinLoadBalancer:
 
         # Act
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        yielded: list[WorkerMetadata] = []
-        metadata, _ = await anext(generator)
-        yielded.append(metadata)
+        yielded: list[uuid.UUID] = []
+        uid = await anext(generator)
+        yielded.append(uid)
         for _ in range(failure_count):
-            metadata, _ = await generator.athrow(TransientRpcError())
-            yielded.append(metadata)
+            uid = await generator.athrow(TransientRpcError())
+            yielded.append(uid)
         with pytest.raises(StopAsyncIteration):
             await generator.asend(yielded[-1])
 
         # Assert
-        assert yielded == workers[: failure_count + 1]
+        assert yielded == [worker.uid for worker in workers[: failure_count + 1]]
 
     @pytest.mark.asyncio
     @settings(max_examples=32)
@@ -364,7 +423,7 @@ class TestRoundRobinLoadBalancer:
         worker_count=st.integers(min_value=1, max_value=8),
         dispatch_count=st.integers(min_value=1, max_value=24),
     )
-    async def test_delegate_with_successive_calls(
+    async def test_delegate_should_rotate_start_when_called_successively(
         self, worker_count: int, dispatch_count: int
     ):
         """Test delegate rotates the starting worker across calls.
@@ -384,20 +443,20 @@ class TestRoundRobinLoadBalancer:
         ctx, workers = _make_context(worker_count)
 
         # Act
-        starts: list[WorkerMetadata] = []
+        starts: list[uuid.UUID] = []
         for _ in range(dispatch_count):
             generator = loadbalancer.delegate(_TASK, context=ctx)
-            metadata, _ = await anext(generator)
-            starts.append(metadata)
+            uid = await anext(generator)
+            starts.append(uid)
             with pytest.raises(StopAsyncIteration):
-                await generator.asend(metadata)
+                await generator.asend(uid)
 
         # Assert
-        expected = [workers[k % worker_count] for k in range(dispatch_count)]
+        expected = [workers[k % worker_count].uid for k in range(dispatch_count)]
         assert starts == expected
 
     @pytest.mark.asyncio
-    async def test_delegate_with_concurrent_drivers(self):
+    async def test_delegate_should_offer_distinct_workers_when_drivers_concurrent(self):
         """Test concurrent delegate drivers land on distinct workers.
 
         Given:
@@ -412,24 +471,24 @@ class TestRoundRobinLoadBalancer:
         loadbalancer = RoundRobinLoadBalancer()
         ctx, workers = _make_context(4)
 
-        async def drive_one() -> WorkerMetadata:
+        async def drive_one() -> uuid.UUID:
             generator = loadbalancer.delegate(_TASK, context=ctx)
-            metadata, _ = await anext(generator)
+            uid = await anext(generator)
             try:
                 with pytest.raises(StopAsyncIteration):
-                    await generator.asend(metadata)
+                    await generator.asend(uid)
             finally:
                 await generator.aclose()
-            return metadata
+            return uid
 
         # Act
         results = await asyncio.gather(*[drive_one() for _ in range(4)])
 
         # Assert
-        assert set(results) == set(workers)
+        assert set(results) == {worker.uid for worker in workers}
 
     @pytest.mark.asyncio
-    async def test_delegate_terminates_when_checkpoint_evicted(self):
+    async def test_delegate_should_terminate_when_checkpoint_evicted(self):
         """Test delegate ends when the checkpoint worker is evicted.
 
         Given:
@@ -445,29 +504,29 @@ class TestRoundRobinLoadBalancer:
         """
         # Arrange
         loadbalancer = RoundRobinLoadBalancer()
-        ctx, workers = _make_context(3)
+        ctx, _ = _make_context(3)
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        first, _ = await anext(generator)
-        ctx.remove_worker(first)  # proxy evicts the checkpoint (non-transient)
+        first = await anext(generator)
+        _evict(ctx, first)  # proxy evicts the checkpoint (non-transient)
 
         # Act
-        yielded: list[WorkerMetadata] = [first]
+        yielded: list[uuid.UUID] = [first]
         terminated = False
         for _ in range(100):
             try:
-                metadata, _ = await generator.athrow(TransientRpcError())
+                uid = await generator.athrow(TransientRpcError())
             except StopAsyncIteration:
                 terminated = True
                 break
-            yielded.append(metadata)
+            yielded.append(uid)
 
         # Assert
         assert terminated, "delegate did not terminate after checkpoint eviction"
-        assert first.uid not in ctx.workers
+        assert first not in ctx.workers
         assert first not in yielded[1:]
 
     @pytest.mark.asyncio
-    async def test_delegate_skips_worker_evicted_after_snapshot(self):
+    async def test_delegate_should_skip_worker_when_evicted_after_snapshot(self):
         """Test delegate skips a candidate evicted after the snapshot.
 
         Given:
@@ -483,40 +542,38 @@ class TestRoundRobinLoadBalancer:
         loadbalancer = RoundRobinLoadBalancer()
         ctx, workers = _make_context(3)
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        first, _ = await anext(generator)
+        first = await anext(generator)
         ctx.remove_worker(workers[2])  # evict a not-yet-reached worker
 
         # Act
-        yielded: list[WorkerMetadata] = [first]
+        yielded: list[uuid.UUID] = [first]
         terminated = False
         for _ in range(100):
             try:
-                metadata, _ = await generator.athrow(TransientRpcError())
+                uid = await generator.athrow(TransientRpcError())
             except StopAsyncIteration:
                 terminated = True
                 break
-            yielded.append(metadata)
+            yielded.append(uid)
 
         # Assert
         assert terminated, "delegate did not terminate after mid-cycle eviction"
         assert workers[2].uid not in ctx.workers
-        assert workers[2] not in yielded
+        assert workers[2].uid not in yielded
 
     @pytest.mark.asyncio
-    async def test_delegate_should_yield_fresh_record_when_sole_worker_updated(self):
-        """Test a refreshed sole worker is served fresh on the next call.
+    async def test_delegate_should_exhaust_cycle_when_sole_worker_updated(self):
+        """Test a mid-cycle refresh does not re-offer the sole worker.
 
         Given:
             A single-worker context whose worker is refreshed with a
             same-uid changed record and a new connection after its
             first yield
         When:
-            The proxy reports the failure via athrow and then starts a
-            new delegate call
+            The proxy reports the failure via athrow
         Then:
-            It should exhaust the current cycle — the worker's one
-            attempt was already consumed — and yield the fresh record
-            paired with the new connection on the next call
+            It should exhaust the cycle — the worker's one attempt was
+            already consumed
         """
         # Arrange
         loadbalancer = RoundRobinLoadBalancer()
@@ -528,40 +585,68 @@ class TestRoundRobinLoadBalancer:
             pid=9999,
             version="1.0.0",
         )
-        fresh_connection = WorkerConnection(fresh.address)
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        first, _ = await anext(generator)
-        ctx.update_worker(fresh, fresh_connection)
+        first = await anext(generator)
+        ctx.update_worker(fresh, WorkerConnection(fresh.address))
 
-        # Act
+        # Act & assert
+        assert first == stale.uid
         with pytest.raises(StopAsyncIteration):
             await generator.athrow(TransientRpcError())
-        retry = loadbalancer.delegate(_TASK, context=ctx)
-        metadata, connection = await anext(retry)
-        await retry.aclose()
-
-        # Assert
-        assert first == stale
-        assert metadata == fresh
-        assert connection is fresh_connection
 
     @pytest.mark.asyncio
-    async def test_delegate_should_resolve_candidate_when_worker_updated_mid_cycle(
-        self,
-    ):
-        """Test a mid-cycle refresh is offered under its current entry.
+    async def test_delegate_should_reoffer_uid_when_called_after_update(self):
+        """Test a refreshed sole worker is offered again on the next call.
+
+        Given:
+            A single-worker context whose worker was refreshed with a
+            same-uid changed record and a new connection while a
+            delegate cycle was in flight, and that cycle has since
+            exhausted
+        When:
+            A new delegate call is driven with anext
+        Then:
+            It should offer the same uid again
+        """
+        # Arrange
+        loadbalancer = RoundRobinLoadBalancer()
+        ctx, workers = _make_context(1)
+        stale = workers[0]
+        fresh = WorkerMetadata(
+            uid=stale.uid,
+            address="localhost:60000",
+            pid=9999,
+            version="1.0.0",
+        )
+        generator = loadbalancer.delegate(_TASK, context=ctx)
+        await anext(generator)
+        ctx.update_worker(fresh, WorkerConnection(fresh.address))
+        with pytest.raises(StopAsyncIteration):
+            await generator.athrow(TransientRpcError())
+
+        # Act
+        retry = loadbalancer.delegate(_TASK, context=ctx)
+        uid = await anext(retry)
+        await retry.aclose()
+
+        # Assert — the balancer names workers; it is the pool that
+        # carries the record, so a refresh cannot drop a worker from
+        # the rotation.
+        assert uid == stale.uid
+
+    @pytest.mark.asyncio
+    async def test_delegate_should_visit_uid_once_when_worker_updated_mid_cycle(self):
+        """Test a mid-cycle refresh neither skips nor repeats the worker.
 
         Given:
             A three-worker context in which a not-yet-reached worker is
             refreshed with a same-uid changed record and a new
-            connection after the first yield, leaving a same-hash
-            unequal fresh key in the pool
+            connection after the first yield
         When:
             The proxy drives the generator to exhaustion via athrow
         Then:
-            It should never yield the stale snapshot pair — the
-            refreshed worker is offered under its fresh record and new
-            connection within the same cycle — and should terminate
+            It should still visit each of the three uids exactly once
+            and terminate
         """
         # Arrange
         loadbalancer = RoundRobinLoadBalancer()
@@ -573,30 +658,26 @@ class TestRoundRobinLoadBalancer:
             pid=9999,
             version="1.0.0",
         )
-        fresh_connection = WorkerConnection(fresh.address)
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        first, first_connection = await anext(generator)
-        ctx.update_worker(fresh, fresh_connection)
+        first = await anext(generator)
+        ctx.update_worker(fresh, WorkerConnection(fresh.address))
 
         # Act
-        yielded: list[tuple[WorkerMetadata, WorkerConnection]] = [
-            (first, first_connection)
-        ]
+        yielded: list[uuid.UUID] = [first]
         terminated = False
         for _ in range(100):
             try:
-                metadata, connection = await generator.athrow(TransientRpcError())
+                uid = await generator.athrow(TransientRpcError())
             except StopAsyncIteration:
                 terminated = True
                 break
-            yielded.append((metadata, connection))
+            yielded.append(uid)
 
-        # Assert
+        # Assert — the refreshed worker keeps its place in the cycle
+        # because a refresh changes the pooled record, not the uid the
+        # balancer cycles on.
         assert terminated, "delegate did not terminate after mid-cycle update"
-        candidates = [metadata for metadata, _ in yielded]
-        assert stale not in candidates
-        assert candidates == [workers[0], workers[1], fresh]
-        assert yielded[2][1] is fresh_connection
+        assert yielded == [workers[0].uid, workers[1].uid, workers[2].uid]
 
     @pytest.mark.asyncio
     async def test_delegate_should_keep_boundary_when_checkpoint_updated(self):
@@ -611,9 +692,8 @@ class TestRoundRobinLoadBalancer:
             The proxy drives the generator to termination via athrow
         Then:
             It should terminate without livelock when the boundary uid
-            recurs, never re-yielding the stale checkpoint record or
-            offering the fresh record, and yielding each candidate at
-            most twice
+            recurs, yielding the checkpoint uid exactly once and each
+            uid at most twice
         """
         # Arrange
         loadbalancer = RoundRobinLoadBalancer()
@@ -626,102 +706,91 @@ class TestRoundRobinLoadBalancer:
             version="1.0.0",
         )
         generator = loadbalancer.delegate(_TASK, context=ctx)
-        first, _ = await anext(generator)
+        first = await anext(generator)
         ctx.update_worker(fresh, WorkerConnection(fresh.address))
 
         # Act
-        yielded: list[WorkerMetadata] = [first]
+        yielded: list[uuid.UUID] = [first]
         terminated = False
         for _ in range(100):
             try:
-                metadata, _ = await generator.athrow(TransientRpcError())
+                uid = await generator.athrow(TransientRpcError())
             except StopAsyncIteration:
                 terminated = True
                 break
-            yielded.append(metadata)
+            yielded.append(uid)
 
         # Assert
         assert terminated, "delegate did not terminate after checkpoint update"
-        assert yielded.count(workers[0]) == 1
-        assert fresh not in yielded
+        assert yielded.count(checkpoint.uid) == 1
         assert len(yielded) <= 2 * len(workers)
         uid_counts: dict = {}
-        for metadata in yielded:
-            uid_counts[metadata.uid] = uid_counts.get(metadata.uid, 0) + 1
+        for uid in yielded:
+            uid_counts[uid] = uid_counts.get(uid, 0) + 1
         assert all(count <= 2 for count in uid_counts.values())
 
     @pytest.mark.asyncio
-    @settings(
-        max_examples=50,
-        deadline=None,
-        suppress_health_check=[HealthCheck.function_scoped_fixture],
-    )
-    @given(
-        worker_count=st.integers(min_value=2, max_value=6),
-        position=st.integers(min_value=0, max_value=5),
-        step=st.integers(min_value=0, max_value=5),
-    )
+    @settings(max_examples=50, deadline=None)
+    @given(injection=refresh_injection())
     async def test_delegate_should_terminate_when_update_lands_at_any_step(
-        self, worker_count: int, position: int, step: int
+        self, injection: tuple[int, int, int, int]
     ):
         """Test refresh timing and position never break cycle termination.
 
         Given:
-            A context of 2-6 workers, a drawn worker position to
-            refresh, and a drawn injection step, with every dispatch
-            failing transiently
+            A context of 2-6 workers, a drawn count of prior successful
+            dispatches leaving the balancer's cursor anywhere in the
+            pool, a drawn position of the worker to refresh, and a
+            drawn injection step anywhere in the cycle — including
+            after the cursor has wrapped past the end of the snapshot —
+            with every dispatch failing transiently
         When:
             The refresh is injected after the drawn yield while athrow
             drives the generator to termination
         Then:
-            It should always terminate, yield at most two candidates
-            per uid and at most two full cycles in total, and never
-            yield the stale record after the injection
+            It should always terminate, yielding at most two candidates
+            per uid and at most two full cycles in total
         """
         # Arrange
+        worker_count, warmup, position, injection_step = injection
         loadbalancer = RoundRobinLoadBalancer()
         ctx, workers = _make_context(worker_count)
-        target = workers[position % worker_count]
+        await _advance_cursor(loadbalancer, ctx, warmup)
+        target = workers[position]
         fresh = WorkerMetadata(
             uid=target.uid,
             address="localhost:60000",
             pid=9999,
             version="1.0.0",
         )
-        injection_step = step % worker_count
         generator = loadbalancer.delegate(_TASK, context=ctx)
 
         # Act & assert
-        yielded: list[WorkerMetadata] = []
+        yielded: list[uuid.UUID] = []
         terminated = False
-        injected = False
-        metadata, _ = await anext(generator)
-        yielded.append(metadata)
+        uid = await anext(generator)
+        yielded.append(uid)
         if injection_step == 0:
             ctx.update_worker(fresh, WorkerConnection(fresh.address))
-            injected = True
         for current in range(1, 3 * worker_count + 4):
             try:
-                metadata, _ = await generator.athrow(TransientRpcError())
+                uid = await generator.athrow(TransientRpcError())
             except StopAsyncIteration:
                 terminated = True
                 break
-            yielded.append(metadata)
-            if injected:
-                assert metadata != target
+            yielded.append(uid)
             if current == injection_step:
                 ctx.update_worker(fresh, WorkerConnection(fresh.address))
-                injected = True
 
         assert terminated, "delegate did not terminate within the bound"
         assert len(yielded) <= 2 * worker_count
         uid_counts: dict = {}
-        for metadata in yielded:
-            uid_counts[metadata.uid] = uid_counts.get(metadata.uid, 0) + 1
+        for uid in yielded:
+            uid_counts[uid] = uid_counts.get(uid, 0) + 1
         assert all(count <= 2 for count in uid_counts.values())
 
     @pytest.mark.asyncio
-    async def test_delegate_snapshots_once_per_wrap(self):
+    async def test_delegate_should_snapshot_once_per_wrap(self):
         """Test delegate materializes the worker order once per wrap.
 
         Given:
@@ -742,22 +811,22 @@ class TestRoundRobinLoadBalancer:
 
         # Act
         generator = loadbalancer.delegate(_TASK, context=counting)
-        yielded: list[WorkerMetadata] = []
-        metadata, _ = await anext(generator)
-        yielded.append(metadata)
+        yielded: list[uuid.UUID] = []
+        uid = await anext(generator)
+        yielded.append(uid)
         while True:
             try:
-                metadata, _ = await generator.athrow(TransientRpcError())
+                uid = await generator.athrow(TransientRpcError())
             except StopAsyncIteration:
                 break
-            yielded.append(metadata)
+            yielded.append(uid)
 
         # Assert
         assert len(yielded) == len(workers)
         assert counting.snapshot_calls <= 2
 
     @pytest.mark.asyncio
-    async def test_delegate_does_not_pin_retired_contexts(self):
+    async def test_delegate_should_release_context_when_retired(self):
         """Test the balancer does not pin retired contexts against GC.
 
         Given:

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -12,6 +12,7 @@ import inspect
 import pickle
 import uuid
 import warnings
+from dataclasses import replace
 from types import MappingProxyType
 
 import cloudpickle
@@ -85,24 +86,26 @@ def make_delegating_balancer(
     """Build a delegating balancer that yields workers in context order.
 
     The returned balancer's ``delegate`` walks ``context.workers`` in
-    insertion order, yielding each ``(metadata, connection)`` pair for the
-    proxy to dispatch to. Four optional hooks observe the handshake
+    insertion order, yielding each worker's uid for the proxy to
+    resolve and dispatch to. Four optional hooks observe the handshake
     without altering control flow: ``on_task(task)`` fires once with the
     routed task before any candidate is offered, ``on_yield(metadata)``
-    fires before each candidate is offered, ``on_throw(exception,
-    context)`` fires when the proxy reports a dispatch failure via
-    ``athrow``, and ``on_success(metadata)`` fires when the proxy
-    acknowledges a successful dispatch via ``asend``. Any hook may return
-    an awaitable, which is awaited before the generator continues.
+    fires before each candidate is offered — with the record the
+    balancer read, so tests can assert on the candidate it chose —
+    ``on_throw(exception, context)`` fires when the proxy reports a
+    dispatch failure via ``athrow``, and ``on_success(sent)`` fires when
+    the proxy acknowledges a successful dispatch via ``asend``, carrying
+    the proxy's echo verbatim (a uid). Any hook may return an awaitable,
+    which is awaited before the generator continues.
     """
 
     class DelegatingBalancer:
         async def delegate(self, task, *, context):
             await _run_hook(on_task, task)
-            for metadata, connection in list(context.workers.values()):
+            for uid, (metadata, _) in list(context.workers.items()):
                 await _run_hook(on_yield, metadata)
                 try:
-                    sent = yield metadata, connection
+                    sent = yield uid
                 except Exception as exception:
                     await _run_hook(on_throw, exception, context)
                     continue
@@ -174,6 +177,71 @@ class SpyStream:
 
     async def aclose(self):
         self._on_close()
+
+
+class _SteppedDiscovery:
+    """Discovery stream that hands the sentinel one event at a time.
+
+    ``apply`` publishes a single event and returns only once the
+    sentinel has finished applying it. The sentinel consumes the stream
+    strictly in order and asks for the next event only after applying
+    the current one, so its next ``__anext__`` call is the
+    acknowledgement. This lets a test observe the pool after every
+    single event rather than only after the stream drains.
+    """
+
+    def __init__(self):
+        self._pending: asyncio.Queue = asyncio.Queue()
+        self._requested = asyncio.Event()
+        self._requests = 0
+        self._published = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        self._requests += 1
+        self._requested.set()
+        return await self._pending.get()
+
+    async def apply(self, event, *, timeout=5.0):
+        """Publish one event and return once the sentinel has applied it."""
+        self._published += 1
+        await self._pending.put(event)
+        async with asyncio.timeout(timeout):
+            while self._requests <= self._published:
+                self._requested.clear()
+                await self._requested.wait()
+
+
+@st.composite
+def _worker_event_sequence(draw):
+    """Generate a lease cap and a sequence of worker lifecycle events.
+
+    Draws an optional lease alongside up to twelve
+    ``(event_type, uid_slot, mutate)`` tuples over a pool of three uid
+    slots. ``mutate`` selects between a changed record and an equal copy
+    of that uid's last record, so a refresh that changes nothing is
+    drawn as readily as one that does.
+
+    :param draw:
+        Hypothesis draw function
+
+    :returns:
+        Tuple of ``(lease, events)``
+    """
+    lease = draw(st.one_of(st.none(), st.integers(min_value=1, max_value=3)))
+    events = draw(
+        st.lists(
+            st.tuples(
+                st.sampled_from(("worker-added", "worker-updated", "worker-dropped")),
+                st.integers(min_value=0, max_value=2),
+                st.booleans(),
+            ),
+            max_size=12,
+        )
+    )
+    return lease, events
 
 
 # ============================================================================
@@ -1617,64 +1685,6 @@ class TestWorkerProxy:
         await proxy.stop()
 
     @pytest.mark.asyncio
-    async def test_start_allows_worker_updated_at_capacity(
-        self, mock_proxy_session, mocker: MockerFixture
-    ):
-        """Test sentinel refreshes changed metadata even at capacity.
-
-        Given:
-            A non-lazy WorkerProxy with lease=2, already at capacity,
-            receiving a worker-updated event whose same-uid metadata
-            changed
-        When:
-            The sentinel processes the update event
-        Then:
-            It should refresh the worker's entry with the updated
-            record without being blocked by the cap
-        """
-        # Arrange
-        mocker.patch.object(protocol, "__version__", "1.0.0")
-        worker1 = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="192.168.1.1:50051",
-            pid=1001,
-            version="1.0.0",
-        )
-        worker2 = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="192.168.1.2:50051",
-            pid=1002,
-            version="1.0.0",
-        )
-        updated1 = WorkerMetadata(
-            uid=worker1.uid,
-            address="192.168.1.9:50059",
-            pid=1009,
-            version="1.0.0",
-            tags=frozenset(["updated"]),
-        )
-        events = [
-            DiscoveryEvent("worker-added", metadata=worker1),
-            DiscoveryEvent("worker-added", metadata=worker2),
-            DiscoveryEvent("worker-updated", metadata=updated1),
-        ]
-        discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery, lease=2, lazy=False)
-
-        # Act
-        await proxy.start()
-        await _drain_until(lambda: updated1 in proxy.workers)
-
-        # Assert
-        assert len(proxy.workers) == 2
-        assert updated1 in proxy.workers
-        assert worker1 not in proxy.workers
-        assert worker2 in proxy.workers
-
-        # Cleanup
-        await proxy.stop()
-
-    @pytest.mark.asyncio
     async def test_start_accepts_worker_after_drop_frees_capacity(
         self, mock_proxy_session, mocker: MockerFixture
     ):
@@ -1832,139 +1842,20 @@ class TestWorkerProxy:
         await proxy.stop()
 
     @pytest.mark.asyncio
-    async def test_start_should_remove_worker_when_dropped_metadata_changes(
+    async def test_start_should_refresh_worker_when_updated_at_capacity(
         self, mock_proxy_session, mocker: MockerFixture
     ):
-        """Test worker-dropped with changed metadata still evicts the worker.
+        """Test sentinel refreshes changed metadata even at capacity.
 
         Given:
-            A non-lazy WorkerProxy with a discovered worker and a
-            worker-dropped event carrying the same uid with changed
-            fields, followed by an unrelated worker-added event
+            A non-lazy WorkerProxy with lease=2, already at capacity,
+            receiving a worker-updated event whose same-uid metadata
+            changed
         When:
-            The sentinel processes all events
+            The sentinel processes the update event
         Then:
-            It should remove the dropped worker despite the changed
-            metadata, leaving only the unrelated worker
-        """
-        # Arrange
-        mocker.patch.object(protocol, "__version__", "1.0.0")
-        worker_uid = uuid.uuid4()
-        initial_metadata = WorkerMetadata(
-            uid=worker_uid,
-            address="192.168.1.1:50051",
-            pid=1001,
-            version="1.0.0",
-        )
-        changed_metadata = WorkerMetadata(
-            uid=worker_uid,
-            address="192.168.1.2:50052",
-            pid=1002,
-            version="1.0.0",
-        )
-        other_worker = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="192.168.1.3:50053",
-            pid=1003,
-            version="1.0.0",
-        )
-        events = [
-            DiscoveryEvent("worker-added", metadata=initial_metadata),
-            DiscoveryEvent("worker-dropped", metadata=changed_metadata),
-            DiscoveryEvent("worker-added", metadata=other_worker),
-        ]
-        discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery, lazy=False)
-
-        # Act
-        await proxy.start()
-        await _drain_until(lambda: other_worker in proxy.workers)
-
-        # Assert
-        assert other_worker in proxy.workers
-        assert initial_metadata not in proxy.workers
-        assert changed_metadata not in proxy.workers
-        assert len(proxy.workers) == 1
-
-        # Cleanup
-        await proxy.stop()
-
-    @pytest.mark.asyncio
-    async def test_start_should_evict_worker_when_dropped_after_metadata_update(
-        self, mock_proxy_session, mocker: MockerFixture
-    ):
-        """Test a drop carrying the post-update record evicts the worker.
-
-        Given:
-            A non-lazy WorkerProxy whose discovered worker is updated
-            with a same-uid changed record and then dropped with that
-            updated record, followed by an unrelated worker-added event
-        When:
-            The sentinel processes the composed lifecycle
-        Then:
-            It should retain only the unrelated worker — neither the
-            original nor the updated record survives the drop
-        """
-        # Arrange
-        mocker.patch.object(protocol, "__version__", "1.0.0")
-        worker_uid = uuid.uuid4()
-        initial_metadata = WorkerMetadata(
-            uid=worker_uid,
-            address="192.168.1.1:50051",
-            pid=1001,
-            version="1.0.0",
-        )
-        updated_metadata = WorkerMetadata(
-            uid=worker_uid,
-            address="192.168.1.2:50052",
-            pid=1002,
-            version="1.0.0",
-        )
-        beacon = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="192.168.1.3:50053",
-            pid=1003,
-            version="1.0.0",
-        )
-        events = [
-            DiscoveryEvent("worker-added", metadata=initial_metadata),
-            DiscoveryEvent("worker-updated", metadata=updated_metadata),
-            DiscoveryEvent("worker-dropped", metadata=updated_metadata),
-            DiscoveryEvent("worker-added", metadata=beacon),
-        ]
-        discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery, lazy=False)
-
-        # Act
-        await proxy.start()
-        await _drain_until(lambda: beacon in proxy.workers)
-
-        # Assert
-        assert beacon in proxy.workers
-        assert initial_metadata not in proxy.workers
-        assert updated_metadata not in proxy.workers
-        assert len(proxy.workers) == 1
-
-        # Cleanup
-        await proxy.stop()
-
-    @pytest.mark.asyncio
-    async def test_start_should_ignore_update_when_rejected_worker_metadata_changes(
-        self, mock_proxy_session, mocker: MockerFixture
-    ):
-        """Test a changed-record update cannot admit a cap-rejected worker.
-
-        Given:
-            A non-lazy WorkerProxy with lease=1 whose second discovered
-            worker was rejected by the cap, then a worker-updated event
-            with that worker's uid and changed fields, a drop freeing
-            capacity, and an unrelated worker-added event
-        When:
-            The sentinel processes all events
-        Then:
-            It should never admit the rejected worker in any form —
-            after the drop frees capacity only the unrelated worker is
-            present
+            It should refresh the worker's entry with the updated
+            record without being blocked by the cap
         """
         # Arrange
         mocker.patch.object(protocol, "__version__", "1.0.0")
@@ -1976,160 +1867,34 @@ class TestWorkerProxy:
         )
         worker2 = WorkerMetadata(
             uid=uuid.uuid4(),
-            address="192.168.1.2:50052",
+            address="192.168.1.2:50051",
             pid=1002,
             version="1.0.0",
         )
-        updated2 = WorkerMetadata(
-            uid=worker2.uid,
+        updated1 = WorkerMetadata(
+            uid=worker1.uid,
             address="192.168.1.9:50059",
             pid=1009,
             version="1.0.0",
             tags=frozenset(["updated"]),
         )
-        beacon = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="192.168.1.3:50053",
-            pid=1003,
-            version="1.0.0",
-        )
         events = [
             DiscoveryEvent("worker-added", metadata=worker1),
-            DiscoveryEvent("worker-added", metadata=worker2),  # rejected
-            DiscoveryEvent("worker-updated", metadata=updated2),  # dropped
-            DiscoveryEvent("worker-dropped", metadata=worker1),
-            DiscoveryEvent("worker-added", metadata=beacon),
-        ]
-        discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery, lease=1, lazy=False)
-
-        # Act
-        await proxy.start()
-        await _drain_until(lambda: beacon in proxy.workers)
-
-        # Assert
-        assert len(proxy.workers) == 1
-        assert beacon in proxy.workers
-        assert worker2 not in proxy.workers
-        assert updated2 not in proxy.workers
-
-        # Cleanup
-        await proxy.stop()
-
-    @pytest.mark.asyncio
-    async def test_start_should_replace_worker_when_readded_with_changed_metadata(
-        self, mock_proxy_session, mocker: MockerFixture
-    ):
-        """Test a same-uid re-announcement replaces its worker's entry.
-
-        Given:
-            A non-lazy WorkerProxy with lease=2 whose discovered worker
-            is re-announced via worker-added with the same uid and
-            changed fields, followed by a distinct second worker
-        When:
-            The sentinel processes all events
-        Then:
-            It should replace the original entry rather than duplicate
-            it, leaving a lease slot free for the second worker
-        """
-        # Arrange
-        mocker.patch.object(protocol, "__version__", "1.0.0")
-        worker_uid = uuid.uuid4()
-        initial_metadata = WorkerMetadata(
-            uid=worker_uid,
-            address="192.168.1.1:50051",
-            pid=1001,
-            version="1.0.0",
-        )
-        readded_metadata = WorkerMetadata(
-            uid=worker_uid,
-            address="192.168.1.2:50052",
-            pid=1002,
-            version="1.0.0",
-        )
-        worker2 = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="192.168.1.3:50053",
-            pid=1003,
-            version="1.0.0",
-        )
-        events = [
-            DiscoveryEvent("worker-added", metadata=initial_metadata),
-            DiscoveryEvent("worker-added", metadata=readded_metadata),
             DiscoveryEvent("worker-added", metadata=worker2),
+            DiscoveryEvent("worker-updated", metadata=updated1),
         ]
         discovery = wp.ReducibleAsyncIterator(events)
         proxy = WorkerProxy(discovery=discovery, lease=2, lazy=False)
 
         # Act
         await proxy.start()
-        await _drain_until(lambda: worker2 in proxy.workers)
+        await _drain_until(lambda: updated1 in proxy.workers)
 
         # Assert
         assert len(proxy.workers) == 2
-        assert readded_metadata in proxy.workers
-        assert initial_metadata not in proxy.workers
+        assert updated1 in proxy.workers
+        assert worker1 not in proxy.workers
         assert worker2 in proxy.workers
-
-        # Cleanup
-        await proxy.stop()
-
-    @pytest.mark.asyncio
-    async def test_start_should_drop_worker_by_uid_when_address_shared(
-        self, mock_proxy_session, mocker: MockerFixture
-    ):
-        """Test drop events match workers by uid, never by address.
-
-        Given:
-            A non-lazy WorkerProxy with two discovered workers holding
-            DISTINCT uids but the SAME address (a restart race), then a
-            worker-dropped event for the first uid and an unrelated
-            worker-added event
-        When:
-            The sentinel processes all events
-        Then:
-            It should remove only the first worker — the same-address
-            replacement instance survives its predecessor's drop
-        """
-        # Arrange
-        mocker.patch.object(protocol, "__version__", "1.0.0")
-        shared_address = "192.168.1.1:50051"
-        worker_a = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address=shared_address,
-            pid=1001,
-            version="1.0.0",
-        )
-        worker_b = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address=shared_address,
-            pid=1002,
-            version="1.0.0",
-        )
-        beacon = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="192.168.1.3:50053",
-            pid=1003,
-            version="1.0.0",
-        )
-        events = [
-            DiscoveryEvent("worker-added", metadata=worker_a),
-            DiscoveryEvent("worker-added", metadata=worker_b),
-            DiscoveryEvent("worker-dropped", metadata=worker_a),
-            DiscoveryEvent("worker-added", metadata=beacon),
-        ]
-        discovery = wp.ReducibleAsyncIterator(events)
-        proxy = WorkerProxy(discovery=discovery, lazy=False)
-
-        # Act
-        await proxy.start()
-        await _drain_until(lambda: beacon in proxy.workers)
-
-        # Assert
-        assert len(proxy.workers) == 2
-        assert worker_b in proxy.workers
-        assert worker_a not in proxy.workers
-        assert beacon in proxy.workers
 
         # Cleanup
         await proxy.stop()
@@ -2200,11 +1965,6 @@ class TestWorkerProxy:
     ):
         """Test a same-uid re-announcement bypasses the lease cap.
 
-        The admission gate applies only to pool-growing adds: a
-        worker-added event re-announcing an already-admitted uid
-        replaces that worker's entry in place without consuming a
-        lease slot, even at capacity.
-
         Given:
             A non-lazy WorkerProxy with lease=2 at capacity, receiving
             a worker-added event re-announcing an admitted uid with
@@ -2256,7 +2016,9 @@ class TestWorkerProxy:
         await proxy.start()
         await _drain_until(lambda: beacon in proxy.workers)
 
-        # Assert
+        # Assert — the admission gate applies only to pool-growing
+        # adds: re-announcing an already-admitted uid replaces that
+        # worker's entry in place without consuming a lease slot.
         assert len(proxy.workers) == 2
         assert readded_a in proxy.workers
         assert worker_a not in proxy.workers
@@ -2264,6 +2026,81 @@ class TestWorkerProxy:
 
         # Cleanup
         await proxy.stop()
+
+    @given(_worker_event_sequence())
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @pytest.mark.asyncio
+    async def test_workers_should_mirror_uid_keyed_model_when_events_interleave(
+        self, mock_proxy_session, mocker: MockerFixture, scenario
+    ):
+        """Test the workers list against a uid-keyed reference model.
+
+        Given:
+            A non-lazy WorkerProxy under a drawn lease cap and a drawn
+            sequence of worker-added, worker-updated, and worker-dropped
+            events over a pool of three uids — two of which share an
+            address, so uid-keyed matching is exercised against a
+            colliding address — each event carrying either a mutated
+            record or an equal copy of that uid's last record
+        When:
+            The sentinel consumes the events in order alongside a plain
+            uid-keyed dict model implementing the documented semantics:
+            an add admits or replaces, an update refreshes an admitted
+            uid but never admits and never resurrects a dropped one, a
+            drop evicts by uid regardless of the record it carries, and
+            the lease gates only pool-growing adds
+        Then:
+            After every event the workers list should equal the model
+            exactly — one entry per live uid, carrying that uid's
+            last-written record
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        lease, events = scenario
+        bases = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                # Slots 0 and 1 deliberately share an address so a drop
+                # or refresh that matched on address rather than uid
+                # would corrupt the model.
+                address=f"192.168.1.{min(slot, 1)}:50051",
+                pid=1000 + slot,
+                version="1.0.0",
+            )
+            for slot in range(3)
+        ]
+        stream = _SteppedDiscovery()
+        proxy = WorkerProxy(discovery=stream, lease=lease, lazy=False, quorum=0)
+        await proxy.start()
+        model: dict[uuid.UUID, WorkerMetadata] = {}
+
+        # Act & assert
+        try:
+            for event_type, slot, mutate in events:
+                last = model.get(bases[slot].uid)
+                base = bases[slot] if last is None else last
+                record = replace(base, pid=base.pid + 1) if mutate else replace(base)
+                admitted = record.uid in model
+
+                await stream.apply(DiscoveryEvent(event_type, metadata=record))
+
+                if event_type == "worker-added":
+                    if lease is None or admitted or len(model) < lease:
+                        model[record.uid] = record
+                elif event_type == "worker-updated":
+                    if admitted:
+                        model[record.uid] = record
+                else:
+                    model.pop(record.uid, None)
+
+                assert proxy.workers == list(model.values())
+        finally:
+            # Cleanup
+            await proxy.stop()
 
     @pytest.mark.asyncio
     async def test_dispatch_should_use_refreshed_connection_when_metadata_updates(
@@ -2323,6 +2160,449 @@ class TestWorkerProxy:
         # Assert
         assert results == ["ok"]
         assert stale_connection.dispatch.await_count == 0
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_evict_worker_by_uid_when_refreshed_mid_dispatch(
+        self,
+        mock_proxy_session,
+        mock_wool_task,
+        mocker: MockerFixture,
+    ):
+        """Test non-transient eviction removes a concurrently refreshed worker.
+
+        Given:
+            Two workers behind a delegating balancer, a gated discovery
+            stream holding a same-uid changed-record update for the
+            first worker, and a first-worker connection that releases
+            the gate, awaits the refresh, and then raises a
+            non-transient RpcError
+        When:
+            dispatch() is called and fails over
+        Then:
+            It should evict the first worker by uid — neither the stale
+            nor the refreshed record remains — while the balancer
+            observes only the surviving worker and dispatch succeeds on
+            it
+        """
+        # Arrange
+        gate = asyncio.Event()
+        worker_a = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version="1.0.0",
+        )
+        worker_b = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50101",
+            pid=9001,
+            version="1.0.0",
+        )
+        refreshed_a = WorkerMetadata(
+            uid=worker_a.uid,
+            address="127.0.0.1:50109",
+            pid=9009,
+            version="1.0.0",
+        )
+        proxy = None
+        stale_connection = mocker.MagicMock(spec=WorkerConnection)
+
+        async def _stale_dispatch(task, *, timeout=None):
+            gate.set()
+            await _drain_until(lambda: refreshed_a in proxy.workers)
+            raise RpcError()
+
+        stale_connection.dispatch = _stale_dispatch
+        success_streams: list = []
+        survivor_connection = _make_success_connection(mocker, success_streams)
+        fresh_connection = mocker.MagicMock(spec=WorkerConnection)
+        fresh_connection.dispatch = mocker.AsyncMock()
+        observed_pools: list = []
+        discovery = _GatedDiscovery(
+            initial=[
+                DiscoveryEvent("worker-added", metadata=worker_a),
+                DiscoveryEvent("worker-added", metadata=worker_b),
+            ],
+            deferred=[DiscoveryEvent("worker-updated", metadata=refreshed_a)],
+            gate=gate,
+        )
+        proxy, _ = await _make_proxy_with_workers(
+            connections=[stale_connection, survivor_connection, fresh_connection],
+            loadbalancer=make_delegating_balancer(
+                on_throw=lambda _, context: observed_pools.append(
+                    [m for m, _ in context.workers.values()]
+                )
+            ),
+            mocker=mocker,
+            discovery=discovery,
+            metadata_list=[worker_a, worker_b],
+        )
+
+        # Act
+        stream = await proxy.dispatch(mock_wool_task)
+        results = [result async for result in stream]
+
+        # Assert
+        assert results == ["ok"]
+        assert len(proxy.workers) == 1
+        assert worker_b in proxy.workers
+        assert refreshed_a not in proxy.workers
+        assert worker_a not in proxy.workers
+        assert observed_pools == [[worker_b]]
+        assert fresh_connection.dispatch.await_count == 0
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_keep_refreshed_worker_when_failure_transient(
+        self,
+        mock_proxy_session,
+        mock_wool_task,
+        mocker: MockerFixture,
+    ):
+        """Test a transient failure neither evicts nor clobbers a refresh.
+
+        Given:
+            Two workers behind a delegating balancer, a gated discovery
+            stream holding a same-uid changed-record update for the
+            first worker, and a first-worker connection that releases
+            the gate, awaits the refresh, and then raises a
+            TransientRpcError
+        When:
+            dispatch() is called
+        Then:
+            It should leave the refreshed entry in the pool keyed by
+            the updated record and succeed on the second worker
+        """
+        # Arrange
+        gate = asyncio.Event()
+        worker_a = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version="1.0.0",
+        )
+        worker_b = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50101",
+            pid=9001,
+            version="1.0.0",
+        )
+        refreshed_a = WorkerMetadata(
+            uid=worker_a.uid,
+            address="127.0.0.1:50109",
+            pid=9009,
+            version="1.0.0",
+        )
+        proxy = None
+        stale_connection = mocker.MagicMock(spec=WorkerConnection)
+
+        async def _stale_dispatch(task, *, timeout=None):
+            gate.set()
+            await _drain_until(lambda: refreshed_a in proxy.workers)
+            raise TransientRpcError()
+
+        stale_connection.dispatch = _stale_dispatch
+        success_streams: list = []
+        survivor_connection = _make_success_connection(mocker, success_streams)
+        fresh_connection = mocker.MagicMock(spec=WorkerConnection)
+        fresh_connection.dispatch = mocker.AsyncMock()
+        discovery = _GatedDiscovery(
+            initial=[
+                DiscoveryEvent("worker-added", metadata=worker_a),
+                DiscoveryEvent("worker-added", metadata=worker_b),
+            ],
+            deferred=[DiscoveryEvent("worker-updated", metadata=refreshed_a)],
+            gate=gate,
+        )
+        proxy, _ = await _make_proxy_with_workers(
+            connections=[stale_connection, survivor_connection, fresh_connection],
+            loadbalancer=make_delegating_balancer(),
+            mocker=mocker,
+            discovery=discovery,
+            metadata_list=[worker_a, worker_b],
+        )
+
+        # Act
+        stream = await proxy.dispatch(mock_wool_task)
+        results = [result async for result in stream]
+
+        # Assert
+        assert results == ["ok"]
+        assert len(proxy.workers) == 2
+        assert refreshed_a in proxy.workers
+        assert worker_a not in proxy.workers
+        assert worker_b in proxy.workers
+        assert fresh_connection.dispatch.await_count == 0
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_use_fresh_connection_when_selection_precedes_refresh(
+        self,
+        mock_proxy_session,
+        mock_wool_task,
+        mocker: MockerFixture,
+    ):
+        """Test a uid selected before a refresh dispatches to the fresh entry.
+
+        Given:
+            A balancer that selects a worker's uid and only then lets a
+            same-uid changed-record update land, so its selection was
+            made against a pool state that no longer exists
+        When:
+            dispatch() is called
+        Then:
+            It should dispatch through the refreshed worker's
+            connection and never touch the superseded one — the proxy
+            resolves the uid against the live pool at dispatch time, so
+            a selection cannot carry a stale address
+        """
+        # Arrange
+        gate = asyncio.Event()
+        worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version="1.0.0",
+        )
+        refreshed = WorkerMetadata(
+            uid=worker.uid,
+            address="127.0.0.1:50109",
+            pid=9009,
+            version="1.0.0",
+        )
+        proxy = None
+        stale_connection = mocker.MagicMock(spec=WorkerConnection)
+        stale_connection.dispatch = mocker.AsyncMock()
+        success_streams: list = []
+        fresh_connection = _make_success_connection(mocker, success_streams)
+
+        async def _land_refresh(_):
+            # Fires after the balancer has read the pool and chosen a
+            # candidate, but before the proxy resolves it.
+            gate.set()
+            await _drain_until(lambda: refreshed in proxy.workers)
+
+        discovery = _GatedDiscovery(
+            initial=[DiscoveryEvent("worker-added", metadata=worker)],
+            deferred=[DiscoveryEvent("worker-updated", metadata=refreshed)],
+            gate=gate,
+        )
+        proxy, _ = await _make_proxy_with_workers(
+            connections=[stale_connection, fresh_connection],
+            loadbalancer=make_delegating_balancer(on_yield=_land_refresh),
+            mocker=mocker,
+            discovery=discovery,
+            metadata_list=[worker],
+        )
+
+        # Act
+        stream = await proxy.dispatch(mock_wool_task)
+        results = [result async for result in stream]
+
+        # Assert
+        assert results == ["ok"]
+        assert len(success_streams) == 1
+        assert stale_connection.dispatch.await_count == 0
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_skip_candidate_when_uid_no_longer_pooled(
+        self,
+        mock_proxy_session,
+        mock_wool_task,
+        mocker: MockerFixture,
+    ):
+        """Test a departed candidate is skipped rather than dispatched to.
+
+        Given:
+            Two pooled workers and a balancer that selects both, with
+            the first dropped from the pool after selection but before
+            the proxy resolves it
+        When:
+            dispatch() is called
+        Then:
+            It should skip the departed worker without dispatching to
+            it and without reporting a failure against it — a worker
+            that has left the pool has not failed anything — and
+            dispatch should succeed on the survivor
+        """
+        # Arrange
+        gate = asyncio.Event()
+        departed = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version="1.0.0",
+        )
+        survivor = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50101",
+            pid=9001,
+            version="1.0.0",
+        )
+        proxy = None
+        departed_connection = mocker.MagicMock(spec=WorkerConnection)
+        departed_connection.dispatch = mocker.AsyncMock()
+        success_streams: list = []
+        survivor_connection = _make_success_connection(mocker, success_streams)
+        throws: list = []
+
+        async def _drop_first(metadata):
+            if metadata != departed:
+                return
+            gate.set()
+            await _drain_until(lambda: departed not in proxy.workers)
+
+        discovery = _GatedDiscovery(
+            initial=[
+                DiscoveryEvent("worker-added", metadata=departed),
+                DiscoveryEvent("worker-added", metadata=survivor),
+            ],
+            deferred=[DiscoveryEvent("worker-dropped", metadata=departed)],
+            gate=gate,
+        )
+        proxy, _ = await _make_proxy_with_workers(
+            connections=[departed_connection, survivor_connection],
+            loadbalancer=make_delegating_balancer(
+                on_yield=_drop_first,
+                on_throw=lambda exception, _: throws.append(exception),
+            ),
+            mocker=mocker,
+            discovery=discovery,
+            metadata_list=[departed, survivor],
+        )
+
+        # Act
+        stream = await proxy.dispatch(mock_wool_task)
+        results = [result async for result in stream]
+
+        # Assert
+        assert results == ["ok"]
+        assert departed_connection.dispatch.await_count == 0
+        assert len(success_streams) == 1
+        assert throws == []
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_raise_when_every_candidate_departed(
+        self,
+        mock_proxy_session,
+        mock_wool_task,
+        mocker: MockerFixture,
+    ):
+        """Test exhausting the balancer on departed uids raises.
+
+        Given:
+            A single pooled worker and a balancer that selects it, with
+            the worker dropped from the pool after selection but before
+            the proxy resolves it
+        When:
+            dispatch() is called
+        Then:
+            It should raise NoWorkersAvailable once the balancer is
+            exhausted, having dispatched to nothing — skipping a
+            departed candidate must not loop forever
+        """
+        # Arrange
+        gate = asyncio.Event()
+        departed = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version="1.0.0",
+        )
+        proxy = None
+        departed_connection = mocker.MagicMock(spec=WorkerConnection)
+        departed_connection.dispatch = mocker.AsyncMock()
+        throws: list = []
+
+        async def _drop_it(_):
+            gate.set()
+            await _drain_until(lambda: departed not in proxy.workers)
+
+        discovery = _GatedDiscovery(
+            initial=[DiscoveryEvent("worker-added", metadata=departed)],
+            deferred=[DiscoveryEvent("worker-dropped", metadata=departed)],
+            gate=gate,
+        )
+        proxy, _ = await _make_proxy_with_workers(
+            connections=[departed_connection],
+            loadbalancer=make_delegating_balancer(
+                on_yield=_drop_it,
+                on_throw=lambda exception, _: throws.append(exception),
+            ),
+            mocker=mocker,
+            discovery=discovery,
+            metadata_list=[departed],
+        )
+
+        # Act & assert
+        with pytest.raises(NoWorkersAvailable):
+            await proxy.dispatch(mock_wool_task)
+        assert departed_connection.dispatch.await_count == 0
+        assert throws == []
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_evict_worker_when_legacy_record_stale(
+        self,
+        mock_proxy_session,
+        mock_wool_task,
+        mocker: MockerFixture,
+    ):
+        """Test a legacy balancer's stale-record eviction takes effect.
+
+        Given:
+            A started proxy with one worker and a legacy
+            DispatchingLoadBalancerLike whose dispatch removes the
+            worker using a same-uid record with changed fields and then
+            raises NoWorkersAvailable
+        When:
+            dispatch() is called
+        Then:
+            It should propagate NoWorkersAvailable and leave the pool
+            empty — the stale-record eviction matches by uid
+        """
+
+        # Arrange
+        class EvictingBalancer:
+            async def dispatch(self, task, *, context, timeout=None):
+                [(current, _)] = list(context.workers.values())
+                stale = WorkerMetadata(
+                    uid=current.uid,
+                    address="127.0.0.1:50109",
+                    pid=9099,
+                    version=current.version,
+                )
+                context.remove_worker(stale)
+                raise NoWorkersAvailable()
+
+        dummy_connection = mocker.MagicMock(spec=WorkerConnection)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            proxy, _ = await _make_proxy_with_workers(
+                connections=[dummy_connection],
+                loadbalancer=EvictingBalancer(),
+                mocker=mocker,
+            )
+
+        # Act & assert
+        with pytest.raises(NoWorkersAvailable):
+            await proxy.dispatch(mock_wool_task)
+        assert len(proxy.workers) == 0
 
         # Cleanup
         await proxy.stop()
@@ -4676,47 +4956,6 @@ class TestWorkerProxy:
         )
         assert filter_fn(secure_matching) is False
 
-    @given(worker_count=st.integers(min_value=0, max_value=10))
-    @settings(
-        max_examples=100, suppress_health_check=[HealthCheck.function_scoped_fixture]
-    )
-    @pytest.mark.asyncio
-    async def test_property_workers_list_accurate(
-        self, mock_discovery_service, worker_count
-    ):
-        """Test the workers list remains consistent.
-
-        Given:
-            A WorkerProxy with varying numbers of discovered workers
-        When:
-            Workers are added via discovery
-        Then:
-            The workers list remains consistent
-        """
-        # Arrange
-        await mock_discovery_service.start()
-        workers = []
-        for i in range(worker_count):
-            worker = WorkerMetadata(
-                uid=uuid.uuid4(),
-                address=f"192.168.1.{100 + i}:50051",
-                pid=1000 + i,
-                version="1.0.0",
-                tags=frozenset(["test"]),
-                extra=MappingProxyType({}),
-            )
-            workers.append(worker)
-            mock_discovery_service.inject_worker_added(worker)
-
-        proxy = WorkerProxy(discovery=mock_discovery_service)
-
-        # Act
-        async with proxy:
-            await asyncio.sleep(0.1)
-            # Workers list should be consistent
-
-        await mock_discovery_service.stop()
-
     @given(num_proxies=st.integers(min_value=2, max_value=20))
     @settings(
         max_examples=100, suppress_health_check=[HealthCheck.function_scoped_fixture]
@@ -5345,8 +5584,9 @@ class TestWorkerProxyDispatchRetryEviction:
         When:
             dispatch() succeeds
         Then:
-            The balancer observed a sent value equal to the metadata
-            of the successful worker, and the generator terminated.
+            The balancer observed a sent value equal to the uid of the
+            successful worker — the candidate it yielded, echoed back —
+            and the generator terminated.
         """
         # Arrange
         sent_values: list = []
@@ -5366,7 +5606,7 @@ class TestWorkerProxyDispatchRetryEviction:
         await stream.aclose()
 
         # Assert
-        assert sent_values == [metadata]
+        assert sent_values == [metadata.uid]
         await proxy.stop()
 
     @pytest.mark.asyncio
@@ -5389,22 +5629,16 @@ class TestWorkerProxyDispatchRetryEviction:
             orphaned gRPC stream is closed (its aclose was called).
         """
         # Arrange
-        sentinel_metadata = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="127.0.0.1:50200",
-            pid=9100,
-            version="1.0.0",
-        )
+        sentinel_uid = uuid.uuid4()
 
         class MalformedBalancer:
             async def delegate(self, task, *, context):
-                items = list(context.workers.values())
-                if not items:
+                uids = list(context.workers)
+                if not uids:
                     return
-                metadata, connection = items[0]
-                _ = yield metadata, connection
+                _ = yield uids[0]
                 # Contract violation: yield again after asend.
-                yield sentinel_metadata, connection
+                yield sentinel_uid
 
         stream_close_calls: list[bool] = []
         spy_stream = SpyStream(["ok"], on_close=lambda: stream_close_calls.append(True))
@@ -5626,184 +5860,6 @@ class TestWorkerProxyDispatchRetryEviction:
         assert deprecations == []
         await proxy.stop()
 
-    @pytest.mark.asyncio
-    async def test_dispatch_should_evict_worker_by_uid_when_refreshed_mid_dispatch(
-        self,
-        mock_proxy_session,
-        mock_wool_task,
-        mocker: MockerFixture,
-    ):
-        """Test non-transient eviction removes a concurrently refreshed worker.
-
-        Given:
-            Two workers behind a delegating balancer, a gated discovery
-            stream holding a same-uid changed-record update for the
-            first worker, and a first-worker connection that releases
-            the gate, awaits the refresh, and then raises a
-            non-transient RpcError
-        When:
-            dispatch() is called and fails over
-        Then:
-            It should evict the first worker by uid — neither the stale
-            nor the refreshed record remains — while the balancer
-            observes only the surviving worker and dispatch succeeds on
-            it
-        """
-        # Arrange
-        gate = asyncio.Event()
-        worker_a = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="127.0.0.1:50100",
-            pid=9000,
-            version="1.0.0",
-        )
-        worker_b = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="127.0.0.1:50101",
-            pid=9001,
-            version="1.0.0",
-        )
-        refreshed_a = WorkerMetadata(
-            uid=worker_a.uid,
-            address="127.0.0.1:50109",
-            pid=9009,
-            version="1.0.0",
-        )
-        proxy = None
-        stale_connection = mocker.MagicMock(spec=WorkerConnection)
-
-        async def _stale_dispatch(task, *, timeout=None):
-            gate.set()
-            await _drain_until(lambda: refreshed_a in proxy.workers)
-            raise RpcError()
-
-        stale_connection.dispatch = _stale_dispatch
-        success_streams: list = []
-        survivor_connection = _make_success_connection(mocker, success_streams)
-        fresh_connection = mocker.MagicMock(spec=WorkerConnection)
-        fresh_connection.dispatch = mocker.AsyncMock()
-        observed_pools: list = []
-        discovery = _GatedDiscovery(
-            initial=[
-                DiscoveryEvent("worker-added", metadata=worker_a),
-                DiscoveryEvent("worker-added", metadata=worker_b),
-            ],
-            deferred=[DiscoveryEvent("worker-updated", metadata=refreshed_a)],
-            gate=gate,
-        )
-        proxy, _ = await _make_proxy_with_workers(
-            connections=[stale_connection, survivor_connection, fresh_connection],
-            loadbalancer=make_delegating_balancer(
-                on_throw=lambda _, context: observed_pools.append(
-                    [m for m, _ in context.workers.values()]
-                )
-            ),
-            mocker=mocker,
-            discovery=discovery,
-            metadata_list=[worker_a, worker_b],
-        )
-
-        # Act
-        stream = await proxy.dispatch(mock_wool_task)
-        results = [result async for result in stream]
-
-        # Assert
-        assert results == ["ok"]
-        assert len(proxy.workers) == 1
-        assert worker_b in proxy.workers
-        assert refreshed_a not in proxy.workers
-        assert worker_a not in proxy.workers
-        assert observed_pools == [[worker_b]]
-        assert fresh_connection.dispatch.await_count == 0
-
-        # Cleanup
-        await proxy.stop()
-
-    @pytest.mark.asyncio
-    async def test_dispatch_should_keep_refreshed_worker_when_failure_transient(
-        self,
-        mock_proxy_session,
-        mock_wool_task,
-        mocker: MockerFixture,
-    ):
-        """Test a transient failure neither evicts nor clobbers a refresh.
-
-        Given:
-            Two workers behind a delegating balancer, a gated discovery
-            stream holding a same-uid changed-record update for the
-            first worker, and a first-worker connection that releases
-            the gate, awaits the refresh, and then raises a
-            TransientRpcError
-        When:
-            dispatch() is called
-        Then:
-            It should leave the refreshed entry in the pool keyed by
-            the updated record and succeed on the second worker
-        """
-        # Arrange
-        gate = asyncio.Event()
-        worker_a = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="127.0.0.1:50100",
-            pid=9000,
-            version="1.0.0",
-        )
-        worker_b = WorkerMetadata(
-            uid=uuid.uuid4(),
-            address="127.0.0.1:50101",
-            pid=9001,
-            version="1.0.0",
-        )
-        refreshed_a = WorkerMetadata(
-            uid=worker_a.uid,
-            address="127.0.0.1:50109",
-            pid=9009,
-            version="1.0.0",
-        )
-        proxy = None
-        stale_connection = mocker.MagicMock(spec=WorkerConnection)
-
-        async def _stale_dispatch(task, *, timeout=None):
-            gate.set()
-            await _drain_until(lambda: refreshed_a in proxy.workers)
-            raise TransientRpcError()
-
-        stale_connection.dispatch = _stale_dispatch
-        success_streams: list = []
-        survivor_connection = _make_success_connection(mocker, success_streams)
-        fresh_connection = mocker.MagicMock(spec=WorkerConnection)
-        fresh_connection.dispatch = mocker.AsyncMock()
-        discovery = _GatedDiscovery(
-            initial=[
-                DiscoveryEvent("worker-added", metadata=worker_a),
-                DiscoveryEvent("worker-added", metadata=worker_b),
-            ],
-            deferred=[DiscoveryEvent("worker-updated", metadata=refreshed_a)],
-            gate=gate,
-        )
-        proxy, _ = await _make_proxy_with_workers(
-            connections=[stale_connection, survivor_connection, fresh_connection],
-            loadbalancer=make_delegating_balancer(),
-            mocker=mocker,
-            discovery=discovery,
-            metadata_list=[worker_a, worker_b],
-        )
-
-        # Act
-        stream = await proxy.dispatch(mock_wool_task)
-        results = [result async for result in stream]
-
-        # Assert
-        assert results == ["ok"]
-        assert len(proxy.workers) == 2
-        assert refreshed_a in proxy.workers
-        assert worker_a not in proxy.workers
-        assert worker_b in proxy.workers
-        assert fresh_connection.dispatch.await_count == 0
-
-        # Cleanup
-        await proxy.stop()
-
 
 class TestWorkerProxyDispatchingBalancerBackcompat:
     """Tests for the deprecated `DispatchingLoadBalancerLike` dispatch path.
@@ -5951,8 +6007,8 @@ class TestWorkerProxyDispatchingBalancerBackcompat:
         # Arrange
         class DualBalancer:
             async def delegate(self, task, *, context):
-                for metadata, connection in list(context.workers.values()):
-                    sent = yield metadata, connection
+                for uid in list(context.workers):
+                    sent = yield uid
                     if sent is not None:
                         return
 
@@ -5979,55 +6035,4 @@ class TestWorkerProxyDispatchingBalancerBackcompat:
         # Assert
         assert results == ["ok"]
         assert _dispatch_deprecations(caught) == []
-        await proxy.stop()
-
-    @pytest.mark.asyncio
-    async def test_dispatch_should_evict_worker_when_legacy_record_stale(
-        self,
-        mock_proxy_session,
-        mock_wool_task,
-        mocker: MockerFixture,
-    ):
-        """Test a legacy balancer's stale-record eviction takes effect.
-
-        Given:
-            A started proxy with one worker and a legacy
-            DispatchingLoadBalancerLike whose dispatch removes the
-            worker using a same-uid record with changed fields and then
-            raises NoWorkersAvailable
-        When:
-            dispatch() is called
-        Then:
-            It should propagate NoWorkersAvailable and leave the pool
-            empty — the stale-record eviction matches by uid
-        """
-
-        # Arrange
-        class EvictingBalancer:
-            async def dispatch(self, task, *, context, timeout=None):
-                [(current, _)] = list(context.workers.values())
-                stale = WorkerMetadata(
-                    uid=current.uid,
-                    address="127.0.0.1:50109",
-                    pid=9099,
-                    version=current.version,
-                )
-                context.remove_worker(stale)
-                raise NoWorkersAvailable()
-
-        dummy_connection = mocker.MagicMock(spec=WorkerConnection)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            proxy, _ = await _make_proxy_with_workers(
-                connections=[dummy_connection],
-                loadbalancer=EvictingBalancer(),
-                mocker=mocker,
-            )
-
-        # Act & assert
-        with pytest.raises(NoWorkersAvailable):
-            await proxy.dispatch(mock_wool_task)
-        assert len(proxy.workers) == 0
-
-        # Cleanup
         await proxy.stop()

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -43,16 +43,24 @@ from wool.runtime.worker.proxy import is_version_compatible
 from wool.runtime.worker.proxy import parse_version
 
 
-async def _drain_discovery(proxy, *, expect, timeout=2.0):
-    """Wait until proxy.workers reaches the expected count or times out.
+async def _drain_until(predicate, *, timeout=2.0):
+    """Yield the event loop until predicate() holds, or fail.
 
-    Yields the event loop in a tight loop so the sentinel can process
-    events from a finite ReducibleAsyncIterator without a hard sleep.
+    The sentinel consumes discovery events strictly in order, so waiting
+    for the last event's observable effect implies all earlier events
+    were processed.
+
+    Raises `AssertionError` when the predicate does not hold within
+    ``timeout``: a caller that drains to establish a precondition would
+    otherwise proceed on an unmet one, and pass for the wrong reason.
     """
     deadline = asyncio.get_event_loop().time() + timeout
-    while len(proxy.workers) != expect:
+    while not predicate():
         if asyncio.get_event_loop().time() > deadline:
-            break
+            raise AssertionError(
+                f"drain timed out after {timeout}s: the awaited condition "
+                f"never held, so the state it was establishing is absent"
+            )
         await asyncio.sleep(0)
 
 
@@ -91,7 +99,7 @@ def make_delegating_balancer(
     class DelegatingBalancer:
         async def delegate(self, task, *, context):
             await _run_hook(on_task, task)
-            for metadata, connection in list(context.workers.items()):
+            for metadata, connection in list(context.workers.values()):
                 await _run_hook(on_yield, metadata)
                 try:
                     sent = yield metadata, connection
@@ -1434,7 +1442,8 @@ class TestWorkerProxy:
         Then:
             It should create WorkerConnection with
             options=ChannelOptions(keepalive_time_ms=90000) for the
-            updated event
+            updated event and refresh the pool entry with the updated
+            record
         """
         # Arrange
         mocker.patch.object(protocol, "__version__", "1.0.0")
@@ -1467,12 +1476,14 @@ class TestWorkerProxy:
 
         # Act
         await proxy.start()
-        await asyncio.sleep(0.1)
+        await _drain_until(lambda: updated_metadata in proxy.workers)
 
         # Assert
         assert mock_conn_cls.call_count == 2
         _, updated_kwargs = mock_conn_cls.call_args_list[1]
         assert updated_kwargs["options"] == updated_opts
+        assert updated_metadata in proxy.workers
+        assert initial_metadata not in proxy.workers
 
         # Cleanup
         await proxy.stop()
@@ -1558,7 +1569,7 @@ class TestWorkerProxy:
 
         # Act
         await proxy.start()
-        await _drain_discovery(proxy, expect=2)
+        await _drain_until(lambda: len(proxy.workers) == 2)
 
         # Assert
         assert len(proxy.workers) == 2
@@ -1597,7 +1608,7 @@ class TestWorkerProxy:
 
         # Act
         await proxy.start()
-        await _drain_discovery(proxy, expect=3)
+        await _drain_until(lambda: len(proxy.workers) == 3)
 
         # Assert
         assert len(proxy.workers) == 3
@@ -1609,15 +1620,17 @@ class TestWorkerProxy:
     async def test_start_allows_worker_updated_at_capacity(
         self, mock_proxy_session, mocker: MockerFixture
     ):
-        """Test sentinel processes worker-updated events even at capacity.
+        """Test sentinel refreshes changed metadata even at capacity.
 
         Given:
             A non-lazy WorkerProxy with lease=2, already at capacity,
-            receiving a worker-updated event
+            receiving a worker-updated event whose same-uid metadata
+            changed
         When:
             The sentinel processes the update event
         Then:
-            It should process the update without being blocked by the cap
+            It should refresh the worker's entry with the updated
+            record without being blocked by the cap
         """
         # Arrange
         mocker.patch.object(protocol, "__version__", "1.0.0")
@@ -1633,21 +1646,30 @@ class TestWorkerProxy:
             pid=1002,
             version="1.0.0",
         )
+        updated1 = WorkerMetadata(
+            uid=worker1.uid,
+            address="192.168.1.9:50059",
+            pid=1009,
+            version="1.0.0",
+            tags=frozenset(["updated"]),
+        )
         events = [
             DiscoveryEvent("worker-added", metadata=worker1),
             DiscoveryEvent("worker-added", metadata=worker2),
-            DiscoveryEvent("worker-updated", metadata=worker1),
+            DiscoveryEvent("worker-updated", metadata=updated1),
         ]
         discovery = wp.ReducibleAsyncIterator(events)
         proxy = WorkerProxy(discovery=discovery, lease=2, lazy=False)
 
         # Act
         await proxy.start()
-        await _drain_discovery(proxy, expect=2)
+        await _drain_until(lambda: updated1 in proxy.workers)
 
         # Assert
         assert len(proxy.workers) == 2
-        assert worker1 in proxy.workers
+        assert updated1 in proxy.workers
+        assert worker1 not in proxy.workers
+        assert worker2 in proxy.workers
 
         # Cleanup
         await proxy.stop()
@@ -1698,7 +1720,7 @@ class TestWorkerProxy:
 
         # Act
         await proxy.start()
-        await _drain_discovery(proxy, expect=2)
+        await _drain_until(lambda: len(proxy.workers) == 2)
 
         # Assert — worker3 was accepted after worker1 was dropped
         assert len(proxy.workers) == 2
@@ -1747,7 +1769,7 @@ class TestWorkerProxy:
 
         # Act
         await proxy.start()
-        await _drain_discovery(proxy, expect=1)
+        await _drain_until(lambda: len(proxy.workers) == 1)
 
         # Assert — only worker1 is present; worker2 was never admitted
         assert len(proxy.workers) == 1
@@ -1756,6 +1778,592 @@ class TestWorkerProxy:
 
         # Cleanup
         await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_refresh_worker_when_updated_metadata_changes(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test worker-updated with changed metadata refreshes the pool entry.
+
+        Given:
+            A non-lazy WorkerProxy with a discovered worker and a
+            worker-updated event carrying the same uid with a changed
+            address, pid, and tags
+        When:
+            The sentinel processes the update event
+        Then:
+            It should replace the worker's stale metadata with the
+            updated record without changing the pool size
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker_uid = uuid.uuid4()
+        initial_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+            tags=frozenset(["cpu"]),
+        )
+        updated_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.2:50052",
+            pid=1002,
+            version="1.0.0",
+            tags=frozenset(["gpu"]),
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=initial_metadata),
+            DiscoveryEvent("worker-updated", metadata=updated_metadata),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lazy=False)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: updated_metadata in proxy.workers)
+
+        # Assert
+        assert updated_metadata in proxy.workers
+        assert initial_metadata not in proxy.workers
+        assert len(proxy.workers) == 1
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_remove_worker_when_dropped_metadata_changes(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test worker-dropped with changed metadata still evicts the worker.
+
+        Given:
+            A non-lazy WorkerProxy with a discovered worker and a
+            worker-dropped event carrying the same uid with changed
+            fields, followed by an unrelated worker-added event
+        When:
+            The sentinel processes all events
+        Then:
+            It should remove the dropped worker despite the changed
+            metadata, leaving only the unrelated worker
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker_uid = uuid.uuid4()
+        initial_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        changed_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.2:50052",
+            pid=1002,
+            version="1.0.0",
+        )
+        other_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.3:50053",
+            pid=1003,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=initial_metadata),
+            DiscoveryEvent("worker-dropped", metadata=changed_metadata),
+            DiscoveryEvent("worker-added", metadata=other_worker),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lazy=False)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: other_worker in proxy.workers)
+
+        # Assert
+        assert other_worker in proxy.workers
+        assert initial_metadata not in proxy.workers
+        assert changed_metadata not in proxy.workers
+        assert len(proxy.workers) == 1
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_evict_worker_when_dropped_after_metadata_update(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test a drop carrying the post-update record evicts the worker.
+
+        Given:
+            A non-lazy WorkerProxy whose discovered worker is updated
+            with a same-uid changed record and then dropped with that
+            updated record, followed by an unrelated worker-added event
+        When:
+            The sentinel processes the composed lifecycle
+        Then:
+            It should retain only the unrelated worker — neither the
+            original nor the updated record survives the drop
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker_uid = uuid.uuid4()
+        initial_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        updated_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.2:50052",
+            pid=1002,
+            version="1.0.0",
+        )
+        beacon = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.3:50053",
+            pid=1003,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=initial_metadata),
+            DiscoveryEvent("worker-updated", metadata=updated_metadata),
+            DiscoveryEvent("worker-dropped", metadata=updated_metadata),
+            DiscoveryEvent("worker-added", metadata=beacon),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lazy=False)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: beacon in proxy.workers)
+
+        # Assert
+        assert beacon in proxy.workers
+        assert initial_metadata not in proxy.workers
+        assert updated_metadata not in proxy.workers
+        assert len(proxy.workers) == 1
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_ignore_update_when_rejected_worker_metadata_changes(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test a changed-record update cannot admit a cap-rejected worker.
+
+        Given:
+            A non-lazy WorkerProxy with lease=1 whose second discovered
+            worker was rejected by the cap, then a worker-updated event
+            with that worker's uid and changed fields, a drop freeing
+            capacity, and an unrelated worker-added event
+        When:
+            The sentinel processes all events
+        Then:
+            It should never admit the rejected worker in any form —
+            after the drop frees capacity only the unrelated worker is
+            present
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker1 = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        worker2 = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50052",
+            pid=1002,
+            version="1.0.0",
+        )
+        updated2 = WorkerMetadata(
+            uid=worker2.uid,
+            address="192.168.1.9:50059",
+            pid=1009,
+            version="1.0.0",
+            tags=frozenset(["updated"]),
+        )
+        beacon = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.3:50053",
+            pid=1003,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=worker1),
+            DiscoveryEvent("worker-added", metadata=worker2),  # rejected
+            DiscoveryEvent("worker-updated", metadata=updated2),  # dropped
+            DiscoveryEvent("worker-dropped", metadata=worker1),
+            DiscoveryEvent("worker-added", metadata=beacon),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lease=1, lazy=False)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: beacon in proxy.workers)
+
+        # Assert
+        assert len(proxy.workers) == 1
+        assert beacon in proxy.workers
+        assert worker2 not in proxy.workers
+        assert updated2 not in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_replace_worker_when_readded_with_changed_metadata(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test a same-uid re-announcement replaces its worker's entry.
+
+        Given:
+            A non-lazy WorkerProxy with lease=2 whose discovered worker
+            is re-announced via worker-added with the same uid and
+            changed fields, followed by a distinct second worker
+        When:
+            The sentinel processes all events
+        Then:
+            It should replace the original entry rather than duplicate
+            it, leaving a lease slot free for the second worker
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker_uid = uuid.uuid4()
+        initial_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        readded_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.2:50052",
+            pid=1002,
+            version="1.0.0",
+        )
+        worker2 = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.3:50053",
+            pid=1003,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=initial_metadata),
+            DiscoveryEvent("worker-added", metadata=readded_metadata),
+            DiscoveryEvent("worker-added", metadata=worker2),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lease=2, lazy=False)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: worker2 in proxy.workers)
+
+        # Assert
+        assert len(proxy.workers) == 2
+        assert readded_metadata in proxy.workers
+        assert initial_metadata not in proxy.workers
+        assert worker2 in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_drop_worker_by_uid_when_address_shared(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test drop events match workers by uid, never by address.
+
+        Given:
+            A non-lazy WorkerProxy with two discovered workers holding
+            DISTINCT uids but the SAME address (a restart race), then a
+            worker-dropped event for the first uid and an unrelated
+            worker-added event
+        When:
+            The sentinel processes all events
+        Then:
+            It should remove only the first worker — the same-address
+            replacement instance survives its predecessor's drop
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        shared_address = "192.168.1.1:50051"
+        worker_a = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address=shared_address,
+            pid=1001,
+            version="1.0.0",
+        )
+        worker_b = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address=shared_address,
+            pid=1002,
+            version="1.0.0",
+        )
+        beacon = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.3:50053",
+            pid=1003,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=worker_a),
+            DiscoveryEvent("worker-added", metadata=worker_b),
+            DiscoveryEvent("worker-dropped", metadata=worker_a),
+            DiscoveryEvent("worker-added", metadata=beacon),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lazy=False)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: beacon in proxy.workers)
+
+        # Assert
+        assert len(proxy.workers) == 2
+        assert worker_b in proxy.workers
+        assert worker_a not in proxy.workers
+        assert beacon in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_not_resurrect_worker_when_updated_after_drop(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test a post-drop update cannot resurrect a removed worker.
+
+        Given:
+            A non-lazy WorkerProxy whose discovered worker is dropped
+            and then updated with a same-uid changed record, followed
+            by an unrelated worker-added event
+        When:
+            The sentinel processes all events
+        Then:
+            It should keep the dropped worker out in both forms, and
+            the unrelated worker's arrival proves the sentinel survived
+            the post-drop update
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker_uid = uuid.uuid4()
+        initial_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        updated_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.2:50052",
+            pid=1002,
+            version="1.0.0",
+        )
+        beacon = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.3:50053",
+            pid=1003,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=initial_metadata),
+            DiscoveryEvent("worker-dropped", metadata=initial_metadata),
+            DiscoveryEvent("worker-updated", metadata=updated_metadata),
+            DiscoveryEvent("worker-added", metadata=beacon),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lazy=False)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: beacon in proxy.workers)
+
+        # Assert
+        assert len(proxy.workers) == 1
+        assert beacon in proxy.workers
+        assert initial_metadata not in proxy.workers
+        assert updated_metadata not in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_refresh_readded_worker_when_pool_at_capacity(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test a same-uid re-announcement bypasses the lease cap.
+
+        The admission gate applies only to pool-growing adds: a
+        worker-added event re-announcing an already-admitted uid
+        replaces that worker's entry in place without consuming a
+        lease slot, even at capacity.
+
+        Given:
+            A non-lazy WorkerProxy with lease=2 at capacity, receiving
+            a worker-added event re-announcing an admitted uid with
+            changed fields, then a drop freeing capacity and an
+            unrelated worker-added event
+        When:
+            The sentinel processes all events
+        Then:
+            It should replace the re-announced worker's entry with the
+            new record while the pool stays within the lease
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker_a = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        worker_b = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50052",
+            pid=1002,
+            version="1.0.0",
+        )
+        readded_a = WorkerMetadata(
+            uid=worker_a.uid,
+            address="192.168.1.9:50059",
+            pid=1009,
+            version="1.0.0",
+        )
+        beacon = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.3:50053",
+            pid=1003,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=worker_a),
+            DiscoveryEvent("worker-added", metadata=worker_b),
+            DiscoveryEvent("worker-added", metadata=readded_a),  # at capacity
+            DiscoveryEvent("worker-dropped", metadata=worker_b),
+            DiscoveryEvent("worker-added", metadata=beacon),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lease=2, lazy=False)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: beacon in proxy.workers)
+
+        # Assert
+        assert len(proxy.workers) == 2
+        assert readded_a in proxy.workers
+        assert worker_a not in proxy.workers
+        assert beacon in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_use_refreshed_connection_when_metadata_updates(
+        self, mock_proxy_session, mock_wool_task, mocker: MockerFixture
+    ):
+        """Test dispatch routes through the connection built from an update.
+
+        Given:
+            A non-lazy WorkerProxy with a delegating balancer whose
+            discovered worker is refreshed by a worker-updated event
+            carrying a changed address
+        When:
+            A task is dispatched after the refresh is visible
+        Then:
+            It should dispatch through the connection built from the
+            updated metadata and never touch the stale connection
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker_uid = uuid.uuid4()
+        initial_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        updated_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.2:50052",
+            pid=1002,
+            version="1.0.0",
+        )
+        stale_connection = mocker.MagicMock(spec=WorkerConnection)
+        stale_connection.dispatch = mocker.AsyncMock()
+        success_streams: list = []
+        fresh_connection = _make_success_connection(mocker, success_streams)
+        mocker.patch.object(
+            wp, "WorkerConnection", side_effect=[stale_connection, fresh_connection]
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=initial_metadata),
+            DiscoveryEvent("worker-updated", metadata=updated_metadata),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(
+            discovery=discovery,
+            loadbalancer=make_delegating_balancer(),
+            lazy=False,
+        )
+        await proxy.start()
+        await _drain_until(lambda: updated_metadata in proxy.workers)
+
+        # Act
+        stream = await proxy.dispatch(mock_wool_task)
+        results = [result async for result in stream]
+
+        # Assert
+        assert results == ["ok"]
+        assert stale_connection.dispatch.await_count == 0
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_timeout_quorum_when_only_updates_arrive(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test worker-updated events cannot satisfy the quorum gate.
+
+        Given:
+            A non-lazy WorkerProxy with quorum=1 and a small
+            quorum_timeout whose discovery stream yields only a
+            worker-updated event for a never-admitted worker
+        When:
+            start() is awaited
+        Then:
+            It should raise asyncio.TimeoutError — updates neither
+            admit workers nor satisfy the quorum gate
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        metadata = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        events = [DiscoveryEvent("worker-updated", metadata=metadata)]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(
+            discovery=discovery,
+            lazy=False,
+            quorum=1,
+            quorum_timeout=0.2,
+        )
+
+        # Act & assert
+        with pytest.raises(asyncio.TimeoutError):
+            await proxy.start()
+        assert proxy.workers == []
 
     @pytest.mark.asyncio
     async def test_cloudpickle_serialization_preserves_lease(
@@ -1797,7 +2405,7 @@ class TestWorkerProxy:
         pickled_data = wool.__serializer__.dumps(proxy)
         restored = cloudpickle.loads(pickled_data)
         await restored.start()
-        await _drain_discovery(restored, expect=2)
+        await _drain_until(lambda: len(restored.workers) == 2)
 
         # Assert — restored proxy enforces the cap
         assert len(restored.workers) == 2
@@ -2537,7 +3145,7 @@ class TestWorkerProxy:
         # Act — pickle round-trip, then start the restored proxy
         restored = cloudpickle.loads(wool.__serializer__.dumps(proxy))
         await restored.start()
-        await _drain_discovery(restored, expect=3)
+        await _drain_until(lambda: len(restored.workers) == 3)
 
         # Assert — quorum survived the round-trip
         assert len(restored.workers) >= 2
@@ -2668,7 +3276,7 @@ class TestWorkerProxy:
         )
 
         await proxy.start()
-        await _drain_discovery(proxy, expect=1)
+        await _drain_until(lambda: len(proxy.workers) == 1)
 
         # Act
         result_iterator = await proxy.dispatch(mock_wool_task)
@@ -3068,7 +3676,7 @@ class TestWorkerProxy:
         proxy = WorkerProxy(discovery=discovery, loadbalancer=failing_loadbalancer)
 
         await proxy.start()
-        await _drain_discovery(proxy, expect=1)
+        await _drain_until(lambda: len(proxy.workers) == 1)
 
         # Act & assert
         with pytest.raises(Exception, match="Load balancer error"):
@@ -4268,6 +4876,8 @@ async def _make_proxy_with_workers(
     connections: list,
     loadbalancer,
     mocker: MockerFixture,
+    discovery=None,
+    metadata_list=None,
 ) -> tuple[WorkerProxy, list[WorkerMetadata]]:
     """Build and start a WorkerProxy seeded via the public discovery flow.
 
@@ -4276,30 +4886,37 @@ async def _make_proxy_with_workers(
     discovery stream, starts it, and waits until all workers are visible
     on ``proxy.workers``.
 
+    A custom ``discovery`` stream (e.g. `_GatedDiscovery`) and matching
+    ``metadata_list`` may be supplied; the drain then waits only for the
+    ``metadata_list`` workers, and ``connections`` must cover every
+    event the stream will ever emit.
+
     :returns:
         ``(proxy, metadata_list)`` where the metadata matches the
         connections in order.
     """
-    metadata_list = [
-        WorkerMetadata(
-            uid=uuid.uuid4(),
-            address=f"127.0.0.1:{50100 + i}",
-            pid=9000 + i,
-            version="1.0.0",
-        )
-        for i in range(len(connections))
-    ]
+    if metadata_list is None:
+        metadata_list = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"127.0.0.1:{50100 + i}",
+                pid=9000 + i,
+                version="1.0.0",
+            )
+            for i in range(len(connections))
+        ]
     mocker.patch.object(wp, "WorkerConnection", side_effect=connections)
-    discovery = wp.ReducibleAsyncIterator(
-        [DiscoveryEvent("worker-added", metadata=m) for m in metadata_list]
-    )
+    if discovery is None:
+        discovery = wp.ReducibleAsyncIterator(
+            [DiscoveryEvent("worker-added", metadata=m) for m in metadata_list]
+        )
     proxy = WorkerProxy(
         discovery=discovery,
         loadbalancer=loadbalancer,
         lazy=False,
     )
     await proxy.start()
-    await _drain_discovery(proxy, expect=len(connections))
+    await _drain_until(lambda: len(proxy.workers) == len(metadata_list))
     return proxy, metadata_list
 
 
@@ -4341,6 +4958,30 @@ def _make_outcome_connection(outcome, marker, mocker: MockerFixture):
     else:
         connection.dispatch = mocker.AsyncMock(side_effect=RpcError())
     return connection
+
+
+class _GatedDiscovery:
+    """Discovery stream yielding initial events, then gated deferred events.
+
+    Yields ``initial`` immediately, waits for ``gate`` to be set, then
+    yields ``deferred`` — landing a discovery event deterministically in
+    the middle of an in-flight dispatch.
+    """
+
+    def __init__(self, initial, deferred, gate):
+        self._initial = list(initial)
+        self._deferred = list(deferred)
+        self._gate = gate
+
+    def __aiter__(self):
+        return self._events()
+
+    async def _events(self):
+        for event in self._initial:
+            yield event
+        await self._gate.wait()
+        for event in self._deferred:
+            yield event
 
 
 class TestWorkerProxyDispatchRetryEviction:
@@ -4470,7 +5111,9 @@ class TestWorkerProxyDispatchRetryEviction:
             connections=[failing_connection, success_connection],
             loadbalancer=make_delegating_balancer(
                 on_throw=lambda exception, context: (
-                    observed_workers_during_athrow.append(list(context.workers.keys()))
+                    observed_workers_during_athrow.append(
+                        [m for m, _ in context.workers.values()]
+                    )
                 )
             ),
             mocker=mocker,
@@ -4755,7 +5398,7 @@ class TestWorkerProxyDispatchRetryEviction:
 
         class MalformedBalancer:
             async def delegate(self, task, *, context):
-                items = list(context.workers.items())
+                items = list(context.workers.values())
                 if not items:
                     return
                 metadata, connection = items[0]
@@ -4983,6 +5626,184 @@ class TestWorkerProxyDispatchRetryEviction:
         assert deprecations == []
         await proxy.stop()
 
+    @pytest.mark.asyncio
+    async def test_dispatch_should_evict_worker_by_uid_when_refreshed_mid_dispatch(
+        self,
+        mock_proxy_session,
+        mock_wool_task,
+        mocker: MockerFixture,
+    ):
+        """Test non-transient eviction removes a concurrently refreshed worker.
+
+        Given:
+            Two workers behind a delegating balancer, a gated discovery
+            stream holding a same-uid changed-record update for the
+            first worker, and a first-worker connection that releases
+            the gate, awaits the refresh, and then raises a
+            non-transient RpcError
+        When:
+            dispatch() is called and fails over
+        Then:
+            It should evict the first worker by uid — neither the stale
+            nor the refreshed record remains — while the balancer
+            observes only the surviving worker and dispatch succeeds on
+            it
+        """
+        # Arrange
+        gate = asyncio.Event()
+        worker_a = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version="1.0.0",
+        )
+        worker_b = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50101",
+            pid=9001,
+            version="1.0.0",
+        )
+        refreshed_a = WorkerMetadata(
+            uid=worker_a.uid,
+            address="127.0.0.1:50109",
+            pid=9009,
+            version="1.0.0",
+        )
+        proxy = None
+        stale_connection = mocker.MagicMock(spec=WorkerConnection)
+
+        async def _stale_dispatch(task, *, timeout=None):
+            gate.set()
+            await _drain_until(lambda: refreshed_a in proxy.workers)
+            raise RpcError()
+
+        stale_connection.dispatch = _stale_dispatch
+        success_streams: list = []
+        survivor_connection = _make_success_connection(mocker, success_streams)
+        fresh_connection = mocker.MagicMock(spec=WorkerConnection)
+        fresh_connection.dispatch = mocker.AsyncMock()
+        observed_pools: list = []
+        discovery = _GatedDiscovery(
+            initial=[
+                DiscoveryEvent("worker-added", metadata=worker_a),
+                DiscoveryEvent("worker-added", metadata=worker_b),
+            ],
+            deferred=[DiscoveryEvent("worker-updated", metadata=refreshed_a)],
+            gate=gate,
+        )
+        proxy, _ = await _make_proxy_with_workers(
+            connections=[stale_connection, survivor_connection, fresh_connection],
+            loadbalancer=make_delegating_balancer(
+                on_throw=lambda _, context: observed_pools.append(
+                    [m for m, _ in context.workers.values()]
+                )
+            ),
+            mocker=mocker,
+            discovery=discovery,
+            metadata_list=[worker_a, worker_b],
+        )
+
+        # Act
+        stream = await proxy.dispatch(mock_wool_task)
+        results = [result async for result in stream]
+
+        # Assert
+        assert results == ["ok"]
+        assert len(proxy.workers) == 1
+        assert worker_b in proxy.workers
+        assert refreshed_a not in proxy.workers
+        assert worker_a not in proxy.workers
+        assert observed_pools == [[worker_b]]
+        assert fresh_connection.dispatch.await_count == 0
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_keep_refreshed_worker_when_failure_transient(
+        self,
+        mock_proxy_session,
+        mock_wool_task,
+        mocker: MockerFixture,
+    ):
+        """Test a transient failure neither evicts nor clobbers a refresh.
+
+        Given:
+            Two workers behind a delegating balancer, a gated discovery
+            stream holding a same-uid changed-record update for the
+            first worker, and a first-worker connection that releases
+            the gate, awaits the refresh, and then raises a
+            TransientRpcError
+        When:
+            dispatch() is called
+        Then:
+            It should leave the refreshed entry in the pool keyed by
+            the updated record and succeed on the second worker
+        """
+        # Arrange
+        gate = asyncio.Event()
+        worker_a = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version="1.0.0",
+        )
+        worker_b = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50101",
+            pid=9001,
+            version="1.0.0",
+        )
+        refreshed_a = WorkerMetadata(
+            uid=worker_a.uid,
+            address="127.0.0.1:50109",
+            pid=9009,
+            version="1.0.0",
+        )
+        proxy = None
+        stale_connection = mocker.MagicMock(spec=WorkerConnection)
+
+        async def _stale_dispatch(task, *, timeout=None):
+            gate.set()
+            await _drain_until(lambda: refreshed_a in proxy.workers)
+            raise TransientRpcError()
+
+        stale_connection.dispatch = _stale_dispatch
+        success_streams: list = []
+        survivor_connection = _make_success_connection(mocker, success_streams)
+        fresh_connection = mocker.MagicMock(spec=WorkerConnection)
+        fresh_connection.dispatch = mocker.AsyncMock()
+        discovery = _GatedDiscovery(
+            initial=[
+                DiscoveryEvent("worker-added", metadata=worker_a),
+                DiscoveryEvent("worker-added", metadata=worker_b),
+            ],
+            deferred=[DiscoveryEvent("worker-updated", metadata=refreshed_a)],
+            gate=gate,
+        )
+        proxy, _ = await _make_proxy_with_workers(
+            connections=[stale_connection, survivor_connection, fresh_connection],
+            loadbalancer=make_delegating_balancer(),
+            mocker=mocker,
+            discovery=discovery,
+            metadata_list=[worker_a, worker_b],
+        )
+
+        # Act
+        stream = await proxy.dispatch(mock_wool_task)
+        results = [result async for result in stream]
+
+        # Assert
+        assert results == ["ok"]
+        assert len(proxy.workers) == 2
+        assert refreshed_a in proxy.workers
+        assert worker_a not in proxy.workers
+        assert worker_b in proxy.workers
+        assert fresh_connection.dispatch.await_count == 0
+
+        # Cleanup
+        await proxy.stop()
+
 
 class TestWorkerProxyDispatchingBalancerBackcompat:
     """Tests for the deprecated `DispatchingLoadBalancerLike` dispatch path.
@@ -5130,7 +5951,7 @@ class TestWorkerProxyDispatchingBalancerBackcompat:
         # Arrange
         class DualBalancer:
             async def delegate(self, task, *, context):
-                for metadata, connection in list(context.workers.items()):
+                for metadata, connection in list(context.workers.values()):
                     sent = yield metadata, connection
                     if sent is not None:
                         return
@@ -5158,4 +5979,55 @@ class TestWorkerProxyDispatchingBalancerBackcompat:
         # Assert
         assert results == ["ok"]
         assert _dispatch_deprecations(caught) == []
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_evict_worker_when_legacy_record_stale(
+        self,
+        mock_proxy_session,
+        mock_wool_task,
+        mocker: MockerFixture,
+    ):
+        """Test a legacy balancer's stale-record eviction takes effect.
+
+        Given:
+            A started proxy with one worker and a legacy
+            DispatchingLoadBalancerLike whose dispatch removes the
+            worker using a same-uid record with changed fields and then
+            raises NoWorkersAvailable
+        When:
+            dispatch() is called
+        Then:
+            It should propagate NoWorkersAvailable and leave the pool
+            empty — the stale-record eviction matches by uid
+        """
+
+        # Arrange
+        class EvictingBalancer:
+            async def dispatch(self, task, *, context, timeout=None):
+                [(current, _)] = list(context.workers.values())
+                stale = WorkerMetadata(
+                    uid=current.uid,
+                    address="127.0.0.1:50109",
+                    pid=9099,
+                    version=current.version,
+                )
+                context.remove_worker(stale)
+                raise NoWorkersAvailable()
+
+        dummy_connection = mocker.MagicMock(spec=WorkerConnection)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            proxy, _ = await _make_proxy_with_workers(
+                connections=[dummy_connection],
+                loadbalancer=EvictingBalancer(),
+                mocker=mocker,
+            )
+
+        # Act & assert
+        with pytest.raises(NoWorkersAvailable):
+            await proxy.dispatch(mock_wool_task)
+        assert len(proxy.workers) == 0
+
+        # Cleanup
         await proxy.stop()


### PR DESCRIPTION
## Summary

`WorkerMetadata` hashes by `uid` alone while the generated dataclass equality compares every field, so a pool keyed by the metadata record could not address a worker whose record had changed. Every membership test failed for exactly the events that mattered: the discovery sentinel dropped `worker-updated` events carrying changed metadata, a `worker-dropped` event whose record differed from the cached one missed its entry, and a re-announcement inserted a duplicate that consumed a second lease slot.

Key the pool by the worker's uid, which is what actually identifies a worker. `LoadBalancerContext` maps uid to the worker's current record and connection, so membership, lookup, and eviction all follow from the key, the mutators become single dict operations, and a duplicate entry is no longer possible to express. The lease cap counts distinct uids, so a worker re-announcing itself refreshes its entry rather than being turned away at capacity.

The second commit applies the same move to the balancer protocol, and fixes a defect the first one exposes rather than introduces. A balancer yielded the `(metadata, connection)` pair it had read from the pool, and the proxy dispatched through whatever pair it was handed — but a balancer selects from a view it may have read *before* a refresh replaced a worker's entry, so that pair could name a superseded address. `delegate` now yields the worker's **uid**, and the proxy resolves that name against the live pool at the moment it dispatches. A balancer cannot route a task to a superseded address however stale the view it chose from, because the record it read is not the record dispatched through.

Closes #292

## Proposed changes

### Key the worker pool by uid

`LoadBalancerContext` stores `dict[uuid.UUID, tuple[WorkerMetadata, WorkerConnection]]`. Presence is `uid in workers`, resolution is `workers[uid]`, and the three mutators are one dict operation each. `add_worker` admits or replaces; `update_worker` refreshes what is already admitted; `remove_worker` evicts. The `upsert` flag is gone — the two verbs carry two contracts and no longer need a boolean to tell them apart.

`LoadBalancerContextView` exposes the uid-keyed mapping and nothing else. Its member set is unchanged, so no existing context implementation breaks its `isinstance` conformance. The mapping's **key type** does change, which is breaking for a custom balancer that iterates `context.workers.items()`.

Connections displaced by a refresh are deliberately left unclosed. A connection is a lazy handle, and the channel it names is owned by the pooling layer, which reaps it by refcount and TTL; closing one on displacement would evict a channel the replacement may still share, since the pool key is `(target, credentials, options)` and an update that changes only tags or pid yields the same key. That rationale now lives on `WorkerConnection`, where channel lifetime is actually owned, and the sites that depend on it point there rather than restating it.

### Select workers by uid in `LoadBalancerLike.delegate`

A selection *names* a worker; the proxy resolves it against the pool at dispatch time and connects through the entry it finds there. Staleness stops being something balancer authors must defend against and becomes something they cannot express.

The connection half of the yield was a round trip in any case — the balancer took a connection out of the pool and handed it back to the proxy, which owns the pool — and it was the half that went stale. Balancers that need a record or a connection to *decide* (match tags, pin a version, weigh a connection) still read them from `context.workers`; they simply no longer carry what they read back across the boundary. The success echo narrows with the yield: `asend` now sends back the uid.

Selecting a worker that has left the pool is no longer an error a balancer must avoid. The proxy finds no entry, requests the next candidate, and reports nothing back — a departed worker has not failed a dispatch.

### Round-robin

The rotation snapshots uids once per wrap and indexes them in O(1). Because candidates are uids, a worker refreshed mid-cycle needs no special handling in the balancer at all. The cycle boundary is a uid and survives refreshes; it is reseeded only when that uid leaves the pool, since a departed uid can never recur and would otherwise never close the cycle.

### Documentation

The load-balancer README's protocol excerpt declared the superseded `(metadata, connection)` signature and is replaced by a pointer to `LoadBalancerLike`, which owns the contract; the README now states the uid identity model in prose rather than only in its examples. The public docstrings on `LoadBalancerLike`, `LoadBalancerContextView`, `LoadBalancerContext`, and `WorkerProxy.workers` state the caller-visible contract and move mechanism into `Implementation notes` rubrics, so the guarantees a balancer author must honor are stated once, in the entity that owns them.

### Breaking changes

This is a pre-1.0 surface, and both changes delete API rather than add it. A custom balancer migrates as follows:

```python
# before
for metadata, connection in context.workers.items():
    sent = yield metadata, connection

# after
for uid in context.workers:
    sent = yield uid
```

`update_worker` no longer accepts `upsert`; call `add_worker` to admit a worker that may not be pooled yet.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestLoadBalancerContext` | A pooled worker | A caller assigns through `workers` | It should raise `TypeError` | Read-only surface |
| 2 | `TestLoadBalancerContext` | A `workers` view captured before any mutation | A worker is admitted, a second refreshed, and a third evicted | It should reflect all three mutations through the captured view | Live-view contract |
| 3 | `TestLoadBalancerContext` | A uid absent from the pool | The worker is admitted | It should hold exactly one entry for that uid | `add_worker` admit |
| 4 | `TestLoadBalancerContext` | A worker already in the pool | It is re-admitted under the same uid with changed metadata | It should replace the entry rather than duplicate it | `add_worker` replace |
| 5 | `TestLoadBalancerContext` | A worker evicted from the pool | A changed record with that uid is admitted | It should re-admit exactly one entry | Re-admission after eviction |
| 6 | `TestLoadBalancerContext` | Any non-empty subset of the non-uid fields mutated | The worker is refreshed with the mutated record | It should carry the new record and connection | Refresh across the full field space |
| 7 | `TestLoadBalancerContext` | A chain of successive record variants | Each is applied in turn | It should retain one entry carrying the last | Repeated refresh |
| 8 | `TestLoadBalancerContext` | A worker refreshed, so an earlier record is stale | The stale record is written again | It should regress the entry — writes are last-writer-wins | Documented write semantics |
| 9 | `TestLoadBalancerContext` | Three workers in a known order | The middle one is refreshed | It should preserve iteration order | Rotation fairness under refresh |
| 10 | `TestLoadBalancerContext` | A fresh-uid clone of a pooled worker's fields | It is passed to `update_worker` | It should change nothing | Identity is uid, never field equality |
| 11 | `TestLoadBalancerContext` | A worker evicted from the pool | A changed record with that uid is refreshed | It should not resurrect the worker | Eviction retires a uid |
| 12 | `TestLoadBalancerContext` | Any non-empty subset of the non-uid fields mutated | The worker is evicted with the mutated record | It should evict the entry | Eviction matches by uid |
| 13 | `TestLoadBalancerContext` | A uid absent from the pool | The worker is evicted | It should change nothing | Eviction of an absent uid |
| 14 | `TestLoadBalancerContext` | An empty context | A worker is evicted | It should change nothing | Eviction on an empty pool |
| 15 | `TestLoadBalancerContext` | A drawn sequence of admit, refresh, and evict operations over colliding uids | Each is applied alongside a uid-keyed reference model | It should equal the model after every operation | Whole-surface model conformance (Hypothesis) |
| 16 | `TestRoundRobinLoadBalancer` | An empty context | The balancer is driven | It should yield nothing | Empty pool |
| 17 | `TestRoundRobinLoadBalancer` | One pooled worker | The balancer is driven | It should yield that uid | Single candidate |
| 18 | `TestRoundRobinLoadBalancer` | A prior dispatch that succeeded | A new call starts | It should advance the cursor past the served worker | Rotation across calls |
| 19 | `TestRoundRobinLoadBalancer` | A candidate whose dispatch failed | The generator is driven on | It should advance to the next uid | Failure advances the cursor |
| 20 | `TestRoundRobinLoadBalancer` | Every worker failing | The generator is driven to exhaustion | It should end the cycle | Cycle termination |
| 21 | `TestRoundRobinLoadBalancer` | A worker evicted mid-cycle | The generator is driven on | It should skip the evicted uid | Mutation during a cycle |
| 22 | `TestRoundRobinLoadBalancer` | A candidate whose dispatch succeeded | Success is reported via `asend` | It should terminate the cycle | Success ends the cycle |
| 23 | `TestRoundRobinLoadBalancer` | Failures preceding a success | The generator is driven | It should offer workers in rotation order | Ordering |
| 24 | `TestRoundRobinLoadBalancer` | Successive `delegate` calls | Each is driven | It should rotate the starting worker | Fairness across calls |
| 25 | `TestRoundRobinLoadBalancer` | Two concurrent drivers | Both are driven | It should offer each distinct workers | Concurrent delegation |
| 26 | `TestRoundRobinLoadBalancer` | The checkpoint worker evicted | The generator is driven | It should terminate | Boundary eviction |
| 27 | `TestRoundRobinLoadBalancer` | A worker evicted after the snapshot | The generator is driven | It should skip that uid | Snapshot versus live pool |
| 28 | `TestRoundRobinLoadBalancer` | A sole worker refreshed after its yield | The generator is driven | It should exhaust the current cycle | A refresh consumes the worker's one attempt |
| 29 | `TestRoundRobinLoadBalancer` | A sole worker refreshed after its yield | A new call starts | It should offer the uid again, resolving to the fresh entry | A refresh cannot drop a worker from the rotation |
| 30 | `TestRoundRobinLoadBalancer` | A not-yet-reached worker refreshed mid-cycle | The generator is driven to exhaustion | It should visit each uid exactly once | A refresh changes the record, not the cycle |
| 31 | `TestRoundRobinLoadBalancer` | The checkpoint worker refreshed after its yield | The generator is driven to termination | It should terminate when the boundary uid recurs | Boundary survives refresh |
| 32 | `TestRoundRobinLoadBalancer` | 2-6 workers, a drawn warmup, and a refresh drawn at any position and step | All dispatches fail transiently | It should always terminate within bounds | Termination sweep, including post-wrap refreshes (Hypothesis) |
| 33 | `TestRoundRobinLoadBalancer` | A full rotation | The cycle wraps | It should snapshot the pool once per wrap | O(1) cursor |
| 34 | `TestRoundRobinLoadBalancer` | A retired context | The balancer is released | It should not pin the context | Context lifetime |
| 35 | `TestWorkerProxy` | `lease=None` | Workers are discovered | It should accept all of them | Uncapped admission |
| 36 | `TestWorkerProxy` | A pool at capacity | A drop frees a slot | It should accept the next worker | Capacity accounting |
| 37 | `TestWorkerProxy` | `lease=1` and a cap-rejected worker | A changed-record update arrives for it | It should keep the worker out | A refresh never admits |
| 38 | `TestWorkerProxy` | A discovered worker | `worker-updated` arrives with changed metadata | It should refresh the pool entry | Sentinel refresh (#292) |
| 39 | `TestWorkerProxy` | A pool at capacity | An admitted worker is updated | It should refresh the entry without consuming a slot | Admission is per uid |
| 40 | `TestWorkerProxy` | A dropped worker | A changed-record update arrives for it | It should not resurrect the worker | Post-drop guard |
| 41 | `TestWorkerProxy` | `lease=2` at capacity | An admitted worker re-announces | It should refresh its entry without consuming a slot | Re-announcement at capacity |
| 42 | `TestWorkerProxy` | A drawn sequence of added, updated, and dropped events over uids sharing an address | The sentinel drains the stream | It should mirror a uid-keyed reference model after every event | Sentinel model conformance (Hypothesis) |
| 43 | `TestWorkerProxy` | A worker refreshed to a new address | A task is dispatched | It should serve the task through the connection built from the update | Dispatch follows the refresh |
| 44 | `TestWorkerProxy` | A worker refreshed mid-dispatch, failing non-transiently | Dispatch fails over | It should evict the uid entirely and let the survivor serve | uid-keyed eviction versus concurrent refresh |
| 45 | `TestWorkerProxy` | The same refresh, failing transiently | Dispatch runs | It should preserve the refreshed entry | Transient path preserves refreshes |
| 46 | `TestWorkerProxy` | A balancer that selects a uid and only then lets a refresh land | A task is dispatched | It should dispatch through the refreshed connection, never the superseded one | A selection cannot carry a stale address |
| 47 | `TestWorkerProxy` | Two workers, the selected one leaving the pool before the proxy resolves it | A task is dispatched | It should skip the candidate with no failure reported against it | Departed candidates are skipped, not failed |
| 48 | `TestWorkerProxy` | A sole worker that leaves the pool after being selected | A task is dispatched | It should raise `NoWorkersAvailable` once the balancer exhausts | Skipping cannot loop forever |
| 49 | `TestWorkerProxy` | A legacy balancer evicting with a changed record | `dispatch()` is called | It should raise `NoWorkersAvailable` and leave the pool empty | Deprecated mutable-context surface |
| 50 | `TestWorkerProxy` | `quorum=1` and an update-only discovery stream | `start()` is awaited | It should raise `TimeoutError` and leave no sentinel | Updates cannot satisfy quorum |
| 51 | `TestWorkerUpdatePropagation` | A live pool over real `LocalDiscovery` and a second live worker | `worker-updated` republishes the uid at the new address | It should follow the dispatch to the new worker | End-to-end propagation |
| 52 | `TestWorkerUpdatePropagation` | The refresh applied | The original worker's process is stopped | It should keep reaching the second worker | The refresh replaced the connection |
| 53 | `TestWorkerUpdatePropagation` | The refresh applied | `worker-dropped` is published for the uid | It should raise `NoWorkersAvailable` | No ghost worker |
| 54 | `TestWorkerUpdatePropagation` | `lease=1` and a worker discovery registered but the pool never admitted | `worker-updated` arrives for that worker | It should raise `NoWorkersAvailable` — the update neither admits it nor grows the pool | Removal of the `upsert` path, end to end |
