### PR TITLE
Security/version compatibility filter is not applied uniformly across discovery paths — Closes #293

### DIFF
--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -56,6 +56,7 @@ from wool.runtime.worker.connection import RpcError
 from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.connection import UnexpectedResponse
 from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.exceptions import UnparsableVersionWarning
 from wool.runtime.worker.local import LocalWorker
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.pool import IneffectiveLeaseWarning
@@ -140,6 +141,7 @@ __all__ = [
     "TransientRpcError",
     "UndefinedType",
     "UnexpectedResponse",
+    "UnparsableVersionWarning",
     "WoolError",
     "WoolWarning",
     "Worker",

--- a/wool/src/wool/runtime/worker/exceptions.py
+++ b/wool/src/wool/runtime/worker/exceptions.py
@@ -1,0 +1,26 @@
+"""The worker subsystem's shared exceptions and warnings.
+
+`UnparsableVersionWarning` is emitted when a protocol version string
+cannot be parsed into a comparable version — most visibly by the
+`WorkerProxy` admission gate for its own local protocol version.
+"""
+
+from __future__ import annotations
+
+from wool.exceptions import WoolWarning
+
+
+# public
+class UnparsableVersionWarning(WoolWarning):
+    """Emitted when a protocol version string cannot be parsed.
+
+    `parse_version` returned ``None`` for the version string — it is
+    not valid PEP 440, typically because a distribution's metadata is
+    missing and its version falls back to a non-version sentinel such
+    as ``"unknown"``.  The `WorkerProxy` admission gate emits this for
+    its own local protocol version: an unparsable local version makes
+    the version half of the gate reject every worker, so the pool stays
+    empty because of the proxy's own misconfiguration rather than an
+    absent fleet.  Filter this category to ``"error"`` (via
+    `warnings.filterwarnings`) to fail loudly instead.
+    """

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -211,7 +211,9 @@ class WorkerPool:
     :param discovery:
         Discovery service to attach — a `~wool.DiscoveryLike` instance
         or any `Factory` form resolving to one. The resolved object is
-        validated against the protocol at context entry.
+        validated against the protocol at context entry. Workers it
+        surfaces are additionally subject to the underlying
+        `WorkerProxy`'s admission gate.
     :param loadbalancer:
         Load balancer instance, factory, or context manager.
     :param credentials:

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import uuid
 import warnings
 from contextlib import AsyncExitStack
@@ -46,6 +47,7 @@ from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.connection import RpcError
 from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.exceptions import UnparsableVersionWarning
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.noreentry import noreentry
 
@@ -53,6 +55,8 @@ if TYPE_CHECKING:
     from contextvars import Token
 
     from wool.runtime.routine.task import Task
+
+_logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -64,7 +68,7 @@ def parse_version(version: str) -> Version | None:
         A version string (e.g. ``"1.2.3"``).
     :returns:
         A :class:`~packaging.version.Version` instance, or
-        ``None`` if unparseable.
+        ``None`` if unparsable.
     """
     try:
         return Version(version)
@@ -217,6 +221,36 @@ class WorkerProxy:
     worker lists. Handles connection lifecycle and fault tolerance
     automatically.
 
+    Every worker on every construction path — discovery stream, pool
+    URI, or static list — passes a security/version admission gate
+    before joining the pool: the worker's ``secure`` flag must match
+    the proxy's credentials, and its version must share the local
+    protocol version's major and be at least the local version.
+    Workers surfaced by a user-supplied ``discovery`` subscriber are
+    subject to the same gate — they are not trusted verbatim. The gate
+    is a non-overridable invariant rather than tunable policy. It fails
+    closed — a worker whose advertised version does not parse is
+    rejected, and if the local protocol version is unresolvable no
+    worker is admitted at all (observable as the quorum
+    `asyncio.TimeoutError`). The gate is re-derived from the credential
+    context and protocol version of whichever process holds the proxy,
+    so a static-worker proxy re-gated after serialization may admit
+    fewer workers than at construction, and its construction-time
+    quorum check (see ``:raises ValueError:``) does not carry across a
+    pickle.
+
+    .. rubric:: Implementation notes
+
+    The gate is non-overridable because the version floor is a
+    wire-protocol guarantee the worker interceptor also enforces
+    server-side, and an uncredentialed proxy cannot complete a TLS
+    handshake with a ``secure`` worker.
+
+    .. versionchanged:: 0.12.0
+       Workers from every discovery path, including a user-supplied
+       ``discovery`` subscriber, are now screened by the admission gate;
+       previously such workers were admitted unconditionally.
+
     **Connect via pool URI:**
 
     .. code-block:: python
@@ -285,7 +319,8 @@ class WorkerProxy:
     :param tags:
         Additional tags for filtering discovered workers.
     :param discovery:
-        Discovery service or event stream.
+        Discovery service or event stream. Workers it surfaces are
+        admitted only after passing the admission gate described above.
     :param workers:
         Static worker list for direct connection.
     :param loadbalancer:
@@ -346,6 +381,8 @@ class WorkerProxy:
         AsyncContextManager[LoadBalancerLike] | ContextManager[LoadBalancerLike]
     )
     _credentials: WorkerCredentials | None
+    _security_filter: Callable[[WorkerMetadata], bool]
+    _version_filter: Callable[[WorkerMetadata], bool]
 
     # ``wool.__proxy__`` is a plain ``contextvars.ContextVar``, invisible to
     # the chain-contention guard; this ``wool.ContextVar`` is the guarded
@@ -503,26 +540,30 @@ class WorkerProxy:
         else:
             self._credentials = credentials
 
-        # Create security filter based on resolved credentials
-        security_filter = self._create_security_filter(self._credentials)
-        version_filter = self._create_version_filter()
-
-        def compatible(w):
-            return security_filter(w) and version_filter(w)
+        # Build both halves of the admission gate from the resolved
+        # credentials and the local protocol version. Deliberately not
+        # serialized: __wool_reduce__ restores the proxy through __init__,
+        # so a restored proxy rebuilds the gate from its own credential
+        # context and protocol version.
+        self._security_filter = self._create_security_filter(self._credentials)
+        self._version_filter = self._create_version_filter()
 
         match (pool_uri, discovery, workers):
             case (pool_uri, None, None) if pool_uri is not None:
-                # Combine tag and compatibility filters
-                def combined_filter(w):
-                    return bool({pool_uri, *tags} & w.tags) and compatible(w)
+                # Tag semantics only — compatibility is enforced at
+                # sentinel admission.
+                match_tags = frozenset({pool_uri, *tags})
 
-                self._discovery = LocalDiscovery(pool_uri).subscribe(
-                    filter=combined_filter
-                )
+                def tag_filter(w):
+                    return bool(match_tags & w.tags)
+
+                self._discovery = LocalDiscovery(pool_uri).subscribe(filter=tag_filter)
             case (None, discovery, None) if discovery is not None:
                 self._discovery = discovery
             case (None, None, workers) if workers is not None:
-                compatible_workers = [w for w in workers if compatible(w)]
+                compatible_workers = [
+                    w for w in workers if self._incompatibility_reason(w) is None
+                ]
                 if quorum is not None and quorum > len(compatible_workers):
                     raise ValueError(
                         f"Quorum ({quorum}) cannot exceed compatible worker "
@@ -1051,16 +1092,18 @@ class WorkerProxy:
     def _create_security_filter(
         self, credentials: WorkerCredentials | None
     ) -> Callable[[WorkerMetadata], bool]:
-        """Create discovery filter based on proxy credentials.
+        """Create the security half of the sentinel admission gate.
 
         Workers and proxies must have compatible security settings:
-        - Proxy with credentials only discovers workers with secure=True
-        - Proxy without credentials only discovers workers with secure=False
+        - Proxy with credentials only admits workers with secure=True
+        - Proxy without credentials only admits workers with secure=False
 
         :param credentials:
             Channel credentials for this proxy.
         :returns:
-            Predicate function for filtering workers by security compatibility.
+            Predicate function for filtering workers by security
+            compatibility, enforced at `_worker_sentinel`
+            admission.
         """
         if credentials is not None:
             # Proxy has credentials: only accept secure workers
@@ -1071,19 +1114,28 @@ class WorkerProxy:
 
     @staticmethod
     def _create_version_filter() -> Callable[[WorkerMetadata], bool]:
-        """Create discovery filter based on major version compatibility.
+        """Create the version half of the sentinel admission gate.
 
         A worker is accepted when its version is greater than or
         equal to the local proxy version within the same major
-        version.  Workers with unparseable versions are rejected.
+        version.  Workers with unparsable versions are rejected.
 
         :returns:
             Predicate function for filtering workers by version
-            compatibility.
+            compatibility, enforced at `_worker_sentinel`
+            admission.
         """
         from wool import protocol
 
         local_version = parse_version(protocol.__version__)
+        if local_version is None:
+            warnings.warn(
+                f"Local protocol version {protocol.__version__!r} is not "
+                "a parsable version; the admission gate rejects every "
+                "worker until the proxy's own version metadata is available.",
+                UnparsableVersionWarning,
+                stacklevel=3,
+            )
 
         def version_filter(metadata: WorkerMetadata) -> bool:
             worker_version = parse_version(metadata.version)
@@ -1092,6 +1144,18 @@ class WorkerProxy:
             return is_version_compatible(local_version, worker_version)
 
         return version_filter
+
+    def _incompatibility_reason(self, metadata: WorkerMetadata) -> str | None:
+        """Return which gate half rejects ``metadata``, or None if it passes.
+
+        Security is reported first when both halves fail. Enforced by
+        `_worker_sentinel` on every discovery path.
+        """
+        if not self._security_filter(metadata):
+            return "security"
+        if not self._version_filter(metadata):
+            return "version"
+        return None
 
     async def _await_workers(self):
         """Block until at least ``quorum`` workers are admitted.
@@ -1115,6 +1179,24 @@ class WorkerProxy:
             self._workers_changed.clear()
 
     async def _worker_sentinel(self):
+        """Reconcile discovery events against the load-balancer context.
+
+        The single admission gate for every discovery source.
+        ``worker-added`` and ``worker-updated`` are handled
+        identically — each reconciles the worker's membership to its
+        current eligibility, regardless of how the proxy was
+        constructed (a subscription filter screens on tags or any
+        user-chosen metadata field, never on security/version
+        compatibility). An event whose metadata fails the combined
+        security/version predicate evicts the worker if it was admitted
+        and is otherwise ignored; an eligible worker not yet held is
+        admitted subject to the lease; an eligible worker already held
+        is refreshed in place. Because either event type can admit or
+        evict, a worker that crosses the compatibility boundary in
+        either direction is tracked correctly on every path.
+        ``worker-dropped`` events remove unconditionally: removing an
+        unknown worker is a no-op.
+        """
         assert self._loadbalancer_context is not None
         assert self._discovery_stream is not None
         assert self._workers_changed is not None
@@ -1133,31 +1215,56 @@ class WorkerProxy:
 
         async for event in self._discovery_stream:
             match event.type:
-                case "worker-added":
-                    if (
-                        self._lease is not None
-                        and event.metadata.uid not in self._loadbalancer_context.workers
-                        and len(self._loadbalancer_context.workers) >= self._lease
-                    ):
+                case "worker-added" | "worker-updated":
+                    uid = event.metadata.uid
+                    # Bind once: the ``workers`` property builds a fresh
+                    # MappingProxyType per access, and this branch runs per
+                    # still-registered worker every rescan.
+                    workers = self._loadbalancer_context.workers
+                    present = uid in workers
+                    reason = self._incompatibility_reason(event.metadata)
+                    if reason is not None:
+                        # Incompatible now — evict an admitted worker
+                        # whose posture flipped; ignore one never held.
+                        # Admission and eviction are one authority here,
+                        # independent of the event type.
+                        if present:
+                            _logger.debug(
+                                "Admission gate evicted worker %s: %s incompatible",
+                                uid,
+                                reason,
+                            )
+                            self._loadbalancer_context.remove_worker(event.metadata)
+                            self._workers_changed.set()
+                        else:
+                            # Fires per rescan for standing chaff, so
+                            # debug keeps it out of the default log.
+                            _logger.debug(
+                                "Admission gate rejected worker %s: %s incompatible",
+                                uid,
+                                reason,
+                            )
+                        continue
+                    if present:
+                        # Refresh in place; membership is unchanged, so
+                        # the quorum wait need not re-evaluate. Displaced
+                        # connections are not closed — see
+                        # LoadBalancerContextLike.
+                        self._loadbalancer_context.update_worker(
+                            event.metadata, connect(event.metadata)
+                        )
+                    elif self._lease is not None and len(workers) >= self._lease:
                         # Admission is per uid — see the ``lease``
                         # parameter on this class.
                         continue
-                    # Displaced connections are not closed — see
-                    # LoadBalancerContextLike.
-                    self._loadbalancer_context.add_worker(
-                        event.metadata, connect(event.metadata)
-                    )
-                    self._workers_changed.set()
-                case "worker-updated":
-                    if event.metadata.uid not in self._loadbalancer_context.workers:
-                        # A refresh never admits a worker; skip before
-                        # minting a connection this event cannot use.
-                        continue
-                    # Displaced connections are not closed — see
-                    # LoadBalancerContextLike.
-                    self._loadbalancer_context.update_worker(
-                        event.metadata, connect(event.metadata)
-                    )
+                    else:
+                        _logger.debug("Admission gate admitted worker %s", uid)
+                        # Displaced connections are not closed — see
+                        # LoadBalancerContextLike.
+                        self._loadbalancer_context.add_worker(
+                            event.metadata, connect(event.metadata)
+                        )
+                        self._workers_changed.set()
                 case "worker-dropped":
                     self._loadbalancer_context.remove_worker(event.metadata)
                     self._workers_changed.set()

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -33,6 +33,7 @@ from hypothesis import strategies as st
 
 from wool.runtime.context.runtime import dispatch_timeout
 from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.loadbalancer.base import NoWorkersAvailable
 from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import ChannelOptions
@@ -42,6 +43,63 @@ from wool.runtime.worker.pool import WorkerPool
 
 from . import routines
 from .routines import ContextVarPattern
+
+
+async def poll_until_count(get_uids, expected_count, *, timeout=5.0, interval=0.02):
+    """Poll get_uids() until it reports expected_count uids, or fail.
+
+    Returns the uid set once its size equals expected_count. Replaces a
+    fixed settle sleep: it waits no longer than necessary and fails
+    loudly — rather than silently passing on a change that arrived late
+    — if the count never reaches the expected value within the deadline.
+    """
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while True:
+        uids = get_uids()
+        if len(uids) == expected_count:
+            return uids
+        assert loop.time() < deadline, (
+            f"admitted count never reached {expected_count}; last saw {len(uids)}"
+        )
+        await asyncio.sleep(interval)
+
+
+async def poll_dispatch_until_pid(target_pid, message, *, timeout=15.0, interval=0.1):
+    """Dispatch get_pid until it reaches target_pid, or fail.
+
+    Tolerates NoWorkersAvailable during the window between an admitting
+    event being published and the sentinel admitting the worker, so an
+    empty pool mid-propagation is retried rather than raised.
+    """
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while True:
+        try:
+            if await routines.get_pid() == target_pid:
+                return
+        except NoWorkersAvailable:
+            pass
+        assert loop.time() < deadline, message
+        await asyncio.sleep(interval)
+
+
+async def poll_dispatch_until_unavailable(message, *, timeout=15.0, interval=0.1):
+    """Dispatch get_pid until the pool has no admitted workers, or fail.
+
+    The eviction counterpart of `poll_dispatch_until_pid`: an
+    evicted worker is observable only as a dispatch that can no longer
+    be routed.
+    """
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while True:
+        try:
+            await routines.get_pid()
+        except NoWorkersAvailable:
+            return
+        assert loop.time() < deadline, message
+        await asyncio.sleep(interval)
 
 
 class RoutineShape(Enum):

--- a/wool/tests/integration/test_admission_gate.py
+++ b/wool/tests/integration/test_admission_gate.py
@@ -1,0 +1,445 @@
+"""Admission-gate integration tests (issue #293).
+
+These are targeted standalone tests rather than pairwise scenarios: the
+security/version admission gate is observable only through deliberate
+pool/worker mismatches, and a mismatched-posture dimension member would
+break the pairwise array's single dispatch-success oracle. The oracle
+here is the exact admitted-worker set read from the active proxy, which
+the scenario builder does not surface.
+
+Fabricated incompatible metadata ("chaff") is published through the real
+LocalDiscovery pipeline — the untrusted-discovery-source threat model
+the fix addresses — alongside real workers. Each test asserts the
+admitted set is exactly the compatible workers, both before and after
+dispatching, so late chaff admission and spurious eviction are caught in
+one check.
+"""
+
+import asyncio
+import uuid
+from dataclasses import replace
+
+import pytest
+
+import wool
+from wool import protocol
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.worker.local import LocalWorker
+from wool.runtime.worker.metadata import WorkerMetadata
+from wool.runtime.worker.pool import WorkerPool
+from wool.runtime.worker.proxy import WorkerProxy
+from wool.runtime.worker.proxy import is_version_compatible
+from wool.runtime.worker.proxy import parse_version
+
+from . import routines
+from .conftest import CredentialType
+from .conftest import _DirectDiscovery
+from .conftest import poll_dispatch_until_pid
+from .conftest import poll_dispatch_until_unavailable
+from .conftest import poll_until_count
+
+_DISPATCH_TIMEOUT = 30
+"""Seconds to bound a posture-transition test's dispatch loop."""
+
+
+def _make_chaff():
+    """Fabricate incompatible worker metadata for a discovery namespace.
+
+    Versions derive from the running protocol version so a future
+    version-scheme change cannot silently neuter the chaff; every
+    record is guard-asserted incompatible via the public predicates.
+    The dead address yields an instant connection refusal, not a hang,
+    if a regression ever admits and dials one.
+    """
+    local = parse_version(protocol.__version__)
+    assert local is not None
+    older_same_major = f"{local.major}.0.0.dev0"
+    next_major = f"{local.major + 1}.0.0"
+    chaff = [
+        WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:1",
+            pid=1,
+            version=older_same_major,
+        ),
+        WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:1",
+            pid=1,
+            version=next_major,
+        ),
+        WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:1",
+            pid=1,
+            version="not-a-version",
+        ),
+        WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:1",
+            pid=1,
+            version=protocol.__version__,
+            secure=True,
+        ),
+    ]
+    older = parse_version(older_same_major)
+    assert older is not None and not is_version_compatible(local, older)
+    bumped = parse_version(next_major)
+    assert bumped is not None and not is_version_compatible(local, bumped)
+    assert parse_version("not-a-version") is None
+    assert chaff[3].secure
+    return chaff
+
+
+def _admitted_uids():
+    """Snapshot the active proxy's admitted worker uids."""
+    proxy = wool.__proxy__.get()
+    assert proxy is not None
+    return {worker.uid for worker in proxy.workers}
+
+
+@pytest.mark.integration
+class TestDiscoveryAdmissionGate:
+    @pytest.mark.asyncio
+    async def test___aenter___should_admit_only_compatible_worker_when_chaffed(
+        self, retry_grpc_internal
+    ):
+        """Test the gate screens a custom discovery source end to end.
+
+        Given:
+            A durable pool over a LocalDiscovery namespace carrying one
+            real insecure worker and four fabricated incompatible
+            records — older same-major, next-major, unparsable, and a
+            secure twin at the real version.
+        When:
+            The pool is entered eagerly and a routine is dispatched
+            more times than there are chaff records.
+        Then:
+            It should admit exactly the real worker before and after
+            the dispatches, and every dispatch should succeed with no
+            eviction noise.
+        """
+
+        async def body():
+            # Arrange
+            namespace = f"admission-{uuid.uuid4().hex[:12]}"
+            chaff = _make_chaff()
+            real_worker = LocalWorker()
+            await real_worker.start()
+            try:
+                with LocalDiscovery(namespace) as discovery:
+                    publisher = discovery.publisher
+                    async with publisher:
+                        for record in chaff:
+                            await publisher.publish("worker-added", record)
+                        await publisher.publish("worker-added", real_worker.metadata)
+                        pool = WorkerPool(
+                            discovery=_DirectDiscovery(discovery),
+                            quorum=1,
+                            lazy=False,
+                        )
+
+                        # Act & assert
+                        async with pool:
+                            assert real_worker.metadata is not None
+                            expected = {real_worker.metadata.uid}
+                            await poll_until_count(_admitted_uids, len(expected))
+                            assert _admitted_uids() == expected
+
+                            results = [await routines.add(1, 2) for _ in range(5)]
+                            assert results == [3] * 5
+                            assert _admitted_uids() == expected
+
+                        await publisher.publish("worker-dropped", real_worker.metadata)
+            finally:
+                await real_worker.stop()
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestSecurityPostureAdmission:
+    @pytest.mark.asyncio
+    async def test___aenter___should_admit_only_insecure_worker(
+        self, retry_grpc_internal, credentials_map
+    ):
+        """Test an insecure pool never admits a real secure worker.
+
+        Given:
+            Two real workers in one namespace — one insecure and one
+            advertising mTLS — and a durable pool without credentials.
+        When:
+            The pool is entered and a routine is dispatched several
+            times.
+        Then:
+            It should admit only the insecure worker and every
+            dispatch should succeed — the secure worker is screened at
+            admission instead of failing the TLS handshake at dispatch.
+        """
+
+        async def body():
+            # Arrange
+            namespace = f"admission-{uuid.uuid4().hex[:12]}"
+            insecure_worker = LocalWorker()
+            secure_worker = LocalWorker(credentials=credentials_map[CredentialType.MTLS])
+            await insecure_worker.start()
+            await secure_worker.start()
+            try:
+                with LocalDiscovery(namespace) as discovery:
+                    publisher = discovery.publisher
+                    async with publisher:
+                        await publisher.publish("worker-added", insecure_worker.metadata)
+                        await publisher.publish("worker-added", secure_worker.metadata)
+                        pool = WorkerPool(
+                            discovery=_DirectDiscovery(discovery),
+                            quorum=1,
+                            lazy=False,
+                        )
+
+                        # Act & assert
+                        async with pool:
+                            assert insecure_worker.metadata is not None
+                            expected = {insecure_worker.metadata.uid}
+                            await poll_until_count(_admitted_uids, len(expected))
+                            assert _admitted_uids() == expected
+
+                            for _ in range(3):
+                                assert await routines.add(1, 2) == 3
+                            assert _admitted_uids() == expected
+            finally:
+                await secure_worker.stop()
+                await insecure_worker.stop()
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_admit_only_secure_worker(
+        self, retry_grpc_internal, credentials_map
+    ):
+        """Test a credentialed pool never admits a real insecure worker.
+
+        Given:
+            The mirror topology — the same two real workers and a
+            durable pool holding mTLS credentials.
+        When:
+            The pool is entered and a routine is dispatched several
+            times.
+        Then:
+            It should admit only the secure worker and every dispatch
+            should succeed over a real mTLS channel.
+        """
+
+        async def body():
+            # Arrange
+            namespace = f"admission-{uuid.uuid4().hex[:12]}"
+            credentials = credentials_map[CredentialType.MTLS]
+            insecure_worker = LocalWorker()
+            secure_worker = LocalWorker(credentials=credentials)
+            await insecure_worker.start()
+            await secure_worker.start()
+            try:
+                with LocalDiscovery(namespace) as discovery:
+                    publisher = discovery.publisher
+                    async with publisher:
+                        await publisher.publish("worker-added", insecure_worker.metadata)
+                        await publisher.publish("worker-added", secure_worker.metadata)
+                        pool = WorkerPool(
+                            discovery=_DirectDiscovery(discovery),
+                            credentials=credentials,
+                            quorum=1,
+                            lazy=False,
+                        )
+
+                        # Act & assert
+                        async with pool:
+                            assert secure_worker.metadata is not None
+                            expected = {secure_worker.metadata.uid}
+                            await poll_until_count(_admitted_uids, len(expected))
+                            assert _admitted_uids() == expected
+
+                            for _ in range(3):
+                                assert await routines.add(1, 2) == 3
+                            assert _admitted_uids() == expected
+            finally:
+                await secure_worker.stop()
+                await insecure_worker.stop()
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestHybridAdmissionGate:
+    @pytest.mark.asyncio
+    async def test___aenter___should_admit_only_spawned_worker_when_chaffed(
+        self, retry_grpc_internal
+    ):
+        """Test the gate covers the spawn-plus-discovery pool path.
+
+        Given:
+            A hybrid pool spawning one worker into a LocalDiscovery
+            namespace pre-seeded with the fabricated incompatible
+            records.
+        When:
+            The pool is entered eagerly and a routine is dispatched
+            several times.
+        Then:
+            It should admit exactly the spawned worker — never any
+            chaff — and every dispatch should succeed.
+        """
+
+        async def body():
+            # Arrange
+            namespace = f"admission-{uuid.uuid4().hex[:12]}"
+            chaff = _make_chaff()
+            chaff_uids = {record.uid for record in chaff}
+            with LocalDiscovery(namespace) as discovery:
+                publisher = discovery.publisher
+                async with publisher:
+                    for record in chaff:
+                        await publisher.publish("worker-added", record)
+                    pool = WorkerPool(
+                        spawn=1,
+                        discovery=_DirectDiscovery(discovery),
+                        quorum=1,
+                        lazy=False,
+                    )
+
+                    # Act & assert
+                    async with pool:
+                        admitted = await poll_until_count(_admitted_uids, 1)
+                        assert not admitted & chaff_uids
+
+                        for _ in range(3):
+                            assert await routines.add(1, 2) == 3
+                        assert _admitted_uids() == admitted
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestStaticWorkersAdmission:
+    @pytest.mark.asyncio
+    async def test___aenter___should_admit_only_real_worker_when_chaffed(
+        self, retry_grpc_internal
+    ):
+        """Test the static-workers path end to end with real dispatch.
+
+        Given:
+            A WorkerProxy built from a static list containing one real
+            started worker's metadata plus the fabricated incompatible
+            records, with quorum=1.
+        When:
+            The proxy is entered eagerly and a routine is dispatched.
+        Then:
+            It should enter successfully — the quorum counts only the
+            compatible worker — admit exactly the real worker, and
+            return the dispatch result.
+        """
+
+        async def body():
+            # Arrange
+            chaff = _make_chaff()
+            real_worker = LocalWorker()
+            await real_worker.start()
+            try:
+                assert real_worker.metadata is not None
+                proxy = WorkerProxy(
+                    workers=[real_worker.metadata, *chaff],
+                    quorum=1,
+                    lazy=False,
+                )
+
+                # Act & assert
+                async with proxy:
+                    await poll_until_count(lambda: {w.uid for w in proxy.workers}, 1)
+                    expected = {real_worker.metadata.uid}
+                    assert {w.uid for w in proxy.workers} == expected
+
+                    assert await routines.add(1, 2) == 3
+                    assert {w.uid for w in proxy.workers} == expected
+            finally:
+                await real_worker.stop()
+
+        await retry_grpc_internal(body)
+
+
+@pytest.mark.integration
+class TestPostureTransitionAdmission:
+    @pytest.mark.asyncio
+    async def test___aenter___should_evict_worker_when_update_flips_incompatible(
+        self, worker_update_pool, retry_grpc_internal
+    ):
+        """Test an admitted worker flipped incompatible is evicted end to end.
+
+        Given:
+            A pool over a real LocalDiscovery holding one admitted
+            insecure worker
+        When:
+            The publisher publishes worker-updated for that worker's uid
+            carrying a secure=True record the credential-less pool cannot
+            admit
+        Then:
+            It should evict the worker within a bounded deadline —
+            dispatch raises NoWorkersAvailable rather than routing to a
+            worker the gate now rejects
+        """
+        _, publisher, worker_a, _worker_b = worker_update_pool
+
+        async def body():
+            async with asyncio.timeout(_DISPATCH_TIMEOUT):
+                # Arrange
+                assert await routines.get_pid() == worker_a.metadata.pid
+
+                # Act
+                await publisher.publish(
+                    "worker-updated", replace(worker_a.metadata, secure=True)
+                )
+
+                # Assert
+                await poll_dispatch_until_unavailable(
+                    "the posture-flipped worker was never evicted"
+                )
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_readmit_worker_when_update_flips_back_compatible(
+        self, worker_update_pool, retry_grpc_internal
+    ):
+        """Test an update re-admits a worker the gate had evicted.
+
+        Given:
+            A pool over a real LocalDiscovery whose one admitted worker
+            was evicted by a worker-updated flipping it secure=True, so
+            the pool is empty
+        When:
+            The publisher publishes worker-updated for that uid carrying
+            the worker's real, compatible metadata
+        Then:
+            It should re-admit the worker into the pool — dispatch
+            reaches it within a bounded deadline, proving an update
+            admits a worker not currently held
+        """
+        _, publisher, worker_a, _worker_b = worker_update_pool
+
+        async def body():
+            async with asyncio.timeout(_DISPATCH_TIMEOUT):
+                # Arrange — evict the worker via an incompatible flip.
+                assert await routines.get_pid() == worker_a.metadata.pid
+                await publisher.publish(
+                    "worker-updated", replace(worker_a.metadata, secure=True)
+                )
+                await poll_dispatch_until_unavailable(
+                    "the posture-flipped worker was never evicted"
+                )
+
+                # Act — its real metadata is compatible again.
+                await publisher.publish("worker-updated", worker_a.metadata)
+
+                # Assert
+                await poll_dispatch_until_pid(
+                    worker_a.metadata.pid,
+                    "the re-compatible worker was never admitted on update",
+                )
+
+        await retry_grpc_internal(body)

