### PR TITLE
Live worker processes wedge interpreter exit via the multiprocessing atexit join — Closes #294

### DIFF
--- a/wool/src/wool/runtime/worker/local.py
+++ b/wool/src/wool/runtime/worker/local.py
@@ -8,6 +8,8 @@ from typing import Final
 import grpc.aio
 
 from wool import protocol
+from wool.runtime.typing import Undefined
+from wool.runtime.typing import UndefinedType
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import Worker
 from wool.runtime.worker.base import WorkerOptions
@@ -82,6 +84,10 @@ class LocalWorker(Worker):
         gRPC ``RESOURCE_EXHAUSTED``, causing the load balancer to
         skip to the next worker. ``None`` (default) accepts all
         tasks unconditionally.
+    :param daemon:
+        Whether the worker subprocess is daemonic. Forwarded to
+        `WorkerProcess`, which owns the default and the per-value
+        semantics; omit to accept that default.
     :param extra:
         Additional metadata as key-value pairs.
     """
@@ -99,6 +105,7 @@ class LocalWorker(Worker):
         credentials: WorkerCredentials | None = None,
         options: WorkerOptions | None = None,
         backpressure: BackpressureLike | None = None,
+        daemon: bool | None | UndefinedType = Undefined,
         **extra: Any,
     ):
         super().__init__(*tags, **extra)
@@ -114,6 +121,7 @@ class LocalWorker(Worker):
             tags=frozenset(self._tags),
             extra=self._extra,
             backpressure=backpressure,
+            **({} if daemon is Undefined else {"daemon": daemon}),
         )
 
     @property

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -247,11 +247,12 @@ class WorkerPool:
         the full teardown sequence: each worker's ``stop()`` receives
         ``shutdown_timeout`` as its per-worker bound, the gather waits
         for whatever time remains, and publisher cleanup gets whatever
-        is left. When the deadline elapses, abandoned worker UIDs are
-        logged via ``logging.warning`` and teardown proceeds — an
-        abandoned `LocalWorker` is still reaped off-loop (see
-        `LocalWorker._stop`), which can hold ``__aexit__`` past the
-        deadline by up to the reap escalation. ``None`` disables the
+        is left. When the deadline elapses, the pool stops waiting and
+        logs the UIDs it stopped waiting on via ``logging.warning``.
+        Those workers are not leaked: a `LocalWorker` is still reaped
+        off-loop (see `LocalWorker._stop`), which can hold ``__aexit__``
+        past the deadline by up to the reap escalation — what is lost is
+        the graceful drain, not the process. ``None`` disables the
         bound. Must be positive when provided. Defaults to ``60.0``.
     :param lazy:
         When ``True`` (default), defer discovery setup and the quorum
@@ -617,8 +618,8 @@ class WorkerPool:
         bind host (see `~wool.DiscoveryPublisherLike.bind_host`);
         bound factories own their binding. Teardown applies the
         pool's ``shutdown_timeout`` as a single deadline across worker
-        stops and publisher cleanup, logging any workers it abandons
-        (see ``shutdown_timeout``), and runs even when publisher
+        stops and publisher cleanup, logging any workers it stops
+        waiting on (see ``shutdown_timeout``), and runs even when publisher
         validation or worker construction fails, so an entered
         publisher context is never leaked.
 
@@ -689,23 +690,24 @@ class WorkerPool:
                 for task in pending:
                     task.cancel()
                 await asyncio.gather(*done, *pending, return_exceptions=True)
-                abandoned_tasks = set(pending)
+                reaped_tasks = set(pending)
                 for task in done:
                     if not task.cancelled() and isinstance(
                         task.exception(), TimeoutError
                     ):
-                        abandoned_tasks.add(task)
-                if abandoned_tasks:
-                    abandoned_uids = sorted(
-                        str(worker_by_task[task].uid) for task in abandoned_tasks
+                        reaped_tasks.add(task)
+                if reaped_tasks:
+                    reaped_uids = sorted(
+                        str(worker_by_task[task].uid) for task in reaped_tasks
                     )
                     logger.warning(
-                        "WorkerPool shutdown abandoned %d worker(s) "
-                        "that did not stop within %ss: %s",
-                        len(abandoned_uids),
+                        "WorkerPool shutdown stopped waiting for %d worker(s) "
+                        "that did not stop gracefully within %ss and reaped "
+                        "them; in-flight work may have been lost: %s",
+                        len(reaped_uids),
                         self._shutdown_timeout,
-                        abandoned_uids,
-                        extra={"abandoned_worker_uids": abandoned_uids},
+                        reaped_uids,
+                        extra={"reaped_worker_uids": reaped_uids},
                     )
 
             try:

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -252,8 +252,11 @@ class WorkerPool:
         Those workers are not leaked: a `LocalWorker` is still reaped
         off-loop (see `LocalWorker._stop`), which can hold ``__aexit__``
         past the deadline by up to the reap escalation — what is lost is
-        the graceful drain, not the process. ``None`` disables the
-        bound. Must be positive when provided. Defaults to ``60.0``.
+        the graceful drain, not the process. A stop that fails for any
+        other reason is logged via ``logging.error`` and teardown
+        continues, so one worker's failure never strands another's
+        cleanup. ``None`` disables the bound. Must be positive when
+        provided. Defaults to ``60.0``.
     :param lazy:
         When ``True`` (default), defer discovery setup and the quorum
         wait to the first `WorkerProxy.dispatch`.  When ``False``,
@@ -657,7 +660,14 @@ class WorkerPool:
                     await publisher_svc.publish("worker-added", worker.metadata)
 
                 async def stop(worker):
-                    await publisher_svc.publish("worker-dropped", worker.metadata)
+                    if (metadata := worker.metadata) is None:
+                        # A worker whose start failed was never announced
+                        # and cannot be stopped (`Worker.stop` rejects it),
+                        # so teardown has nothing to undo.
+                        return
+                    # Announce the drop before stopping so subscribers
+                    # stop routing to a worker that is about to go away.
+                    await publisher_svc.publish("worker-dropped", metadata)
                     await worker.stop(timeout=self._shutdown_timeout)
 
                 task = asyncio.create_task(start(worker))
@@ -691,11 +701,19 @@ class WorkerPool:
                     task.cancel()
                 await asyncio.gather(*done, *pending, return_exceptions=True)
                 reaped_tasks = set(pending)
-                for task in done:
-                    if not task.cancelled() and isinstance(
-                        task.exception(), TimeoutError
-                    ):
+                for task in worker_by_task:
+                    if task.cancelled():
+                        continue
+                    if (error := task.exception()) is None:
+                        continue
+                    if isinstance(error, TimeoutError):
                         reaped_tasks.add(task)
+                    else:
+                        logger.error(
+                            "WorkerPool shutdown could not stop worker %s cleanly",
+                            worker_by_task[task].uid,
+                            exc_info=error,
+                        )
                 if reaped_tasks:
                     reaped_uids = sorted(
                         str(worker_by_task[task].uid) for task in reaped_tasks

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -64,6 +64,14 @@ class WorkerProcess(Process):
     Communicates the bound port back to the parent process via pipe after
     startup. Handles SIGTERM and SIGINT for graceful shutdown.
 
+    Spawned daemonic by default, so a worker still alive at interpreter
+    exit never blocks it and never outlives its parent. One
+    consequence: daemonic processes cannot spawn
+    `multiprocessing` children (including
+    `concurrent.futures.ProcessPoolExecutor`), so a routine that must
+    create them requires a non-daemonic worker; `subprocess` and
+    `asyncio` subprocesses are unaffected.
+
     :param host:
         Host address to bind.
     :param port:
@@ -76,7 +84,7 @@ class WorkerProcess(Process):
         Optional worker credentials for TLS/mTLS.
     :param options:
         gRPC message size options. Defaults to
-        :class:`WorkerOptions` with 100 MB limits.
+        `WorkerOptions` with 100 MB limits.
     :param uid:
         Unique identifier for this worker. Auto-generated if not
         provided.
@@ -86,13 +94,30 @@ class WorkerProcess(Process):
         Additional metadata as key-value pairs.
     :param backpressure:
         Optional admission control hook. See
-        :class:`~wool.runtime.worker.service.BackpressureLike`.
-        Serialized via :data:`wool.__serializer__` for transfer to
+        `~wool.runtime.worker.service.BackpressureLike`.
+        Serialized via `wool.__serializer__` for transfer to
         the subprocess.
+    :param daemon:
+        Whether the worker process is daemonic. Defaults to ``True``.
+        ``False`` opts out, which a routine that must create
+        `multiprocessing` children requires. ``None`` inherits from the
+        creating process, per `multiprocessing.Process`.
     :param args:
-        Additional args for :class:`multiprocessing.Process`.
+        Additional args for `multiprocessing.Process`.
     :param kwargs:
-        Additional kwargs for :class:`multiprocessing.Process`.
+        Additional kwargs for `multiprocessing.Process`.
+
+    .. rubric:: Implementation notes
+
+    The daemonic default and the parent-death watchdog cover opposite
+    directions of one invariant: neither process outlives the other.
+    `multiprocessing`'s atexit handler terminates daemonic children
+    before joining them, and the SIGTERM handler turns that termination
+    into a graceful stop. Were the child non-daemonic, the same handler
+    would join it while still live — and the child's watchdog cannot
+    fire until the parent is already gone, so the join wedges
+    interpreter exit. The watchdog covers the reverse case, where the
+    parent dies first.
     """
 
     _port: int | None
