### PR TITLE
Fix LocalDiscovery's registry capacity calculation — Closes #299

### DIFF
--- a/wool/src/wool/__init__.py
+++ b/wool/src/wool/__init__.py
@@ -28,6 +28,7 @@ from wool.runtime.discovery.base import DiscoveryLike
 from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.base import PredicateFunction
+from wool.runtime.discovery.exceptions import DiscoveryCapacityExhausted
 from wool.runtime.discovery.lan import AdvertiseHostError
 from wool.runtime.discovery.lan import LanDiscovery
 from wool.runtime.discovery.lan import LoopbackAdvertisementWarning
@@ -110,6 +111,7 @@ __all__ = [
     "ContextVar",
     "ContextVarCollision",
     "Discovery",
+    "DiscoveryCapacityExhausted",
     "DiscoveryEvent",
     "DiscoveryEventType",
     "DiscoveryLike",

--- a/wool/src/wool/runtime/discovery/exceptions.py
+++ b/wool/src/wool/runtime/discovery/exceptions.py
@@ -1,0 +1,25 @@
+"""The discovery subsystem's exceptions.
+
+Single home for the typed errors the discovery backends raise.
+"""
+
+from __future__ import annotations
+
+from wool.exceptions import WoolError
+
+
+# public
+class DiscoveryCapacityExhausted(WoolError):
+    """Raised when a registration would exceed the segment's capacity.
+
+    A namespace's shared-memory segment is sized to a fixed number of
+    worker slots by its owner (`LocalDiscovery`'s ``capacity``). Once that
+    many workers are registered, publishing another raises this — a typed
+    signal a caller can catch by class rather than by matching a message
+    string. The stamped capacity, when known, is available as ``capacity``.
+    """
+
+    def __init__(self, capacity: int | None = None):
+        self.capacity = capacity
+        detail = "" if capacity is None else f" (capacity {capacity})"
+        super().__init__(f"No available slots in shared memory registrar{detail}")

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -14,6 +14,7 @@ from typing import AsyncGenerator
 from typing import AsyncIterator
 from typing import Callable
 from typing import Final
+from typing import Iterator
 from typing import Self
 from uuid import UUID
 from uuid import uuid4
@@ -30,6 +31,7 @@ from wool.runtime.discovery.base import DiscoveryEventType
 from wool.runtime.discovery.base import DiscoveryPublisherLike
 from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.base import PredicateFunction
+from wool.runtime.discovery.exceptions import DiscoveryCapacityExhausted
 from wool.runtime.discovery.pool import SubscriberMeta
 from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.worker.metadata import WorkerMetadata
@@ -38,6 +40,8 @@ from wool.utilities.noreentry import noreentry
 
 REF_WIDTH: Final = 16
 NULL_REF: Final = b"\x00" * REF_WIDTH
+_HEADER_MAGIC: Final = b"WLD1"
+_HEADER_SIZE: Final = REF_WIDTH
 
 
 class _Watchdog(FileSystemEventHandler):
@@ -203,8 +207,11 @@ class LocalDiscovery(Discovery):
         Used by `subscriber` and as the default for `subscribe` when no
         explicit filter is provided.
     :param capacity:
-        Maximum number of workers that can be registered
-        simultaneously. Defaults to 128.
+        Maximum number of workers registrable — and discoverable —
+        simultaneously. The owner stamps it into the segment on entry, so
+        every publisher and subscriber enforces the same bound without
+        re-declaring it. Publishing a worker once ``capacity`` are
+        registered raises `RuntimeError`. Defaults to 128.
     :param block_size:
         Size in bytes for each worker's serialized data block.
         Defaults to 1024.
@@ -244,6 +251,8 @@ class LocalDiscovery(Discovery):
         capacity: int = 128,
         block_size: int = 1024,
     ):
+        if capacity < 1:
+            raise ValueError(f"Expected capacity of at least 1, got {capacity}")
         self._namespace = namespace or f"workerpool-{uuid4()}"
         self._filter = filter
         self._capacity = capacity
@@ -260,7 +269,7 @@ class LocalDiscovery(Discovery):
         :raises RuntimeError:
             If this instance has already been entered.
         """
-        size = self._capacity * 4
+        size = _HEADER_SIZE + self._capacity * REF_WIDTH
         try:
             self._address_space = SharedMemory(
                 name=_short_hash(self._namespace),
@@ -284,6 +293,9 @@ class LocalDiscovery(Discovery):
             self._cleanup = atexit.register(cleanup)
             for i in range(size):
                 self._address_space.buf[i] = 0
+            struct.pack_into(
+                "<4sI", self._address_space.buf, 0, _HEADER_MAGIC, self._capacity
+            )
         return self
 
     def __exit__(self, *_):
@@ -367,11 +379,13 @@ class LocalDiscovery(Discovery):
     class Publisher:
         """Publisher for broadcasting worker discovery events.
 
-        Publishes worker :class:`discovery events
-        <~wool.DiscoveryEvent>` to a shared memory region where
-        subscribers can discover them. Multiple publishers in different
-        processes can safely write to the same namespace using
-        cross-platform file locking for synchronization.
+        Publishes worker discovery events (see `~wool.DiscoveryEvent`) to
+        a shared memory region where subscribers can discover them.
+        Multiple publishers in different processes can safely write to the
+        same namespace using cross-platform file locking for
+        synchronization. The capacity bound is read from the segment the
+        owning `LocalDiscovery` stamped, so a publisher never re-declares
+        it.
 
         :param namespace:
             The namespace identifier for the shared memory region.
@@ -393,7 +407,7 @@ class LocalDiscovery(Discovery):
         #: See `~wool.DiscoveryPublisherLike.bind_host` for the contract.
         bind_host: str = "127.0.0.1"
 
-        def __init__(self, namespace: str, *, block_size: int = 512):
+        def __init__(self, namespace: str, *, block_size: int = 1024):
             if block_size < 0:
                 raise ValueError("Block size must be positive")
             self._namespace = namespace
@@ -435,11 +449,20 @@ class LocalDiscovery(Discovery):
             :param metadata:
                 Worker metadata to publish.
             :raises RuntimeError:
-                If an unexpected event type is provided or if the
-                shared memory is not properly initialized.
+                If an unexpected event type is provided, or the segment is
+                not yet initialized (a peer attached before the owner
+                stamped the header); the pool's startup aborts and retries
+                in that case.
+            :raises DiscoveryCapacityExhausted:
+                For ``worker-added``, if the segment is already at capacity.
             """
             async with _lock(self._namespace):
                 with _shared_memory(_short_hash(self._namespace)) as address_space:
+                    if (
+                        address_space.buf is None
+                        or _read_capacity(address_space.buf) is None
+                    ):  # pragma: no cover
+                        raise RuntimeError("Registrar service not properly initialized")
                     match type:
                         case "worker-added":
                             await self._add(metadata, address_space)
@@ -460,23 +483,18 @@ class LocalDiscovery(Discovery):
 
             :param metadata:
                 The worker to publish to the namespace's shared memory.
-            :raises RuntimeError:
-                If the shared memory region is not properly initialized or no
-                slots are available.
+            :raises DiscoveryCapacityExhausted:
+                If no slots are available.
             :raises ValueError:
                 If the worker UID is not specified.
             """