--- a/wool/tests/integration/test_worker_update.py
+++ b/wool/tests/integration/test_worker_update.py
@@ -17,16 +17,12 @@ from dataclasses import replace
 
 import pytest
 
-from wool.runtime.loadbalancer.base import NoWorkersAvailable
-
 from . import routines
+from .conftest import poll_dispatch_until_pid
+from .conftest import poll_dispatch_until_unavailable
 
 _TIMEOUT = 30
 _PROPAGATION_TIMEOUT = 15.0
-# Long enough for the publish to traverse the rescan and the subscriber
-# diff, so a sentinel that wrongly admitted the worker would have done
-# so before the assertion reads the pool.
-_SETTLE = 2.0
 
 
 async def _poll_until(predicate, message):
@@ -40,23 +36,6 @@ async def _poll_until(predicate, message):
     deadline = loop.time() + _PROPAGATION_TIMEOUT
     while not predicate(pid := await routines.get_pid()):
         assert loop.time() < deadline, f"dispatch still reaches pid {pid}; {message}"
-        await asyncio.sleep(0.1)
-
-
-async def _poll_until_unavailable(message):
-    """Dispatch get_pid until the pool has no workers left, or fail.
-
-    The eviction counterpart of :func:`_poll_until`: an evicted worker
-    is observable only as a dispatch that can no longer be routed.
-    """
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + _PROPAGATION_TIMEOUT
-    while True:
-        try:
-            await routines.get_pid()
-        except NoWorkersAvailable:
-            return
-        assert loop.time() < deadline, message
         await asyncio.sleep(0.1)
 
 