@@ -117,9 +142,10 @@ class WorkerProcess(Process):
         tags: frozenset[str] = frozenset(),
         extra: dict[str, Any] | None = None,
         backpressure: BackpressureLike | None = None,
+        daemon: bool | None = True,
         **kwargs,
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, daemon=daemon, **kwargs)
         if not host:
             raise ValueError("Host must be a non-blank string")
         self._host = host

--- a/wool/tests/integration/test_integration.py
+++ b/wool/tests/integration/test_integration.py
@@ -32,6 +32,13 @@ from .conftest import scenarios_strategy
 
 _INTEGRATION_TIMEOUT = 30
 
+# The Hypothesis exploration is load-sensitive: a heavy example on a
+# busy machine can overrun the 30s bound the pairwise cases run under,
+# and the resulting asyncio.timeout cancellation strands live workers in
+# pool teardown (#294). It gets its own, looser bound rather than
+# sharing one.
+_HYPOTHESIS_TIMEOUT = 90
+
 
 @pytest.mark.integration
 def test_pairwise_scenarios_cover_all_discovery_members():
@@ -166,7 +173,7 @@ async def test_dispatch_hypothesis(scenario, credentials_map, retry_grpc_interna
 
     # Arrange, act, & assert
     async def body():
-        async with asyncio.timeout(_INTEGRATION_TIMEOUT):
+        async with asyncio.timeout(_HYPOTHESIS_TIMEOUT):
             async with build_pool_from_scenario(scenario, credentials_map):
                 # See ``test_dispatch_pairwise`` above for the
                 # rationale behind isolating each Hypothesis example

--- a/wool/tests/integration/test_worker_shutdown.py
+++ b/wool/tests/integration/test_worker_shutdown.py
@@ -21,6 +21,9 @@ from . import routines
 from .conftest import build_pool_from_scenario
 from .conftest import default_scenario
 
+# This helper script must stay a `python -c` string: it has no
+# `__main__` guard, so as a script file the spawn bootstrap's re-import
+# of `__main__` would re-run it in every worker child.
 _PARENT_SCRIPT = """
 import asyncio
 
@@ -33,6 +36,27 @@ async def main():
     assert worker.metadata is not None
     print(worker.metadata.pid, flush=True)
     await asyncio.sleep(300)
+
+
+asyncio.run(main())
+"""
+
+# `python -c` string for the same reason as `_PARENT_SCRIPT` above.
+_ABANDON_SCRIPT = """
+import asyncio
+import sys
+
+from wool.runtime.worker.local import LocalWorker
+
+
+async def main():
+    worker = LocalWorker(shutdown_grace_period=5.0)
+    await worker.start(timeout=30)
+    assert worker.metadata is not None
+    print(worker.metadata.pid, flush=True)
+    # Hold here so the test owns the moment abandonment begins.
+    sys.stdin.readline()
+    # Return without stopping the worker — abandonment distilled.
 
 
 asyncio.run(main())
@@ -145,6 +169,53 @@ class TestWorkerOrphanPrevention:
                 helper.wait(timeout=10)
             _ensure_killed(worker_pid)
 
+    def test_interpreter_exit_should_not_block_when_worker_abandoned(self):
+        """Test an abandoned worker cannot wedge parent interpreter exit.
+
+        Given:
+            A parent process that started a LocalWorker and reaches
+            interpreter exit without ever stopping it, leaving
+            multiprocessing's atexit handler to deal with the live
+            child.
+        When:
+            The parent interpreter exits.
+        Then:
+            The parent should exit cleanly within a bound instead of
+            blocking in the atexit join, and the abandoned worker
+            subprocess should be terminated rather than orphaned.
+        """
+        # Arrange
+        helper = subprocess.Popen(
+            [sys.executable, "-c", _ABANDON_SCRIPT],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        worker_pid = None
+        try:
+            assert helper.stdout is not None
+            assert helper.stdin is not None
+            worker_pid = int(helper.stdout.readline().strip())
+            assert _pid_alive(worker_pid)
+
+            # Act
+            helper.stdin.write("go\n")
+            helper.stdin.flush()
+            returncode = helper.wait(timeout=30)
+
+            # Assert
+            assert returncode == 0
+            deadline = time.monotonic() + 15.0
+            while _pid_alive(worker_pid) and time.monotonic() < deadline:
+                time.sleep(0.1)
+            assert not _pid_alive(worker_pid)
+        finally:
+            if helper.poll() is None:
+                helper.kill()
+                helper.wait(timeout=10)
+            _ensure_killed(worker_pid)
+
     @pytest.mark.asyncio
     async def test_pool_exit_should_leave_no_live_worker_processes(self):
         """Test pool teardown reaps every spawned worker process.
@@ -211,6 +282,87 @@ class TestWorkerOrphanPrevention:
         finally:
             for pid in spawned:
                 _ensure_killed(pid)
+
+    @pytest.mark.asyncio
+    async def test_pool_exit_should_reap_workers_when_teardown_cancelled(self):
+        """Test a cancelled teardown still reaps every spawned worker.
+
+        Given:
+            An entered WorkerPool with two spawned local workers, under
+            an asyncio.timeout armed only once the workers are up, so
+            the cancellation lands in teardown rather than startup.
+        When:
+            The timeout cancels the pool's teardown at its first await.
+        Then:
+            It should still leave no worker subprocess alive, since each
+            worker's reap runs in an executor thread that a cancelled
+            stop cannot call off.
+        """
+        # Arrange
+        before = {child.pid for child in multiprocessing.active_children()}
+        spawned = []
+        cancelled = False
+
+        try:
+            # Act
+            try:
+                async with asyncio.timeout(None) as cancellation:
+                    async with WorkerPool("cancelled-teardown-test", spawn=2):
+                        spawned = [
+                            child.pid
+                            for child in multiprocessing.active_children()
+                            if child.pid not in before
+                        ]
+                        assert len(spawned) == 2
+                        # Arm only now, with a deadline already behind
+                        # us: the cancellation then lands at teardown's
+                        # first await, whatever teardown costs.
+                        loop = asyncio.get_running_loop()
+                        cancellation.reschedule(loop.time())
+            except TimeoutError:
+                cancelled = True
+
+            # Assert
+            assert cancelled
+            deadline = time.monotonic() + 30.0
+            while (
+                any(_pid_alive(pid) for pid in spawned) and time.monotonic() < deadline
+            ):
+                await asyncio.sleep(0.1)
+            for pid in spawned:
+                assert not _pid_alive(pid)
+        finally:
+            for pid in spawned:
+                _ensure_killed(pid)
+
+    def test_worker_should_exit_gracefully_when_sigtermed(self):
+        """Test a worker turns SIGTERM into a graceful stop.
+
+        Given:
+            A started real WorkerProcess.
+        When:
+            SIGTERM is sent to the worker process.
+        Then:
+            It should exit with exit code 0 within a bounded join, i.e.,
+            the installed handler's graceful stop rather than the
+            signal's default disposition.
+        """
+        # Arrange
+        process = WorkerProcess(shutdown_grace_period=5.0)
+        process.start(timeout=30)
+        pid = process.pid
+        assert pid is not None
+        assert _pid_alive(pid)
+
+        try:
+            # Act
+            os.kill(pid, signal.SIGTERM)
+            process.join(timeout=15)
+
+            # Assert
+            assert process.exitcode == 0
+        finally:
+            _ensure_killed(pid)
 
     def test_reap_should_terminate_worker_without_stop_rpc(self):
         """Test reap force-terminates a worker that was never stopped.

--- a/wool/tests/runtime/worker/conftest.py
+++ b/wool/tests/runtime/worker/conftest.py
@@ -313,7 +313,7 @@ class MockWorker:
         )
         self._started = True
 
-    async def stop(self) -> None:
+    async def stop(self, *, timeout: float | None = None) -> None:
         """Stop the mock worker (always succeeds)."""
         self._started = False
         self._info = None

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -1563,18 +1563,18 @@ class TestWorkerPool:
         assert elapsed < shutdown_timeout * 5
 
     @pytest.mark.asyncio
-    async def test___aexit___should_log_warning_when_workers_abandoned(
+    async def test___aexit___should_log_warning_when_workers_reaped(
         self, mocker: MockerFixture, caplog
     ):
-        """Test pool logs a warning naming the abandoned worker count and uid.
+        """Test pool logs a warning naming the reaped worker count and uid.
 
         Given:
             A WorkerPool whose worker has a stop() that never returns
         When:
             The async-with block exits and the shutdown bound elapses
         Then:
-            It should emit a logger.warning identifying the abandoned
-            count and the abandoned worker's uid
+            It should emit a logger.warning identifying the count of
+            workers it stopped waiting on and the reaped worker's uid
         """
         # Arrange
         uid = uuid.uuid4()
@@ -1605,7 +1605,7 @@ class TestWorkerPool:
             r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
         ]
         assert any(
-            "abandoned 1 worker" in message and str(uid) in message
+            "stopped waiting for 1 worker" in message and str(uid) in message
             for message in warnings
         )
 
