### PR TITLE
Fix @noreentry breaking contextlib ExitStack support for decorated context managers — Closes #306

### DIFF
--- a/wool/src/wool/utilities/noreentry.py
+++ b/wool/src/wool/utilities/noreentry.py
@@ -6,7 +6,6 @@ import inspect
 import sys
 import weakref
 from typing import Callable
-from typing import Never
 from typing import ParamSpec
 from typing import TypeVar
 
@@ -20,19 +19,51 @@ class _Token:
     pass
 
 
-class NoReentryBoundMethod:
-    """Descriptor implementing single-use guard for bound methods.
+class NoReentryDescriptor:
+    """Guard a method against a second invocation on the same instance.
 
-    On the first call the decorated method executes normally. Any
-    subsequent call raises :class:`RuntimeError`.
+    A descriptor that wraps one method of one class. It exists for the
+    once-per-instance operations — teardown, shutdown, close — whose second
+    execution is a latent bug rather than a no-op, and turns that bug into an
+    immediate, attributable failure.
 
-    Guard state uses a per-instance token stored on the instance under
-    ``__noreentry_token__``. The token is unique, hashable, and tied to the
-    instance's lifetime. The descriptor tracks tokens in a WeakSet to auto-clean
-    when instances are garbage collected.
+    The guard is per instance, not per class: each instance of the owning class
+    may invoke the method once. The first call executes the method and returns
+    its result; every later call on the same instance raises `RuntimeError`.
+    Guard state lives on the instance under ``__noreentry_token__`` and is
+    discarded with it, so a fresh instance is unguarded and an instance that is
+    garbage collected leaves nothing behind.
 
-    Works with both synchronous and asynchronous methods. Only supports
-    bound methods; using @noreentry on bare functions raises TypeError.
+    Because the guard keys on the receiver, the method must be reached with one:
+    it may be called on an instance, or unbound off the owning class with the
+    instance as the first argument, i.e., the form `contextlib` uses to enter a
+    context manager (``type(cm).__enter__(cm)``). The latter reaches the
+    descriptor rather than a bound wrapper, so a guarded ``__enter__`` or
+    ``__aenter__`` composes with `contextlib.ExitStack` and
+    `contextlib.AsyncExitStack`. Synchronous and asynchronous methods are both
+    supported. A receiver of any other type, or none at all, raises `TypeError`,
+    as does decorating a bare function, which has no receiver to key on.
+
+    .. rubric:: Implementation notes
+
+    Owner tracking is the reason this is a descriptor rather than a plain
+    function decorator. A decorator that leans on Python's descriptor protocol
+    to do the binding never sees the unbound call form at all — the arguments
+    arrive as an ordinary positional tuple — so it cannot tell an unbound call
+    on the owning instance from a call whose first argument merely happens to be
+    an object, and would silently run the method against a foreign receiver.
+    Holding the owner lets that case be rejected.
+
+    ``__set_name__`` supplies the discriminator: the interpreter invokes it only
+    for a descriptor assigned in a class body, so ``_owner`` stays ``None`` for a
+    bare function. A ``None`` owner therefore means "no receiver exists" and a
+    set owner means "a receiver is required", which is the distinction ``__call__``
+    dispatches on.
+
+    An owned descriptor called with its own instance first is a bound call in
+    disguise: rebinding through ``__get__`` and re-dispatching routes it through
+    the same wrapper and the same guard state as an instance call, so the two
+    call forms cannot diverge.
     """
 
     def __init__(self, fn, /):
@@ -43,10 +74,34 @@ class NoReentryBoundMethod:
             else:
                 self._is_coroutine = asyncio.coroutines._is_coroutine  # type: ignore[attr-defined]
         self._fn = fn
+        self._owner = None
         self._invocations = weakref.WeakSet()
 
-    def __call__(self, *args, **kwargs) -> Never:
-        raise TypeError("@noreentry only decorates methods, not bare functions")
+    def __set_name__(self, owner, name):
+        """Record the class the descriptor is defined on."""
+        self._owner = owner
+
+    def __call__(self, *args, **kwargs):
+        """Dispatch an unbound call to the receiver's bound wrapper.
+
+        This is the path `contextlib` takes when it enters a context manager by
+        invoking the special method off the type (``type(cm).__enter__(cm)``).
+        See the class docstring for the guard semantics and the supported call
+        forms.
+
+        :raises TypeError:
+            If the decorated object is a bare function, or if the first
+            positional argument is not an instance of the owning class.
+        """
+        if self._owner is None:
+            raise TypeError("@noreentry only decorates methods, not bare functions")
+        if not args or not isinstance(args[0], self._owner):
+            raise TypeError(
+                f"'{self._fn.__qualname__}' must be called with an instance of "
+                f"'{self._owner.__name__}' as the first argument"
+            )
+        obj, *rest = args
+        return self.__get__(obj, self._owner)(*rest, **kwargs)
 
     def __get__(self, obj, objtype=None):
         if obj is None:
@@ -95,19 +150,10 @@ class NoReentryBoundMethod:
 def noreentry(fn: Callable[P, R]) -> Callable[P, R]:
     """Mark a method as single-use.
 