@@ -168,7 +147,7 @@ class TestWorkerUpdatePropagation:
                 await publisher.publish("worker-dropped", updated)
 
                 # Assert
-                await _poll_until_unavailable(
+                await poll_dispatch_until_unavailable(
                     "worker-dropped never evicted the refreshed entry"
                 )
 
@@ -176,48 +155,43 @@ class TestWorkerUpdatePropagation:
 
     @pytest.mark.parametrize("worker_update_pool", [1], indirect=True)
     @pytest.mark.asyncio
-    async def test_dispatch_should_raise_when_update_precedes_add(
+    async def test_dispatch_should_admit_capacity_freed_worker_on_refresh(
         self, worker_update_pool, retry_grpc_internal
     ):
-        """Test a worker-updated event never admits an unadmitted worker.
+        """Test a worker refused for capacity is admitted once a slot frees.
 
         Given:
             A pool over a real LocalDiscovery with lease=1, holding its
             one announced worker, and a second announced worker the cap
-            rejected, after which the admitted worker is dropped and the
-            pool is empty
+            rejected
         When:
-            The publisher publishes worker-updated for the rejected
-            worker's uid
+            The admitted worker is dropped, freeing the lease slot, so
+            discovery's next scan re-publishes the rejected worker as a
+            worker-updated event
         Then:
-            It should leave the pool empty — dispatch keeps raising
-            NoWorkersAvailable, because a refresh never admits a worker
+            It should admit that worker into the freed slot — dispatch
+            reaches it within a bounded deadline, because the sentinel
+            reconciles membership on every event rather than admitting
+            only on worker-added
         """
         _, publisher, worker_a, worker_b = worker_update_pool
 
         async def body():
             async with asyncio.timeout(_TIMEOUT):
-                # Arrange — discovery's registrar refuses to publish
-                # worker-updated for a uid it has never registered, so
-                # the only worker a refresh can name that the pool does
-                # not hold is one the pool never admitted: one the lease
-                # cap rejected. Dispatch once so the lazy pool starts and
-                # admits worker_a against the cap, announce worker_b so
-                # the cap rejects it, then retire worker_a so only an
-                # admission could repopulate the pool.
+                # Arrange — dispatch once so the lazy pool starts and
+                # admits worker_a against the cap, then announce worker_b
+                # so the cap rejects it.
                 assert await routines.get_pid() == worker_a.metadata.pid
                 await publisher.publish("worker-added", worker_b.metadata)
-                await publisher.publish("worker-dropped", worker_a.metadata)
-                await _poll_until_unavailable(
-                    "the cap-rejected worker was admitted, or worker_a was never evicted"
-                )
 
-                # Act
-                await publisher.publish("worker-updated", worker_b.metadata)
-                await asyncio.sleep(_SETTLE)
+                # Act — retire worker_a, freeing its lease slot; the same
+                # scan that drops it re-publishes worker_b as an update.
+                await publisher.publish("worker-dropped", worker_a.metadata)
 
                 # Assert
-                with pytest.raises(NoWorkersAvailable):
-                    await routines.get_pid()
+                await poll_dispatch_until_pid(
+                    worker_b.metadata.pid,
+                    "the capacity-freed worker was never admitted on refresh",
+                )
 
         await retry_grpc_internal(body)

--- a/wool/tests/runtime/worker/conftest.py
+++ b/wool/tests/runtime/worker/conftest.py
@@ -20,6 +20,7 @@ from pytest_mock import MockerFixture
 
 import wool.runtime.worker.pool as wp
 from tests.helpers import scoped_context
+from wool import protocol
 from wool.runtime.context.factory import _loops_with_factory
 from wool.runtime.context.factory import install_task_factory
 from wool.runtime.discovery.base import DiscoveryEvent
@@ -222,12 +223,17 @@ def worker_extra():
 
 
 def _make_worker_metadata(*tags: str) -> WorkerMetadata:
-    """Build a valid WorkerMetadata with a fresh UUID."""
+    """Build a valid WorkerMetadata with a fresh UUID.
+
+    Advertises the ambient protocol version — what a real in-process
+    worker would — so the metadata passes the proxy's security/version
+    admission gate.
+    """
     return WorkerMetadata(
         uid=uuid.uuid4(),
         address="localhost:50051",
         pid=12345,
-        version="1.0.0",
+        version=protocol.__version__,
         tags=frozenset(tags),
         extra=MappingProxyType({}),
     )
@@ -294,12 +300,14 @@ class MockWorker:
         if self.start_delay > 0:
             await asyncio.sleep(self.start_delay)
 
-        # Create WorkerMetadata after successful start
+        # Create WorkerMetadata after successful start; advertise the
+        # ambient protocol version so the mock worker passes the
+        # proxy's security/version admission gate.
         self._info = WorkerMetadata(
             uid=self._uid,
             address="localhost:50051",
             pid=12345,
-            version="1.0.0",
+            version=protocol.__version__,
             tags=frozenset(self._tags),
             extra=MappingProxyType({}),
         )

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -23,6 +23,10 @@ from hypothesis import settings
 from hypothesis import strategies as st
 from pytest_mock import MockerFixture
 
+import wool
+import wool.runtime.worker.pool as wp
+from wool import protocol
+from wool.runtime.discovery.base import DiscoveryEvent
 from wool.runtime.discovery.base import DiscoveryLike
 from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.base import DiscoverySubscriberLike
@@ -31,6 +35,7 @@ from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.pool import IneffectiveLeaseWarning
 from wool.runtime.worker.pool import WorkerPool
 from wool.runtime.worker.proxy import IneffectiveQuorumTimeoutWarning
+from wool.runtime.worker.proxy import ReducibleAsyncIterator
 
 
 def _make_worker_metadata(*tags: str) -> WorkerMetadata:
@@ -43,6 +48,54 @@ def _make_worker_metadata(*tags: str) -> WorkerMetadata:
         tags=frozenset(tags),
         extra=MappingProxyType({}),
     )
+
+
+class _FakePublisher:
+    """Minimal ``DiscoveryPublisherLike`` double for ``_FakeDiscovery``.
+
+    A concrete class rather than a mock: the pool validates the
+    publisher with a runtime ``isinstance`` against the protocol, which
+    a spec'd mock fails and a specless one sends into recursion.
+    """
+
+    bind_host = "127.0.0.1"
+
+    def __init__(self, mocker):
+        self.publish = mocker.AsyncMock()
+
+
+class _FakeDiscovery(DiscoveryLike):
+    """Custom ``DiscoveryLike`` double for admission-gate pool tests.
+
+    Serves both shapes the sentinel tests need through one surface:
+    when ``events`` is supplied, ``subscriber`` and ``subscribe`` yield
+    a ``ReducibleAsyncIterator`` over them (durable admission tests);
+    otherwise they return a plain mock subscriber. ``subscribe`` always
+    records the predicate it was handed on ``captured_filter`` so
+    filter-composition tests can evaluate it.
+    """
+
+    def __init__(self, mocker, events=None):
+        self._events = events
+        self._publisher = _FakePublisher(mocker)
+        self._subscriber = mocker.MagicMock(spec=DiscoverySubscriberLike)
+        self.captured_filter = None
+
+    @property
+    def publisher(self):
+        return self._publisher
+
+    @property
+    def subscriber(self):
+        if self._events is not None:
+            return ReducibleAsyncIterator(self._events)
+        return self._subscriber
+
+    def subscribe(self, filter=None):
+        self.captured_filter = filter
+        if self._events is not None:
+            return ReducibleAsyncIterator(self._events)
+        return self._subscriber
 
 
 class TestWorkerPool:
@@ -564,7 +617,6 @@ class TestWorkerPool:
             pass
 
         # Assert
-        import wool.runtime.worker.pool as wp
 
         wp.LocalWorker.assert_called()
         _, kwargs = wp.LocalWorker.call_args
@@ -592,7 +644,6 @@ class TestWorkerPool:
             pass
 
         # Assert
-        import wool.runtime.worker.pool as wp
 
         wp.LocalWorker.assert_called()
         _, kwargs = wp.LocalWorker.call_args
@@ -625,7 +676,6 @@ class TestWorkerPool:
             pass
 
         # Assert
-        import wool.runtime.worker.pool as wp
 
         wp.LocalWorker.assert_called()
         _, kwargs = wp.LocalWorker.call_args
@@ -1058,7 +1108,6 @@ class TestWorkerPool:
             pass
 
         # Assert
-        import wool.runtime.worker.pool as wp
 
         wp.LocalWorker.assert_called()
         args, kwargs = wp.LocalWorker.call_args
@@ -1097,7 +1146,6 @@ class TestWorkerPool:
             pass
 
         # Assert
-        import wool.runtime.worker.pool as wp
 
         wp.LocalWorker.assert_called()
         _, kwargs = wp.LocalWorker.call_args
@@ -1128,7 +1176,6 @@ class TestWorkerPool:
             pass
 
         # Assert
-        import wool.runtime.worker.pool as wp
 
         wp.LocalWorker.assert_not_called()
 
@@ -1157,7 +1204,6 @@ class TestWorkerPool:
             pass
 
         # Assert
-        import wool.runtime.worker.pool as wp
 
         assert wp.LocalWorker.call_count == 2
         for _, kwargs in wp.LocalWorker.call_args_list:
@@ -2855,7 +2901,6 @@ class TestWorkerPool:
             It should not pass an options parameter to WorkerProxy
         """
         # Arrange
-        import wool.runtime.worker.pool as wp
 
         mock_proxy_cls = mocker.patch.object(
             wp, "WorkerProxy", return_value=mock_worker_proxy
@@ -3030,7 +3075,6 @@ class TestWorkerPool:
             It should pass lease=6 (spawn + lease) to WorkerProxy
         """
         # Arrange
-        import wool.runtime.worker.pool as wp
 
         mock_proxy_cls = mocker.patch.object(
             wp, "WorkerProxy", return_value=mock_worker_proxy
@@ -3063,7 +3107,6 @@ class TestWorkerPool:
             It should pass lease=6 to WorkerProxy
         """
         # Arrange
-        import wool.runtime.worker.pool as wp
 
         mock_proxy_cls = mocker.patch.object(
             wp, "WorkerProxy", return_value=mock_worker_proxy
@@ -3078,6 +3121,238 @@ class TestWorkerPool:
         mock_proxy_cls.assert_called_once()
         _, proxy_kwargs = mock_proxy_cls.call_args
         assert proxy_kwargs["lease"] == 6
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_timeout_when_only_incompatible_discovered(
+        self, mocker: MockerFixture
+    ):
+        """Test custom-source incompatible workers never satisfy quorum.
+
+        Given:
+            A durable WorkerPool over a custom DiscoveryLike source
+            whose unfiltered subscriber yields only a next-major-version
+            worker, with quorum=1 and a short quorum timeout
+        When:
+            The pool context is entered eagerly
+        Then:
+            It should raise asyncio.TimeoutError at entry — the
+            proxy's admission gate rejects the worker, so the quorum
+            is never met
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        incompatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="2.0.0",
+        )
+        events = [DiscoveryEvent("worker-added", metadata=incompatible_worker)]
+        pool = WorkerPool(
+            discovery=_FakeDiscovery(mocker, events=events),
+            quorum=1,
+            quorum_timeout=0.05,
+            lazy=False,
+        )
+
+        # Act & assert
+        with pytest.raises(asyncio.TimeoutError):
+            async with pool:
+                pass
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_admit_only_compatible_workers_within_lease(
+        self, mocker: MockerFixture
+    ):
+        """Test the gate composes with pool lease and quorum wiring.
+
+        Given:
+            A durable WorkerPool with lease=1 and quorum=1 over a
+            custom DiscoveryLike source yielding an incompatible worker
+            followed by a compatible one
+        When:
+            The pool context is entered eagerly and the admitted set is
+            read from the active proxy
+        Then:
+            It should enter successfully with exactly the compatible
+            worker admitted — the rejected worker did not occupy the
+            single lease slot
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        incompatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="2.0.0",
+        )
+        compatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=incompatible_worker),
+            DiscoveryEvent("worker-added", metadata=compatible_worker),
+        ]
+        pool = WorkerPool(
+            discovery=_FakeDiscovery(mocker, events=events),
+            lease=1,
+            quorum=1,
+            lazy=False,
+        )
+
+        # Act & assert
+        async with pool:
+            proxy = wool.__proxy__.get()
+            assert proxy is not None
+            assert len(proxy.workers) == 1
+            assert compatible_worker in proxy.workers
+            assert incompatible_worker not in proxy.workers
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_subscribe_with_tag_only_filter_when_tags_given(
+        self,
+        mocker: MockerFixture,
+        mock_worker_proxy,
+        mock_local_worker,
+        mock_shared_memory,
+    ):
+        """Test hybrid subscriptions carry tag semantics only.
+
+        Given:
+            A hybrid WorkerPool with a tag and a filter-capturing
+            DiscoveryLike source
+        When:
+            The pool context is entered and the captured subscription
+            predicate is evaluated
+        Then:
+            It should admit workers by tag intersection alone —
+            version and security mismatches pass through to the
+            proxy's admission gate, and non-matching tags are rejected
+        """
+        # Arrange
+        discovery = _FakeDiscovery(mocker)
+
+        # Act
+        async with WorkerPool("gpu", spawn=1, discovery=discovery):
+            pass
+
+        filter_fn = discovery.captured_filter
+
+        # Assert — tag match passes despite a version mismatch
+        version_mismatched = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="2.0.0",
+            tags=frozenset(["gpu"]),
+        )
+        assert filter_fn(version_mismatched) is True
+
+        # Assert — tag match passes despite a security mismatch
+        secure_mismatched = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+            tags=frozenset(["gpu"]),
+            secure=True,
+        )
+        assert filter_fn(secure_mismatched) is True
+
+        # Assert — non-matching tags are rejected
+        non_matching = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.3:50051",
+            pid=1003,
+            version="1.0.0",
+            tags=frozenset(["other"]),
+        )
+        assert filter_fn(non_matching) is False
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_subscribe_with_match_all_filter_when_no_tags(
+        self,
+        mocker: MockerFixture,
+        mock_worker_proxy,
+        mock_local_worker,
+        mock_shared_memory,
+    ):
+        """Test untagged hybrid subscriptions match every worker.
+
+        Given:
+            A hybrid WorkerPool with no tags and a filter-capturing
+            DiscoveryLike source
+        When:
+            The pool context is entered and the captured subscription
+            predicate is evaluated
+        Then:
+            It should match tagged and untagged workers alike
+        """
+        # Arrange
+        discovery = _FakeDiscovery(mocker)
+
+        # Act
+        async with WorkerPool(spawn=1, discovery=discovery):
+            pass
+
+        filter_fn = discovery.captured_filter
+
+        # Assert
+        tagged = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+            tags=frozenset(["anything"]),
+        )
+        untagged = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+        )
+        assert filter_fn(tagged) is True
+        assert filter_fn(untagged) is True
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_forward_credentials_to_proxy(
+        self,
+        mocker: MockerFixture,
+        mock_worker_proxy,
+        mock_discovery_service_for_pool,
+        worker_credentials,
+    ):
+        """Test durable mode forwards credentials to WorkerProxy.
+
+        Given:
+            A WorkerPool with discovery only and WorkerCredentials
+        When:
+            The pool context is entered
+        Then:
+            It should pass the exact credentials instance to
+            WorkerProxy — the wiring that aims the security half of
+            the proxy's admission gate
+        """
+        # Arrange
+
+        mock_proxy_cls = mocker.patch.object(
+            wp, "WorkerProxy", return_value=mock_worker_proxy
+        )
+
+        # Act
+        async with WorkerPool(
+            discovery=mock_discovery_service_for_pool,
+            credentials=worker_credentials,
+        ):
+            pass
+
+        # Assert
+        mock_proxy_cls.assert_called_once()
+        _, proxy_kwargs = mock_proxy_cls.call_args
+        assert proxy_kwargs["credentials"] is worker_credentials
 
     @pytest.mark.asyncio
     async def test___aenter___no_lease_forwards_none(
@@ -3097,7 +3372,6 @@ class TestWorkerPool:
             It should pass lease=None to WorkerProxy
         """
         # Arrange
-        import wool.runtime.worker.pool as wp
 
         mock_proxy_cls = mocker.patch.object(
             wp, "WorkerProxy", return_value=mock_worker_proxy
@@ -3377,7 +3651,6 @@ class TestWorkerPool:
             It should pass quorum=2 to WorkerProxy
         """
         # Arrange
-        import wool.runtime.worker.pool as wp
 
         mock_proxy_cls = mocker.patch.object(
             wp, "WorkerProxy", return_value=mock_worker_proxy
@@ -3411,7 +3684,6 @@ class TestWorkerPool:
             pre-quorum implicit-wait semantics)
         """
         # Arrange
-        import wool.runtime.worker.pool as wp
 
         mock_proxy_cls = mocker.patch.object(
             wp, "WorkerProxy", return_value=mock_worker_proxy
@@ -3445,7 +3717,6 @@ class TestWorkerPool:
             forwarding quorum_timeout
         """
         # Arrange
-        import wool.runtime.worker.pool as wp
 
         mock_proxy_cls = mocker.patch.object(
             wp, "WorkerProxy", return_value=mock_worker_proxy
@@ -3482,7 +3753,6 @@ class TestWorkerPool:
             typed overload contract
         """
         # Arrange
-        import wool.runtime.worker.pool as wp
 
         mock_proxy_cls = mocker.patch.object(
             wp, "WorkerProxy", return_value=mock_worker_proxy
@@ -3515,7 +3785,6 @@ class TestWorkerPool:
             It should pass quorum=3 to WorkerProxy
         """
         # Arrange
-        import wool.runtime.worker.pool as wp
 
         mock_proxy_cls = mocker.patch.object(
             wp, "WorkerProxy", return_value=mock_worker_proxy
@@ -3550,7 +3819,6 @@ class TestWorkerPool:
             It should pass quorum=3 to WorkerProxy
         """
         # Arrange
-        import wool.runtime.worker.pool as wp
 
         mock_proxy_cls = mocker.patch.object(
             wp, "WorkerProxy", return_value=mock_worker_proxy

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -18,6 +18,7 @@ from types import MappingProxyType
 import cloudpickle
 import pytest
 from hypothesis import HealthCheck
+from hypothesis import assume
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
@@ -38,10 +39,12 @@ from wool.runtime.worker.base import ChannelOptions
 from wool.runtime.worker.connection import RpcError
 from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.exceptions import UnparsableVersionWarning
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.proxy import WorkerProxy
 from wool.runtime.worker.proxy import is_version_compatible
 from wool.runtime.worker.proxy import parse_version
+from wool.utilities.afilter import afilter
 
 
 async def _drain_until(predicate, *, timeout=2.0):
@@ -335,9 +338,13 @@ def spy_discovery_with_events(mocker: MockerFixture):
             """Add event to be yielded by the discovery service."""
             self._events.append(event)
 
-    # Create default worker info for testing
+    # Create default worker info for testing; advertise the ambient
+    # protocol version so the worker passes the sentinel admission gate.
     metadata = WorkerMetadata(
-        uid=uuid.uuid4(), address="127.0.0.1:50051", pid=1234, version="1.0.0"
+        uid=uuid.uuid4(),
+        address="127.0.0.1:50051",
+        pid=1234,
+        version=protocol.__version__,
     )
 
     # Create discovery with default worker-added event
@@ -501,6 +508,211 @@ def test_is_version_compatible_different_major():
 
     # Assert
     assert result is False
+
+
+_version_suffixes = st.sampled_from(["", "a1", "b2", "rc3", ".post1", ".dev2"])
+
+_versions = st.builds(
+    lambda release, suffix: Version(".".join(map(str, release)) + suffix),
+    st.tuples(
+        st.integers(min_value=0, max_value=99),
+        st.integers(min_value=0, max_value=99),
+        st.integers(min_value=0, max_value=99),
+    ),
+    _version_suffixes,
+)
+
+_same_major_version_pairs = st.builds(
+    lambda major, tail_a, tail_b: (
+        Version(f"{major}.{tail_a[0]}.{tail_a[1]}{tail_a[2]}"),
+        Version(f"{major}.{tail_b[0]}.{tail_b[1]}{tail_b[2]}"),
+    ),
+    st.integers(min_value=0, max_value=99),
+    st.tuples(
+        st.integers(min_value=0, max_value=99),
+        st.integers(min_value=0, max_value=99),
+        _version_suffixes,
+    ),
+    st.tuples(
+        st.integers(min_value=0, max_value=99),
+        st.integers(min_value=0, max_value=99),
+        _version_suffixes,
+    ),
+)
+
+
+@given(text=st.one_of(st.text(max_size=30), _versions.map(str)))
+@settings(max_examples=200)
+def test_parse_version_should_return_version_or_none_when_text_arbitrary(text):
+    """Test parse_version tolerates arbitrary input without raising.
+
+    Given:
+        Arbitrary text, biased to include stringified valid versions.
+    When:
+        parse_version is called.
+    Then:
+        It should return None or a Version whose string form re-parses
+        to an equal Version, never raising.
+    """
+    # Act
+    result = parse_version(text)
+
+    # Assert
+    assert result is None or parse_version(str(result)) == result
+
+
+@given(version=_versions)
+@settings(max_examples=100)
+def test_is_version_compatible_should_accept_equal_versions(version):
+    """Test equal versions are always mutually compatible.
+
+    Given:
+        Any generated PEP 440 version.
+    When:
+        is_version_compatible is called with it as both client and
+        server.
+    Then:
+        It should return True.
+    """
+    # Act & assert
+    assert is_version_compatible(version, version) is True
+
+
+@given(pair=_same_major_version_pairs)
+@settings(max_examples=100)
+def test_is_version_compatible_should_accept_only_lower_client_when_same_major(pair):
+    """Test same-major compatibility holds in exactly one direction.
+
+    Given:
+        Two distinct generated versions sharing a major version.
+    When:
+        is_version_compatible is evaluated in both directions.
+    Then:
+        It should return True only when the client is the lower
+        version — there is no forward-compatibility guarantee.
+    """
+    # Arrange
+    version_a, version_b = pair
+    assume(version_a != version_b)
+    lower, higher = sorted((version_a, version_b))
+
+    # Act & assert
+    assert is_version_compatible(lower, higher) is True
+    assert is_version_compatible(higher, lower) is False
+
+
+@given(client=_versions, server=_versions)
+@settings(max_examples=200)
+def test_is_version_compatible_should_reject_differing_majors(client, server):
+    """Test major-version fencing regardless of ordering.
+
+    Given:
+        Two generated versions with differing major versions.
+    When:
+        is_version_compatible is evaluated in both directions.
+    Then:
+        It should return False both ways.
+    """
+    # Arrange
+    assume(client.major != server.major)
+
+    # Act & assert
+    assert is_version_compatible(client, server) is False
+    assert is_version_compatible(server, client) is False
+
+
+_gate_worker_versions = st.one_of(
+    st.builds(
+        lambda release: ".".join(map(str, release)),
+        st.tuples(
+            st.integers(min_value=0, max_value=3),
+            st.integers(min_value=0, max_value=3),
+            st.integers(min_value=0, max_value=3),
+        ),
+    ),
+    st.sampled_from(["1.0.0a1", "not-a-version", ""]),
+)
+
+
+@st.composite
+def _gate_worker_lists(draw, min_size=1, max_size=6):
+    """Build static worker lists with mixed versions and secure flags."""
+    specs = draw(
+        st.lists(
+            st.tuples(_gate_worker_versions, st.booleans()),
+            min_size=min_size,
+            max_size=max_size,
+        )
+    )
+    return [
+        WorkerMetadata(
+            uid=uuid.uuid4(),
+            address=f"127.0.0.1:{51000 + index}",
+            pid=8000 + index,
+            version=version,
+            secure=secure,
+        )
+        for index, (version, secure) in enumerate(specs)
+    ]
+
+
+@st.composite
+def _gate_event_scenarios(draw):
+    """Draw a local version, lease, uid pool, and an event stream.
+
+    Each add/update event carries an independently drawn version and
+    secure flag, so the same uid can cross the compatibility boundary in
+    either direction across successive events — the transitions a
+    universe of fixed-metadata records could never express.
+    """
+    local_version = draw(st.sampled_from(["1.0.0", "1.2.0"]))
+    lease = draw(st.one_of(st.none(), st.integers(min_value=1, max_value=3)))
+    size = draw(st.integers(min_value=1, max_value=4))
+    slots = [
+        (uuid.uuid4(), f"127.0.0.1:{52000 + index}", 8100 + index)
+        for index in range(size)
+    ]
+    specs = draw(
+        st.lists(
+            st.tuples(
+                st.sampled_from(("worker-added", "worker-updated", "worker-dropped")),
+                st.integers(min_value=0, max_value=size - 1),
+                _gate_worker_versions,
+                st.booleans(),
+            ),
+            max_size=12,
+        )
+    )
+    events = [
+        DiscoveryEvent(
+            kind,
+            metadata=WorkerMetadata(
+                uid=slots[index][0],
+                address=slots[index][1],
+                pid=slots[index][2],
+                version=version,
+                secure=secure,
+            ),
+        )
+        for kind, index, version, secure in specs
+    ]
+    return local_version, lease, events
+
+
+def _gate_predicate(local_version):
+    """Build the public security/version predicate for an insecure proxy."""
+    local = parse_version(local_version)
+    assert local is not None
+
+    def compatible(metadata):
+        version = parse_version(metadata.version)
+        return (
+            not metadata.secure
+            and version is not None
+            and is_version_compatible(local, version)
+        )
+
+    return compatible
 
 
 # ============================================================================
@@ -1383,7 +1595,7 @@ class TestWorkerProxy:
             uid=uuid.uuid4(),
             address="192.168.1.100:50051",
             pid=1001,
-            version="1.0.0",
+            version=protocol.__version__,
         )
 
         events = [
@@ -1900,10 +2112,10 @@ class TestWorkerProxy:
         await proxy.stop()
 
     @pytest.mark.asyncio
-    async def test_start_should_not_resurrect_worker_when_updated_after_drop(
+    async def test_start_should_readmit_worker_when_updated_after_drop(
         self, mock_proxy_session, mocker: MockerFixture
     ):
-        """Test a post-drop update cannot resurrect a removed worker.
+        """Test a post-drop update re-admits the worker it names.
 
         Given:
             A non-lazy WorkerProxy whose discovered worker is dropped
@@ -1912,9 +2124,10 @@ class TestWorkerProxy:
         When:
             The sentinel processes all events
         Then:
-            It should keep the dropped worker out in both forms, and
-            the unrelated worker's arrival proves the sentinel survived
-            the post-drop update
+            It should re-admit the worker from the post-drop update —
+            the sentinel reconciles an update like an add — so both the
+            re-admitted worker (carrying the updated record) and the
+            unrelated worker are pooled
         """
         # Arrange
         mocker.patch.object(protocol, "__version__", "1.0.0")
@@ -1950,11 +2163,12 @@ class TestWorkerProxy:
         await proxy.start()
         await _drain_until(lambda: beacon in proxy.workers)
 
-        # Assert
-        assert len(proxy.workers) == 1
+        # Assert — the post-drop update re-admits the worker under its
+        # updated record; the original record is gone, replaced by it.
+        assert len(proxy.workers) == 2
         assert beacon in proxy.workers
+        assert updated_metadata in proxy.workers
         assert initial_metadata not in proxy.workers
-        assert updated_metadata not in proxy.workers
 
         # Cleanup
         await proxy.stop()
@@ -2049,10 +2263,10 @@ class TestWorkerProxy:
         When:
             The sentinel consumes the events in order alongside a plain
             uid-keyed dict model implementing the documented semantics:
-            an add admits or replaces, an update refreshes an admitted
-            uid but never admits and never resurrects a dropped one, a
-            drop evicts by uid regardless of the record it carries, and
-            the lease gates only pool-growing adds
+            an add and an update reconcile membership identically —
+            admitting or replacing subject to the lease — a drop evicts
+            by uid regardless of the record it carries, and the lease
+            gates only pool-growing admissions
         Then:
             After every event the workers list should equal the model
             exactly — one entry per live uid, carrying that uid's
@@ -2088,11 +2302,8 @@ class TestWorkerProxy:
 
                 await stream.apply(DiscoveryEvent(event_type, metadata=record))
 
-                if event_type == "worker-added":
+                if event_type in ("worker-added", "worker-updated"):
                     if lease is None or admitted or len(model) < lease:
-                        model[record.uid] = record
-                elif event_type == "worker-updated":
-                    if admitted:
                         model[record.uid] = record
                 else:
                     model.pop(record.uid, None)
@@ -2193,19 +2404,19 @@ class TestWorkerProxy:
             uid=uuid.uuid4(),
             address="127.0.0.1:50100",
             pid=9000,
-            version="1.0.0",
+            version=protocol.__version__,
         )
         worker_b = WorkerMetadata(
             uid=uuid.uuid4(),
             address="127.0.0.1:50101",
             pid=9001,
-            version="1.0.0",
+            version=protocol.__version__,
         )
         refreshed_a = WorkerMetadata(
             uid=worker_a.uid,
             address="127.0.0.1:50109",
             pid=9009,
-            version="1.0.0",
+            version=protocol.__version__,
         )
         proxy = None
         stale_connection = mocker.MagicMock(spec=WorkerConnection)
@@ -2284,19 +2495,19 @@ class TestWorkerProxy:
             uid=uuid.uuid4(),
             address="127.0.0.1:50100",
             pid=9000,
-            version="1.0.0",
+            version=protocol.__version__,
         )
         worker_b = WorkerMetadata(
             uid=uuid.uuid4(),
             address="127.0.0.1:50101",
             pid=9001,
-            version="1.0.0",
+            version=protocol.__version__,
         )
         refreshed_a = WorkerMetadata(
             uid=worker_a.uid,
             address="127.0.0.1:50109",
             pid=9009,
-            version="1.0.0",
+            version=protocol.__version__,
         )
         proxy = None
         stale_connection = mocker.MagicMock(spec=WorkerConnection)
@@ -2369,13 +2580,13 @@ class TestWorkerProxy:
             uid=uuid.uuid4(),
             address="127.0.0.1:50100",
             pid=9000,
-            version="1.0.0",
+            version=protocol.__version__,
         )
         refreshed = WorkerMetadata(
             uid=worker.uid,
             address="127.0.0.1:50109",
             pid=9009,
-            version="1.0.0",
+            version=protocol.__version__,
         )
         proxy = None
         stale_connection = mocker.MagicMock(spec=WorkerConnection)