@@ -1663,7 +1663,7 @@ class TestWorkerPool:
         When:
             The async-with block exits with shutdown_timeout configured
         Then:
-            It should complete without an abandonment warning
+            It should complete without a stopped-waiting warning
         """
 
         # Arrange
@@ -1685,7 +1685,7 @@ class TestWorkerPool:
 
         # Assert
         assert not any(
-            "abandoned" in r.getMessage()
+            "stopped waiting" in r.getMessage()
             for r in caplog.records
             if r.levelno == logging.WARNING
         )
@@ -1739,10 +1739,10 @@ class TestWorkerPool:
         assert elapsed < shutdown_timeout * 5
 
     @pytest.mark.asyncio
-    async def test___aexit___should_log_abandonment_promptly_when_stop_times_out(
+    async def test___aexit___should_log_reap_promptly_when_stop_times_out(
         self, mocker: MockerFixture, caplog
     ):
-        """Test a stop that raises TimeoutError counts as abandoned.
+        """Test a stop that raises TimeoutError counts as reaped.
 
         Given:
             A WorkerPool with a generous shutdown bound whose worker's
@@ -1750,8 +1750,8 @@ class TestWorkerPool:
         When:
             The async-with block exits
         Then:
-            It should emit the abandonment warning promptly even though
-            the pool's own deadline never elapses
+            It should emit the warning promptly even though the pool's
+            own deadline never elapses
         """
         # Arrange
         shutdown_timeout = 30.0
