### PR TITLE
Decouple worker shutdown from discovery health so a failed publish cannot silently leak a worker — Closes #298

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -15,6 +15,7 @@ jobs:
   detect-changes:
     name: Detect code changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       has_code_changes: ${{ steps.get-touched-files.outputs.touched && 'true' || 'false' }}
     steps:
@@ -32,6 +33,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_code_changes == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,6 +58,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_code_changes == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         namespace: ['wool']
@@ -74,6 +77,7 @@ jobs:
     needs: [detect-changes, unit-tests]
     if: needs.detect-changes.outputs.has_code_changes == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
       matrix:
         namespace: ['wool']
@@ -92,6 +96,7 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_code_changes == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: ['3.11', '3.12', '3.13']

--- a/wool/pyproject.toml
+++ b/wool/pyproject.toml
@@ -93,6 +93,11 @@ asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
 addopts = "--cov --cov-config=.coveragerc"
 pythonpath = ["."]
+# Dump every thread's stack (non-fatally) when a single test exceeds
+# this bound, so a hang self-diagnoses in the log instead of stalling
+# CI silently until the job is killed. Set well above the slowest
+# legitimate test (the Hypothesis dispatch exploration, ~2-3 minutes).
+faulthandler_timeout = 300
 markers = [
     "integration: end-to-end integration tests against real WorkerPool",
     "stdlib_parity: stdlib contextvars propagation parity pins",

--- a/wool/src/wool/runtime/discovery/base.py
+++ b/wool/src/wool/runtime/discovery/base.py
@@ -84,10 +84,17 @@ class DiscoveryPublisherLike(Protocol):
         the application requires strict lifecycle ordering; wool is
         unopinionated about which.
 
-        Exceptions raised here propagate to the publishing pool: a
-        failure while announcing a spawned worker aborts the pool's
-        startup, so transient transport errors worth surviving must
-        be retried or suppressed inside the implementation.
+        What an exception raised here costs depends on the event. A
+        failure announcing ``worker-added`` propagates and aborts the
+        pool's startup, so transient transport errors worth surviving
+        must be retried or suppressed inside the implementation. A
+        failure announcing ``worker-dropped`` is best-effort: the
+        publishing pool logs it and stops the worker regardless, since
+        a pool must be able to reap its own workers when the discovery
+        service is exactly what has failed. A publisher that rejects
+        out-of-order drops to enforce strict lifecycle ordering should
+        therefore expect that rejection to be recorded rather than to
+        reach the caller.
 
         :param type:
             The type of discovery event.

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -244,10 +244,10 @@ class WorkerPool:
     :param shutdown_timeout:
         Maximum number of seconds to wait for spawned workers to stop
         during pool teardown. The bound applies as a single deadline to
-        the full teardown sequence: each worker's ``stop()`` receives
-        ``shutdown_timeout`` as its per-worker bound, the gather waits
-        for whatever time remains, and publisher cleanup gets whatever
-        is left. When the deadline elapses, the pool stops waiting and
+        the full teardown sequence: each worker's drop announcement and
+        ``stop()`` share whatever remains of it, the gather waits for
+        whatever time remains, and publisher cleanup gets whatever is
+        left. When the deadline elapses, the pool stops waiting and
         logs the UIDs it stopped waiting on via ``logging.warning``.
         Those workers are not leaked: a `LocalWorker` is still reaped
         off-loop (see `LocalWorker._stop`), which can hold ``__aexit__``
@@ -255,7 +255,15 @@ class WorkerPool:
         the graceful drain, not the process. A stop that fails for any
         other reason is logged via ``logging.error`` and teardown
         continues, so one worker's failure never strands another's
-        cleanup. ``None`` disables the bound. Must be positive when
+        cleanup. Reaping does not depend on discovery health: a
+        ``worker-dropped`` announcement that raises *or* hangs is logged
+        via ``logging.error`` and the worker is stopped regardless. A
+        hanging announcement consumes the deadline it shares with the
+        stop, so the worker it precedes is reaped rather than drained —
+        discovery cannot strand a worker, but it can cost that worker
+        its graceful drain. ``None`` disables the bound, in which case a
+        hanging announcement blocks teardown indefinitely, in keeping
+        with that value's unbounded-wait contract. Must be positive when
         provided. Defaults to ``60.0``.
     :param lazy:
         When ``True`` (default), defer discovery setup and the quorum
@@ -619,15 +627,37 @@ class WorkerPool:
         `ExceptionGroup`. Factories that declare ``host``, including
         the default `LocalWorker`, receive the publisher's prescribed
         bind host (see `~wool.DiscoveryPublisherLike.bind_host`);
-        bound factories own their binding. Teardown applies the
-        pool's ``shutdown_timeout`` as a single deadline across worker
-        stops and publisher cleanup, logging any workers it stops
-        waiting on (see ``shutdown_timeout``), and runs even when publisher
-        validation or worker construction fails, so an entered
-        publisher context is never leaked.
+        bound factories own their binding. Teardown applies the pool's
+        ``shutdown_timeout`` as a single deadline across worker stops
+        and publisher cleanup — see that parameter for the contract
+        this implements — and runs even when publisher validation or
+        worker construction fails, so an entered publisher context is
+        always exited rather than dropped on the floor. Cleanup is
+        itself bounded by what remains of the deadline, so a teardown
+        that exhausts the deadline can time cleanup out before the
+        publisher's ``__aexit__`` runs.
 
         :yields:
             Metadata for the spawned workers.
+
+        .. rubric:: Implementation notes
+
+        The drop announcement gets its own cancellation arm because
+        `asyncio.CancelledError` is a `BaseException`: an ``except
+        Exception`` guard cannot see the cancellation the shutdown
+        deadline delivers to an announcement that hangs rather than
+        raises, so without that arm the discovery failure driving the
+        teardown goes unreported and the reap warning is left blaming
+        the worker for a fault that was discovery's.
+
+        The stop sits in that ``try``'s ``finally`` rather than after
+        it, so it outlives the same cancellation, and it takes
+        ``remaining()`` rather than the full ``shutdown_timeout``. The
+        deadline has already elapsed by the time a hanging announcement
+        reaches the stop, and handing it a fresh budget there would let
+        an already-cancelled task outlive the deadline that the gather
+        below exists to enforce — trading a leaked worker for an
+        unbounded teardown.
         """
         publisher_svc, publisher_ctx = await self._enter_context(publisher)
         try:
@@ -665,10 +695,42 @@ class WorkerPool:
                         # and cannot be stopped (`Worker.stop` rejects it),
                         # so teardown has nothing to undo.
                         return
-                    # Announce the drop before stopping so subscribers
-                    # stop routing to a worker that is about to go away.
-                    await publisher_svc.publish("worker-dropped", metadata)
-                    await worker.stop(timeout=self._shutdown_timeout)
+                    try:
+                        # Announce the drop before stopping so subscribers
+                        # stop routing to a worker that is about to go away.
+                        await publisher_svc.publish("worker-dropped", metadata)
+                    except Exception:
+                        # An announcement failure never abandons the stop —
+                        # see the docstring's implementation notes.
+                        logger.error(
+                            "WorkerPool shutdown could not announce worker %s as "
+                            "dropped; the stop is attempted regardless and "
+                            "reported separately if it fails, but subscribers "
+                            "may keep routing to it until they observe the drop "
+                            "by other means",
+                            worker.uid,
+                            exc_info=True,
+                            extra={"undropped_worker_uid": str(worker.uid)},
+                        )
+                    except asyncio.CancelledError:
+                        # `except Exception` cannot see a cancelled
+                        # announcement — see the docstring's implementation
+                        # notes.
+                        logger.error(
+                            "WorkerPool shutdown could not announce worker %s as "
+                            "dropped within the shutdown deadline; the stop is "
+                            "attempted regardless, but subscribers may keep "
+                            "routing to it until they observe the drop by other "
+                            "means",
+                            worker.uid,
+                            extra={"undropped_worker_uid": str(worker.uid)},
+                        )
+                        raise
+                    finally:
+                        # The stop outlives the cancellation above, bounded by
+                        # what remains of the deadline — see the docstring's
+                        # implementation notes.
+                        await worker.stop(timeout=remaining())
 
                 task = asyncio.create_task(start(worker))
                 tasks.append(task)

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -75,6 +75,117 @@ class WorkerPool:
     - **Hybrid pools** spawn local workers and additionally admit
       remote workers found through discovery.
 
+    :param tags:
+        Capability tags for spawned workers.
+    :param spawn:
+        Number of workers to spawn (0 = CPU count).
+    :param size:
+        .. deprecated::
+            Use ``spawn`` instead. Will be removed in the next major release.
+    :param lease:
+        Maximum number of additionally discovered workers to admit to the
+        pool. The total pool capacity is ``spawn + lease`` when both are
+        set, or just ``lease`` for a durable pool with no spawned
+        workers. Defaults to ``None`` (unbounded). Only meaningful when
+        a ``discovery`` service is configured; supplying ``lease``
+        without ``discovery`` records the value but never consults it,
+        accompanied by an `IneffectiveLeaseWarning`. Admission semantics
+        are `WorkerProxy`'s — see its ``lease`` parameter.
+    :param worker:
+        Worker factory callable. A `WorkerFactory` declares a ``host``
+        keyword and receives the discovery publisher's prescribed bind
+        host. A `BoundWorkerFactory` declares no ``host`` and owns its
+        binding. Classification is by explicit signature declaration;
+        see `WorkerFactory` for the rules. Defaults to `LocalWorker`,
+        which declares ``host`` and therefore binds the publisher's
+        prescribed host.
+    :param discovery:
+        Discovery service to attach — a `~wool.DiscoveryLike` instance
+        or any `Factory` form resolving to one. The resolved object is
+        validated against the protocol at context entry. Workers it
+        surfaces are additionally subject to the underlying
+        `WorkerProxy`'s admission gate.
+
+        .. caution::
+
+           A pre-called context-manager instance passed as
+           ``discovery`` is not picklable and breaks nested routine
+           dispatch. Pass a callable returning it instead (see
+           `Factory`).
+    :param loadbalancer:
+        Load balancer instance, factory, or context manager.
+
+        .. caution::
+
+           A pre-called context-manager instance passed as
+           ``loadbalancer`` is not picklable and breaks nested routine
+           dispatch. Pass a callable returning it instead (see
+           `Factory`).
+    :param credentials:
+        Optional channel credentials for TLS/mTLS connections to workers.
+    :param quorum:
+        Minimum number of workers that must be discovered before the proxy
+        considers itself ready. Defaults to ``1`` — block until at least
+        one worker is admitted. Pass a larger integer to require more
+        workers, or ``None``/``0`` to disable the gate entirely
+        (``dispatch`` may then raise immediately if no workers have been
+        discovered yet). When ``lazy=True`` (default), the quorum wait is
+        deferred to the first dispatch; with ``lazy=False`` it blocks at
+        context entry.
+    :param quorum_timeout:
+        Seconds to wait for ``quorum`` workers to be discovered before
+        raising `asyncio.TimeoutError`. Only meaningful when
+        ``quorum`` is a positive integer; supplying it with
+        ``quorum=None`` or ``quorum=0`` records the value but never
+        consults it, accompanied by an `IneffectiveQuorumTimeoutWarning`.
+        Defaults to ``60``; pass ``None`` to wait indefinitely.  With
+        ``lazy=False`` the timeout fires at ``__aenter__``; the pool,
+        never having entered, is unusable per its single-use
+        semantics, so construct a new pool to retry.  With
+        ``lazy=True`` (default) the timeout fires on the first
+        `WorkerProxy.dispatch`; a later dispatch retries and recovers
+        once a worker is admitted.
+    :param shutdown_timeout:
+        Maximum number of seconds to wait for spawned workers to stop
+        during pool teardown, applied as a single deadline to the full
+        teardown sequence. When it elapses the pool stops waiting and
+        logs the workers it gave up on; those workers are reaped
+        regardless, so what is lost is the graceful drain, not the
+        process. A stop that fails for any other reason is logged and
+        teardown continues, so one worker's failure never strands
+        another's cleanup. Reaping does not depend on discovery health:
+        a ``worker-dropped`` announcement that fails or hangs is logged
+        and the worker stopped regardless — discovery cannot strand a
+        worker, but a hanging announcement can consume the deadline and
+        cost that worker its graceful drain. A finite value overrides a
+        worker's own shutdown grace period; ``None`` disables the bound,
+        in which case a hanging announcement blocks teardown
+        indefinitely, in keeping with that value's unbounded-wait
+        contract. Must be positive when provided. Defaults to ``60.0``.
+
+        .. caution::
+
+           Size ``shutdown_timeout`` for the slowest worker the pool
+           spawns. Because a finite value overrides the worker's own
+           grace period, a worker configured to shut down more slowly
+           than the pool waits — e.g., ``partial(LocalWorker,
+           shutdown_grace_period=120)`` under the default
+           ``shutdown_timeout=60.0`` — never receives that grace; it is
+           silently ignored unless the pool waits unbounded
+           (``shutdown_timeout=None``).
+    :param lazy:
+        When ``True`` (default), defer discovery setup and the quorum
+        wait to the first `WorkerProxy.dispatch`.  When ``False``,
+        eagerly enter the underlying proxy at ``__aenter__`` time and
+        run the quorum wait there.
+    :raises ValueError:
+        If configuration is invalid, CPU count unavailable, or
+        ``shutdown_timeout`` is not positive.
+    :raises asyncio.TimeoutError:
+        If the quorum wait does not complete within ``quorum_timeout``
+        — raised by the underlying `WorkerProxy` at context entry
+        (``lazy=False``) or first dispatch (``lazy=True``).
+
     **Basic ephemeral pool:**
 
     .. code-block:: python
@@ -181,109 +292,20 @@ class WorkerPool:
         async with WorkerPool(spawn=4, quorum=4, quorum_timeout=30, lazy=False):
             result = await task()
 
-    :param tags:
-        Capability tags for spawned workers.
-    :param spawn:
-        Number of workers to spawn (0 = CPU count).
-    :param size:
-        .. deprecated::
-            Use ``spawn`` instead. Will be removed in the next major release.
-    :param lease:
-        Maximum number of additionally discovered workers to admit to the
-        pool. The total pool capacity is ``spawn + lease`` when both are
-        set, or just ``lease`` for external pools. Defaults to ``None``
-        (unbounded). Only meaningful when a ``discovery`` service is
-        configured; supplying ``lease`` without ``discovery`` records
-        the value but never consults it, accompanied by an
-        `IneffectiveLeaseWarning`. Admission semantics are
-        `WorkerProxy`'s — see its ``lease`` parameter.
-    :param worker:
-        Worker factory callable. A `WorkerFactory` declares a ``host``
-        keyword and receives the discovery publisher's prescribed bind
-        host. A `BoundWorkerFactory` declares no ``host`` and owns its
-        binding. Classification is by explicit signature declaration;
-        see `WorkerFactory` for the rules. Defaults to `LocalWorker`,
-        which declares ``host`` and therefore binds the publisher's
-        prescribed host; a partial of it that leaves ``host`` unset
-        (e.g. ``partial(LocalWorker, ...)``) stays bind-host-aware,
-        while ``partial(LocalWorker, host="...")`` pins the bind and
-        classifies bound.
-    :param discovery:
-        Discovery service to attach — a `~wool.DiscoveryLike` instance
-        or any `Factory` form resolving to one. The resolved object is
-        validated against the protocol at context entry. Workers it
-        surfaces are additionally subject to the underlying
-        `WorkerProxy`'s admission gate.
-    :param loadbalancer:
-        Load balancer instance, factory, or context manager.
-    :param credentials:
-        Optional channel credentials for TLS/mTLS connections to workers.
-    :param quorum:
-        Minimum number of workers that must be discovered before the proxy
-        considers itself ready. Defaults to ``1`` — block until at least
-        one worker is admitted, preserving the pre-quorum implicit-wait
-        behaviour. Pass a larger integer to require more workers, or
-        ``None``/``0`` to disable the gate entirely (``dispatch`` may
-        then raise immediately if no workers have been discovered yet).
-        When ``lazy=True`` (default), the quorum wait is deferred to the
-        first dispatch; with ``lazy=False`` it blocks at context entry.
-    :param quorum_timeout:
-        Seconds to wait for ``quorum`` workers to be discovered before
-        raising `asyncio.TimeoutError`. Only meaningful when
-        ``quorum`` is a positive integer; supplying it with
-        ``quorum=None`` or ``quorum=0`` records the value but never
-        consults it, accompanied by an
-        `~wool.runtime.worker.proxy.IneffectiveQuorumTimeoutWarning`.
-        Defaults to ``60``; pass ``None`` to wait indefinitely.  With
-        ``lazy=False`` the timeout fires at ``__aenter__``; the pool,
-        never having entered, is unusable per its single-use
-        semantics, so construct a new pool to retry.  With
-        ``lazy=True`` (default) the timeout fires on the first
-        `WorkerProxy.dispatch`, which leaves the proxy un-started so a
-        later dispatch retries and recovers once a worker is admitted.
-    :param shutdown_timeout:
-        Maximum number of seconds to wait for spawned workers to stop
-        during pool teardown. The bound applies as a single deadline to
-        the full teardown sequence: each worker's drop announcement and
-        ``stop()`` share whatever remains of it, the gather waits for
-        whatever time remains, and publisher cleanup gets whatever is
-        left. When the deadline elapses, the pool stops waiting and
-        logs the UIDs it stopped waiting on via ``logging.warning``.
-        Those workers are not leaked: a `LocalWorker` is still reaped
-        off-loop (see `LocalWorker._stop`), which can hold ``__aexit__``
-        past the deadline by up to the reap escalation — what is lost is
-        the graceful drain, not the process. A stop that fails for any
-        other reason is logged via ``logging.error`` and teardown
-        continues, so one worker's failure never strands another's
-        cleanup. Reaping does not depend on discovery health: a
-        ``worker-dropped`` announcement that raises *or* hangs is logged
-        via ``logging.error`` and the worker is stopped regardless. A
-        hanging announcement consumes the deadline it shares with the
-        stop, so the worker it precedes is reaped rather than drained —
-        discovery cannot strand a worker, but it can cost that worker
-        its graceful drain. ``None`` disables the bound, in which case a
-        hanging announcement blocks teardown indefinitely, in keeping
-        with that value's unbounded-wait contract. Must be positive when
-        provided. Defaults to ``60.0``.
-    :param lazy:
-        When ``True`` (default), defer discovery setup and the quorum
-        wait to the first `WorkerProxy.dispatch`.  When ``False``,
-        eagerly enter the underlying proxy at ``__aenter__`` time and
-        run the quorum wait there.
-    :raises ValueError:
-        If configuration is invalid, CPU count unavailable, or
-        ``shutdown_timeout`` is not positive.
-    :raises asyncio.TimeoutError:
-        If the quorum wait does not complete within ``quorum_timeout``
-        — raised by the underlying `WorkerProxy` at context entry
-        (``lazy=False``) or first dispatch (``lazy=True``).
+    .. rubric:: Implementation notes
 
-    .. caution::
-
-       Pre-called context manager instances passed as ``loadbalancer``
-       or ``discovery`` are not picklable and will cause nested routine
-       dispatch to fail.  Pass a callable returning the context manager
-       instead.  See `Factory`.
+    ``shutdown_timeout`` is apportioned across teardown in order:
+    each worker's drop announcement and ``stop()`` share whatever
+    remains of the deadline, the gather waits for whatever is left,
+    and publisher cleanup gets the remainder. Workers the pool stops
+    waiting on are logged via ``logging.warning``; a `LocalWorker`
+    is still reaped off-loop (see `LocalWorker._stop`), which can
+    hold ``__aexit__`` past the deadline by up to the reap
+    escalation. A ``worker-dropped`` announcement that raises is
+    logged via ``logging.error``, and one that hangs is cancelled at
+    the deadline and logged there; either way the stop runs on the
+    deadline's remainder. `_worker_context` owns the rationale for
+    that cancellation handling.
     """
 
     _workers: Final[dict[WorkerLike, Coroutine]]

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -339,13 +339,20 @@ class _DirectDiscovery:
     Does NOT implement ``__enter__``/``__exit__``/``__aenter__``/
     ``__aexit__``, forcing ``WorkerPool._enter_context`` to take the
     passthrough path. Used for the ``*_DIRECT`` factory form arrangements.
+
+    ``publisher`` overrides the wrapped service's publisher, for tests
+    that need the real subscribe path but a publisher that misbehaves
+    on demand.
     """
 
-    def __init__(self, discovery):
+    def __init__(self, discovery, publisher=None):
         self._discovery = discovery
+        self._publisher = publisher
 
     @property
     def publisher(self):
+        if self._publisher is not None:
+            return self._publisher
         return self._discovery.publisher
 
     @property

--- a/wool/tests/integration/test_integration.py
+++ b/wool/tests/integration/test_integration.py
@@ -212,8 +212,12 @@ class TestNestedDispatch:
                 lazy=LazyMode.EAGER,
                 quorum=QuorumMode.ABOVE_DEFAULT,
             )
-            async with build_pool_from_scenario(scenario, credentials_map):
-                outer_pid, inner_pids = await routines.nested_pid_fanout(4)
+            # The same bound every sibling in this module runs under.
+            # Without it, a worker child that wedges before reporting
+            # its metadata hangs pool entry — and this test — forever.
+            async with asyncio.timeout(_INTEGRATION_TIMEOUT):
+                async with build_pool_from_scenario(scenario, credentials_map):
+                    outer_pid, inner_pids = await routines.nested_pid_fanout(4)
             caller_pid = os.getpid()
             assert outer_pid != caller_pid
             assert all(pid != caller_pid for pid in inner_pids)

--- a/wool/tests/integration/test_local_discovery_teardown.py
+++ b/wool/tests/integration/test_local_discovery_teardown.py
@@ -12,6 +12,7 @@ in ``tests/runtime/discovery/test_local.py``.
 
 import asyncio
 import contextlib
+import logging
 import multiprocessing
 import os
 import signal
@@ -216,21 +217,15 @@ class TestOverlappingNamespaceLifecycles:
         try:
             await retry_grpc_internal(body)
         finally:
-            # Hygiene, not assertion: pool b's worker currently leaks
-            # after an owner-first exit (#298); kill any stragglers so
-            # they cannot pollute the session.
+            # Hygiene, not assertion: kill any stragglers so a worker
+            # this test failed to reap cannot pollute the session.
             for child in multiprocessing.active_children():
                 if child.pid not in before:
                     _ensure_killed(child.pid)
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        strict=True,
-        raises=AssertionError,
-        reason="surviving pool's worker leaks after owner-first exit (#298)",
-    )
     async def test___aexit___should_reap_worker_when_owner_pool_exited_first(
-        self, retry_grpc_internal
+        self, retry_grpc_internal, caplog
     ):
         """Test a surviving pool reaps its worker despite owner exit.
 
@@ -251,10 +246,9 @@ class TestOverlappingNamespaceLifecycles:
         release_owner = asyncio.Event()
         b_pids: list[int] = []
 
-        # The strict xfail below pins #298 via ``raises=AssertionError``, so
-        # the reap check must be the only ``assert`` in this test: arrange
-        # and act failures use ``pytest.fail``, which raises ``Failed`` and
-        # therefore cannot satisfy the xfail.
+        # Arrange and act failures use ``pytest.fail`` rather than
+        # ``assert`` so a broken setup stays distinguishable from a
+        # genuine leak.
         async def owner():
             async with WorkerPool("a", spawn=1, discovery=LocalDiscovery(namespace)):
                 if await routines.add(1, 2) != 3:
@@ -289,14 +283,30 @@ class TestOverlappingNamespaceLifecycles:
                         await owner_task
 
         try:
-            await retry_grpc_internal(body)
+            with caplog.at_level(logging.ERROR, "wool.runtime.worker.pool"):
+                await retry_grpc_internal(body)
 
             # Assert — join any finished children first so an
             # exited-but-unreaped worker cannot masquerade as alive
             # under os.kill(pid, 0)
             multiprocessing.active_children()
+            # Cardinality first: an empty ``b_pids`` would satisfy the
+            # loop below vacuously.
+            assert len(b_pids) == 1
             for pid in b_pids:
                 assert not _pid_alive(pid)
+
+            # Vacuity guard: the reap above proves nothing unless b's
+            # drop announcement actually failed. #300 would let that
+            # publish succeed, reaping b's worker without exercising
+            # #298's fix at all — so pin that the announcement really
+            # did fail here. If #300 lands, this fails loudly rather
+            # than rotting into a green test that guards nothing.
+            assert any(
+                "could not announce" in record.getMessage()
+                for record in caplog.records
+                if record.levelno == logging.ERROR
+            )
         finally:
             for child in multiprocessing.active_children():
                 if child.pid not in before:

--- a/wool/tests/integration/test_worker_shutdown.py
+++ b/wool/tests/integration/test_worker_shutdown.py
@@ -2,24 +2,34 @@
 
 import asyncio
 import contextlib
+import logging
 import multiprocessing
 import os
 import signal
 import subprocess
 import sys
 import time
+import uuid
 
 import grpc
 import grpc.aio
 import pytest
 
+from wool.runtime.discovery.local import LocalDiscovery
 from wool.runtime.worker.local import LocalWorker
 from wool.runtime.worker.pool import WorkerPool
 from wool.runtime.worker.process import WorkerProcess
 
 from . import routines
+from .conftest import _DirectDiscovery
 from .conftest import build_pool_from_scenario
 from .conftest import default_scenario
+
+#: Hang the ``worker-dropped`` announcement rather than failing it,
+#: modelling a discovery service that has stopped responding rather
+#: than one that errors outright. Mirrors the unit suite's sentinel of
+#: the same name, so one convention governs both.
+_HANG = object()
 
 # This helper script must stay a `python -c` string: it has no
 # `__main__` guard, so as a script file the spawn bootstrap's re-import
@@ -425,6 +435,159 @@ class TestWorkerOrphanPrevention:
             assert not _pid_alive(pid)
         finally:
             _ensure_killed(pid)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_reap_workers_when_drop_announcement_fails(
+        self, caplog
+    ):
+        """Test a pool reaps its workers despite a broken publisher.
+
+        Given:
+            A pool of two workers on a real LocalDiscovery whose
+            worker-dropped announcement raises PermissionError, a
+            discovery failure unrelated to segment ownership
+        When:
+            The async-with block exits
+        Then:
+            It should leave no worker subprocess alive and report one
+            announcement failure per worker, rather than abandoning the
+            stops behind the failed announcements
+        """
+        # Arrange
+        namespace = f"drop-fails-{uuid.uuid4().hex[:12]}"
+        before = {child.pid for child in multiprocessing.active_children()}
+        pids: list[int] = []
+
+        try:
+            # Act
+            with caplog.at_level(logging.ERROR, "wool.runtime.worker.pool"):
+                with LocalDiscovery(namespace) as discovery:
+                    async with asyncio.timeout(30):
+                        async with WorkerPool(
+                            spawn=2,
+                            shutdown_timeout=10.0,
+                            discovery=_DirectDiscovery(
+                                discovery,
+                                _BrokenDropPublisher(
+                                    discovery.publisher,
+                                    PermissionError("discovery is not writable"),
+                                ),
+                            ),
+                        ):
+                            pids.extend(
+                                child.pid
+                                for child in multiprocessing.active_children()
+                                if child.pid not in before
+                            )
+
+            # Assert — join any finished children first so an
+            # exited-but-unreaped worker cannot masquerade as alive
+            # under os.kill(pid, 0)
+            multiprocessing.active_children()
+            assert len(pids) == 2
+            for pid in pids:
+                assert not _pid_alive(pid)
+            errors = [
+                r.getMessage() for r in caplog.records if r.levelno == logging.ERROR
+            ]
+            assert sum("announce" in message for message in errors) == 2
+        finally:
+            # The Act belongs inside this `try`: this test constructs the
+            # scenario where stragglers exist, so an Act that raises is
+            # exactly when cleanup matters most.
+            for child in multiprocessing.active_children():
+                if child.pid not in before:
+                    _ensure_killed(child.pid)
+            for pid in pids:
+                _ensure_killed(pid)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_reap_worker_when_drop_announcement_hangs(self):
+        """Test a pool reaps its worker despite a wedged publisher.
+
+        Given:
+            A pool on a real LocalDiscovery whose worker-dropped
+            announcement never returns, as an unresponsive discovery
+            service leaves it
+        When:
+            The async-with block exits and the shutdown deadline
+            cancels the pending announcement
+        Then:
+            It should leave no worker subprocess alive, rather than
+            abandoning the stop inside the cancelled announcement
+        """
+        # Arrange
+        namespace = f"drop-hangs-{uuid.uuid4().hex[:12]}"
+        before = {child.pid for child in multiprocessing.active_children()}
+        pids: list[int] = []
+
+        try:
+            # Act
+            with LocalDiscovery(namespace) as discovery:
+                async with asyncio.timeout(30):
+                    async with WorkerPool(
+                        spawn=1,
+                        shutdown_timeout=5.0,
+                        discovery=_DirectDiscovery(
+                            discovery,
+                            _BrokenDropPublisher(discovery.publisher, _HANG),
+                        ),
+                    ):
+                        pids.extend(
+                            child.pid
+                            for child in multiprocessing.active_children()
+                            if child.pid not in before
+                        )
+
+            # Assert — join any finished children first so an
+            # exited-but-unreaped worker cannot masquerade as alive
+            # under os.kill(pid, 0)
+            multiprocessing.active_children()
+            assert len(pids) == 1
+            for pid in pids:
+                assert not _pid_alive(pid)
+        finally:
+            # The Act belongs inside this `try`: if the fix regresses and
+            # the hang wedges teardown until `asyncio.timeout(30)` fires,
+            # the Act raises and live workers would otherwise escape.
+            for child in multiprocessing.active_children():
+                if child.pid not in before:
+                    _ensure_killed(child.pid)
+            for pid in pids:
+                _ensure_killed(pid)
+
+
+class _BrokenDropPublisher:
+    """Wraps a real publisher, breaking only ``worker-dropped``.
+
+    Every other event, and the publisher's context-manager protocol,
+    delegate to the wrapped publisher: `LocalDiscovery.Publisher` is an
+    async context manager, and hiding that would send
+    ``WorkerPool._enter_context`` down the passthrough path, leaving the
+    real publisher neither entered nor exited and teardown's publisher
+    cleanup a no-op. Passing `_HANG` hangs the announcement instead of
+    raising it, modelling an unresponsive discovery service.
+    """
+
+    def __init__(self, publisher, error):
+        self._publisher = publisher
+        self._error = error
+        self.bind_host = publisher.bind_host
+
+    async def __aenter__(self):
+        await self._publisher.__aenter__()
+        return self
+
+    async def __aexit__(self, *args):
+        return await self._publisher.__aexit__(*args)
+
+    async def publish(self, type, metadata):
+        if type == "worker-dropped":
+            # `_HANG` never returns; the shutdown deadline ends the wait.
+            if self._error is _HANG:
+                await asyncio.Event().wait()
+            raise self._error
+        return await self._publisher.publish(type, metadata)
 
 
 def _pid_alive(pid: int) -> bool:

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -37,6 +37,16 @@ from wool.runtime.worker.pool import WorkerPool
 from wool.runtime.worker.proxy import IneffectiveQuorumTimeoutWarning
 from wool.runtime.worker.proxy import ReducibleAsyncIterator
 
+#: Hang the ``worker-dropped`` announcement rather than failing it,
+#: modelling a discovery service that has stopped responding rather
+#: than one that errors outright. A named sentinel rather than
+#: ``None``, which already means "raise the default error".
+_HANG = object()
+
+
+class _BrokenPublisherError(Exception):
+    """A publisher failure of a type the pool has never heard of."""
+
 
 def _make_worker_metadata(*tags: str) -> WorkerMetadata:
     """Build a valid WorkerMetadata with a fresh UUID."""
@@ -48,6 +58,36 @@ def _make_worker_metadata(*tags: str) -> WorkerMetadata:
         tags=frozenset(tags),
         extra=MappingProxyType({}),
     )