@@ -2441,13 +2652,13 @@ class TestWorkerProxy:
             uid=uuid.uuid4(),
             address="127.0.0.1:50100",
             pid=9000,
-            version="1.0.0",
+            version=protocol.__version__,
         )
         survivor = WorkerMetadata(
             uid=uuid.uuid4(),
             address="127.0.0.1:50101",
             pid=9001,
-            version="1.0.0",
+            version=protocol.__version__,
         )
         proxy = None
         departed_connection = mocker.MagicMock(spec=WorkerConnection)
@@ -2520,7 +2731,7 @@ class TestWorkerProxy:
             uid=uuid.uuid4(),
             address="127.0.0.1:50100",
             pid=9000,
-            version="1.0.0",
+            version=protocol.__version__,
         )
         proxy = None
         departed_connection = mocker.MagicMock(spec=WorkerConnection)
@@ -2608,20 +2819,21 @@ class TestWorkerProxy:
         await proxy.stop()
 
     @pytest.mark.asyncio
-    async def test_start_should_timeout_quorum_when_only_updates_arrive(
+    async def test_start_should_admit_worker_when_only_update_arrives(
         self, mock_proxy_session, mocker: MockerFixture
     ):
-        """Test worker-updated events cannot satisfy the quorum gate.
+        """Test a lone worker-updated event admits its worker.
 
         Given:
-            A non-lazy WorkerProxy with quorum=1 and a small
-            quorum_timeout whose discovery stream yields only a
-            worker-updated event for a never-admitted worker
+            A non-lazy WorkerProxy with quorum=1 whose discovery stream
+            yields only a worker-updated event for a compatible,
+            not-yet-admitted worker
         When:
             start() is awaited
         Then:
-            It should raise asyncio.TimeoutError — updates neither
-            admit workers nor satisfy the quorum gate
+            It should admit the worker and satisfy the quorum — the
+            sentinel reconciles an update like an add, so start()
+            returns instead of timing out
         """
         # Arrange
         mocker.patch.object(protocol, "__version__", "1.0.0")
@@ -2637,13 +2849,1201 @@ class TestWorkerProxy:
             discovery=discovery,
             lazy=False,
             quorum=1,
-            quorum_timeout=0.2,
+            quorum_timeout=5,
+        )
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: metadata in proxy.workers)
+
+        # Assert
+        assert proxy.workers == [metadata]
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_reject_version_incompatible_workers_from_discovery(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test sentinel admission rejects version-incompatible workers.
+
+        Given:
+            A non-lazy WorkerProxy with a user-supplied discovery stream
+            yielding a version-compatible worker, a same-major-but-older
+            worker, and different-major workers above and below the
+            local major
+        When:
+            The sentinel processes all events
+        Then:
+            It should admit only the version-compatible worker
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.1.0")
+        compatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.2.0",
+        )
+        older_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+        )
+        next_major_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.3:50051",
+            pid=1003,
+            version="2.0.0",
+        )
+        prior_major_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.4:50051",
+            pid=1004,
+            version="0.9.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=compatible_worker),
+            DiscoveryEvent("worker-added", metadata=older_worker),
+            DiscoveryEvent("worker-added", metadata=next_major_worker),
+            DiscoveryEvent("worker-added", metadata=prior_major_worker),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lazy=False)
+
+        # Act
+        await proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert len(proxy.workers) == 1
+        assert compatible_worker in proxy.workers
+        assert older_worker not in proxy.workers
+        assert next_major_worker not in proxy.workers
+        assert prior_major_worker not in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_reject_secure_workers_when_credentials_absent(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test sentinel admission rejects secure workers on an insecure proxy.
+
+        Given:
+            A non-lazy WorkerProxy with explicit credentials=None and a
+            user-supplied discovery stream yielding a secure and an
+            insecure worker
+        When:
+            The sentinel processes all events
+        Then:
+            It should admit only the insecure worker
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        secure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=True,
+        )
+        insecure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+            secure=False,
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=secure_worker),
+            DiscoveryEvent("worker-added", metadata=insecure_worker),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, credentials=None, lazy=False)
+
+        # Act
+        await proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert insecure_worker in proxy.workers
+        assert secure_worker not in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_admit_only_secure_workers_when_credentials_present(
+        self, mock_proxy_session, worker_credentials, mocker: MockerFixture
+    ):
+        """Test sentinel admission rejects insecure workers on a secure proxy.
+
+        Given:
+            A non-lazy WorkerProxy with credentials and a user-supplied
+            discovery stream yielding a secure and an insecure worker
+        When:
+            The sentinel processes all events
+        Then:
+            It should admit only the secure worker
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        secure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=True,
+        )
+        insecure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+            secure=False,
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=secure_worker),
+            DiscoveryEvent("worker-added", metadata=insecure_worker),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(
+            discovery=discovery, credentials=worker_credentials, lazy=False
+        )
+
+        # Act
+        await proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert secure_worker in proxy.workers
+        assert insecure_worker not in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_reject_workers_when_version_unparsable(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test sentinel admission rejects workers with unparsable versions.
+
+        Given:
+            A non-lazy WorkerProxy with a user-supplied discovery stream
+            yielding a worker with an unparsable version alongside a
+            compatible worker
+        When:
+            The sentinel processes all events
+        Then:
+            It should admit only the worker with a parsable,
+            compatible version
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        unparsable_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="not-a-semver",
+        )
+        compatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=unparsable_worker),
+            DiscoveryEvent("worker-added", metadata=compatible_worker),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lazy=False)
+
+        # Act
+        await proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert compatible_worker in proxy.workers
+        assert unparsable_worker not in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_not_count_incompatible_workers_against_lease(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test rejected workers do not consume lease capacity.
+
+        Given:
+            A non-lazy WorkerProxy with lease=1 and a discovery stream
+            yielding an incompatible worker followed by a compatible one
+        When:
+            The sentinel processes all events
+        Then:
+            It should admit the compatible worker — the incompatible
+            worker must not occupy the single lease slot
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        incompatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="2.0.0",
+        )
+        compatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=incompatible_worker),
+            DiscoveryEvent("worker-added", metadata=compatible_worker),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, lease=1, lazy=False)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: len(proxy.workers) == 1)
+
+        # Assert
+        assert len(proxy.workers) == 1
+        assert compatible_worker in proxy.workers
+        assert incompatible_worker not in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_evict_worker_when_updated_metadata_incompatible(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test an incompatible update evicts an admitted worker.
+
+        Given:
+            A non-lazy WorkerProxy with explicit credentials=None and a
+            discovery stream yielding a compatible worker-added event
+            followed by a worker-updated event whose metadata flips the
+            same worker to secure=True
+        When:
+            The sentinel processes both events
+        Then:
+            It should evict the worker whose posture flipped — the pool
+            is left empty and no connection is created for the update
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        worker_uid = uuid.uuid4()
+        initial_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=False,
+        )
+        updated_metadata = WorkerMetadata(
+            uid=worker_uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=True,
+        )
+        mock_conn_cls = mocker.patch.object(
+            wp, "WorkerConnection", return_value=mocker.MagicMock()
+        )
+        stream = _SteppedDiscovery()
+        proxy = WorkerProxy(discovery=stream, credentials=None, lazy=False, quorum=0)
+        await proxy.start()
+
+        try:
+            # Act & assert — the compatible add admits the worker...
+            await stream.apply(DiscoveryEvent("worker-added", metadata=initial_metadata))
+            assert proxy.workers == [initial_metadata]
+
+            # ...and the incompatible update evicts it, minting no
+            # connection of its own — the add produced the only one.
+            await stream.apply(
+                DiscoveryEvent("worker-updated", metadata=updated_metadata)
+            )
+            assert proxy.workers == []
+            assert mock_conn_cls.call_count == 1
+        finally:
+            # Cleanup
+            await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_tolerate_worker_dropped_when_worker_never_admitted(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test a drop for a worker rejected at admission is a safe no-op.
+
+        Given:
+            A non-lazy WorkerProxy with quorum=None and a discovery
+            stream yielding an incompatible worker-added event followed
+            by a worker-dropped event for the same worker
+        When:
+            The sentinel processes both events
+        Then:
+            It should process the drop without error and admit no
+            workers
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        incompatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="2.0.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=incompatible_worker),
+            DiscoveryEvent("worker-dropped", metadata=incompatible_worker),
+        ]
+        discovery = wp.ReducibleAsyncIterator(events)
+        proxy = WorkerProxy(discovery=discovery, quorum=None, lazy=False)
+
+        # Act
+        await proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert proxy.workers == []
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_reject_incompatible_workers_when_pool_uri_supplied(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test the admission gate covers the pool-URI construction path.
+
+        Given:
+            A non-lazy WorkerProxy constructed with a pool URI whose
+            (mocked) local discovery surfaces a tag-matching but
+            version-incompatible worker alongside a tag-matching
+            compatible worker
+        When:
+            The sentinel processes both events
+        Then:
+            It should admit only the compatible worker — compatibility
+            is enforced at admission even though the subscription
+            filter passed both workers through
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        incompatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="2.0.0",
+            tags=frozenset(["pool-1"]),
+        )
+        compatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+            tags=frozenset(["pool-1"]),
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=incompatible_worker),
+            DiscoveryEvent("worker-added", metadata=compatible_worker),
+        ]
+        mock_local_discovery = mocker.MagicMock()
+        mock_local_discovery.subscribe.return_value = wp.ReducibleAsyncIterator(events)
+        mocker.patch.object(wp, "LocalDiscovery", return_value=mock_local_discovery)
+        proxy = WorkerProxy("pool-1", quorum=None, lazy=False)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: len(proxy.workers) == 1)
+
+        # Assert — the compatible worker proves the event path was live
+        assert len(proxy.workers) == 1
+        assert compatible_worker in proxy.workers
+        assert incompatible_worker not in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.parametrize(
+        "flipped",
+        [
+            {"secure": True, "version": "1.0.0"},
+            {"secure": False, "version": "2.0.0"},
+        ],
+        ids=["security", "version"],
+    )
+    @pytest.mark.asyncio
+    async def test_start_should_evict_via_afilter_when_pool_uri_flips_incompatible(
+        self, mock_proxy_session, mocker: MockerFixture, flipped
+    ):
+        """Test the pool-URI path evicts a worker that flips incompatible.
+
+        Given:
+            A pool-URI proxy whose real afilter-wrapped subscription
+            first surfaces a tag-matching compatible worker, then a
+            worker-updated for the same uid flipped incompatible on one
+            gate half
+        When:
+            The sentinel admits the worker and then processes the flip
+        Then:
+            It should evict the worker — the afilter path tracks the
+            posture flip end to end, unlike the bypassed-afilter tests
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        uid = uuid.uuid4()
+        compatible = WorkerMetadata(
+            uid=uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=False,
+            tags=frozenset(["pool-1"]),
+        )
+        incompatible = WorkerMetadata(
+            uid=uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            tags=frozenset(["pool-1"]),
+            **flipped,
+        )
+        release = asyncio.Event()
+
+        class _Inner:
+            def __aiter__(self):
+                async def gen():
+                    yield DiscoveryEvent("worker-added", metadata=compatible)
+                    await release.wait()
+                    yield DiscoveryEvent("worker-updated", metadata=incompatible)
+                    await asyncio.Event().wait()
+
+                return gen()
+
+        mock_local = mocker.MagicMock()
+        mock_local.subscribe.side_effect = lambda filter=None, **_: afilter(
+            filter, _Inner()
+        )
+        mocker.patch.object(wp, "LocalDiscovery", return_value=mock_local)
+        proxy = WorkerProxy("pool-1", credentials=None, quorum=None, lazy=False)
+
+        try:
+            # Act — admit the compatible worker, then release the flip
+            await proxy.start()
+            await _drain_until(lambda: [w.uid for w in proxy.workers] == [uid])
+            release.set()
+
+            # Assert
+            await _drain_until(lambda: proxy.workers == [])
+        finally:
+            # Cleanup
+            await proxy.stop()
+
+    @pytest.mark.parametrize(
+        "initial",
+        [
+            {"secure": True, "version": "1.0.0"},
+            {"secure": False, "version": "2.0.0"},
+        ],
+        ids=["security", "version"],
+    )
+    @pytest.mark.asyncio
+    async def test_start_should_admit_via_afilter_when_pool_uri_flips_compatible(
+        self, mock_proxy_session, mocker: MockerFixture, initial
+    ):
+        """Test the pool-URI path admits a worker that becomes compatible.
+
+        Given:
+            A pool-URI proxy whose real afilter-wrapped subscription
+            first surfaces a tag-matching but incompatible worker
+            (rejected), then a worker-updated for the same uid carrying
+            compatible metadata
+        When:
+            The sentinel rejects the first event and processes the update
+        Then:
+            It should admit the now-compatible worker on the update —
+            the afilter path delivers the transition as worker-updated,
+            which reconciliation admits
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        uid = uuid.uuid4()
+        incompatible = WorkerMetadata(
+            uid=uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            tags=frozenset(["pool-1"]),
+            **initial,
+        )
+        compatible = WorkerMetadata(
+            uid=uid,
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=False,
+            tags=frozenset(["pool-1"]),
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=incompatible),
+            DiscoveryEvent("worker-updated", metadata=compatible),
+        ]
+
+        class _Inner:
+            def __aiter__(self):
+                async def gen():
+                    for event in events:
+                        yield event
+                    await asyncio.Event().wait()
+
+                return gen()
+
+        mock_local = mocker.MagicMock()
+        mock_local.subscribe.side_effect = lambda filter=None, **_: afilter(
+            filter, _Inner()
+        )
+        mocker.patch.object(wp, "LocalDiscovery", return_value=mock_local)
+        proxy = WorkerProxy("pool-1", credentials=None, quorum=None, lazy=False)
+
+        try:
+            # Act
+            await proxy.start()
+            await _drain_until(lambda: [w.uid for w in proxy.workers] == [uid])
+
+            # Assert — admitted under the compatible record
+            assert proxy.workers == [compatible]
+        finally:
+            # Cleanup
+            await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_raise_timeout_when_all_workers_incompatible(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test gate-rejected workers never satisfy the quorum wait.
+
+        Given:
+            A non-lazy WorkerProxy with quorum=1, a short quorum
+            timeout, and a discovery stream yielding only incompatible
+            workers — one next-major version and one secure-mismatched
+        When:
+            The proxy is entered as an async context manager
+        Then:
+            It should raise asyncio.TimeoutError out of __aenter__,
+            leaving the proxy un-started with no admitted workers
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        next_major_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="2.0.0",
+        )
+        secure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+            secure=True,
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=next_major_worker),
+            DiscoveryEvent("worker-added", metadata=secure_worker),
+        ]
+        proxy = WorkerProxy(
+            discovery=wp.ReducibleAsyncIterator(events),
+            credentials=None,
+            quorum=1,
+            quorum_timeout=0.1,
+            lazy=False,
         )
 
         # Act & assert
         with pytest.raises(asyncio.TimeoutError):