@@ -1777,7 +1777,7 @@ class TestWorkerPool:
 
         # Assert
         assert any(
-            "abandoned 1 worker" in r.getMessage()
+            "stopped waiting for 1 worker" in r.getMessage()
             for r in caplog.records
             if r.levelno == logging.WARNING
         )

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -1290,6 +1290,32 @@ class TestWorkerPool:
         mock_worker_proxy.__aexit__.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test___aexit___should_stop_spawned_workers(self, mock_worker_factory):
+        """Test pool teardown stops every spawned worker.
+
+        Given:
+            A WorkerPool with two spawned mock workers
+        When:
+            The async-with block exits
+        Then:
+            It should stop each worker, leaving its metadata cleared
+        """
+        # Arrange
+        spawned = []
+
+        def capturing_factory(*tags, credentials=None):
+            worker = mock_worker_factory(*tags, credentials=credentials)
+            spawned.append(worker)
+            return worker
+
+        # Act & assert
+        async with WorkerPool(worker=capturing_factory, spawn=2):
+            assert len(spawned) == 2
+            assert all(worker.metadata is not None for worker in spawned)
+
+        assert all(worker.metadata is None for worker in spawned)
+
+    @pytest.mark.asyncio
     async def test___aexit___cleanup_on_error(self, mock_worker_factory):
         """Test cleanup still occurs and exception propagates correctly.
 
@@ -1537,22 +1563,25 @@ class TestWorkerPool:
         assert elapsed < shutdown_timeout * 5
 
     @pytest.mark.asyncio
-    async def test___aexit___logs_warning_when_workers_abandoned(
+    async def test___aexit___should_log_warning_when_workers_abandoned(
         self, mocker: MockerFixture, caplog
     ):
-        """Test pool logs a warning naming the abandoned worker count.
+        """Test pool logs a warning naming the abandoned worker count and uid.
 
         Given:
             A WorkerPool whose worker has a stop() that never returns
         When:
             The async-with block exits and the shutdown bound elapses
         Then:
-            It should emit a logger.warning identifying the abandoned count
+            It should emit a logger.warning identifying the abandoned
+            count and the abandoned worker's uid
         """