+
+
+def _dropped_publish(error=None, *, only=None):
+    """Build a ``publish`` side effect that breaks the drop announcement.
+
+    Lets a worker start and register normally, then breaks teardown's
+    ``worker-dropped`` announcement with ``error`` — by default the
+    ``FileNotFoundError`` an unlinked discovery segment raises, or
+    `_HANG` to hang the announcement forever instead, in which case
+    the shutdown deadline is what ends the wait. ``only`` narrows the
+    breakage to the workers whose metadata it accepts, leaving their
+    siblings' announcements intact. The inner parameter is named
+    ``type`` to match `DiscoveryPublisherLike.publish`.
+    """
+    error = (
+        error
+        if error is not None
+        else FileNotFoundError("discovery segment unlinked by a peer")
+    )
+
+    async def publish(type, metadata):
+        if type != "worker-dropped":
+            return
+        if only is not None and not only(metadata):
+            return
+        if error is _HANG:
+            await asyncio.Event().wait()
+        raise error
+
+    return publish
 
 
 class _FakePublisher:
@@ -1787,15 +1827,17 @@ class TestWorkerPool:
     async def test___aexit___should_forward_shutdown_timeout_to_worker_stop(
         self, mocker: MockerFixture
     ):
-        """Test each worker's stop receives the pool's shutdown timeout.
+        """Test each worker's stop receives what remains of the deadline.
 
         Given:
             A WorkerPool with shutdown_timeout configured
         When:
-            The async-with block exits
+            The async-with block exits with nothing having consumed the
+            deadline
         Then:
-            It should await the worker's stop exactly once with the
-            configured timeout as its per-worker bound
+            It should await the worker's stop exactly once, bounded by
+            what remains of the deadline -- all but a scheduling hair of
+            the configured timeout
         """
         # Arrange
         stop = mocker.AsyncMock()
@@ -1812,7 +1854,12 @@ class TestWorkerPool:
             pass
 
         # Assert
-        stop.assert_awaited_once_with(timeout=5.0)
+        # Approximate by necessity, not by convenience: the bound is the
+        # deadline's *remainder*, so it is a hair under the configured
+        # value and an equality assertion would pin a float identity the
+        # contract does not promise. The tolerance is still tight enough
+        # to catch a dropped kwarg, a None, or a zero.
+        stop.assert_awaited_once_with(timeout=pytest.approx(5.0, abs=0.1))
 
     @pytest.mark.asyncio
     async def test___aexit___should_log_error_when_stop_fails_unexpectedly(
@@ -1849,6 +1896,423 @@ class TestWorkerPool:
         # Assert
         errors = [r for r in caplog.records if r.levelno == logging.ERROR]
         assert any(str(uid) in r.getMessage() and r.exc_info is not None for r in errors)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error",
+        [
+            FileNotFoundError("discovery segment unlinked by a peer"),
+            PermissionError("discovery segment not writable"),
+            OSError("discovery buffer corrupt"),
+            ConnectionError("discovery service unreachable"),
+            TimeoutError("discovery publish timed out"),
+            RuntimeError("publisher is broken"),
+            ValueError("malformed metadata"),
+            _BrokenPublisherError("something the pool has never seen"),
+        ],
+        ids=lambda error: type(error).__name__,
+    )
+    async def test___aexit___should_stop_worker_when_drop_announcement_fails(
+        self, mocker: MockerFixture, error
+    ):
+        """Test a worker is reaped despite an unhealthy publisher.
+
+        Given:
+            A WorkerPool whose publisher raises when announcing
+            worker-dropped, as it does when a peer has unlinked the
+            discovery segment out from under it
+        When:
+            The async-with block exits
+        Then:
+            It should still await the worker's stop with the configured
+            timeout, whatever the announcement raised, rather than
+            abandoning it behind the failed announcement
+        """
+        # Arrange
+        stop = mocker.AsyncMock()
+
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+            worker.stop = stop
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        discovery = _FakeDiscovery(mocker)
+        discovery.publisher.publish.side_effect = _dropped_publish(error)
+
+        # Act
+        async with WorkerPool(
+            worker=factory, spawn=1, shutdown_timeout=5.0, discovery=discovery
+        ):
+            pass
+
+        # Assert
+        stop.assert_awaited_once_with(timeout=pytest.approx(5.0, abs=0.1))
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_stop_worker_when_drop_announcement_hangs(
+        self, mocker: MockerFixture
+    ):
+        """Test a worker is reaped when the announcement never returns.
+
+        Given:
+            A WorkerPool whose publisher hangs forever when announcing
+            worker-dropped, as a discovery service that has stopped
+            responding does
+        When:
+            The async-with block exits and the shutdown deadline
+            cancels the pending announcement
+        Then:
+            It should still await the worker's stop rather than
+            abandoning it inside the cancelled announcement, and bound
+            that stop by what remains of the deadline -- nothing, since
+            the announcement consumed it -- reaping the worker instead
+            of granting it a fresh budget to drain in
+        """
+        # Arrange
+        stop = mocker.AsyncMock()
+
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+            worker.stop = stop
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        discovery = _FakeDiscovery(mocker)
+        discovery.publisher.publish.side_effect = _dropped_publish(_HANG)
+
+        # Act
+        async with WorkerPool(
+            worker=factory, spawn=1, shutdown_timeout=0.1, discovery=discovery
+        ):
+            pass
+
+        # Assert
+        stop.assert_awaited_once_with(timeout=0.0)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_log_error_when_drop_announcement_fails(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test a failed drop announcement is reported on its own path.
+
+        Given:
+            A WorkerPool whose publisher raises when announcing
+            worker-dropped
+        When:
+            The async-with block exits
+        Then:
+            It should log the announcement failure against the worker's
+            uid with the traceback attached, rather than discarding it
+            or reporting it as a stop failure
+        """
+        # Arrange
+        uid = uuid.uuid4()
+
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.uid = uid
+            worker.start = mocker.AsyncMock()
+            worker.stop = mocker.AsyncMock()
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        discovery = _FakeDiscovery(mocker)
+        discovery.publisher.publish.side_effect = _dropped_publish()
+
+        # Act
+        with caplog.at_level(logging.ERROR, "wool.runtime.worker.pool"):
+            async with WorkerPool(
+                worker=factory, spawn=1, shutdown_timeout=5.0, discovery=discovery
+            ):
+                pass
+
+        # Assert — the "announce" clause is load-bearing, not decoration:
+        # teardown's stop-failure handler also logs the uid with exc_info,
+        # so without it this assertion passes even when the announcement
+        # failure is misreported as a stop failure.
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert any(
+            str(uid) in r.getMessage()
+            and "announce" in r.getMessage()
+            and r.exc_info is not None
+            for r in errors
+        )
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_not_bound_worker_stop_when_timeout_is_none(
+        self, mocker: MockerFixture
+    ):
+        """Test an unbounded pool leaves the stop unbounded despite a failure.
+
+        Given:
+            A WorkerPool with shutdown_timeout=None whose publisher
+            raises when announcing worker-dropped
+        When:
+            The async-with block exits
+        Then:
+            It should await the worker's stop with no bound of its own,
+            since there is no deadline for the announcement to consume
+        """
+        # Arrange
+        stop = mocker.AsyncMock()
+
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+            worker.stop = stop
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        discovery = _FakeDiscovery(mocker)
+        discovery.publisher.publish.side_effect = _dropped_publish()
+
+        # Act
+        async with WorkerPool(
+            worker=factory, spawn=1, shutdown_timeout=None, discovery=discovery
+        ):
+            pass
+
+        # Assert
+        stop.assert_awaited_once_with(timeout=None)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_log_error_when_drop_announcement_hangs(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test a hanging drop announcement is reported, not swallowed.
+
+        Given:
+            A WorkerPool whose publisher hangs forever when announcing
+            worker-dropped
+        When:
+            The async-with block exits and the shutdown deadline cancels
+            the pending announcement
+        Then:
+            It should log the announcement failure against the worker's
+            uid, rather than leaving the reap warning as the operator's
+            only signal -- which blames the worker for a fault that was
+            discovery's
+        """
+        # Arrange
+        uid = uuid.uuid4()
+
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.uid = uid
+            worker.start = mocker.AsyncMock()
+            worker.stop = mocker.AsyncMock()
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        discovery = _FakeDiscovery(mocker)
+        discovery.publisher.publish.side_effect = _dropped_publish(_HANG)
+
+        # Act
+        with caplog.at_level(logging.ERROR, "wool.runtime.worker.pool"):
+            async with WorkerPool(
+                worker=factory, spawn=1, shutdown_timeout=0.1, discovery=discovery
+            ):
+                pass
+
+        # Assert — the deadline cancels the announcement rather than
+        # failing it, and `CancelledError` is a `BaseException`: an
+        # `except Exception` guard cannot see this, so the report has to
+        # come from a handler that catches cancellation on purpose.
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert any(
+            str(uid) in r.getMessage() and "announce" in r.getMessage() for r in errors
+        )
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_stop_every_worker_when_some_announcements_fail(
+        self, mocker: MockerFixture
+    ):
+        """Test one bad announcement cannot strand sibling workers.
+
+        Given:
+            A WorkerPool of three workers whose publisher raises when
+            announcing only the second worker as dropped
+        When:
+            The async-with block exits
+        Then:
+            It should await every worker's stop exactly once, leaving
+            no sibling behind the one failed announcement
+        """
+        # Arrange
+        workers = []
+
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.uid = uuid.uuid4()
+            worker.start = mocker.AsyncMock()
+            worker.stop = mocker.AsyncMock()
+            worker.metadata = _make_worker_metadata()
+            workers.append(worker)
+            return worker
+
+        discovery = _FakeDiscovery(mocker)
+        discovery.publisher.publish.side_effect = _dropped_publish(
+            PermissionError("discovery segment not writable"),
+            only=lambda metadata: metadata is workers[1].metadata,
+        )
+
+        # Act
+        async with WorkerPool(
+            worker=factory, spawn=3, shutdown_timeout=5.0, discovery=discovery
+        ):
+            pass
+
+        # Assert
+        assert len(workers) == 3
+        for worker in workers:
+            worker.stop.assert_awaited_once_with(timeout=pytest.approx(5.0, abs=0.1))
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_report_both_when_announcement_and_stop_fail(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test the announcement and stop failures are reported apart.
+
+        Given:
+            A WorkerPool whose publisher raises when announcing
+            worker-dropped and whose worker's stop also raises
+        When:
+            The async-with block exits
+        Then:
+            It should log both failures against the worker's uid as
+            separate records, collapsing neither into the other
+        """
+        # Arrange
+        uid = uuid.uuid4()
+
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.uid = uid
+            worker.start = mocker.AsyncMock()
+            worker.stop = mocker.AsyncMock(side_effect=ValueError("stop is broken"))
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        discovery = _FakeDiscovery(mocker)
+        discovery.publisher.publish.side_effect = _dropped_publish()
+
+        # Act
+        with caplog.at_level(logging.ERROR, "wool.runtime.worker.pool"):
+            async with WorkerPool(
+                worker=factory, spawn=1, shutdown_timeout=5.0, discovery=discovery
+            ):
+                pass
+
+        # Assert
+        messages = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.ERROR and str(uid) in r.getMessage()
+        ]
+        assert any("announce" in message for message in messages)
+        assert any("could not stop worker" in message for message in messages)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_warn_of_abandonment_when_stop_times_out(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test a stop timeout still reaps despite a failed announcement.
+
+        Given:
+            A WorkerPool whose publisher raises when announcing
+            worker-dropped and whose worker's stop then raises
+            TimeoutError
+        When:
+            The async-with block exits
+        Then:
+            It should report the announcement failure and still warn
+            that it stopped waiting on the worker, since the two
+            failures travel independent paths and the announcement's
+            must not divert the stop's out of the reap bucket
+        """
+        # Arrange
+        uid = uuid.uuid4()
+
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.uid = uid
+            worker.start = mocker.AsyncMock()
+            worker.stop = mocker.AsyncMock(
+                side_effect=TimeoutError("worker did not drain in time")
+            )
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        discovery = _FakeDiscovery(mocker)
+        discovery.publisher.publish.side_effect = _dropped_publish()
+
+        # Act
+        with caplog.at_level(logging.DEBUG, "wool.runtime.worker.pool"):
+            async with WorkerPool(
+                worker=factory, spawn=1, shutdown_timeout=5.0, discovery=discovery
+            ):
+                pass
+
+        # Assert
+        assert any(
+            "announce" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.ERROR
+        )
+        assert any(
+            "stopped waiting" in r.getMessage() and str(uid) in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_not_warn_of_abandonment_when_announcement_times_out(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test a publish TimeoutError is not laundered into a reap warning.
+
+        Given:
+            A WorkerPool whose publisher raises TimeoutError when
+            announcing worker-dropped but whose worker stops cleanly
+        When:
+            The async-with block exits
+        Then:
+            It should not warn that it stopped waiting on a worker it
+            never abandoned, since teardown's reap bucket keys on
+            TimeoutError and a publish timeout must not land in it
+        """
+
+        # Arrange
+        def factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.uid = uuid.uuid4()
+            worker.start = mocker.AsyncMock()
+            worker.stop = mocker.AsyncMock()
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        discovery = _FakeDiscovery(mocker)
+        discovery.publisher.publish.side_effect = _dropped_publish(
+            TimeoutError("discovery publish timed out")
+        )
+
+        # Act
+        with caplog.at_level(logging.DEBUG, "wool.runtime.worker.pool"):
+            async with WorkerPool(
+                worker=factory, spawn=1, shutdown_timeout=5.0, discovery=discovery
+            ):
+                pass
+
+        # Assert — the stop and the announcement report are the sibling
+        # tests' behaviors; this one owns only the absent warning.
+        assert not any(
+            "stopped waiting" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
 
     @pytest.mark.asyncio
     async def test___aexit___should_skip_stopping_workers_that_never_started(


### PR DESCRIPTION
## Summary

Isolate the `worker-dropped` announcement from the worker stop sequenced behind it, so a pool reaps its own workers regardless of the state of its discovery service, reports the discovery failure that drove the teardown, and stays inside its shutdown deadline while doing it.

Teardown announced the drop and then stopped the worker with nothing between them, so any discovery failure abandoned the stop and left a live worker subprocess behind a clean `__aexit__`. Two pools sharing a `LocalDiscovery` namespace reach it today when the segment-owning pool exits first, but that shared segment is only the trigger — a permission error, a corrupt buffer, or a discovery service that has stopped responding all arrive at the same unisolated stop.

The announcement now runs under `try`/`except Exception`/`except CancelledError`/`finally`, and every clause is load-bearing. `except Exception` logs ordinary failures, keeping them off the stop-failure path and out of the reap accounting — either of which would otherwise report a worker that stopped perfectly well as one teardown gave up on. `except asyncio.CancelledError` reports the failure that `except Exception` structurally cannot see: `CancelledError` is a `BaseException`, so an announcement that *hangs* rather than raises is otherwise reported nowhere, leaving the reap warning to blame the worker for a fault that was discovery's. `finally` guarantees the stop outlives that cancellation. The stop takes what remains of the deadline rather than a fresh full `shutdown_timeout`, so an already-cancelled task cannot outlive the deadline the gather exists to enforce.

Measured against real worker subprocesses with a hanging announcement and a 2.0s deadline: teardown completes in **2.16s (1.08×)**, the announcement failure is reported, and the worker is reaped. The overshoot is the reap escalation that `shutdown_timeout` already sanctions, and the graceful drain it forfeits is what that same contract already names as lost — so no carve-out is needed.

Trade-off worth naming: a hanging announcement consumes the deadline it shares with the stop, so the worker is reaped rather than drained. Discovery cannot strand a worker, but it can cost that worker its graceful drain.

The second half of the issue — teardown discarding every stop failure that is not a `TimeoutError` — is already fixed on `release` by `0679460`, so this PR does not revisit it.

Known limitations, left unfixed and documented. `shutdown_timeout=None` plus a hanging announcement blocks teardown indefinitely: there is no deadline to cancel the publish, and `None` already means unbounded by contract. #316 bounds the `LocalDiscovery` lock that makes a publish hang in the first place, which closes this in practice. Separately, a teardown that exhausts its deadline times out publisher cleanup before the publisher's `__aexit__` runs; the mechanism predates this PR, and the docstring no longer claims otherwise.

Closes #298

## Proposed changes

### Isolate the drop announcement from the worker stop

`WorkerPool._worker_context`'s per-worker `stop()` wraps the announcement so it cannot take the stop down with it. Failures are logged against the worker uid, with the traceback attached on the raising path, and carry an `undropped_worker_uid` field so handlers can match on structure rather than prose.

### Report an announcement that hangs

A dedicated `except asyncio.CancelledError` arm logs the deadline-cancelled announcement and re-raises to preserve cancellation semantics. Without it the discovery failure driving the teardown goes unreported entirely and the operator's only signal is a warning naming the wrong culprit.

### Bound the stop by what remains of the deadline

The post-cancellation stop receives `remaining()` rather than a fresh `shutdown_timeout`. At zero the worker is reaped rather than drained, which is the trade `shutdown_timeout` documents. Handing it a fresh budget instead trades a leaked worker for an unbounded teardown.

### Tell the truth in the log message

The failure message no longer claims subscribers "may route to it until their lease expires". `lease` here bounds how many workers are admitted, not how long a stale record survives — and for `LocalDiscovery` a drop that never published is a record that never expires. The message states that the stop is *attempted* regardless and reported separately if it fails, since it is written before the `finally` runs and that stop can fail on its own account.

### Move the teardown contract to where callers find it

The caller-facing guarantees move from the private `_worker_context` docstring onto the public `shutdown_timeout` parameter: reaping does not depend on discovery health, an announcement that raises or hangs is logged and the worker stopped regardless, and each worker's stop receives the remaining deadline. The mechanics and rationale move to an `Implementation notes` rubric, leaving one-line pointers at the code.

### Scope the publish protocol's propagation contract

`DiscoveryPublisherLike.publish` told implementers that every exception raised there reaches the publishing pool. That is now true only of `worker-added`; a `worker-dropped` failure is best-effort, logged, and never blocks reaping. An implementer who declined internal retry on the strength of the old promise would otherwise get only a log line.

### Parameterize the discovery double instead of copying it

`_DirectDiscovery` takes an optional publisher override, replacing a near-duplicate that copied it wholesale. The broken-publisher wrapper forwards `__aenter__`/`__aexit__`: `LocalDiscovery.Publisher` is an async context manager, and hiding that sent `_enter_context` down the passthrough path, leaving the real publisher neither entered nor exited and teardown's publisher-cleanup leg untested.

### Release the strict xfail that pinned the leak

`test___aexit___should_reap_worker_when_owner_pool_exited_first` no longer xfails. On its own it cannot tell this fix apart from a fix to the segment ownership that triggers it — #300 alone would turn it green over an untouched bug — so it now also asserts the announcement genuinely failed, and fails loudly if that stops being true.

### Tighten the WorkerPool docstring to contract, not mechanism

A separate `docs:` commit brings the `WorkerPool` class docstring back to the documentation guide. The `shutdown_timeout` entry, which this PR had grown, is cut to its caller-facing contract, with the deadline apportionment, off-loop reaping, and log-call detail moved into an `Implementation notes` rubric that points to `_worker_context` rather than restating the cancellation rationale it owns. The nine usage examples move below the parameter and raises lists so the constructor contract reads first; a caution records that a finite `shutdown_timeout` overrides a worker's own `shutdown_grace_period`; and several smaller drifts are reconciled (vocabulary, an internal-state leak, cross-reference qualification, and a re-derivation the entry already delegates to `WorkerFactory`).

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerPool` | A publisher raising any of eight exception types on `worker-dropped` | The async-with block exits | It awaits the worker's stop with the remaining deadline whatever was raised | Fix is not scoped to `FileNotFoundError` |
| 2 | `TestWorkerPool` | A publisher whose `worker-dropped` announcement never returns | The shutdown deadline cancels the pending announcement | It still awaits the worker's stop, bounded by the exhausted deadline | The `finally` and the remaining-deadline bound |
| 3 | `TestWorkerPool` | A publisher whose `worker-dropped` announcement never returns | The shutdown deadline cancels the pending announcement | It logs the announcement failure against the worker uid | The `CancelledError` arm; a hang is reported at all |
| 4 | `TestWorkerPool` | A publisher raising on `worker-dropped` | The async-with block exits | It logs the failure against the worker uid with the traceback attached | Announcement failure reported on its own path |
| 5 | `TestWorkerPool` | A pool with `shutdown_timeout=None` and a raising announcement | The async-with block exits | It awaits the worker's stop with no bound of its own | Unbounded pools impose no deadline on the stop |
| 6 | `TestWorkerPool` | Three workers where only the second announcement raises | The async-with block exits | It awaits every worker's stop exactly once | One bad announcement cannot strand siblings |
| 7 | `TestWorkerPool` | An announcement that raises and a stop that also raises | The async-with block exits | It logs both against the uid as separate records | Two reporting paths stay independent |
| 8 | `TestWorkerPool` | An announcement that raises and a stop that raises `TimeoutError` | The async-with block exits | It reports the announcement and still warns that it stopped waiting | A stop timeout still reaches the reap bucket |
| 9 | `TestWorkerPool` | An announcement raising `TimeoutError` and a worker that stops cleanly | The async-with block exits | It does not warn that it stopped waiting on the worker | A publish timeout is not laundered into the reap bucket |
| 10 | `TestWorkerOrphanPrevention` | Two workers on real `LocalDiscovery` whose announcement raises `PermissionError` | The async-with block exits | It leaves no worker subprocess alive and reports one failure per worker | Real subprocess reaped; guards #298 independently of #300 |
| 11 | `TestWorkerOrphanPrevention` | A pool whose announcement hangs, with a finite `shutdown_timeout` | The async-with block exits | It leaves no worker subprocess alive | The hang leak, end to end |
| 12 | `TestOverlappingNamespaceLifecycles` | An owner pool and a non-owner pool on one namespace | The owner exits first, then the non-owner | It leaves no non-owner worker alive and confirms the announcement failed | The reachable trigger, with a vacuity guard |

Non-vacuity is verified rather than assumed. Rows 10 through 12 fail against `release`, so they still guard #298 end to end. Rows 2 and 3 fail against the first-round fix, so they guard the reporting and deadline behavior specifically. Row 8 fails against a mutant that disables the `TimeoutError` reap branch.

An earlier draft of this fix bounded the announcement with `asyncio.wait_for` and dropped the `finally`. It is recorded here because it looks correct and is not: the announcement and the outer `asyncio.wait` share one deadline, so the announcement consumes the whole budget and the stop begins exactly as the deadline cancels it. Measured on real subprocesses it runs to **4.17s against a 2.0s deadline** — worse than the unfixed path it replaces.