-    On the first call the decorated method executes normally. Any
-    subsequent call raises :class:`RuntimeError`.
-
-    Guard state uses a per-instance token stored on the instance under
-    ``__noreentry_token__``. The token is unique, hashable, and tied to the
-    instance's lifetime. The descriptor tracks tokens in a :class:`WeakSet`
-    to auto-clean when instances are garbage collected.
-
-    Works with both synchronous and asynchronous methods. Only supports
-    bound methods; using @noreentry on bare functions raises :class:`TypeError`
-    on the first invocation.
+    Returns a `NoReentryDescriptor`; see that class for the guard semantics and
+    the supported call forms.
 
     :param fn:
-        The bound instance or class method to decorate.
+        The instance method to decorate.
     """
-    return NoReentryBoundMethod(fn)
+    return NoReentryDescriptor(fn)

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -10,6 +10,7 @@ import logging
 import os
 import time
 import uuid
+from contextlib import AsyncExitStack
 from contextlib import contextmanager
 from functools import partial
 from types import MappingProxyType
@@ -1189,6 +1190,58 @@ class TestWorkerPool:
 
         # Assert: Context manager returned pool and lifecycle completed
         assert pool_instance is not None
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_return_pool_when_pushed_onto_async_exit_stack(
+        self,
+        mock_shared_memory,
+        mock_worker_proxy,
+        mock_local_worker,
+    ):
+        """Test entering a pool through an AsyncExitStack.
+
+        Given:
+            A WorkerPool
+        When:
+            The pool is pushed onto a contextlib.AsyncExitStack
+        Then:
+            It should return the pool itself.
+        """
+        # Arrange
+        pool = WorkerPool(spawn=1)
+
+        # Act
+        async with AsyncExitStack() as stack:
+            entered = await stack.enter_async_context(pool)
+
+        # Assert
+        assert entered is pool
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_tear_down_pool_when_async_exit_stack_unwinds(
+        self,
+        mock_shared_memory,
+        mock_worker_proxy,
+        mock_local_worker,
+    ):
+        """Test tearing a pool down through an AsyncExitStack.
+
+        Given:
+            A WorkerPool pushed onto a contextlib.AsyncExitStack
+        When:
+            The stack unwinds
+        Then:
+            It should exit the pool's worker proxy context.
+        """
+        # Arrange
+        pool = WorkerPool(spawn=1)
+
+        # Act
+        async with AsyncExitStack() as stack:
+            await stack.enter_async_context(pool)
+
+        # Assert
+        mock_worker_proxy.__aexit__.assert_awaited()
 
     @pytest.mark.asyncio
     async def test___aexit___cleanup_on_error(self, mock_worker_factory):

--- a/wool/tests/utilities/test_noreentry.py
+++ b/wool/tests/utilities/test_noreentry.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import AsyncExitStack
+from contextlib import ExitStack
 
 import pytest
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
 
 from wool.utilities.noreentry import noreentry
 
@@ -24,6 +29,66 @@ class _AsyncDummy:
         return "ok"
 
 
+class _SyncContextDummy:
+    """Sync context manager with both __enter__ and __exit__ guarded.
+
+    Records the exception type handed to __exit__ so the arguments
+    forwarded through the descriptor can be observed.
+    """
+
+    def __init__(self):
+        self.exited_with = "not-exited"
+
+    @noreentry
+    def __enter__(self):
+        return self
+
+    @noreentry
+    def __exit__(self, exc_type, exc, tb):
+        self.exited_with = exc_type
+        return False
+
+
+class _AsyncContextDummy:
+    """Async context manager with both __aenter__ and __aexit__ guarded.
+
+    Records the exception type handed to __aexit__ so the arguments
+    forwarded through the descriptor can be observed.
+    """
+
+    def __init__(self):
+        self.exited_with = "not-exited"
+
+    @noreentry
+    async def __aenter__(self):
+        return self
+
+    @noreentry
+    async def __aexit__(self, exc_type, exc, tb):
+        self.exited_with = exc_type
+        return False
+
+
+class _SubclassedContextDummy(_SyncContextDummy):
+    """Subclass inheriting a @noreentry-guarded __enter__ from its base."""
+
+
+class _ArgumentDummy:
+    """Class with a @noreentry method taking positional and keyword args."""
+
+    @noreentry
+    def run(self, first, *, second=None):
+        return first, second
+
+
+class _PayloadDummy:
+    """Class with a @noreentry method echoing back its whole payload."""
+
+    @noreentry
+    def run(self, *args, **kwargs):
+        return args, kwargs
+
+
 class _MultiMethodDummy:
     """Class with multiple @noreentry methods."""
 
@@ -34,6 +99,28 @@ class _MultiMethodDummy:
     @noreentry
     def second(self):
         return "second"
+
+
+@noreentry
+def _bare_function():
+    """Module-level function decorated with @noreentry, owned by no class."""
+    return "ok"
+
+
+_payloads = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(),
+    st.text(),
+    st.binary(),
+    st.lists(st.integers()),
+)
+
+_keywords = st.text(
+    alphabet=st.characters(min_codepoint=97, max_codepoint=122),
+    min_size=1,
+    max_size=8,
+).filter(lambda name: name != "self")
 
 
 class TestNoReentry:
@@ -203,29 +290,16 @@ class TestNoReentry:
         # Assert
         assert result == "second"
 
-    def test_noreentry_unbound_access_returns_descriptor(self):
-        """Test accessing decorated method via class returns descriptor.
+    def test_noreentry_should_raise_type_error_when_called_unbound_without_instance(
+        self,
+    ):
+        """Test an unbound call with no instance is rejected.
 
         Given:
-            A class with a @noreentry method.
+            A @noreentry method accessed unbound through its class
         When:
-            The method is accessed through the class (unbound).
-        Then:
-            It should return the descriptor itself.
-        """
-        # Act
-        unbound = _SyncDummy.run
-
-        # Assert
-        assert unbound is not None
-
-    def test_noreentry_bare_function_raises_error(self):
-        """Test decorator rejects application to bare functions.
-
-        Given:
-            A @noreentry-decorated function called without a bound instance.
-        When:
-            The descriptor is called directly.
+            It is called with no arguments, so there is no instance to
+            bind
         Then:
             It should raise TypeError.
         """