-            if address_space.buf is None:
-                raise RuntimeError(
-                    "Registrar service not properly initialized"
-                )  # pragma: no cover
+            assert address_space.buf is not None
 
             ref = _WorkerReference(metadata.uid)
             serialized = metadata.to_protobuf().SerializeToString()
             size = len(serialized)
 
-            for i in range(0, len(address_space.buf), REF_WIDTH):
-                slot = struct.unpack_from("16s", address_space.buf, i)[0]
+            for i, slot in _iter_slots(address_space.buf):
                 if slot == NULL_REF:
                     try:
                         memory_block = await self._shared_memory_pool.acquire(str(ref))
@@ -493,25 +511,19 @@ class LocalDiscovery(Discovery):
                         raise
                     break
             else:
-                raise RuntimeError("No available slots in shared memory registrar")
+                raise DiscoveryCapacityExhausted(_read_capacity(address_space.buf))
 
         async def _drop(self, metadata: WorkerMetadata, address_space: SharedMemory):
             """Unregister a worker by removing it from shared memory.
 
             :param metadata:
                 The worker to unpublish from the namespace's shared memory.
-            :raises RuntimeError:
-                If the registrar service is not properly initialized.
             """
-            if address_space.buf is None:
-                raise RuntimeError(
-                    "Registrar service not properly initialized"
-                )  # pragma: no cover
+            assert address_space.buf is not None
 
             target_ref = _WorkerReference(metadata.uid)
 
-            for i in range(0, len(address_space.buf), REF_WIDTH):
-                slot = struct.unpack_from("16s", address_space.buf, i)[0]
+            for i, slot in _iter_slots(address_space.buf):
                 if slot != NULL_REF:
                     ref = _WorkerReference.from_bytes(slot)
                     if ref == target_ref:
@@ -524,22 +536,16 @@ class LocalDiscovery(Discovery):
 
             :param metadata:
                 The updated worker to publish to the namespace's shared memory.
