### PR TITLE
Fix the unrenderable Mermaid sequence diagram in the root README — Closes #323

### DIFF
--- a/wool/README.md
+++ b/wool/README.md
@@ -527,7 +527,7 @@ sequenceDiagram
     participant Worker
 
     %% -- 1. Pool startup --
-    rect rgb(0, 0, 0, 0)
+    rect rgba(0, 0, 0, 0)
         Note over Client, Worker: Worker pool startup
 
         Client ->> Pool: create pool (spawn, discovery, loadbalancer)
@@ -549,7 +549,7 @@ sequenceDiagram
     end
 
     %% -- 2. Discovery --
-    rect rgb(0, 0, 0, 0)
+    rect rgba(0, 0, 0, 0)
         Note over Discovery, Loadbalancer: Worker discovery
 
         par Worker discovery
@@ -569,7 +569,7 @@ sequenceDiagram
     end
 
     %% -- 3. Task dispatch --
-    rect rgb(0, 0, 0, 0)
+    rect rgba(0, 0, 0, 0)
         Note over Client, Worker: Task dispatch
 
         Client ->> Routine: invoke wool routine
@@ -580,7 +580,7 @@ sequenceDiagram
         loop Until handshake resolves or all workers exhausted
             Loadbalancer ->> Loadbalancer: select next worker
             Loadbalancer ->> Worker: open stream, write task frame
-            Worker ->> Worker: VersionInterceptor; DispatchSession.__aenter__ (parse)
+            Worker ->> Worker: VersionInterceptor, then DispatchSession.__aenter__ (parse)
             alt Ack
                 Worker -->> Loadbalancer: Ack
                 Loadbalancer ->> Loadbalancer: break
@@ -600,7 +600,7 @@ sequenceDiagram
         end
 
         Worker ->> Worker: DispatchSession.__aiter__ schedules worker driver lazily
-        Worker ->> Worker: routine_scope enters; routine runs under the work context
+        Worker ->> Worker: routine_scope enters, routine runs under the work context
 
         alt Coroutine (single synthesized "next" request)
             Worker ->> Worker: _drive_step advances coroutine, serializes result + context
@@ -618,7 +618,7 @@ sequenceDiagram
             end
         else Routine or encoding exception
             Worker ->> Worker: drain worker, read final wire context published by worker task
-            Worker -->> Routine: terminal Response.exception (cloudpickled; decode/encode failures ride on __context__/__cause__)
+            Worker -->> Routine: terminal Response.exception (cloudpickled, decode/encode failures ride on __context__/__cause__)
             Routine ->> Routine: deserialize exception (preserves type and traceback)
             Routine -->> Client: re-raise
         end
@@ -626,7 +626,7 @@ sequenceDiagram
     end
 
     %% -- 4. Teardown --
-    rect rgb(0, 0, 0, 0)
+    rect rgba(0, 0, 0, 0)
         Note over Client, Worker: Worker pool teardown
 
         Client ->> Pool: exit pool


### PR DESCRIPTION
## Summary

Repair the Mermaid `sequenceDiagram` in the root `README.md` so it renders. The diagram currently fails to parse on GitHub because three message labels contain semicolons, which Mermaid treats as statement separators — the parser splits each label at the `;` and chokes on the arrow-less remainder. Replace those semicolons with commas so each label stays a single statement. Separately, switch the four section-wrapper rectangles from `rgb(0, 0, 0, 0)` to the valid `rgba(0, 0, 0, 0)`, since a four-argument `rgb()` is invalid legacy CSS that stricter renderers fall back to opaque black. This is a documentation-only change with no source or test impact.

Closes #323

## Proposed changes

### Remove render-blocking semicolons from message labels

Replace the semicolon in three self-message labels (a comma, plus "then" for the one ordered pair) so each stays a single Mermaid statement:

- `VersionInterceptor; DispatchSession.__aenter__ (parse)` → `VersionInterceptor, then DispatchSession.__aenter__ (parse)`
- `routine_scope enters; routine runs under the work context` → `routine_scope enters, routine runs under the work context`
- `terminal Response.exception (cloudpickled; decode/encode failures …)` → same clause with a comma

### Make the transparent section backgrounds portable

Switch all four `rect rgb(0, 0, 0, 0)` wrappers to `rect rgba(0, 0, 0, 0)`, the universally-supported fully-transparent fill.

## Test cases

Documentation-only — no code changes and no automated tests apply. Verified by rendering the corrected diagram locally with `@mermaid-js/mermaid-cli`: it produced a clean SVG with no parse error, all six participants present, and four transparent section backgrounds.