@@ -234,6 +308,373 @@ class TestNoReentry:
 
         # Act & assert
         with pytest.raises(
-            TypeError, match="only decorates methods, not bare functions"
+            TypeError, match="must be called with an instance of '_SyncDummy'"
         ):
             unbound()
+
+    def test_noreentry_should_raise_type_error_when_bare_function_is_called(self):
+        """Test a decorated module-level function rejects invocation.
+
+        Given:
+            A @noreentry-decorated module-level function, owned by no
+            class
+        When:
+            The function is called
+        Then:
+            It should raise TypeError.
+        """
+        # Act & assert
+        with pytest.raises(
+            TypeError, match="only decorates methods, not bare functions"
+        ):
+            _bare_function()
+
+    def test_noreentry_should_raise_type_error_when_called_with_foreign_instance(self):
+        """Test an unbound call rejects an instance it does not own.
+
+        Given:
+            A @noreentry method accessed unbound through its class
+        When:
+            It is called with an object that is not an instance of the
+            class that owns it
+        Then:
+            It should raise TypeError.
+        """
+        # Arrange
+        unbound = _SyncDummy.run
+
+        # Act & assert
+        with pytest.raises(
+            TypeError, match="must be called with an instance of '_SyncDummy'"
+        ):
+            unbound(_MultiMethodDummy())
+
+    def test_noreentry_should_enter_context_when_guarded_enter_pushed_onto_stack(self):
+        """Test a guarded sync manager enters through an ExitStack.
+
+        Given:
+            A sync context manager whose __enter__ is decorated with
+            @noreentry
+        When:
+            The manager is pushed onto a contextlib.ExitStack
+        Then:
+            It should enter successfully and yield the manager.
+        """
+        # Arrange
+        manager = _SyncContextDummy()
+
+        # Act
+        with ExitStack() as stack:
+            entered = stack.enter_context(manager)
+
+            # Assert
+            assert entered is manager
+
+    def test_noreentry_should_raise_when_guarded_enter_pushed_onto_stack_twice(self):
+        """Test the guard still fires for a manager entered on a stack.
+
+        Given:
+            A sync context manager already entered through an ExitStack
+        When:
+            The same manager is pushed onto the stack a second time
+        Then:
+            It should raise RuntimeError.
+        """
+        # Arrange
+        manager = _SyncContextDummy()
+
+        # Act & assert
+        with ExitStack() as stack:
+            stack.enter_context(manager)
+            with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+                stack.enter_context(manager)
+
+    @pytest.mark.asyncio
+    async def test_noreentry_should_enter_context_when_guarded_aenter_pushed_onto_stack(
+        self,
+    ):
+        """Test a guarded async manager enters through an AsyncExitStack.
+
+        Given:
+            An async context manager whose __aenter__ is decorated with
+            @noreentry
+        When:
+            The manager is pushed onto a contextlib.AsyncExitStack
+        Then:
+            It should enter successfully and yield the manager.
+        """
+        # Arrange
+        manager = _AsyncContextDummy()
+
+        # Act
+        async with AsyncExitStack() as stack:
+            entered = await stack.enter_async_context(manager)
+
+            # Assert
+            assert entered is manager
+
+    @pytest.mark.asyncio
+    async def test_noreentry_should_raise_when_guarded_aenter_pushed_onto_stack_twice(
+        self,
+    ):
+        """Test the guard still fires for an async manager on a stack.
+
+        Given:
+            An async context manager already entered through an
+            AsyncExitStack
+        When:
+            The same manager is pushed onto the stack a second time
+        Then:
+            It should raise RuntimeError.
+        """
+        # Arrange
+        manager = _AsyncContextDummy()
+
+        # Act & assert
+        async with AsyncExitStack() as stack:
+            await stack.enter_async_context(manager)
+            with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+                await stack.enter_async_context(manager)
+
+    def test_noreentry_should_enter_context_when_guarded_enter_used_in_with(self):
+        """Test a guarded manager works in a plain with statement.
+
+        Given:
+            A sync context manager whose __enter__ is decorated with
+            @noreentry
+        When:
+            The manager is used in a plain with statement
+        Then:
+            It should enter and yield the manager.
+        """
+        # Arrange
+        manager = _SyncContextDummy()
+
+        # Act
+        with manager as entered:
+            # Assert
+            assert entered is manager
+
+    @pytest.mark.asyncio
+    async def test_noreentry_should_enter_context_when_guarded_aenter_used_in_with(self):
+        """Test a guarded manager works in a plain async with statement.
+
+        Given:
+            An async context manager whose __aenter__ is decorated with
+            @noreentry
+        When:
+            The manager is used in a plain async with statement
+        Then:
+            It should enter and yield the manager.
+        """
+        # Arrange
+        manager = _AsyncContextDummy()
+
+        # Act
+        async with manager as entered:
+            # Assert
+            assert entered is manager
+
+    def test_noreentry_should_forward_exception_details_when_exit_stack_unwinds(self):
+        """Test a guarded __exit__ receives the exception forwarded to it.
+
+        Given:
+            A context manager whose __enter__ and __exit__ are both
+            decorated with @noreentry
+        When:
+            An exception is raised inside an ExitStack body holding the
+            manager
+        Then:
+            It should forward the exception details to __exit__ and let
+            the exception propagate.
+        """
+        # Arrange
+        manager = _SyncContextDummy()
+
+        # Act
+        with pytest.raises(ValueError, match="boom"):
+            with ExitStack() as stack:
+                stack.enter_context(manager)
+                raise ValueError("boom")
+
+        # Assert — contextlib invokes the guarded __exit__ unbound, so
+        # the exception triple must survive the descriptor
+        assert manager.exited_with is ValueError
+
+    @pytest.mark.asyncio
+    async def test_noreentry_should_forward_exception_details_when_async_stack_unwinds(
+        self,
+    ):
+        """Test a guarded __aexit__ receives the exception forwarded to it.
+
+        Given:
+            An async context manager whose __aenter__ and __aexit__ are
+            both decorated with @noreentry
+        When:
+            An exception is raised inside an AsyncExitStack body holding
+            the manager
+        Then:
+            It should forward the exception details to __aexit__ and let
+            the exception propagate.
+        """
+        # Arrange
+        manager = _AsyncContextDummy()
+
+        # Act
+        with pytest.raises(ValueError, match="boom"):
+            async with AsyncExitStack() as stack:
+                await stack.enter_async_context(manager)
+                raise ValueError("boom")
+
+        # Assert
+        assert manager.exited_with is ValueError
+
+    def test_noreentry_should_raise_when_entered_by_statement_then_exit_stack(self):
+        """Test the guard is shared across bound and unbound call forms.
+
+        Given:
+            A guarded context manager already entered with a plain with
+            statement
+        When:
+            The same manager is pushed onto an ExitStack, which enters it
+            through the unbound call form
+        Then:
+            It should raise RuntimeError, the guard being shared across
+            both forms.
+        """
+        # Arrange
+        manager = _SyncContextDummy()
+        with manager:
+            pass
+
+        # Act & assert
+        with ExitStack() as stack:
+            with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+                stack.enter_context(manager)
+
+    @pytest.mark.asyncio
+    async def test_noreentry_should_raise_when_entered_by_async_with_then_stack(self):
+        """Test the async guard is shared across bound and unbound forms.
+
+        Given:
+            A guarded async context manager already entered with a plain
+            async with statement
+        When:
+            The same manager is pushed onto an AsyncExitStack, which
+            enters it through the unbound call form
+        Then:
+            It should raise RuntimeError, the guard being shared across
+            both forms.
+        """
+        # Arrange
+        manager = _AsyncContextDummy()
+        async with manager:
+            pass
+
+        # Act & assert
+        async with AsyncExitStack() as stack:
+            with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+                await stack.enter_async_context(manager)
+
+    def test_noreentry_should_enter_context_when_subclass_pushed_onto_exit_stack(self):
+        """Test a subclass inherits a guarded __enter__ usably.
+
+        Given:
+            A subclass of a context manager whose __enter__ is decorated
+            with @noreentry on the base class
+        When:
+            An instance of the subclass is pushed onto an ExitStack
+        Then:
+            It should enter successfully and yield the manager.
+        """
+        # Arrange
+        manager = _SubclassedContextDummy()
+
+        # Act
+        with ExitStack() as stack:
+            entered = stack.enter_context(manager)
+
+            # Assert
+            assert entered is manager
+
+    def test_noreentry_should_forward_arguments_when_called_unbound(self):
+        """Test an unbound call forwards arguments past the instance.
+
+        Given:
+            A class with a @noreentry method taking a positional and a
+            keyword-only argument
+        When:
+            The method is called unbound through its class with the
+            instance first, followed by both arguments
+        Then:
+            It should return the result computed from both forwarded
+            arguments.
+        """
+        # Arrange
+        obj = _ArgumentDummy()
+
+        # Act
+        result = _ArgumentDummy.run(obj, "first", second="second")
+
+        # Assert
+        assert result == ("first", "second")
+
+    @given(
+        args=st.lists(_payloads, max_size=4),
+        kwargs=st.dictionaries(_keywords, _payloads, max_size=4),
+    )
+    @settings(max_examples=50, deadline=None)
+    def test_noreentry_should_forward_arbitrary_payload_when_called_unbound(
+        self, args, kwargs
+    ):
+        """Test an unbound call forwards any payload past the instance.
+
+        Given:
+            Any tuple of positional arguments and any mapping of keyword
+            arguments
+        When:
+            A guarded echo method is called unbound through its class
+            with a fresh instance first, followed by the payload
+        Then:
+            It should return exactly the payload it was given.
+        """
+        # Arrange — a fresh instance per example, so no example inherits
+        # another's exhausted guard
+        obj = _PayloadDummy()
+
+        # Act
+        result = _PayloadDummy.run(obj, *args, **kwargs)
+
+        # Assert
+        assert result == (tuple(args), kwargs)
+
+    @given(forms=st.lists(st.sampled_from(["bound", "unbound"]), min_size=1, max_size=6))
+    @settings(max_examples=25, deadline=None)
+    def test_noreentry_should_admit_only_the_first_call_when_call_forms_interleave(
+        self, forms
+    ):
+        """Test at most one invocation survives any mix of call forms.
+
+        Given:
+            Any non-empty sequence of invocation forms drawn from the
+            bound and unbound call shapes
+        When:
+            The sequence is applied to a single fresh instance
+        Then:
+            It should let exactly the first invocation through and raise
+            RuntimeError for every later one, whatever the interleaving.
+        """
+        # Arrange — a fresh instance per example, so no example inherits
+        # another's exhausted guard
+        obj = _SyncDummy()
+
+        def invoke(form):
+            if form == "bound":
+                return obj.run()
+            return _SyncDummy.run(obj)
+
+        # Act & assert
+        assert invoke(forms[0]) == "ok"
+        for form in forms[1:]:
+            with pytest.raises(RuntimeError, match="cannot be invoked more than once"):
+                invoke(form)