-            :raises RuntimeError:
-                If the registrar service is not properly initialized.
             :raises KeyError:
                 If the worker is not found in the address space.
             """
-            if address_space.buf is None:
-                raise RuntimeError(
-                    "Registrar service not properly initialized"
-                )  # pragma: no cover
+            assert address_space.buf is not None
 
             target_ref = _WorkerReference(metadata.uid)
             serialized = metadata.to_protobuf().SerializeToString()
             size = len(serialized)
 
-            for i in range(0, len(address_space.buf), REF_WIDTH):
-                slot = struct.unpack_from("16s", address_space.buf, i)[0]
+            for _, slot in _iter_slots(address_space.buf):
                 if slot != NULL_REF:
                     ref = _WorkerReference.from_bytes(slot)
                     if ref == target_ref:
@@ -708,8 +714,7 @@ class LocalDiscovery(Discovery):
                         async with lock:
                             notification.clear()
                             discovered_workers: dict[str, WorkerMetadata] = {}
-                            for i in range(0, len(address_space.buf), REF_WIDTH):
-                                slot = struct.unpack_from("16s", address_space.buf, i)[0]
+                            for _, slot in _iter_slots(address_space.buf):
                                 if slot != NULL_REF:
                                     ref = _WorkerReference.from_bytes(slot)
                                     metadata = self._deserialize_metadata(str(ref))
@@ -790,6 +795,50 @@ class LocalDiscovery(Discovery):
                     "worker-updated", metadata=discovered_workers[uid]
                 )
                 yield event
+
+
+def _read_capacity(buf: memoryview) -> int | None:
+    """Return the owner-stamped capacity, or ``None`` when unstamped.
+
+    The owner writes `_HEADER_MAGIC` and the capacity into the segment
+    header on entry. An attacher that raced that write — or any segment
+    not created by this module — reads a mismatched magic and is reported
+    as not-yet-ready (`None`) rather than trusting a zero-filled header. A
+    subscriber re-reads on its next scan; a publisher instead raises, and
+    the pool's startup aborts and retries.
+
+    :param buf:
+        The mapped address-space buffer.
+    :returns:
+        The stamped capacity, or ``None`` when the header magic is absent.
+    """
+    magic, capacity = struct.unpack_from("<4sI", buf, 0)
+    if magic != _HEADER_MAGIC:  # pragma: no cover
+        return None
+    return capacity
+
+
+def _iter_slots(buf: memoryview) -> Iterator[tuple[int, bytes]]:
+    """Yield each ``(offset, ref_bytes)`` slot bounded by the stamped capacity.
+
+    Reads the owner-stamped capacity from the header and walks exactly
+    that many slots, so ``capacity`` — not the page-rounded mapping — is
+    the enforced ceiling. Yields nothing for a segment whose header is not
+    yet stamped, so a subscriber simply re-reads on its next scan. The
+    capacity is re-read on every call, so a scan always reflects the
+    current header.
+
+    :param buf:
+        The mapped address-space buffer to scan.
+    :yields:
+        ``(offset, ref_bytes)`` for each 16-byte slot, in order.
+    """
+    capacity = _read_capacity(buf)
+    if capacity is None:  # pragma: no cover
+        return
+    limit = _HEADER_SIZE + capacity * REF_WIDTH
+    for offset in range(_HEADER_SIZE, limit, REF_WIDTH):
+        yield offset, struct.unpack_from("16s", buf, offset)[0]
 
 
 def _unlink_quietly(shared_memory: SharedMemory) -> None:

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import asyncio
 import datetime
 import ipaddress
+import os
+import signal
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -134,6 +136,8 @@ class DiscoveryFactory(Enum):
     LAN_DIRECT = auto()
     LAN_CALLABLE = auto()
     LAN_ASYNC_CM = auto()
+    LOCAL_CAPACITY_BOUNDED = auto()
+    LOCAL_CAPACITY_EXACT = auto()
 
 
 class LbFactory(Enum):
@@ -438,6 +442,18 @@ async def build_pool_from_scenario(
         match scenario.discovery:
             case DiscoveryFactory.LOCAL_SYNC_CM:
                 discovery_obj = LocalDiscovery(namespace)
+            case DiscoveryFactory.LOCAL_CAPACITY_BOUNDED:
+                # A sub-page capacity (4 slots) that still admits the
+                # single HYBRID worker — exercises the sized segment and
+                # capacity-bounded publish/subscribe scans end-to-end.
+                discovery_obj = LocalDiscovery(namespace, capacity=4)
+            case DiscoveryFactory.LOCAL_CAPACITY_EXACT:
+                # Capacity exactly equal to the single HYBRID-spawned
+                # worker: the segment is completely full the moment that
+                # worker announces, yet still admits it and dispatches —
+                # the tightest end-to-end bound satisfying the
+                # dispatch-success oracle.
+                discovery_obj = LocalDiscovery(namespace, capacity=1)
             case DiscoveryFactory.LOCAL_CALLABLE:
                 discovery_obj = lambda: LocalDiscovery(namespace)  # noqa: E731
             case DiscoveryFactory.LOCAL_DIRECT:
@@ -1362,6 +1378,53 @@ PAIRWISE_SCENARIOS.append(
     )
 )
 
+# LOCAL_CAPACITY_BOUNDED pairs only with HYBRID (like the LAN factories),
+# so allpairspy's greedy placement can drop it from the generated array.
+# Pin one canonical scenario to guarantee the cover-all guard stays green
+# and the capacity-bounded LocalDiscovery gets a deterministic
+# dispatch-success case.
+PAIRWISE_SCENARIOS.append(
+    Scenario(
+        shape=RoutineShape.COROUTINE,
+        pool_mode=PoolMode.HYBRID,
+        discovery=DiscoveryFactory.LOCAL_CAPACITY_BOUNDED,
+        lb=LbFactory.CLASS_REF,
+        credential=CredentialType.INSECURE,
+        options=WorkerOptionsKind.DEFAULT,
+        timeout=TimeoutKind.NONE,
+        binding=RoutineBinding.MODULE_FUNCTION,
+        lazy=LazyMode.LAZY,
+        backpressure=BackpressureMode.NONE,
+        ctx_var_1=ContextVarPattern.NONE,
+        ctx_var_2=ContextVarPattern.NONE,
+        ctx_var_3=ContextVarPattern.NONE,
+        quorum=QuorumMode.DEFAULT,
+    )
+)
+
+
+# LOCAL_CAPACITY_EXACT is likewise HYBRID-only, so pin one canonical
+# scenario: capacity == the single spawned worker exercises a completely
+# full self-describing segment end-to-end while still dispatching.
+PAIRWISE_SCENARIOS.append(
+    Scenario(
+        shape=RoutineShape.COROUTINE,
+        pool_mode=PoolMode.HYBRID,
+        discovery=DiscoveryFactory.LOCAL_CAPACITY_EXACT,
+        lb=LbFactory.CLASS_REF,
+        credential=CredentialType.INSECURE,
+        options=WorkerOptionsKind.DEFAULT,
+        timeout=TimeoutKind.NONE,
+        binding=RoutineBinding.MODULE_FUNCTION,
+        lazy=LazyMode.LAZY,
+        backpressure=BackpressureMode.NONE,
+        ctx_var_1=ContextVarPattern.NONE,
+        ctx_var_2=ContextVarPattern.NONE,
+        ctx_var_3=ContextVarPattern.NONE,
+        quorum=QuorumMode.DEFAULT,
+    )
+)
+
 
 @st.composite
 def scenarios_strategy(draw):
@@ -1665,3 +1728,21 @@ def retry_grpc_internal():
                 raise
 
     return run
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return whether a process with the given pid currently exists."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _ensure_killed(pid: int | None) -> None:
+    """Send a best-effort SIGKILL so a failing run cannot leak a worker."""
+    if pid is not None and _pid_alive(pid):
+        with suppress(OSError):
+            os.kill(pid, signal.SIGKILL)

--- a/wool/tests/integration/test_local_discovery_capacity.py
+++ b/wool/tests/integration/test_local_discovery_capacity.py
@@ -1,0 +1,175 @@
+"""End-to-end tests for LocalDiscovery capacity enforcement.
+
+These are targeted standalone tests rather than pairwise scenarios:
+capacity **exhaustion** deliberately under-provisions the discovery
+segment so a worker announcement fails, aborting pool entry. That is a
+dispatch *failure*, which would break the pairwise array's single
+dispatch-**success** oracle (`test_dispatch_pairwise`). The
+capacity-bounded happy path — where capacity comfortably admits the
+spawned workers — is exercised through the pairwise array via the
+`DiscoveryFactory.LOCAL_CAPACITY_BOUNDED` shape. Unit-level coverage of
+the cap lives in ``tests/runtime/discovery/test_local.py``.
+"""
+
+import asyncio
+import multiprocessing
+import uuid
+
+import pytest
+
+from wool.runtime.discovery.exceptions import DiscoveryCapacityExhausted
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.worker.pool import WorkerPool
+
+from . import routines
+from .conftest import _ensure_killed
+
+_TIMEOUT = 30
+
+
+@pytest.mark.integration
+class TestLocalDiscoveryCapacity:
+    @pytest.mark.asyncio
+    async def test___aenter___should_raise_when_spawn_exceeds_capacity(self):
+        """Test pool entry fails when spawned workers exceed capacity.
+
+        Given:
+            A hybrid WorkerPool spawning more workers than the declared
+            LocalDiscovery capacity of one slot
+        When:
+            The pool is entered so every worker announces itself
+        Then:
+            It should abort entry with an ExceptionGroup carrying a
+            DiscoveryCapacityExhausted, and leave no spawned worker process
+            alive.
+        """
+        # Arrange
+        namespace = f"capacity-exhaust-{uuid.uuid4().hex[:12]}"
+        before = {child.pid for child in multiprocessing.active_children()}
+
+        # Act & assert
+        try:
+            with pytest.raises(ExceptionGroup) as excinfo:
+                async with asyncio.timeout(_TIMEOUT):
+                    async with WorkerPool(
+                        spawn=3, discovery=LocalDiscovery(namespace, capacity=1)
+                    ):
+                        pass
+
+            leaves = list(_iter_leaf_exceptions(excinfo.value))
+            assert any(
+                isinstance(leaf, DiscoveryCapacityExhausted) for leaf in leaves
+            ), f"expected a DiscoveryCapacityExhausted, got: {leaves!r}"
+
+            # Join finished children so an exited-but-unreaped worker
+            # cannot masquerade as alive under os.kill(pid, 0).
+            multiprocessing.active_children()
+            leaked = [
+                child.pid
+                for child in multiprocessing.active_children()
+                if child.pid not in before
+            ]
+            assert leaked == []
+        finally:
+            for child in multiprocessing.active_children():
+                if child.pid not in before:
+                    _ensure_killed(child.pid)
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_admit_all_workers_when_capacity_equals_spawn(
+        self, retry_grpc_internal
+    ):
+        """Test a pool admits every worker when capacity equals its spawn.
+
+        Given:
+            A hybrid WorkerPool spawning exactly as many workers as the
+            declared LocalDiscovery capacity
+        When:
+            The pool is entered and a routine is dispatched
+        Then:
+            It should enter cleanly, admit every worker, return the
+            routine result, and leave no worker process alive after exit.
+        """
+        # Arrange
+        namespace = f"capacity-ok-{uuid.uuid4().hex[:12]}"
+        before = {child.pid for child in multiprocessing.active_children()}
+
+        async def body():
+            async with asyncio.timeout(_TIMEOUT):
+                async with WorkerPool(
+                    spawn=2, discovery=LocalDiscovery(namespace, capacity=2)
+                ):
+                    assert await routines.add(1, 2) == 3
+
+        # Act & assert
+        try:
+            await retry_grpc_internal(body)
+
+            leaked = [
+                child.pid
+                for child in multiprocessing.active_children()
+                if child.pid not in before
+            ]
+            assert leaked == []
+        finally:
+            for child in multiprocessing.active_children():
+                if child.pid not in before:
+                    _ensure_killed(child.pid)
+
+    @pytest.mark.asyncio
+    async def test___aenter___should_raise_when_non_owner_exceeds_owner_capacity(self):
+        """Test a pool attaching as a non-owner is bound by the owner's cap.
+
+        Given:
+            A pre-entered owner LocalDiscovery holding the namespace at
+            capacity one, and a hybrid WorkerPool whose discovery attaches
+            to the same namespace as a non-owner declaring capacity 128 and
+            spawning two workers
+        When:
+            The pool is entered so both workers announce themselves
+        Then:
+            It should abort entry with an ExceptionGroup carrying a
+            DiscoveryCapacityExhausted and leave no worker process alive — the
+            owner's stamped cap of one governs and the non-owner's declared
+            128 is ignored.
+        """
+        # Arrange — an owner already holds the namespace at capacity one.
+        namespace = f"capacity-nonowner-{uuid.uuid4().hex[:12]}"
+        before = {child.pid for child in multiprocessing.active_children()}
+
+        # Act & assert
+        try:
+            with LocalDiscovery(namespace, capacity=1):
+                with pytest.raises(ExceptionGroup) as excinfo:
+                    async with asyncio.timeout(_TIMEOUT):
+                        async with WorkerPool(
+                            spawn=2,
+                            discovery=LocalDiscovery(namespace, capacity=128),
+                        ):
+                            pass
+
+                leaves = list(_iter_leaf_exceptions(excinfo.value))
+                assert any(
+                    isinstance(leaf, DiscoveryCapacityExhausted) for leaf in leaves
+                ), f"expected a DiscoveryCapacityExhausted, got: {leaves!r}"
+
+                multiprocessing.active_children()
+                leaked = [
+                    child.pid
+                    for child in multiprocessing.active_children()
+                    if child.pid not in before
+                ]
+                assert leaked == []
+        finally:
+            for child in multiprocessing.active_children():
+                if child.pid not in before:
+                    _ensure_killed(child.pid)
+
+
+def _iter_leaf_exceptions(exc: BaseException):
+    """Yield the non-group leaf exceptions of a (possibly nested) group."""
+    if isinstance(exc, BaseExceptionGroup):
+        for sub in exc.exceptions:
+            yield from _iter_leaf_exceptions(sub)
+    else:
+        yield exc

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -1690,13 +1690,6 @@ class TestLocalDiscoveryPublisher:
                 with pytest.raises(KeyError, match=str(metadata.uid)):
                     await publisher.publish("worker-updated", metadata)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "capacity is not enforced until #299 — page rounding inflates "
-            "the segment to a full page"
-        ),
-    )
     @pytest.mark.asyncio
     async def test_publish_to_full_address_space_raises_runtime_error(self, namespace):
         """Test publish to full address space raises RuntimeError.