-            await proxy.start()
+            async with proxy:
+                pass
+        assert not proxy.started
         assert proxy.workers == []
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_retry_start_when_incompatible_caused_timeout(
+        self, mocker: MockerFixture
+    ):
+        """Test a gate-caused quorum failure leaves the proxy retryable.
+
+        Given:
+            A lazy WorkerProxy with quorum=1 and a short quorum timeout
+            whose discovery yields an incompatible worker immediately
+            and a compatible worker behind an event gate
+        When:
+            A first dispatch is awaited, then the gate is released and
+            the dispatch retried
+        Then:
+            The first dispatch should raise asyncio.TimeoutError
+            leaving the proxy un-started without invoking the
+            balancer, and the retried dispatch should start the proxy
+            and dispatch successfully
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        gate = asyncio.Event()
+        incompatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="2.0.0",
+        )
+        compatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+        )
+
+        class RecoveringDiscovery:
+            def __init__(self):
+                self._index = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._index == 0:
+                    self._index += 1
+                    return DiscoveryEvent("worker-added", metadata=incompatible_worker)
+                await gate.wait()
+                if self._index == 1:
+                    self._index += 1
+                    return DiscoveryEvent("worker-added", metadata=compatible_worker)
+                await asyncio.Event().wait()
+                raise StopAsyncIteration
+
+        class StubLoadBalancer:
+            def __init__(self):
+                self.dispatched = False
+
+            async def dispatch(self, task, *, context, timeout=None):
+                self.dispatched = True
+
+        stub_lb = StubLoadBalancer()
+        proxy = WorkerProxy(
+            discovery=RecoveringDiscovery(),
+            loadbalancer=stub_lb,
+            credentials=None,
+            quorum=1,
+            quorum_timeout=0.1,
+        )
+        mock_task = mocker.MagicMock(spec=Task)
+
+        # Act & assert — the rejected worker never satisfies quorum
+        with pytest.raises(asyncio.TimeoutError):
+            await proxy.dispatch(mock_task)
+        assert not proxy.started
+        assert not stub_lb.dispatched
+
+        # Act — the compatible worker appears and a retry recovers
+        gate.set()
+        await asyncio.wait_for(proxy.dispatch(mock_task), timeout=2.0)
+
+        # Assert
+        assert proxy.started
+        assert stub_lb.dispatched
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_gate_with_credentials_resolved_at_construction(
+        self, mock_proxy_session, worker_credentials, mocker: MockerFixture
+    ):
+        """Test implicit credential resolution feeds the admission gate.
+
+        Given:
+            A WorkerProxy constructed inside a CredentialContext with
+            credentials left to default resolution, the context exited
+            before start, and a discovery stream yielding one secure
+            and one insecure worker
+        When:
+            The proxy is started outside the credential context
+        Then:
+            It should admit only the secure worker — the gate binds
+            the credentials resolved at construction time
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        secure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=True,
+        )
+        insecure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+            secure=False,
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=secure_worker),
+            DiscoveryEvent("worker-added", metadata=insecure_worker),
+        ]
+        with CredentialContext(worker_credentials):
+            proxy = WorkerProxy(discovery=wp.ReducibleAsyncIterator(events), lazy=False)
+
+        # Act
+        await proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert secure_worker in proxy.workers
+        assert insecure_worker not in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_reject_all_workers_when_local_version_unparsable(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test the version gate fails closed on an unparsable local version.
+
+        Given:
+            The local protocol version patched to "unknown" — the real
+            missing-distribution fallback — and a discovery stream
+            yielding a valid-version worker and an "unknown"-version
+            worker
+        When:
+            The proxy is started and the sentinel processes both events
+        Then:
+            It should warn that the local version is unresolvable and
+            admit no workers — identical unparsable strings do not match
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "unknown")
+        valid_version_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        unknown_version_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="unknown",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=valid_version_worker),
+            DiscoveryEvent("worker-added", metadata=unknown_version_worker),
+        ]
+        with pytest.warns(UnparsableVersionWarning):
+            proxy = WorkerProxy(
+                discovery=wp.ReducibleAsyncIterator(events),
+                credentials=None,
+                quorum=None,
+                lazy=False,
+            )
+
+        # Act
+        await proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert proxy.workers == []
+
+        # Cleanup
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_await_live_worker_count_when_drop_races_quorum(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test the quorum wait tracks the live count across drops.
+
+        Given:
+            A non-lazy WorkerProxy with quorum=2 and a step-gated
+            discovery stream releasing add A, drop A, add B, then add C
+            one event at a time
+        When:
+            The proxy is entered while the events are released stepwise
+        Then:
+            It should remain blocked after add/drop/add — only one
+            live worker — and complete only after the fourth event,
+            with exactly B and C admitted
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        gate = asyncio.Event()
+        worker_a, worker_b, worker_c = (
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+            )
+            for i in range(3)
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=worker_a),
+            DiscoveryEvent("worker-dropped", metadata=worker_a),
+            DiscoveryEvent("worker-added", metadata=worker_b),
+            DiscoveryEvent("worker-added", metadata=worker_c),
+        ]
+        call_count = 0
+
+        class GatedDiscovery:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                nonlocal call_count
+                await gate.wait()
+                gate.clear()
+                if call_count < len(events):
+                    event = events[call_count]
+                    call_count += 1
+                    return event
+                await asyncio.Event().wait()
+                raise StopAsyncIteration
+
+        proxy = WorkerProxy(discovery=GatedDiscovery(), quorum=2, lazy=False)
+        entered = asyncio.Event()
+        hold = asyncio.Event()
+
+        async def enter():
+            async with proxy:
+                entered.set()
+                await hold.wait()
+
+        # Act — release add A, drop A, add B; quorum must stay unmet
+        enter_task = asyncio.create_task(enter())
+        await asyncio.sleep(0)
+        try:
+            for _ in range(3):
+                gate.set()
+                await asyncio.sleep(0.05)
+                assert not entered.is_set()
+
+            # Release add C — the live count reaches the quorum
+            gate.set()
+            await asyncio.wait_for(entered.wait(), timeout=2.0)
+
+            # Assert
+            assert len(proxy.workers) == 2
+            assert worker_b in proxy.workers
+            assert worker_c in proxy.workers
+            assert worker_a not in proxy.workers
+        finally:
+            # Cleanup — release the held context and cancel the entry
+            # task so it unwinds inside the context that entered it,
+            # running ``__aexit__`` on the started proxy.
+            hold.set()
+            enter_task.cancel()
+            try:
+                await enter_task
+            except asyncio.CancelledError:
+                pass
+
+    def test_workers_should_return_empty_list_when_proxy_unstarted(
+        self, mock_discovery_service
+    ):
+        """Test the workers property is safe on an un-started proxy.
+
+        Given:
+            A lazy WorkerProxy that has never been entered or started
+        When:
+            The workers property is accessed
+        Then:
+            It should return an empty list without raising
+        """
+        # Arrange
+        proxy = WorkerProxy(discovery=mock_discovery_service)
+
+        # Act & assert
+        assert proxy.workers == []
+
+    def test___init___should_succeed_when_quorum_matches_compatible_worker_count(
+        self, mocker: MockerFixture
+    ):
+        """Test construction succeeds when quorum equals the compatible count.
+
+        Given:
+            A static list of three workers of which exactly two are
+            version-compatible, and quorum=2
+        When:
+            The proxy is constructed
+        Then:
+            It should return a WorkerProxy instance rather than raising
+            ValueError — the just-satisfiable quorum is accepted
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        compatible_workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+            )
+            for i in range(2)
+        ]
+        incompatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.9:50051",
+            pid=1009,
+            version="2.0.0",
+        )
+
+        # Act
+        proxy = WorkerProxy(
+            workers=[*compatible_workers, incompatible_worker],
+            quorum=2,
+            lazy=False,
+        )
+
+        # Assert
+        assert isinstance(proxy, WorkerProxy)
+
+    @pytest.mark.asyncio
+    async def test_start_should_admit_only_compatible_workers_when_static_list_mixed(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test start admits exactly the compatible workers from a mixed list.
+
+        Given:
+            A non-lazy proxy over a static list of two version-compatible
+            workers and one incompatible worker, with quorum=2
+        When:
+            The proxy is started
+        Then:
+            It should admit exactly the two compatible workers and never
+            the incompatible one
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        compatible_workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+            )
+            for i in range(2)
+        ]
+        incompatible_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.9:50051",
+            pid=1009,
+            version="2.0.0",
+        )
+        proxy = WorkerProxy(
+            workers=[*compatible_workers, incompatible_worker],
+            quorum=2,
+            lazy=False,
+        )
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: len(proxy.workers) == 2)
+
+        # Assert
+        assert len(proxy.workers) == 2
+        assert compatible_workers[0] in proxy.workers
+        assert compatible_workers[1] in proxy.workers
+        assert incompatible_worker not in proxy.workers
+
+        # Cleanup
+        await proxy.stop()
+
+    def test___init___should_raise_when_quorum_exceeds_insecure_worker_count(
+        self, mocker: MockerFixture
+    ):
+        """Test the security half reduces the construction-time count.
+
+        Given:
+            An explicit credentials=None proxy over a static list of
+            one insecure and one secure version-compatible worker, and
+            quorum=2
+        When:
+            The proxy is constructed
+        Then:
+            It should raise ValueError reporting "1 of 2" — the secure
+            worker fails the security half of the compatibility count
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        insecure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=False,
+        )
+        secure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+            secure=True,
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError, match=r"compatible worker count \(1 of 2"):
+            WorkerProxy(
+                workers=[insecure_worker, secure_worker],
+                credentials=None,
+                quorum=2,
+            )
+
+    @pytest.mark.asyncio
+    async def test_start_should_admit_no_workers_when_static_list_incompatible(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test an all-incompatible static list is legal without a quorum.
+
+        Given:
+            A static list whose workers are all version-incompatible
+            and quorum=None
+        When:
+            The proxy is constructed and started
+        Then:
+            It should construct without error and start with an empty
+            worker set — the fail-fast is quorum-gated
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="2.0.0",
+            )
+            for i in range(2)
+        ]
+        proxy = WorkerProxy(workers=workers, credentials=None, quorum=None, lazy=False)
+
+        # Act
+        await proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert proxy.workers == []
+
+        # Cleanup
+        await proxy.stop()
+
+    @given(
+        workers=_gate_worker_lists(),
+        quorum=st.one_of(st.none(), st.integers(min_value=0, max_value=8)),
+    )
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test___init___should_validate_quorum_against_compatible_static_workers(
+        self, mocker: MockerFixture, workers, quorum
+    ):
+        """Test constructor-gate consistency over generated static lists.
+
+        Given:
+            A generated non-empty static worker list with mixed secure
+            flags and compatible, older, other-major, and unparsable
+            versions, and a generated quorum.
+        When:
+            WorkerProxy is instantiated with the workers and quorum.
+        Then:
+            It should raise ValueError naming the compatible worker
+            count exactly when the quorum exceeds the number of
+            workers passing the public security/version predicate, and
+            construct successfully otherwise.
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.2.0")
+        compatible = _gate_predicate("1.2.0")
+        compatible_count = sum(1 for worker in workers if compatible(worker))
+
+        # Act & assert
+        if quorum is not None and quorum > compatible_count:
+            with pytest.raises(ValueError, match="compatible worker count"):
+                WorkerProxy(workers=workers, credentials=None, quorum=quorum)
+        else:
+            proxy = WorkerProxy(workers=workers, credentials=None, quorum=quorum)
+            assert isinstance(proxy, WorkerProxy)
+
+    @given(scenario=_gate_event_scenarios())
+    @settings(
+        max_examples=75,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_start_should_admit_exactly_compatible_workers_when_stream_arbitrary(
+        self, mocker: MockerFixture, scenario
+    ):
+        """Test the sentinel admits exactly the model-predicted set.
+
+        Given:
+            A generated stream of add, update, and drop events over a
+            small worker universe with mixed versions and secure
+            flags, a drawn local protocol version, and a drawn lease.
+        When:
+            A non-lazy insecure proxy consumes the full stream.
+        Then:
+            It should admit exactly the workers a reconcile model
+            predicts — adds and updates alike admit a compatible worker
+            under the lease, evict one that becomes incompatible, and
+            refresh one already held; drops always remove.
+        """
+        # Arrange
+        local_version, lease, events = scenario
+        mocker.patch.object(protocol, "__version__", local_version)
+        mocker.patch.object(wp, "WorkerConnection", return_value=mocker.MagicMock())
+        compatible = _gate_predicate(local_version)
+        model: dict[uuid.UUID, WorkerMetadata] = {}
+        for event in events:
+            metadata = event.metadata
+            uid = metadata.uid
+            if event.type == "worker-dropped":
+                model.pop(uid, None)
+            elif not compatible(metadata):
+                model.pop(uid, None)
+            elif uid in model or lease is None or len(model) < lease:
+                model[uid] = metadata
+        expected = set(model.values())
+
+        async def _scenario():
+            proxy = WorkerProxy(
+                discovery=wp.ReducibleAsyncIterator(events),
+                credentials=None,
+                lease=lease,
+                quorum=None,
+                lazy=False,
+            )
+            await proxy.start()
+            await _drain_until(lambda: len(proxy.workers) == len(model), timeout=1.0)
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            admitted = set(proxy.workers)
+            await proxy.stop()
+            return admitted
+
+        # Act
+        admitted = asyncio.run(_scenario())
+
+        # Assert
+        assert admitted == expected
+        assert not any(worker.secure for worker in admitted)
+        assert all(compatible(worker) for worker in admitted)
+        assert lease is None or len(admitted) <= lease
 
     @pytest.mark.asyncio
     async def test_cloudpickle_serialization_preserves_lease(
@@ -2877,17 +4277,17 @@ class TestWorkerProxy:
         ):
             WorkerProxy(workers=workers, quorum=5)
 
-    def test___init___with_static_workers_unparseable_version_filtered(self):
-        """Test workers with unparseable versions are filtered out of quorum count.
+    def test___init___with_static_workers_unparsable_version_filtered(self):
+        """Test workers with unparsable versions are filtered out of quorum count.
 
         Given:
             A static workers list of length 2 where one worker has an
-            unparseable version, and quorum=2
+            unparsable version, and quorum=2
         When:
             WorkerProxy is instantiated
         Then:
             It should raise ValueError reporting "1 of 2" — the
-            unparseable-version worker is rejected by the version filter
+            unparsable-version worker is rejected by the version filter
         """
         # Arrange
         workers = [
@@ -3015,7 +4415,7 @@ class TestWorkerProxy:
                 uid=uuid.uuid4(),
                 address=f"192.168.1.{i}:50051",
                 pid=1000 + i,
-                version="1.0.0",
+                version=protocol.__version__,
             )
             for i in range(2)
         ]