### PR DESCRIPTION
## Summary

`contextlib` enters a context manager by looking the special method up on the **type** and calling it unbound (`cls = type(cm); _enter = cls.__enter__; result = _enter(cm)`). For a `@noreentry`-decorated `__enter__` that class access returns the descriptor itself, so `contextlib` called it directly and landed in `__call__` — whose only job was to reject bare functions. Any guarded context manager therefore blew up with `TypeError: @noreentry only decorates methods, not bare functions` the moment it was pushed onto a stack. `WorkerPool` is affected on `release` today: a pool cannot be composed onto an `AsyncExitStack` alongside other resources.

Record the owning class with `__set_name__` and teach `__call__` to recognise the unbound-call form — an owned descriptor invoked with an instance of its owner is the bound call it actually is — delegating through `__get__` so the guard, the coroutine-ness, and the per-instance wrapper cache all still apply. `__get__` is deliberately left alone: class-level access keeps returning the descriptor, so `asyncio.iscoroutinefunction`, `__name__`, and the existing zero-argument `TypeError` all behave exactly as before. A bare function never gets an owner, so it is still rejected.

The alternative — having `__get__(None, ...)` return an unbound wrapper — was prototyped and rejected: it silently breaks `iscoroutinefunction` on the class attribute (the wrapper is a sync function returning a coroutine) and changes the bare-function error message. Discriminating in `__call__` preserves all ten pre-existing tests unchanged.