-
         # Arrange
+        uid = uuid.uuid4()
+
         def hanging_factory(*tags, credentials=None):
             worker = mocker.MagicMock(spec=LocalWorker)
+            worker.uid = uid
             worker.start = mocker.AsyncMock()
 
             async def hang(*, timeout=None):
@@ -1572,10 +1601,12 @@ class TestWorkerPool:
                 pass
 
         # Assert
+        warnings = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
         assert any(
-            "abandoned 1 worker" in r.getMessage()
-            for r in caplog.records
-            if r.levelno == logging.WARNING
+            "abandoned 1 worker" in message and str(uid) in message
+            for message in warnings
         )
 
     @pytest.mark.asyncio
@@ -1706,6 +1737,119 @@ class TestWorkerPool:
         # Assert
         fast_stop.assert_awaited_once()
         assert elapsed < shutdown_timeout * 5
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_log_abandonment_promptly_when_stop_times_out(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test a stop that raises TimeoutError counts as abandoned.
+
+        Given:
+            A WorkerPool with a generous shutdown bound whose worker's
+            stop() raises TimeoutError immediately
+        When:
+            The async-with block exits
+        Then:
+            It should emit the abandonment warning promptly even though
+            the pool's own deadline never elapses
+        """
+        # Arrange
+        shutdown_timeout = 30.0
+
+        def timing_out_factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.uid = uuid.uuid4()
+            worker.start = mocker.AsyncMock()
+            worker.stop = mocker.AsyncMock(side_effect=TimeoutError)
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        # Act
+        start = time.monotonic()
+        with caplog.at_level(logging.WARNING, "wool.runtime.worker.pool"):
+            async with WorkerPool(
+                worker=timing_out_factory,
+                spawn=1,
+                shutdown_timeout=shutdown_timeout,
+            ):
+                pass
+        elapsed = time.monotonic() - start
+
+        # Assert
+        assert any(
+            "abandoned 1 worker" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+        assert elapsed < shutdown_timeout / 2
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_forward_shutdown_timeout_to_worker_stop(
+        self, mocker: MockerFixture
+    ):
+        """Test each worker's stop receives the pool's shutdown timeout.
+
+        Given:
+            A WorkerPool with shutdown_timeout configured
+        When:
+            The async-with block exits
+        Then:
+            It should await the worker's stop exactly once with the
+            configured timeout as its per-worker bound
+        """
+        # Arrange
+        stop = mocker.AsyncMock()
+
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+            worker.stop = stop
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        # Act
+        async with WorkerPool(worker=factory, spawn=1, shutdown_timeout=5.0):
+            pass
+
+        # Assert
+        stop.assert_awaited_once_with(timeout=5.0)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_wait_unbounded_when_shutdown_timeout_none(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test teardown waits for a slow worker when the timeout is None.
+
+        Given:
+            A WorkerPool with shutdown_timeout=None whose worker's stop()
+            takes appreciably longer than an instant to return
+        When:
+            The async-with block exits
+        Then:
+            It should let that stop run to completion rather than
+            cancelling it at a bound of the pool's own
+        """
+        # Arrange
+        stopped = asyncio.Event()
+
+        async def slow_stop(*, timeout=None):
+            await asyncio.sleep(0.5)
+            stopped.set()
+
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+            worker.stop = slow_stop
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        # Act
+        with caplog.at_level(logging.WARNING, "wool.runtime.worker.pool"):
+            async with WorkerPool(worker=factory, spawn=1, shutdown_timeout=None):
+                pass
+
+        # Assert
+        assert stopped.is_set()
 
     @pytest.mark.asyncio
     async def test___aenter___default_case_covers_shared_memory_creation(
@@ -1880,24 +2024,6 @@ class TestWorkerPool:
 
         assert len(exc_info.value.exceptions) == 1
         assert "Worker 2 failed" in str(exc_info.value.exceptions[0])
-
-    @pytest.mark.asyncio
-    async def test_stop_terminates_workers(self, mock_worker_factory):
-        """Test all workers are terminated.
-
-        Given:
-            A WorkerPool with running workers
-        When:
-            The pool is stopped
-        Then:
-            All workers are terminated
-        """
-        # Arrange & Act
-        async with WorkerPool(worker=mock_worker_factory, spawn=2) as pool:
-            # Pool is running
-            assert pool is not None
-
-        # Assert - context exit completes without error (cleanup successful)
 
     @pytest.mark.asyncio
     async def test_multiple_workers_startup_and_cleanup(

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -1815,6 +1815,80 @@ class TestWorkerPool:
         stop.assert_awaited_once_with(timeout=5.0)
 
     @pytest.mark.asyncio
+    async def test___aexit___should_log_error_when_stop_fails_unexpectedly(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test an unexpected stop failure is reported rather than swallowed.
+
+        Given:
+            A WorkerPool whose worker's stop() raises an error that is
+            neither a timeout nor a cancellation
+        When:
+            The async-with block exits
+        Then:
+            It should log the failure against the worker's uid with the
+            traceback attached, rather than discarding it into the
+            teardown gather
+        """
+        # Arrange
+        uid = uuid.uuid4()
+
+        def broken_factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.uid = uid
+            worker.start = mocker.AsyncMock()
+            worker.stop = mocker.AsyncMock(side_effect=ValueError("stop is broken"))
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        # Act
+        with caplog.at_level(logging.ERROR, "wool.runtime.worker.pool"):
+            async with WorkerPool(worker=broken_factory, spawn=1, shutdown_timeout=5.0):
+                pass
+
+        # Assert
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert any(str(uid) in r.getMessage() and r.exc_info is not None for r in errors)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_skip_stopping_workers_that_never_started(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test teardown leaves a never-started worker alone.
+
+        Given:
+            A WorkerPool whose worker fails to start, so it is never
+            announced and holds no metadata
+        When:
+            The async-with block exits after the spawn failure
+        Then:
+            It should neither stop nor announce that worker, and should
+            log no error for it — there is nothing to undo
+        """
+        # Arrange
+        stop = mocker.AsyncMock()
+
+        def failing_factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.uid = uuid.uuid4()
+            worker.start = mocker.AsyncMock(side_effect=RuntimeError("spawn boom"))
+            worker.stop = stop
+            worker.metadata = None
+            return worker
+
+        # Act
+        with caplog.at_level(logging.ERROR, "wool.runtime.worker.pool"):
+            with pytest.raises(ExceptionGroup):
+                async with WorkerPool(
+                    worker=failing_factory, spawn=2, shutdown_timeout=5.0
+                ):
+                    pass
+
+        # Assert
+        stop.assert_not_awaited()
+        assert not [r for r in caplog.records if r.levelno == logging.ERROR]
+
+    @pytest.mark.asyncio
     async def test___aexit___should_wait_unbounded_when_shutdown_timeout_none(
         self, mocker: MockerFixture, caplog
     ):

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -495,6 +495,60 @@ class TestWorkerProcess:
         # Assert
         assert isinstance(process, multiprocessing.context.SpawnProcess)
 
+    def test___init___should_default_to_daemonic(self):
+        """Test WorkerProcess is daemonic by default.
+
+        Given:
+            Default parameters
+        When:
+            WorkerProcess is instantiated
+        Then:
+            It should be daemonic (see WorkerProcess for the rationale)
+        """
+        # Act
+        process = WorkerProcess()
+
+        # Assert
+        assert process.daemon is True
+
+    def test___init___should_honor_daemon_override_when_explicitly_false(self):
+        """Test WorkerProcess honors an explicit non-daemonic override.
+
+        Given:
+            An explicit daemon=False keyword argument
+        When:
+            WorkerProcess is instantiated
+        Then:
+            It should remain non-daemonic rather than clobbering the
+            caller's choice with the daemonic default
+        """
+        # Act
+        process = WorkerProcess(daemon=False)
+
+        # Assert
+        assert process.daemon is False
+
+    def test___init___should_inherit_daemon_when_none(self):
+        """Test WorkerProcess forwards an explicit daemon=None.
+
+        Given:
+            An explicit daemon=None keyword argument
+        When:
+            WorkerProcess is instantiated from the non-daemonic main
+            process
+        Then:
+            It should inherit that process's non-daemonic disposition
+            rather than being coerced to the daemonic default —
+            ``None`` is multiprocessing's own inherit-from-parent
+            request, and forwarding it is what keeps inheritance
+            requestable
+        """
+        # Act
+        process = WorkerProcess(daemon=None)
+
+        # Assert
+        assert process.daemon is False
+
     def test___init___raises_error_for_blank_host(self):
         """Test WorkerProcess initialization raises error for blank host.
 


### PR DESCRIPTION
## Summary

`WorkerProcess` extends `multiprocessing.Process` without the daemon flag, and multiprocessing registers an atexit handler that joins every live non-daemonic child. A worker still alive at interpreter exit therefore holds the parent hostage: its parent-death watchdog fires only once the parent dies, which the join itself prevents. The parent blocks in `os.waitpid`, and a one-test flake becomes a whole-suite hang.

Spawn `WorkerProcess` daemonic by default. The same atexit handler terminates daemonic children before joining them, and the worker's SIGTERM handler already turns that termination into an immediate graceful stop, so the join completes promptly. The parent-death watchdog covers the reverse direction, so neither process outlives the other regardless of which exits first.

That default is a backstop, not the primary reap path. `LocalWorker._stop` hands `WorkerProcess.reap` to an executor thread precisely so it survives cancellation of the stop coroutine, and the gather preceding teardown's warning waits for those `finally` blocks to run — so a worker the pool stops waiting on has already been joined, terminated, or killed. The daemonic default covers what that path cannot: a worker never stopped at all, and the narrow window `_stop` documents where a second cancellation lands while the reap is still queued.

Which of those the observed wedge came through is not established. This change makes a live worker at exit survivable rather than pinning down what left one alive, so the regression guard here reproduces the wedge by abandoning a worker outright rather than by reproducing #294's trigger. That trigger — an outer `asyncio.timeout` cancelling the pool context mid-teardown — remains uncharacterized, and #294 carries the open question.

Chasing that distinction surfaced three things teardown was getting wrong, all fixed here. It called those workers "abandoned" — the word issue #294 reasoned from to conclude a leak the reap had already closed. It discarded every stop failure that was not a `TimeoutError`, which is how `MockWorker.stop` went years without the `timeout` keyword the pool passes, raising `TypeError` on every teardown that nobody ever saw. And it announced `worker-dropped` before stopping, reading metadata a never-started worker does not have, so the publish raised `AttributeError` and silently skipped the stop beneath it.

One trade-off: daemonic processes cannot spawn multiprocessing children, so a routine that must create them needs a non-daemonic worker. `WorkerProcess` takes an explicit `daemon` parameter and `LocalWorker` forwards one, so that escape hatch is reachable from the public API.

Closes #294

## Proposed changes

### Spawn workers daemonic by default

Promote `daemon` to an explicit `daemon: bool | None = True` parameter on `WorkerProcess.__init__`, forwarded to `multiprocessing.Process`. The tri-state is deliberate: `True`/`False` set the flag, and `None` is multiprocessing's own inherit-from-parent request, forwarded rather than coerced. Document the contract in the class docstring's `:param daemon:` entry, with the atexit/watchdog mechanics in an `Implementation notes` rubric.

### Make the escape hatch reachable

`LocalWorker` never forwarded `daemon` to the `WorkerProcess` it constructs. The keyword fell into `**extra`, which `Worker.__init__` stores as advertised discovery metadata — so `LocalWorker(daemon=False)` silently produced a still-daemonic worker publishing a junk `daemon: False` metadata entry. `LocalWorker` now accepts `daemon`, defaulting to the `Undefined` sentinel so it forwards nothing when unspecified and leaves `WorkerProcess` the single owner of the default.

### Report what teardown does to unresponsive workers

The warning said the pool "abandoned" workers that missed the shutdown deadline. It does not — it abandons the wait, not the process. Say that, and name the loss that is real: the graceful drain. Align the surrounding vocabulary, including `WorkerProcess`, which now scopes its daemonic default to a worker still alive at interpreter exit rather than one the pool stopped waiting on.

### Report stop failures teardown used to discard

Teardown gathered stops with `return_exceptions=True` and dropped everything that was not a `TimeoutError` — strictly worse than not gathering, since asyncio logs an unretrieved task exception and retrieving it only to discard it suppresses that. Log unexpected failures against the worker uid with the traceback; keep counting `TimeoutError`; keep ignoring self-inflicted cancellations. Do not raise: teardown runs in a `finally`, so raising would demote a caller's in-flight exception, and the reap already guarantees the process dies. Skip workers whose start failed, which removes the `AttributeError` rather than merely logging it — announcing before stopping is deliberate, so subscribers stop routing before a worker goes away.

### Repair hollow pool teardown coverage

`MockWorker.stop` did not accept the `timeout` keyword the pool passes at teardown; the `TypeError` disappeared into `gather(return_exceptions=True)`, so mock workers were never actually stopped and the teardown test asserted nothing. Accept the keyword, rewrite the test to assert workers are genuinely stopped, and cover the remaining branches: a stop that raises `TimeoutError` counts, `shutdown_timeout` is forwarded per worker, and `shutdown_timeout=None` waits unbounded.

### Pin the contract at both levels

Unit tests for the daemonic default, the `daemon=False` override, and the `daemon=None` inherit passthrough. An integration guard starts a `LocalWorker`, holds until the test releases it, then reaches interpreter exit without stopping it; without the daemon default it wedges for its full 30s bound. A SIGTERM test pins the graceful-stop mechanism the atexit terminate-then-join relies on, ordered ahead of the `reap` test that escalates to it. A cancellation test pins that teardown cancelled at its first await still reaps every worker. The helper scripts must remain `python -c` strings: they carry no `__main__` guard, so as files the spawn bootstrap would re-run them in every worker child.

### Give the Hypothesis exploration timeout headroom

Split `_HYPOTHESIS_TIMEOUT = 90` from the shared 30s bound. A heavy example on a loaded machine overran the bound the pairwise cases run under, and the resulting `asyncio.timeout` cancellation is the path this PR hardens. The deterministic pairwise suite keeps 30s.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerProcess` | No custom parameters | `WorkerProcess` is instantiated | The process is daemonic | Daemonic default |
| 2 | `TestWorkerProcess` | An explicit `daemon=False` kwarg | `WorkerProcess` is instantiated | The process remains non-daemonic | Override escape hatch |
| 3 | `TestWorkerProcess` | An explicit `daemon=None` kwarg | `WorkerProcess` is instantiated from the main process | The process inherits that disposition rather than being coerced | Inherit passthrough |
| 4 | `TestWorkerOrphanPrevention` | A parent that started a `LocalWorker` and never stops it | The parent interpreter exits | The parent exits cleanly within a bound and the worker is terminated | Interpreter-exit regression guard |
| 5 | `TestWorkerOrphanPrevention` | A started real `WorkerProcess` | SIGTERM is sent to the worker | The worker exits with code 0 inside a bounded join | Graceful SIGTERM stop |
| 6 | `TestWorkerOrphanPrevention` | An entered pool with two spawned workers under a timeout armed after startup | The timeout cancels teardown at its first await | No worker subprocess survives | Cancelled-teardown reap |
| 7 | `TestWorkerPool` | A pool with two spawned mock workers | The async-with block exits | Every worker is stopped with its metadata cleared | Teardown stops spawned workers |
| 8 | `TestWorkerPool` | A worker whose stop never returns | The shutdown bound elapses | The warning names the count stopped waiting on and the worker's uid | Stopped-waiting log content |
| 9 | `TestWorkerPool` | A worker whose stop raises `TimeoutError` under a generous bound | The async-with block exits | The warning is emitted promptly | Timeout-counted branch |
| 10 | `TestWorkerPool` | A worker whose stop raises an error that is neither timeout nor cancellation | The async-with block exits | The failure is logged against the uid with its traceback | Unexpected stop failure |
| 11 | `TestWorkerPool` | A pool whose worker fails to start, holding no metadata | The async-with block exits after the spawn failure | That worker is neither stopped nor announced, and no error is logged | Never-started skip |
| 12 | `TestWorkerPool` | A pool with `shutdown_timeout=5.0` | The async-with block exits | The worker's stop is awaited once with `timeout=5.0` | Per-worker timeout forwarding |
| 13 | `TestWorkerPool` | A pool with `shutdown_timeout=None` and a slow-stopping worker | The async-with block exits | That stop runs to completion rather than being cancelled at a bound | Unbounded teardown path |