@@ -1721,8 +1714,8 @@ class TestLocalDiscoveryPublisher:
             for i in range(capacity + 1)
         ]
 
-        with LocalDiscovery(namespace, capacity=capacity):
-            publisher = LocalDiscovery.Publisher(namespace)
+        with LocalDiscovery(namespace, capacity=capacity) as discovery:
+            publisher = discovery.publisher
 
             async with publisher:
                 for worker in workers[:capacity]:

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -1,5 +1,6 @@
 import asyncio
 import atexit
+import pickle
 import struct
 import uuid
 from collections import Counter
@@ -15,6 +16,7 @@ from hypothesis import settings
 from hypothesis import strategies as st
 
 from wool.runtime.discovery.base import DiscoverySubscriberLike
+from wool.runtime.discovery.exceptions import DiscoveryCapacityExhausted
 from wool.runtime.discovery.local import LocalDiscovery
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.afilter import afilter
@@ -155,6 +157,22 @@ class TestLocalDiscovery:
 
         # Assert
         assert discovery.namespace == "my-namespace"
+
+    @pytest.mark.parametrize("capacity", [0, -1])
+    def test___init___should_raise_when_capacity_below_one(self, capacity):
+        """Test LocalDiscovery rejects a capacity below one.
+
+        Given:
+            A capacity of zero or a negative capacity
+        When:
+            LocalDiscovery is instantiated
+        Then:
+            It should raise ValueError, since a segment with fewer than one
+            slot can never admit a worker.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="Expected capacity of at least 1"):
+            LocalDiscovery("ns", capacity=capacity)
 
     def test___hash___with_same_namespace(self):
         """Test hash equality for same namespace.
@@ -1143,6 +1161,63 @@ class TestLocalDiscovery:
         assert events[0].type == "worker-added"
         assert events[0].metadata.uid == worker.uid
 
+    @pytest.mark.asyncio
+    async def test___enter___should_restamp_capacity_when_recreated_by_new_owner(
+        self, namespace
+    ):
+        """Test a new owner generation re-stamps the segment's capacity.
+
+        Given:
+            A namespace previously owned at capacity 1 whose owner has
+            entered and exited, unlinking the segment
+        When:
+            A new owner enters the same namespace at capacity 3 and its
+            publisher registers three workers, then a fourth
+        Then:
+            It should admit all three and reject the fourth — the fresh
+            owner re-stamps capacity 3, so the prior generation's cap of 1
+            does not persist.
+        """
+        # Arrange — a prior owner generation stamps capacity 1, then exits.
+        with LocalDiscovery(namespace, capacity=1) as first:
+            async with first.publisher as publisher:
+                await publisher.publish(
+                    "worker-added",
+                    WorkerMetadata(
+                        uid=uuid.uuid4(),
+                        address="localhost:50051",
+                        pid=1,
+                        version="1.0",
+                    ),
+                )
+
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:{50051 + i}",
+                pid=100 + i,
+                version="1.0",
+            )
+            for i in range(3)
+        ]
+
+        # Act & assert — a new owner generation stamps capacity 3.
+        with LocalDiscovery(namespace, capacity=3) as second:
+            async with second.publisher as publisher:
+                for worker in workers:
+                    await publisher.publish("worker-added", worker)
+
+                with pytest.raises(DiscoveryCapacityExhausted):
+                    await publisher.publish(
+                        "worker-added",
+                        WorkerMetadata(
+                            uid=uuid.uuid4(),
+                            address="localhost:60000",
+                            pid=999,
+                            version="1.0",
+                        ),
+                    )
+
 
 class TestLocalDiscoveryPublisher:
     """Tests for LocalDiscovery.Publisher class.
@@ -1691,8 +1766,8 @@ class TestLocalDiscoveryPublisher:
                     await publisher.publish("worker-updated", metadata)
 
     @pytest.mark.asyncio
-    async def test_publish_to_full_address_space_raises_runtime_error(self, namespace):
-        """Test publish to full address space raises RuntimeError.
+    async def test_publish_should_raise_when_address_space_full(self, namespace):
+        """Test publish to full address space raises DiscoveryCapacityExhausted.
 
         Given:
             A LocalDiscovery whose declared capacity has been filled
@@ -1700,7 +1775,7 @@ class TestLocalDiscoveryPublisher:
         When:
             One worker beyond capacity is published
         Then:
-            It should raise RuntimeError with "No available slots".
+            It should raise DiscoveryCapacityExhausted.
         """
         # Arrange
         capacity = 8