@@ -3093,7 +4493,7 @@ class TestWorkerProxy:
                 uid=uuid.uuid4(),
                 address=f"192.168.1.{i}:50051",
                 pid=1000 + i,
-                version="1.0.0",
+                version=protocol.__version__,
             )
             for i in range(2)
         ]
@@ -3659,7 +5059,7 @@ class TestWorkerProxy:
             uid=uuid.uuid4(),
             address="192.168.1.100:50051",
             pid=1001,
-            version="1.0.0",
+            version=protocol.__version__,
         )
 
         class RecoverableDiscovery:
@@ -3736,7 +5136,7 @@ class TestWorkerProxy:
             uid=uuid.uuid4(),
             address="192.168.1.101:50051",
             pid=1002,
-            version="1.0.0",
+            version=protocol.__version__,
         )
 
         class RecoverableDiscovery:
@@ -3982,7 +5382,10 @@ class TestWorkerProxy:
         """
         # Arrange
         metadata = WorkerMetadata(
-            uid=uuid.uuid4(), address="127.0.0.1:50051", pid=1234, version="1.0.0"
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50051",
+            pid=1234,
+            version=protocol.__version__,
         )
 
         # Create discovery service that will emit worker event
@@ -4036,7 +5439,7 @@ class TestWorkerProxy:
             uid=uuid.uuid4(),
             address="192.168.1.100:50051",
             pid=1001,
-            version="1.0.0",
+            version=protocol.__version__,
         )
 
         class GatedDiscovery:
@@ -4197,7 +5600,7 @@ class TestWorkerProxy:
             uid=uuid.uuid4(),
             address="127.0.0.1:50051",
             pid=1234,
-            version="1.0.0",
+            version=protocol.__version__,
         )
 
         # Inject worker into discovery service before starting proxy
@@ -4420,31 +5823,57 @@ class TestWorkerProxy:
         """Test pickle roundtrip does not include credentials.
 
         Given:
-            A started WorkerProxy with WorkerCredentials.
+            A WorkerProxy with WorkerCredentials and a discovery stream
+            carrying one secure and one insecure worker.
         When:
-            Cloudpickle serialization and deserialization are performed
-            outside a WorkerCredentials context.
+            The proxy is serialized, deserialized outside any
+            WorkerCredentials context, and the restored proxy is
+            started.
         Then:
-            The unpickled proxy should resolve to None credentials
-            (insecure) and only discover insecure workers.
+            It should admit only the insecure worker — the restored
+            admission gate is rebuilt from the restoring context's
+            absent credentials, not carried in the pickle.
         """
         # Arrange
         mocker.patch.object(protocol, "__version__", "1.0.0")
-        discovery_service = LocalDiscovery("test-pool").subscriber
+        secure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+            secure=True,
+        )
+        insecure_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="1.0.0",
+            secure=False,
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=secure_worker),
+            DiscoveryEvent("worker-added", metadata=insecure_worker),
+        ]
         proxy = WorkerProxy(
-            discovery=discovery_service,
+            discovery=wp.ReducibleAsyncIterator(events),
             credentials=worker_credentials,
         )
+        pickled_data = wool.__serializer__.dumps(proxy)
 
-        async with proxy:
-            pickled_data = wool.__serializer__.dumps(proxy)
-
-        # Act — unpickle outside any WorkerCredentials context
+        # Act — unpickle outside any WorkerCredentials context and start
         unpickled_proxy = cloudpickle.loads(pickled_data)
+        await unpickled_proxy.start()
+        await asyncio.sleep(0.1)
 
-        # Assert — credentials not carried; proxy acts insecure
+        # Assert — credentials not carried; the restored gate admits
+        # only insecure workers
         assert isinstance(unpickled_proxy, WorkerProxy)
         assert unpickled_proxy.id == proxy.id
+        assert insecure_worker in unpickled_proxy.workers
+        assert secure_worker not in unpickled_proxy.workers
+
+        # Cleanup
+        await unpickled_proxy.stop()
 
     @pytest.mark.asyncio
     async def test_cloudpickle_serialization_resolves_credentials_from_context(
@@ -4453,27 +5882,19 @@ class TestWorkerProxy:
         """Test unpickled proxy resolves credentials from ContextVar.
 
         Given:
-            A WorkerProxy serialized with credentials.
+            An insecure WorkerProxy serialized with a discovery stream
+            carrying one secure and one insecure worker.
         When:
-            Deserialized inside a WorkerCredentials context with
-            secure and insecure static workers.
+            The payload is deserialized inside a WorkerCredentials
+            context and the restored proxy is started after the
+            context exits.
         Then:
-            The restored proxy should discover only secure workers,
-            confirming credentials resolved from the ContextVar.
+            It should admit only the secure worker — the restored gate
+            resolves credentials from the ContextVar at load time, not
+            at start time.
         """
         # Arrange
         mocker.patch.object(protocol, "__version__", "1.0.0")
-        discovery_service = LocalDiscovery("test-pool").subscriber
-        proxy = WorkerProxy(
-            discovery=discovery_service,
-            credentials=worker_credentials,
-        )
-
-        async with proxy:
-            wool.__serializer__.dumps(proxy)
-
-        # Act — unpickle inside a WorkerCredentials context with
-        # static workers so we can observe the security filter
         secure_worker = WorkerMetadata(
             uid=uuid.uuid4(),
             address="192.168.1.100:50051",
@@ -4488,20 +5909,178 @@ class TestWorkerProxy:
             version="1.0.0",
             secure=False,
         )
+        events = [
+            DiscoveryEvent("worker-added", metadata=secure_worker),
+            DiscoveryEvent("worker-added", metadata=insecure_worker),
+        ]
+        proxy = WorkerProxy(
+            discovery=wp.ReducibleAsyncIterator(events),
+            credentials=None,
+        )
+        pickled_data = wool.__serializer__.dumps(proxy)
+
+        # Act — unpickle inside a WorkerCredentials context, then start
+        # after the context has exited
         with CredentialContext(worker_credentials):
-            # Unpickle restores proxy with credentials from ContextVar.
-            # Verify by constructing a new proxy (same mechanism) with
-            # static workers — default credentials resolve from ContextVar.
-            restored_proxy = WorkerProxy(
-                workers=[secure_worker, insecure_worker],
-                lazy=False,
-            )
+            restored_proxy = cloudpickle.loads(pickled_data)
+        await restored_proxy.start()
+        await asyncio.sleep(0.1)
 
         # Assert — resolved credentials from ContextVar: only secure workers
-        await restored_proxy.start()
-        await asyncio.sleep(0.05)
         assert secure_worker in restored_proxy.workers
         assert insecure_worker not in restored_proxy.workers
+
+        # Cleanup
+        await restored_proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_cloudpickle_serialization_should_rebuild_version_gate_on_restore(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test the restored gate uses the restoring process's version.
+
+        Given:
+            An insecure WorkerProxy serialized under local protocol
+            version 1.0.0 with a discovery stream carrying a 1.0.0
+            worker and a 2.5.0 worker.
+        When:
+            The local protocol version is re-patched to 2.0.0 before
+            deserialization and the restored proxy is started.
+        Then:
+            It should admit only the 2.5.0 worker — the origin-side
+            admissible 1.0.0 worker is rejected under the restoring
+            side's major version.
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        origin_major_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.1:50051",
+            pid=1001,
+            version="1.0.0",
+        )
+        next_major_worker = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="192.168.1.2:50051",
+            pid=1002,
+            version="2.5.0",
+        )
+        events = [
+            DiscoveryEvent("worker-added", metadata=origin_major_worker),
+            DiscoveryEvent("worker-added", metadata=next_major_worker),
+        ]
+        proxy = WorkerProxy(
+            discovery=wp.ReducibleAsyncIterator(events),
+            credentials=None,
+        )
+        pickled_data = wool.__serializer__.dumps(proxy)
+
+        # Act — restore under a different local protocol version
+        mocker.patch.object(protocol, "__version__", "2.0.0")
+        restored_proxy = cloudpickle.loads(pickled_data)
+        await restored_proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert next_major_worker in restored_proxy.workers
+        assert origin_major_worker not in restored_proxy.workers
+
+        # Cleanup
+        await restored_proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_cloudpickle_serialization_should_regate_static_workers_on_restore(
+        self, mock_proxy_session, worker_credentials, mocker: MockerFixture
+    ):
+        """Test origin-filtered static workers are re-gated on restore.
+
+        Given:
+            An insecure WorkerProxy built with two compatible insecure
+            static workers and quorum=None, serialized after the
+            construction-time filter passed both into the reduce
+            payload.
+        When:
+            The payload is deserialized inside a WorkerCredentials
+            context and the restored proxy is started.
+        Then:
+            It should admit no workers — the carried events travel the
+            discovery restore path and every one is re-checked by the
+            restored sentinel's credentialed gate.
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+                secure=False,
+            )
+            for i in range(2)
+        ]
+        proxy = WorkerProxy(workers=workers, credentials=None, quorum=None)
+        pickled_data = wool.__serializer__.dumps(proxy)
+
+        # Act — restore inside a credentialed context
+        with CredentialContext(worker_credentials):
+            restored_proxy = cloudpickle.loads(pickled_data)
+        await restored_proxy.start()
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert restored_proxy.workers == []
+
+        # Cleanup
+        await restored_proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_cloudpickle_serialization_should_replay_static_stream_on_restore(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test a consumed static event stream replays after restore.
+
+        Given:
+            A started insecure WorkerProxy built from two compatible
+            static workers whose carried event stream has been fully
+            consumed, serialized while started.
+        When:
+            The payload is deserialized in the same insecure context
+            and the restored proxy is started.
+        Then:
+            It should admit both workers again — the carried iterator
+            resets on reduction, so the restored sentinel replays the
+            full static event list.
+        """
+        # Arrange
+        mocker.patch.object(protocol, "__version__", "1.0.0")
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"192.168.1.{i}:50051",
+                pid=1000 + i,
+                version="1.0.0",
+                secure=False,
+            )
+            for i in range(2)
+        ]
+        proxy = WorkerProxy(workers=workers, credentials=None, quorum=None, lazy=False)
+        await proxy.start()
+        await _drain_until(lambda: len(proxy.workers) == 2)
+        pickled_data = wool.__serializer__.dumps(proxy)
+        await proxy.stop()
+
+        # Act
+        restored_proxy = cloudpickle.loads(pickled_data)
+        await restored_proxy.start()
+        await _drain_until(lambda: len(restored_proxy.workers) == 2)
+
+        # Assert — the positive control for restore-side re-gating:
+        # the carried stream was non-empty and replayed in full
+        assert workers[0] in restored_proxy.workers
+        assert workers[1] in restored_proxy.workers
+
+        # Cleanup
         await restored_proxy.stop()
 
     def test_cloudpickle_serialization_with_sync_cm_loadbalancer_raises(
@@ -4897,18 +6476,20 @@ class TestWorkerProxy:
         # Cleanup
         await proxy.stop()
 
-    @pytest.mark.asyncio
-    async def test_pool_uri_combined_filter(self, mocker: MockerFixture):
-        """Test pool URI filter combines tag matching, security, and version
-        filtering.
+    def test___init___should_build_tag_only_filter_when_pool_uri_supplied(
+        self, mocker: MockerFixture
+    ):
+        """Test pool URI subscription filter applies tag semantics only.
 
         Given:
             A WorkerProxy instantiated with a pool URI and extra tags.
         When:
-            The discovery filter is evaluated against workers.
+            The discovery subscription filter is evaluated against
+            workers.
         Then:
-            Only workers matching the tags, security, and version
-            requirements pass the filter.
+            It should admit workers by tag intersection alone —
+            security and version compatibility are enforced at sentinel
+            admission, not in the subscription filter.
         """
         # Arrange
         mocker.patch.object(protocol, "__version__", "1.0.0")
@@ -4922,7 +6503,7 @@ class TestWorkerProxy:
         # Capture the filter passed to subscribe()
         filter_fn = mock_local_discovery.subscribe.call_args.kwargs["filter"]
 
-        # Act & assert — matching tags, insecure (no credentials)
+        # Act & assert — matching tags pass
         matching = WorkerMetadata(
             uid=uuid.uuid4(),
             address="127.0.0.1:50051",
@@ -4933,7 +6514,7 @@ class TestWorkerProxy:
         )
         assert filter_fn(matching) is True
 
-        # Act & assert — no matching tags
+        # Act & assert — no matching tags fail
         non_matching = WorkerMetadata(
             uid=uuid.uuid4(),
             address="127.0.0.1:50052",
@@ -4944,8 +6525,8 @@ class TestWorkerProxy:
         )
         assert filter_fn(non_matching) is False
 
-        # Act & assert — matching tags but secure (no credentials means
-        # security filter rejects secure workers)
+        # Act & assert — matching tags pass despite a security mismatch;
+        # the sentinel admission gate owns compatibility rejection
         secure_matching = WorkerMetadata(
             uid=uuid.uuid4(),
             address="127.0.0.1:50053",
@@ -4954,7 +6535,29 @@ class TestWorkerProxy:
             tags=frozenset(["pool-1"]),
             secure=True,
         )
-        assert filter_fn(secure_matching) is False
+        assert filter_fn(secure_matching) is True
+
+        # Act & assert — matching tags pass despite a version mismatch
+        version_mismatched = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50054",
+            pid=4,
+            version="2.0.0",
+            tags=frozenset(["pool-1"]),
+            secure=False,
+        )
+        assert filter_fn(version_mismatched) is True
+
+        # Act & assert — the extra-tag member of the union matches alone
+        extra_tag_only = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50055",
+            pid=5,
+            version="1.0.0",
+            tags=frozenset(["extra-tag"]),
+            secure=False,
+        )
+        assert filter_fn(extra_tag_only) is True
 
     @given(num_proxies=st.integers(min_value=2, max_value=20))
     @settings(
@@ -5140,7 +6743,7 @@ async def _make_proxy_with_workers(
                 uid=uuid.uuid4(),
                 address=f"127.0.0.1:{50100 + i}",
                 pid=9000 + i,
-                version="1.0.0",
+                version=protocol.__version__,
             )
             for i in range(len(connections))
         ]