Closes #306

## Proposed changes

### Record the owning class

Add `__set_name__`, which Python calls when the descriptor is bound into a class body. A bare module-level function never triggers it, so `_owner` stays `None` — and that absence is precisely what distinguishes a genuine bare-function invocation from `contextlib`'s unbound call.

### Recognise the unbound-call form in `__call__`

`__call__` now delegates when the descriptor is owned and its first argument is an instance of that owner, forwarding the remaining arguments; otherwise it raises `TypeError` as before. Delegation routes through `__get__`, reusing the existing per-instance wrapper rather than re-implementing the guard, so bound and unbound calls share one guard and one piece of state. `isinstance` (not `type(...) is`) is used deliberately: `contextlib` looks the method up on `type(cm)`, which may be a **subclass** of the class the method was defined on.

This also fixes teardown, which the issue did not mention: `contextlib` registers exit as `MethodType(cls.__exit__, cm)`, so a guarded `__exit__` is routed through the same path and receives its exception triple as trailing arguments.

### Correct the decorator's parameter documentation

`:param fn:` advertised "the bound instance or **class method** to decorate", but `@classmethod` composed with `@noreentry` raises `TypeError` in both stacking orders and always has. Narrow the claim to what the decorator actually accepts.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestNoReentry` | A sync manager whose `__enter__` is guarded | It is pushed onto an `ExitStack` | It enters and yields the manager | The reported failure |
| 2 | `TestNoReentry` | A sync manager already entered on a stack | It is pushed a second time | It raises `RuntimeError` | The guard is not bypassed by the new path |
| 3 | `TestNoReentry` | An async manager whose `__aenter__` is guarded | It is pushed onto an `AsyncExitStack` | It enters and yields the manager | The awaitable return path |
| 4 | `TestNoReentry` | An async manager already entered on a stack | It is pushed a second time | It raises `RuntimeError` | The guard on the async path |
| 5 | `TestNoReentry` | A manager whose `__enter__` and `__exit__` are both guarded | An exception is raised inside an `ExitStack` body | `__exit__` receives the exception details and the exception propagates | Trailing-argument forwarding through the descriptor |
| 6 | `TestNoReentry` | An async manager whose `__aenter__` and `__aexit__` are both guarded | An exception is raised inside an `AsyncExitStack` body | `__aexit__` receives the exception details and the exception propagates | Trailing-argument forwarding on the async exit path |
| 7 | `TestNoReentry` | A guarded manager already entered with a plain `with` statement | It is pushed onto an `ExitStack` | It raises `RuntimeError` | The guard is shared across bound and unbound call forms |
| 8 | `TestNoReentry` | Any non-empty sequence of bound and unbound call forms | The sequence is applied to one fresh instance | Exactly the first invocation succeeds and every later one raises `RuntimeError` | Single-use semantics under arbitrary interleavings |
| 9 | `TestNoReentry` | A subclass of a class whose `__enter__` is guarded on the base | An instance of the subclass is pushed onto an `ExitStack` | It enters successfully | Dispatch admits subclass instances |
| 10 | `TestNoReentry` | A guarded sync manager | It is used in a plain `with` statement | It enters and yields the manager | The implicit special-method path still works |
| 11 | `TestNoReentry` | A guarded async manager | It is used in a plain `async with` statement | It enters and yields the manager | The implicit async path still works |
| 12 | `TestNoReentry` | A guarded method taking a positional and a keyword-only argument | It is called unbound with the instance first, then both arguments | It returns the result computed from both forwarded arguments | Keyword-argument forwarding |
| 13 | `TestNoReentry` | A `@noreentry`-decorated module-level function owned by no class | It is called | It raises `TypeError` | Bare-function rejection, which previously had no real test |
| 14 | `TestNoReentry` | A guarded method accessed unbound | It is called with an instance of another class | It raises `TypeError` | Foreign instances are not admitted |
| 15 | `TestNoReentry` | A guarded method accessed unbound | It is called with no arguments | It raises `TypeError` | The no-instance rejection branch |
| 16 | `TestWorkerPool` | A `WorkerPool`, whose `__aenter__` is guarded | It is pushed onto an `AsyncExitStack` and the stack unwinds | It enters, yields the pool, and is torn down on unwind | The user-facing symptom from the issue |

Two pre-existing tests are also reworked: `test_noreentry_bare_function_raises_error` is renamed to say what it actually asserts (it calls an *owned* descriptor with no arguments — a distinct rejection branch from a genuinely unowned function, which case 13 now covers), and `test_noreentry_unbound_access_returns_descriptor` is dropped, its only assertion being `assert unbound is not None`, which cannot fail.

**Mutation-checked:** cases 5, 6, and 12 fail if `__call__` stops forwarding trailing arguments, and case 9 fails if `isinstance` is weakened to `type(...) is`. Before these were added, both mutations passed the entire 146-test suite.