@@ -1722,7 +1797,7 @@ class TestLocalDiscoveryPublisher:
                     await publisher.publish("worker-added", worker)
 
                 # Act & assert
-                with pytest.raises(RuntimeError, match="No available slots"):
+                with pytest.raises(DiscoveryCapacityExhausted):
                     await publisher.publish("worker-added", workers[capacity])
 
     @pytest.mark.asyncio
@@ -2080,6 +2155,378 @@ class TestLocalDiscoveryPublisher:
             # Assert
             block_registered = registered[baseline:]
             assert Counter(block_registered) == Counter(unregistered)
+
+    @given(capacity=st.integers(min_value=1, max_value=8))
+    @settings(
+        max_examples=10,
+        deadline=5000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @pytest.mark.asyncio
+    async def test_publish_should_bound_registrations_by_capacity(
+        self, namespace, capacity
+    ):
+        """Test capacity caps the number of registerable workers.
+
+        Given:
+            A LocalDiscovery declaring an arbitrary small capacity C
+            and its publisher
+        When:
+            C distinct workers are published, then one more
+        Then:
+            It should accept all C and raise DiscoveryCapacityExhausted on the
+            (C+1)th.
+        """
+        # Arrange — a per-example namespace so shared-memory state does
+        # not carry across Hypothesis examples.
+        example_ns = f"{namespace}-{uuid.uuid4().hex[:8]}"
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:{50051 + i}",
+                pid=123 + i,
+                version="1.0",
+            )
+            for i in range(capacity + 1)
+        ]
+
+        # Act & assert
+        with LocalDiscovery(example_ns, capacity=capacity) as discovery:
+            async with discovery.publisher as publisher:
+                for worker in workers[:capacity]:
+                    await publisher.publish("worker-added", worker)
+
+                with pytest.raises(DiscoveryCapacityExhausted):
+                    await publisher.publish("worker-added", workers[capacity])
+
+    @pytest.mark.asyncio
+    async def test_publish_should_reject_second_worker_when_capacity_is_one(
+        self, namespace
+    ):
+        """Test a capacity-one segment admits exactly one worker.
+
+        Given:
+            A LocalDiscovery(capacity=1) — a single 16-byte slot in a
+            page-rounded mapping — and its publisher
+        When:
+            A first worker is published, then a second
+        Then:
+            It should register the first and raise DiscoveryCapacityExhausted
+            on the second; page rounding grants no extra slot.
+        """
+        # Arrange
+        first = WorkerMetadata(
+            uid=uuid.uuid4(), address="localhost:50051", pid=123, version="1.0"
+        )
+        second = WorkerMetadata(
+            uid=uuid.uuid4(), address="localhost:50052", pid=124, version="1.0"
+        )
+
+        # Act & assert
+        with LocalDiscovery(namespace, capacity=1) as discovery:
+            async with discovery.publisher as publisher:
+                await publisher.publish("worker-added", first)
+
+                with pytest.raises(DiscoveryCapacityExhausted):
+                    await publisher.publish("worker-added", second)
+
+    @pytest.mark.asyncio
+    async def test_publish_should_reject_worker_beyond_default_capacity(self, namespace):
+        """Test the default capacity admits exactly 128 workers.
+
+        Given:
+            A LocalDiscovery constructed with no capacity argument and
+            its default publisher
+        When:
+            128 distinct workers are published, then a 129th
+        Then:
+            It should accept all 128 and raise DiscoveryCapacityExhausted on
+            the 129th, pinning the documented default of 128.
+        """
+        # Arrange
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:{50051 + i}",
+                pid=123 + i,
+                version="1.0",
+            )
+            for i in range(129)
+        ]
+
+        # Act & assert
+        with LocalDiscovery(namespace) as discovery:
+            async with discovery.publisher as publisher:
+                for worker in workers[:128]:
+                    await publisher.publish("worker-added", worker)
+
+                with pytest.raises(DiscoveryCapacityExhausted):
+                    await publisher.publish("worker-added", workers[128])
+
+    @pytest.mark.asyncio
+    async def test_publish_should_free_slot_within_capacity_when_worker_dropped(
+        self, namespace
+    ):
+        """Test dropping a worker frees its capped slot for reuse.
+
+        Given:
+            A LocalDiscovery(capacity=1) whose only slot is filled and a
+            second add already rejected
+        When:
+            The first worker is dropped and a second worker is published
+        Then:
+            It should admit the second worker and make it discoverable —
+            the bounded drop freed the single in-cap slot.
+        """
+        # Arrange
+        first = WorkerMetadata(
+            uid=uuid.uuid4(), address="localhost:50051", pid=123, version="1.0"
+        )
+        second = WorkerMetadata(
+            uid=uuid.uuid4(), address="localhost:50052", pid=124, version="1.0"
+        )
+
+        events = []
+        discovered = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                if event.type == "worker-added" and event.metadata.uid == second.uid:
+                    events.append(event)
+                    discovered.set()
+                    break
+
+        with LocalDiscovery(namespace, capacity=1) as discovery:
+            async with discovery.publisher as publisher:
+                await publisher.publish("worker-added", first)
+                with pytest.raises(DiscoveryCapacityExhausted):
+                    await publisher.publish("worker-added", second)
+
+                # Act
+                await publisher.publish("worker-dropped", first)
+                await publisher.publish("worker-added", second)
+
+                # Assert
+                subscriber = discovery.subscribe(poll_interval=0.05)
+                task = asyncio.create_task(collect(subscriber))
+                try:
+                    await asyncio.wait_for(discovered.wait(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    pytest.fail("Second worker not discoverable after freed slot reuse")
+                finally:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+        assert len(events) == 1
+        assert events[0].metadata.uid == second.uid
+
+    @pytest.mark.asyncio
+    async def test_publish_should_update_worker_within_capacity(self, namespace):
+        """Test updating a worker in the last in-cap slot succeeds.
+
+        Given:
+            A LocalDiscovery(capacity=2) holding a filler in slot 0 and
+            the target worker in the last in-cap slot
+        When:
+            The target is republished as "worker-updated" with a bumped
+            version
+        Then:
+            It should locate the target within the bounded scan (no
+            KeyError) and make the new version discoverable.
+        """
+        # Arrange
+        filler = WorkerMetadata(
+            uid=uuid.uuid4(), address="localhost:50051", pid=123, version="1.0"
+        )
+        target = WorkerMetadata(
+            uid=uuid.uuid4(), address="localhost:50052", pid=124, version="1.0"
+        )
+        updated = WorkerMetadata(
+            uid=target.uid, address="localhost:50052", pid=124, version="2.0"
+        )
+
+        discovered = {}
+        target_seen = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                discovered[event.metadata.uid] = event.metadata
+                if event.metadata.uid == target.uid:
+                    target_seen.set()
+                    break
+
+        with LocalDiscovery(namespace, capacity=2) as discovery:
+            async with discovery.publisher as publisher:
+                await publisher.publish("worker-added", filler)
+                await publisher.publish("worker-added", target)
+
+                # Act
+                await publisher.publish("worker-updated", updated)
+
+                # Assert
+                subscriber = discovery.subscribe(poll_interval=0.05)
+                task = asyncio.create_task(collect(subscriber))
+                try:
+                    await asyncio.wait_for(target_seen.wait(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    pytest.fail("Updated worker not discoverable")
+                finally:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+        assert discovered[target.uid].version == "2.0"
+
+    @pytest.mark.asyncio
+    async def test_publish_should_enforce_owner_capacity_when_non_owner_declares_larger(
+        self, namespace
+    ):
+        """Test a non-owner's publisher enforces the owner's stamped capacity.
+
+        Given:
+            An owner LocalDiscovery holding the segment at capacity 1 and a
+            non-owner attached to the same namespace declaring capacity 100
+        When:
+            The non-owner's publisher publishes a first worker, then a
+            second
+        Then:
+            It should admit the first and raise DiscoveryCapacityExhausted on
+            the second — the owner's stamped cap of 1 governs, and the
+            non-owner's declared 100 is ignored.
+        """
+        # Arrange
+        worker_a = WorkerMetadata(
+            uid=uuid.uuid4(), address="localhost:50051", pid=1, version="1.0"
+        )
+        worker_b = WorkerMetadata(
+            uid=uuid.uuid4(), address="localhost:50052", pid=2, version="1.0"
+        )
+
+        # Act & assert
+        with LocalDiscovery(namespace, capacity=1):
+            with LocalDiscovery(namespace, capacity=100) as non_owner:
+                async with non_owner.publisher as publisher:
+                    await publisher.publish("worker-added", worker_a)
+
+                    with pytest.raises(DiscoveryCapacityExhausted):
+                        await publisher.publish("worker-added", worker_b)
+
+    @given(
+        owner_cap=st.integers(min_value=1, max_value=8),
+        peer_cap=st.integers(min_value=1, max_value=8),
+    )
+    @settings(
+        max_examples=15,
+        deadline=5000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @pytest.mark.asyncio
+    async def test_publish_should_bound_non_owner_registrations_by_owner_capacity(
+        self, namespace, owner_cap, peer_cap
+    ):
+        """Test the owner's stamped capacity bounds a non-owner's publisher.
+
+        Given:
+            An owner declaring an arbitrary capacity and a non-owner
+            attached to the same namespace declaring an unrelated capacity
+        When:
+            The non-owner's publisher publishes owner-capacity workers,
+            then one more
+        Then:
+            It should admit exactly the owner's capacity and raise "No
+            available slots" on the next — the segment header is the single
+            source of truth regardless of the non-owner's declared value.
+        """
+        # Arrange — a per-example namespace so shared-memory state does not
+        # carry across Hypothesis examples.
+        example_ns = f"{namespace}-{uuid.uuid4().hex[:8]}"
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:{50051 + i}",
+                pid=100 + i,
+                version="1.0",
+            )
+            for i in range(owner_cap + 1)
+        ]
+
+        # Act & assert
+        with LocalDiscovery(example_ns, capacity=owner_cap):
+            with LocalDiscovery(example_ns, capacity=peer_cap) as non_owner:
+                async with non_owner.publisher as publisher:
+                    for worker in workers[:owner_cap]:
+                        await publisher.publish("worker-added", worker)
+
+                    with pytest.raises(DiscoveryCapacityExhausted):
+                        await publisher.publish("worker-added", workers[owner_cap])
+
+    @given(
+        ops=st.lists(
+            st.tuples(
+                st.sampled_from(["add", "drop"]),
+                st.integers(min_value=0, max_value=4),
+            ),
+            min_size=1,
+            max_size=20,
+        )
+    )
+    @settings(
+        max_examples=15,
+        deadline=5000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @pytest.mark.asyncio
+    async def test_publish_should_bound_registrations_when_workers_cycle_at_capacity(
+        self, namespace, ops
+    ):
+        """Test a capacity-3 segment reuses freed slots under add/drop churn.
+
+        Given:
+            A capacity-3 discovery, a five-worker roster, and an arbitrary
+            sequence of add/drop operations modelled so a currently-live
+            worker is never re-added (the separate #321 defect)
+        When:
+            The operations are published serially through one publisher
+        Then:
+            It should accept an add exactly when fewer than three workers
+            are live and raise DiscoveryCapacityExhausted when three are live —
+            proving a dropped slot is freed and reused within the cap.
+        """
+        # Arrange
+        capacity = 3
+        example_ns = f"{namespace}-{uuid.uuid4().hex[:8]}"
+        roster = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:{50051 + i}",
+                pid=100 + i,
+                version="1.0",
+            )
+            for i in range(5)
+        ]
+        live: set[int] = set()
+
+        # Act & assert
+        with LocalDiscovery(example_ns, capacity=capacity) as discovery:
+            async with discovery.publisher as publisher:
+                for action, index in ops:
+                    if action == "add":
+                        if index in live:
+                            continue
+                        if len(live) < capacity:
+                            await publisher.publish("worker-added", roster[index])
+                            live.add(index)
+                        else:
+                            with pytest.raises(DiscoveryCapacityExhausted):
+                                await publisher.publish("worker-added", roster[index])
+                    elif index in live:
+                        await publisher.publish("worker-dropped", roster[index])
+                        live.discard(index)
 
 
 class TestWorkerReference:
@@ -2572,6 +3019,265 @@ class TestLocalDiscoverySubscriber:
         assert len(events_2) == 1
         assert events_2[0].type == "worker-added"
         assert events_2[0].metadata.uid == metadata.uid
+
+    @pytest.mark.asyncio
+    async def test___aiter___should_discover_all_workers_up_to_capacity(self, namespace):
+        """Test a subscriber discovers every worker up to capacity.
+
+        Given:
+            A LocalDiscovery(capacity=4) with four distinct workers
+            published through its publisher
+        When:
+            The discovery's subscriber iterates
+        Then:
+            It should discover exactly the four published worker uids.
+        """
+        # Arrange
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:{50051 + i}",
+                pid=123 + i,
+                version="1.0",
+            )
+            for i in range(4)
+        ]
+        expected = {worker.uid for worker in workers}
+        seen = set()
+        all_seen = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                if event.type == "worker-added":
+                    seen.add(event.metadata.uid)
+                    if expected <= seen:
+                        all_seen.set()
+                        break
+
+        with LocalDiscovery(namespace, capacity=4) as discovery:
+            async with discovery.publisher as publisher:
+                for worker in workers:
+                    await publisher.publish("worker-added", worker)
+
+                # Act
+                subscriber = discovery.subscribe(poll_interval=0.05)
+                task = asyncio.create_task(collect(subscriber))
+                try:
+                    await asyncio.wait_for(all_seen.wait(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    pytest.fail("Not all workers discovered within timeout")
+                finally:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+        # Assert
+        assert seen == expected
+
+    @given(capacity=st.integers(min_value=1, max_value=8))
+    @settings(
+        max_examples=10,
+        deadline=5000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @pytest.mark.asyncio
+    async def test___aiter___should_discover_workers_up_to_capacity(
+        self, namespace, capacity
+    ):
+        """Test a subscriber discovers every worker the segment admits.
+
+        Given:
+            A LocalDiscovery declaring an arbitrary small capacity C with
+            C workers published through its publisher
+        When:
+            The discovery's subscriber — told no capacity of its own —
+            iterates
+        Then:
+            It should discover exactly the C published worker uids, its
+            scan bounded by the capacity the owner stamped into the
+            segment.
+        """
+        # Arrange — a per-example namespace so shared-memory state does
+        # not carry across Hypothesis examples.
+        example_ns = f"{namespace}-{uuid.uuid4().hex[:8]}"
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:{50051 + i}",
+                pid=123 + i,
+                version="1.0",
+            )
+            for i in range(capacity)
+        ]
+        expected = {worker.uid for worker in workers}
+        seen = set()
+        all_seen = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                if event.type == "worker-added":
+                    seen.add(event.metadata.uid)
+                    if expected <= seen:
+                        all_seen.set()
+                        break
+
+        # Act
+        with LocalDiscovery(example_ns, capacity=capacity) as discovery:
+            async with discovery.publisher as publisher:
+                for worker in workers:
+                    await publisher.publish("worker-added", worker)
+
+                subscriber = discovery.subscribe(poll_interval=0.05)
+                task = asyncio.create_task(collect(subscriber))
+                try:
+                    await asyncio.wait_for(all_seen.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    pytest.fail("Not all workers discovered within timeout")
+                finally:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+        # Assert
+        assert seen == expected
+
+    @pytest.mark.asyncio
+    async def test___aiter___should_bound_non_owner_subscriber_by_owner_capacity(
+        self, namespace
+    ):
+        """Test a non-owner's subscriber reads the owner's stamped capacity.
+
+        Given:
+            An owner LocalDiscovery at capacity 4 with four workers
+            published, and a non-owner attached to the same namespace
+            declaring capacity 1
+        When:
+            A subscriber obtained from the non-owner iterates
+        Then:
+            It should discover all four workers — the scan is bounded by
+            the owner's stamped capacity, and the non-owner's declared 1 is
+            ignored.
+        """
+        # Arrange
+        workers = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:{50051 + i}",
+                pid=100 + i,
+                version="1.0",
+            )
+            for i in range(4)
+        ]
+        expected = {worker.uid for worker in workers}
+        seen = set()
+        all_seen = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                if event.type == "worker-added":
+                    seen.add(event.metadata.uid)
+                    if expected <= seen:
+                        all_seen.set()
+                        break
+
+        # Act
+        with LocalDiscovery(namespace, capacity=4) as owner:
+            async with owner.publisher as publisher:
+                for worker in workers:
+                    await publisher.publish("worker-added", worker)
+
+                with LocalDiscovery(namespace, capacity=1) as non_owner:
+                    subscriber = non_owner.subscribe(poll_interval=0.05)
+                    task = asyncio.create_task(collect(subscriber))
+                    try:
+                        await asyncio.wait_for(all_seen.wait(), timeout=5.0)
+                    except asyncio.TimeoutError:
+                        pytest.fail("Non-owner subscriber did not discover all workers")
+                    finally:
+                        task.cancel()
+                        try:
+                            await task
+                        except asyncio.CancelledError:
+                            pass
+
+        # Assert
+        assert seen == expected
+
+    def test___new___should_return_distinct_object_when_key_matches(self, namespace):
+        """Test constructing a Subscriber returns a fresh object each call.
+
+        Given:
+            A namespace and a fixed poll interval
+        When:
+            `LocalDiscovery.Subscriber` is constructed twice with the same
+            namespace and poll interval
+        Then:
+            It should return two distinct objects of the same type.
+
+        Note:
+            The metaclass returns a fresh wrapper over a shared source per
+            call; that sharing is not observable through object identity, so
+            this test pins only the per-call distinctness.
+        """
+        # Act
+        first = LocalDiscovery.Subscriber(namespace, poll_interval=0.05)
+        second = LocalDiscovery.Subscriber(namespace, poll_interval=0.05)
+
+        # Assert
+        assert first is not second
+        assert type(first) is type(second)
+
+    @pytest.mark.asyncio
+    async def test___reduce___should_rebind_subscriber_to_its_namespace(
+        self, namespace, metadata
+    ):
+        """Test a pickled subscriber reconstructs bound to its namespace.
+
+        Given:
+            A subscriber for a namespace, pickled before any iteration
+        When:
+            It is unpickled and the reconstructed subscriber iterates while
+            a worker is published to that namespace
+        Then:
+            It should discover the worker — the pickle round-trip rebinds
+            the subscriber to the same namespace.
+        """
+        # Arrange
+        subscriber = LocalDiscovery.Subscriber(namespace, poll_interval=0.05)
+        restored = pickle.loads(pickle.dumps(subscriber))
+
+        events = []
+        received = asyncio.Event()
+
+        async def collect(sub):
+            async for event in sub:
+                events.append(event)
+                received.set()
+                break
+
+        # Act
+        with LocalDiscovery(namespace) as discovery:
+            async with discovery.publisher as publisher:
+                task = asyncio.create_task(collect(restored))
+                await publisher.publish("worker-added", metadata)
+                try:
+                    await asyncio.wait_for(received.wait(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    pytest.fail("Reconstructed subscriber did not discover the worker")
+                finally:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].metadata.uid == metadata.uid
 
 
 def _enter_lifecycle_forest(namespace, forest):

--- a/wool/tests/test_public.py
+++ b/wool/tests/test_public.py
@@ -80,6 +80,7 @@ def test_public_api_completeness_should_match_expected_surface():
         "WorkerProxy",
         "WorkerService",
         "Discovery",
+        "DiscoveryCapacityExhausted",
         "DiscoveryEvent",
         "DiscoveryEventType",
         "DiscoveryLike",


### PR DESCRIPTION
## Summary

Enforce the cap `LocalDiscovery(capacity=N)` documents. The shared-memory segment was under-sized — four bytes per worker against sixteen-byte slots — and every slot scan walked the page-rounded mapping rather than `capacity`, so the effective ceiling was whatever the OS mapped (roughly 1024 slots on a 16 KiB page) and any sub-page capacity was ignored entirely.

Make the segment self-describing. The owner stamps the capacity into a header at the head of the segment on entry, and `Publisher` and `Subscriber` read that bound from the header on every scan instead of taking a `capacity` argument. The segment becomes the single source of truth: an attacher can no longer declare a capacity that disagrees with the owner's, and page rounding no longer masks a sub-page cap. Publishing beyond the cap raises `DiscoveryCapacityExhausted`, a typed `WoolError` a caller can catch by class, and a subscriber discovers workers only up to the stamped capacity.

The adjacent duplicate-`worker-added` defect is out of scope and tracked separately in #321. Reshaping the segment's ownership model — a value that owns teardown by a create-race — is likewise out of scope and tracked in #300.

Closes #299

## Proposed changes

### Stamp the capacity into a segment header

Size the segment at `_HEADER_SIZE + capacity * REF_WIDTH` and, on owner entry, write a magic and capacity header at offset 0; slots begin after the header. Attachers read the owner's stamped capacity rather than re-declaring it. Reject a `capacity` below one at construction with `ValueError`, matching the `block_size` and `poll_interval` guards.

### Read the enforced bound on attach

Drop the `capacity` parameter from `Publisher` and `Subscriber`. Both read the bound from the header on every scan through the new `_read_capacity` and `_iter_slots` helpers, so `capacity` — not the page-rounded mapping — is the ceiling. When an attacher observes the segment before the owner has stamped it, a subscriber re-reads on its next scan and a publisher raises, deferring to the pool's startup retry. Revert the `Subscriber` singleton key to `(namespace, poll_interval)`, since capacity is no longer per-attacher state. Align the `Publisher` `block_size` default with `LocalDiscovery` so direct construction and the `.publisher` property agree.

### Surface a typed exhaustion contract

Introduce `DiscoveryCapacityExhausted`, a public `WoolError` subclass carrying the stamped capacity, raised when a worker is published into a full segment — so callers catch exhaustion by class rather than by matching a message string, joining the existing `AdvertiseHostError` precedent. Document the exhaustion case, and the not-ready case, on the public `publish` and on `LocalDiscovery`'s `capacity` parameter.

### Exercise capacity end-to-end in the pairwise harness

Add a `LOCAL_CAPACITY_BOUNDED` shape (capacity 4, a comfortable margin over the single HYBRID worker) and a `LOCAL_CAPACITY_EXACT` shape (capacity 1, exactly the spawned worker — a completely full segment that still dispatches) so the self-describing segment is driven through the existing pairwise dispatch oracle.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestLocalDiscovery` | A capacity of zero or a negative capacity | `LocalDiscovery` is instantiated | It raises `ValueError` | Capacity lower bound |
| 2 | `TestLocalDiscoveryPublisher` | A `LocalDiscovery(capacity=C)` for arbitrary small C | C workers are published then one more | The C+1th raises `DiscoveryCapacityExhausted` | Capacity boundary (property) |
| 3 | `TestLocalDiscoveryPublisher` | A `LocalDiscovery(capacity=1)` | A second worker is published | It raises `DiscoveryCapacityExhausted` | Sub-page capacity |
| 4 | `TestLocalDiscoveryPublisher` | A default `LocalDiscovery` | 128 workers are published then a 129th | The 129th raises `DiscoveryCapacityExhausted` | Default capacity 128 |
| 5 | `TestLocalDiscoveryPublisher` | A one-slot discovery whose slot is filled | The worker is dropped and another added | The later add succeeds and is discoverable | Freed slot reused |
| 6 | `TestLocalDiscoveryPublisher` | A `capacity=2` discovery holding a worker in the last slot | That worker is updated | The update applies without `KeyError` | Update within the cap |
| 7 | `TestLocalDiscoveryPublisher` | An owner `capacity=1` and a non-owner declaring `capacity=100` | The non-owner's publisher publishes a second worker | It raises `DiscoveryCapacityExhausted` — the owner's stamp governs | Non-owner bound by owner (publisher) |
| 8 | `TestLocalDiscoveryPublisher` | An owner and a non-owner declaring mismatched capacities | The non-owner's publisher fills to the owner's capacity then one more | It admits exactly the owner's capacity regardless of the non-owner's | Header round-trip (property) |
| 9 | `TestLocalDiscoveryPublisher` | A tight-capacity discovery and an add-or-drop operation sequence | The operations are published serially | Each add is admitted below the cap and rejected at it, and freed slots are reused | Freed-slot reuse under churn (property) |
| 10 | `TestLocalDiscoverySubscriber` | A `capacity=4` discovery with four workers | The subscriber iterates | It discovers all four | Discovery up to capacity |
| 11 | `TestLocalDiscoverySubscriber` | A `capacity=C` discovery with C workers | A subscriber told no capacity iterates | It discovers exactly C, bounded by the stamped capacity | Read-side bound (property) |
| 12 | `TestLocalDiscoverySubscriber` | An owner `capacity=4` with four workers and a non-owner declaring `capacity=1` | The non-owner's subscriber iterates | It discovers all four | Non-owner bound by owner (subscriber) |
| 13 | `TestLocalDiscoverySubscriber` | A namespace and poll interval | `Subscriber` is called twice with matching arguments | It returns two distinct objects of the same type | Singleton returns a fresh wrapper |
| 14 | `TestLocalDiscoverySubscriber` | A subscriber pickled before iteration | It is unpickled and iterates while a worker is published | It discovers the worker | Pickle round-trip rebinds the namespace |
| 15 | `TestLocalDiscovery` | A namespace previously owned at `capacity=1` that has exited | A new owner enters at `capacity=3` and publishes three workers | It admits all three and rejects a fourth | Per-generation re-stamp |
| 16 | `TestLocalDiscoveryCapacity` | A pool spawning more workers than its discovery capacity | The pool is entered | Entry raises an `ExceptionGroup` carrying `DiscoveryCapacityExhausted` and leaks no worker | Exhaustion through a real pool |
| 17 | `TestLocalDiscoveryCapacity` | A pool whose capacity equals its worker count | The pool is entered and a routine dispatched | It enters cleanly and returns the result | Capacity-equals-spawn control |
| 18 | `TestLocalDiscoveryCapacity` | A pre-entered owner `capacity=1` and a pool attaching as a non-owner at `capacity=128` | The pool is entered | Entry raises `DiscoveryCapacityExhausted` — the owner's stamp governs | Non-owner bound end-to-end |
| 19 | `test_dispatch_pairwise` | A pairwise scenario using `LOCAL_CAPACITY_BOUNDED` or `LOCAL_CAPACITY_EXACT` | The pool is built and a routine dispatched | It returns the expected result | Self-describing segment end-to-end |