--- a/wool/tests/test_public.py
+++ b/wool/tests/test_public.py
@@ -36,6 +36,7 @@ def test_public_api_completeness_should_match_expected_surface():
         "RpcError",
         "TransientRpcError",
         "UnexpectedResponse",
+        "UnparsableVersionWarning",
         "WorkerConnection",
         "ChainContention",
         "ChainSerializationError",


### PR DESCRIPTION
## Summary

Every discovery source now passes one admission rule enforced in the worker sentinel: `worker-added` and `worker-updated` events are handled identically and reconcile a worker's membership to its current eligibility under the combined security/version predicate — admitting a compatible worker under the lease, evicting one whose posture flips incompatible, and refreshing one already held; `worker-dropped` removes unconditionally. Previously the predicate lived in the construction paths — the pool-URI arm baked it into its subscription filter and the static-workers arm filtered at construction — so user-supplied discovery subscribers and every `WorkerPool` subscription admitted workers unfiltered, deferring the failure to connect and handshake where it surfaced as transient-error and eviction noise.

Reconciling on every event, rather than admitting only on `worker-added`, tracks a worker correctly as it crosses the compatibility boundary in either direction on every path, and fills a freed lease slot from the next refresh that carries an eligible worker. This also retires the narrower rule from #292 that a refresh never admits: because the discovery subscriber emits `worker-added` for a uid once and then re-publishes a still-registered worker as `worker-updated` on every scan, that rule left a worker refused for capacity permanently unadmitted even after a slot freed. Reconciling fixes that pre-existing idle-slot bug as a side effect, and inverts the #292 test that pinned the old behavior. Each rejection and eviction is logged with the worker uid and the failing gate half.

This is a behavior change for callers relying on unfiltered custom discovery: an incompatible worker is never admitted, and quorum waits no longer count one. A proxy restored from a pickle re-derives the predicate from the restoring process's credential context and protocol version — the gate is deliberately not serialized, so admission always reflects the environment doing the admitting.

Closes #293

## Proposed changes

### Reconcile admission in the worker sentinel

Collapse `worker-added` and `worker-updated` into one reconcile branch: an event whose metadata fails the combined security/version predicate evicts the worker if it was admitted and is otherwise ignored; an eligible worker not yet held is admitted subject to the lease; an eligible worker already held is refreshed in place. `worker-dropped` removes unconditionally. The lease is consulted only when admitting an absent worker, so a rejected worker never consumes capacity, and membership changes wake the quorum wait while in-place refreshes do not. Reduce the pool-URI subscription filter to tag semantics only; the static-workers arm keeps its construction-time filter for the fail-fast quorum-versus-compatible-count validation. Log each rejection and eviction at debug with the worker uid and the failing gate half. The predicate is deliberately not serialized: a restored proxy rebuilds its gate from its own credential context and protocol version. Enforcing here rather than restoring compatibility to the pool-URI subscription filter keeps one authoritative gate on every path — including raw `discovery=` streams that never pass through `afilter` — and needs no per-uid "seen but rejected" bookkeeping.

### Own the gate contract in the WorkerProxy docstring

Document the gate on `WorkerProxy` as a non-overridable invariant — the version floor is a wire-protocol requirement the interceptor also enforces server-side, and an uncredentialed proxy cannot handshake with a secure worker — along with its fail-closed semantics (an unparseable worker version is rejected; an unresolvable local version admits nothing) and its restore-time re-derivation. Reduce the `discovery` parameters of `WorkerProxy` and `WorkerPool` to pointers at that owner, and record the behavior change as a `versionchanged` directive rather than inline changelog prose.

### Adapt and extend the worker test suite

Advertise the ambient protocol version from the mock worker factories and discovery fixtures so test doubles behave like real in-process workers, pin the local version explicitly in sentinel-feeding tests, and assert tag-only semantics on the pool-URI subscription filter. Cover the reconcile in both directions — a worker evicted when an update flips it incompatible and one admitted when an update flips it compatible — driven through the real `afilter` on the pool-URI path as well as the raw stream, and extend the Hypothesis event-stream property so its updates may flip a worker across the compatibility boundary. Add live posture-transition coverage with real workers, share one discovery double across the pool admission tests rather than re-declaring it per test, replace the integration settle sleep with a poll against a deadline, and remove `test_property_workers_list_accurate`, which asserted nothing and the fold-model property supersedes.

### Design notes

Admission coordinates through the shared uid-keyed load-balancer context, not a reactive channel back to discovery: the sentinel reconciles each event against its own admitted set, so it needs no signal from the subscriber, and a subscriber that fans out to several proxies is never mutated by one proxy's admission decision. The forward direction — a caller declaring policy through `subscribe(filter=...)` — remains the seam for pushing intent down to a cooperative discovery source, with the sentinel as the authoritative enforcement point regardless of whether that source honors it.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerProxy` | A discovery stream with compatible, same-major-older, next-major, and prior-major workers | The sentinel processes all events | Only the compatible worker is admitted | Version rule at admission |
| 2 | `TestWorkerProxy` | A stream with secure and insecure workers and no credentials | The sentinel processes all events | Only the insecure worker is admitted | Security rule, credentials absent |
| 3 | `TestWorkerProxy` | A stream with secure and insecure workers and mTLS credentials | The sentinel processes all events | Only the secure worker is admitted | Security rule, credentials present |
| 4 | `TestWorkerProxy` | A stream with an unparseable-version worker and a compatible control | The sentinel processes all events | Only the control is admitted | Unparseable worker version |
| 5 | `TestWorkerProxy` | `lease=1` and an incompatible worker preceding a compatible one | The sentinel processes all events | The compatible worker holds the slot | Gate precedes the lease check |
| 6 | `TestWorkerProxy` | An admitted worker and an incompatible update for the same uid | The sentinel processes both events | The worker is evicted and the update builds no connection | Reconcile evicts on a flip |
| 7 | `TestWorkerProxy` | An incompatible worker-added followed by its worker-dropped | The sentinel processes both events | The drop is a safe no-op and nothing is admitted | Ungated worker-dropped |
| 8 | `TestWorkerProxy` | A pool-URI proxy whose subscription surfaces a tag-matching incompatible worker and a compatible one | The sentinel processes both events | Only the compatible worker is admitted | Gate on the pool-URI path |
| 9 | `TestWorkerProxy` | A pool-URI proxy over the real `afilter` that admits a compatible worker, then an update flipping it incompatible | The sentinel processes the flip | The worker is evicted | Reconcile eviction on the afilter path |
| 10 | `TestWorkerProxy` | A pool-URI proxy over the real `afilter` that rejects an incompatible worker, then an update making it compatible | The sentinel processes the update | The worker is admitted under its compatible record | Reconcile admission on the afilter path |
| 11 | `TestWorkerProxy` | A lone worker-updated for a compatible, never-admitted worker with `quorum=1` | The proxy starts | The worker is admitted and quorum is met | An update admits like an add |
| 12 | `TestWorkerProxy` | A worker dropped, then a same-uid update, then an unrelated add | The sentinel processes all events | The dropped worker is re-admitted under the update and the unrelated worker joins | Reconcile re-admits after a drop |
| 13 | `TestWorkerProxy` | A pool URI and extra tags | The subscription filter is evaluated | Tag intersection alone decides, including the extra-tag member | Tag-only subscription filter |
| 14 | `TestWorkerProxy` | `quorum=1`, a short timeout, and an all-incompatible stream | The proxy is entered eagerly | `asyncio.TimeoutError` propagates and nothing is admitted | Gate never satisfies quorum |
| 15 | `TestWorkerProxy` | A lazy proxy, an incompatible worker, and a gated compatible one | Dispatch is awaited, then retried after the gate opens | The first dispatch times out un-started and the retry dispatches | Retryability after gate-caused timeout |
| 16 | `TestWorkerProxy` | A proxy constructed inside a credential context and started outside it | The sentinel processes secure and insecure workers | Only the secure worker is admitted | Credential capture at construction |
| 17 | `TestWorkerProxy` | A local protocol version of "unknown" | The sentinel processes valid and "unknown"-version workers | Nothing is admitted | Fail-closed local version |
| 18 | `TestWorkerProxy` | `quorum=2` and a stepped add/drop/add/add stream | Entry runs while events release one at a time | Entry completes only when two workers are live | Quorum tracks the live count |
| 19 | `TestWorkerProxy` | An un-started lazy proxy | The workers property is read | An empty list returns without error | Pre-start workers access |
| 20 | `TestWorkerProxy` | Three static workers, two compatible, `quorum=2` | The proxy is constructed | Construction returns without error | Quorum equals the compatible count |
| 21 | `TestWorkerProxy` | Three static workers, two compatible, `quorum=2` | The proxy is started | Exactly the two compatible workers are admitted | Start admits only compatible static workers |
| 22 | `TestWorkerProxy` | A static list of one insecure and one secure worker, no credentials, `quorum=2` | The proxy is constructed | ValueError reports one of two compatible | Security in the construction count |
| 23 | `TestWorkerProxy` | An all-incompatible static list and `quorum=None` | The proxy is constructed and started | The pool starts empty without error | Quorum-gated fail-fast |
| 24 | `TestWorkerProxy` | A credentialed proxy over a mixed-security stream, pickled | The payload loads outside any credential context and starts | Only the insecure worker is admitted | Credentials are not serialized |
| 25 | `TestWorkerProxy` | An insecure proxy over a mixed-security stream, pickled | The payload loads inside a credential context and starts after it exits | Only the secure worker is admitted | Gate binds at load time |
| 26 | `TestWorkerProxy` | A proxy pickled under local 1.0.0 with 1.0.0 and 2.5.0 workers | The payload loads under local 2.0.0 and starts | Only the 2.5.0 worker is admitted | Version gate rebuilt on restore |
| 27 | `TestWorkerProxy` | A static-workers proxy pickled from an insecure context | The payload loads inside a credential context and starts | Nothing is admitted | Carried events re-gated on restore |
| 28 | `TestWorkerProxy` | A started static-workers proxy with its stream consumed, pickled | The payload loads and starts in the same context | Both workers are admitted again | Carried stream replays on restore |
| 29 | Module level | Arbitrary text biased with stringified versions | `parse_version` is called | None or a re-parseable Version returns, never an exception | Parse tolerance |
| 30 | Module level | Any generated PEP 440 version | Compatibility is checked against itself | True returns | Reflexivity |
| 31 | Module level | Two distinct same-major versions | Compatibility is checked both ways | Only the lower client passes | Same-major ordering |
| 32 | Module level | Two versions with differing majors | Compatibility is checked both ways | Both directions fail | Major fencing |
| 33 | `TestWorkerProxy` | A generated static list with mixed security and versions, and a generated quorum | The proxy is constructed | ValueError exactly when quorum exceeds the predicate-compatible count | Constructor-gate consistency |
| 34 | `TestWorkerProxy` | A generated add/update/drop stream whose updates may flip a worker across the compatibility boundary, with a drawn local version and lease | A non-lazy proxy consumes the stream | The admitted set equals a reconcile-fold oracle | Reconcile and lease under arbitrary interleavings |
| 35 | `TestWorkerPool` | A durable pool over a custom source yielding only a next-major worker | The pool is entered eagerly | `asyncio.TimeoutError` raises at entry | Pool-level gate and quorum |
| 36 | `TestWorkerPool` | A durable pool with `lease=1` over an incompatible-then-compatible stream | The pool is entered eagerly | Only the compatible worker is admitted | Pool wiring composes with the gate |
| 37 | `TestWorkerPool` | A hybrid pool with a tag and a filter-capturing source | The captured predicate is evaluated | Tag intersection alone decides | Tag-only spawn-arm subscriptions |
| 38 | `TestWorkerPool` | A hybrid pool with no tags | The captured predicate is evaluated | Every worker matches | Match-all no-tags branch |
| 39 | `TestWorkerPool` | A durable pool constructed with credentials | The pool is entered | The proxy receives the same credentials instance | Credentials forwarding |
| 40 | `TestWorkerUpdatePropagation` | A pool with `lease=1` holding one worker and a second the cap rejected | The admitted worker is dropped, freeing the slot | The rejected worker fills the slot on its next refresh and dispatch reaches it | Reconcile fills a freed lease slot end to end |
| 41 | `TestDiscoveryAdmissionGate` | A real worker and four fabricated incompatible records in one namespace | A durable pool enters and dispatches five times | Exactly the real worker is admitted throughout and every dispatch succeeds | End-to-end chaff screening |
| 42 | `TestSecurityPostureAdmission` | Real insecure and mTLS workers and an insecure pool | The pool enters and dispatches | Only the insecure worker is admitted | Insecure pool cross |
| 43 | `TestSecurityPostureAdmission` | The same workers and an mTLS pool | The pool enters and dispatches | Only the secure worker is admitted over mTLS | Credentialed pool cross |
| 44 | `TestHybridAdmissionGate` | A hybrid pool spawning one worker into a chaff-seeded namespace | The pool enters and dispatches | Only the spawned worker is admitted | Hybrid path end to end |
| 45 | `TestStaticWorkersAdmission` | A static list of one real worker plus the chaff records | The proxy enters and dispatches | Only the real worker is admitted and the dispatch returns | Static path end to end |
| 46 | `TestPostureTransitionAdmission` | A real admitted insecure worker | An update flips it to `secure=True` | Dispatch raises `NoWorkersAvailable` within a deadline | Live eviction on a posture flip |
| 47 | `TestPostureTransitionAdmission` | A worker evicted by a secure flip | An update restores its real compatible metadata | Dispatch reaches it within a deadline | Live re-admission on a posture flip |
