### PR TITLE
Bound LocalDiscovery's lock acquisition and stop its busy-spin — Closes #316

### DIFF
--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -40,6 +40,7 @@ from wool.utilities.noreentry import noreentry
 
 REF_WIDTH: Final = 16
 NULL_REF: Final = b"\x00" * REF_WIDTH
+DEFAULT_LOCK_TIMEOUT: Final[float] = 30.0
 _HEADER_MAGIC: Final = b"WLD1"
 _HEADER_SIZE: Final = REF_WIDTH
 
@@ -215,6 +216,11 @@ class LocalDiscovery(Discovery):
     :param block_size:
         Size in bytes for each worker's serialized data block.
         Defaults to 1024.
+    :param lock_timeout:
+        Maximum seconds a publisher waits to acquire the cross-process
+        file lock; see `LocalDiscovery.Publisher` for the acquisition
+        contract. Plumbed through to each `Publisher`. Defaults to
+        `DEFAULT_LOCK_TIMEOUT`.
 
     Example — publish workers:
 
@@ -250,6 +256,7 @@ class LocalDiscovery(Discovery):
         filter: PredicateFunction | None = None,
         capacity: int = 128,
         block_size: int = 1024,
+        lock_timeout: float | None = DEFAULT_LOCK_TIMEOUT,
     ):
         if capacity < 1:
             raise ValueError(f"Expected capacity of at least 1, got {capacity}")
@@ -257,6 +264,7 @@ class LocalDiscovery(Discovery):
         self._filter = filter
         self._capacity = capacity
         self._block_size = block_size
+        self._lock_timeout = lock_timeout
 
     @noreentry
     def __enter__(self) -> Self:
@@ -334,7 +342,11 @@ class LocalDiscovery(Discovery):
         :returns:
             A publisher instance for broadcasting worker events.
         """
-        return self.Publisher(self._namespace, block_size=self._block_size)
+        return self.Publisher(
+            self._namespace,
+            block_size=self._block_size,
+            lock_timeout=self._lock_timeout,
+        )
 
     @property
     def subscriber(self) -> DiscoverySubscriberLike:
@@ -393,12 +405,17 @@ class LocalDiscovery(Discovery):
             Size in bytes for worker metadata storage blocks. Defaults
             to 512 bytes, which accommodates typical worker
             metadata including tags and extra metadata.
+        :param lock_timeout:
+            Maximum seconds to wait for the cross-process file lock before
+            raising `TimeoutError`. ``None`` waits forever. Defaults to
+            `DEFAULT_LOCK_TIMEOUT`.
         :raises ValueError:
-            If block_size is negative.
+            If ``block_size`` is negative, or ``lock_timeout`` is negative.
         """
 
         _block_size: int
         _cleanups: dict[str, Callable]
+        _lock_timeout: float | None
         _namespace: Final[str]
         _shared_memory_pool: ResourcePool[SharedMemory]
 
@@ -407,11 +424,20 @@ class LocalDiscovery(Discovery):
         #: See `~wool.DiscoveryPublisherLike.bind_host` for the contract.
         bind_host: str = "127.0.0.1"
 
-        def __init__(self, namespace: str, *, block_size: int = 1024):
+        def __init__(
+            self,
+            namespace: str,
+            *,
+            block_size: int = 1024,
+            lock_timeout: float | None = DEFAULT_LOCK_TIMEOUT,
+        ):
             if block_size < 0:
                 raise ValueError("Block size must be positive")
+            if lock_timeout is not None and lock_timeout < 0:
+                raise ValueError("Lock timeout must be non-negative")
             self._namespace = namespace
             self._block_size = block_size
+            self._lock_timeout = lock_timeout
             self._cleanups = {}
             self._shared_memory_pool = ResourcePool(
                 factory=self._shared_memory_factory,
@@ -455,8 +481,11 @@ class LocalDiscovery(Discovery):
                 in that case.
             :raises DiscoveryCapacityExhausted:
                 For ``worker-added``, if the segment is already at capacity.
+            :raises TimeoutError:
+                If the cross-process file lock is not acquired within this
+                publisher's ``lock_timeout``.
             """
-            async with _lock(self._namespace):
+            async with _lock(self._namespace, timeout=self._lock_timeout):
                 with _shared_memory(_short_hash(self._namespace)) as address_space:
                     if (
                         address_space.buf is None
@@ -925,30 +954,55 @@ def _shared_memory(name):
 
 
 @asynccontextmanager
-async def _lock(namespace: str):
+async def _lock(namespace: str, *, timeout: float | None = DEFAULT_LOCK_TIMEOUT):
     """Acquire an exclusive lock for the address space identified by namespace.
 
     Uses cross-platform file locking (via portalocker) to synchronize access
     across unrelated processes that may be publishing to the same shared
-    memory region. Works on Windows, Linux, and macOS.
+    memory region. Works on Windows, Linux, and macOS, and does not block the
+    event loop while waiting for acquisition.
 
-    Uses non-blocking lock attempts with async sleep to avoid blocking the
-    event loop while waiting for lock acquisition. Retries every 1ms until
-    the lock is acquired.
+    ``timeout`` bounds **acquisition only, never the held section**. Once the
+    lock is held the ``with`` body runs to completion regardless of how long
+    it takes.
 
     :param namespace:
         The namespace identifying the shared memory region to lock.
+    :param timeout:
+        Maximum seconds to wait for acquisition. ``None`` waits forever.
+        Defaults to `DEFAULT_LOCK_TIMEOUT`.
+    :raises TimeoutError:
+        If the lock is not acquired within ``timeout`` seconds.
+
+    .. rubric:: Implementation notes
+
+    Acquisition uses non-blocking ``portalocker`` attempts, retrying every
+    1ms (``await asyncio.sleep(0.001)``) until the lock is acquired or
+    ``timeout`` elapses. The lock holder is by definition another process, so
+    a hot spin here cannot make it release sooner — it would only burn CPU
+    competing with the process being waited on — hence the 1ms poll rather
+    than a zero-second yield.
+
+    The held section runs to completion because interrupting a holder
+    mid-write would corrupt the shared segment for every attached process.
     """
     lock_name = _short_hash(namespace)
     lock_path = Path(tempfile.gettempdir()).resolve() / f"wool-lock-{lock_name}"
 
     with open(lock_path, "w") as lock_file:
+        loop = asyncio.get_running_loop()
+        deadline = None if timeout is None else loop.time() + timeout
         while True:
             try:
                 portalocker.lock(lock_file, portalocker.LOCK_EX | portalocker.LOCK_NB)
                 break
             except portalocker.LockException:
-                await asyncio.sleep(0)
+                if deadline is not None and loop.time() >= deadline:
+                    raise TimeoutError(
+                        f"Timed out after {timeout}s waiting to acquire the "
+                        f"discovery lock for namespace {namespace!r}"
+                    )
+                await asyncio.sleep(0.001)
 
         try:
             yield

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -11,6 +11,9 @@ import datetime
 import ipaddress
 import os
 import signal
+import subprocess
+import sys
+import threading
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -1746,3 +1749,68 @@ def _ensure_killed(pid: int | None) -> None:
     if pid is not None and _pid_alive(pid):
         with suppress(OSError):
             os.kill(pid, signal.SIGKILL)
+
+
+def _iter_leaf_exceptions(exc: BaseException):
+    """Yield the non-group leaf exceptions of a (possibly nested) group."""
+    if isinstance(exc, BaseExceptionGroup):
+        for sub in exc.exceptions:
+            yield from _iter_leaf_exceptions(sub)
+    else:
+        yield exc
+
+
+def spawn_script_subprocess(script, *args, ready_line, timeout=10):
+    """Run script in a fresh interpreter and wait for its readiness line.
+
+    Spawns ``[sys.executable, "-c", script, *args]`` with an open stdin pipe
+    (so the child can block awaiting release), a captured stdout pipe for the
+    handshake, and a discarded stderr. Returns the process once it prints
+    ``ready_line`` to stdout. If the child does not report readiness within
+    ``timeout`` seconds it is killed before the failure propagates, so a stuck
+    or crashing child never leaks. The caller must release the returned
+    process with `release_subprocess`.
+    """
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script, *args],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    try:
+        assert proc.stdout is not None
+        line_holder: list[str] = []
+
+        def _await_ready():
+            try:
+                line_holder.append(proc.stdout.readline().strip())
+            except (ValueError, OSError):
+                pass  # stdout closed during teardown
+
+        reader = threading.Thread(target=_await_ready, daemon=True)
+        reader.start()
+        reader.join(timeout)
+        if reader.is_alive():
+            raise TimeoutError(
+                f"subprocess did not report {ready_line!r} within {timeout}s"
+            )
+        line = line_holder[0] if line_holder else ""
+        assert line == ready_line, f"subprocess failed to become ready: {line!r}"
+    except BaseException:
+        release_subprocess(proc)
+        raise
+    return proc
+
+
+def release_subprocess(proc: subprocess.Popen | None) -> None:
+    """Best-effort kill and pipe-close so a failing run cannot leak a subprocess."""
+    if proc is None:
+        return
+    if proc.poll() is None:
+        proc.kill()
+        proc.wait(timeout=10)
+    for stream in (proc.stdin, proc.stdout, proc.stderr):
+        if stream is not None:
+            with suppress(Exception):
+                stream.close()

--- a/wool/tests/integration/test_local_discovery_capacity.py
+++ b/wool/tests/integration/test_local_discovery_capacity.py
@@ -23,6 +23,7 @@ from wool.runtime.worker.pool import WorkerPool
 
 from . import routines
 from .conftest import _ensure_killed
+from .conftest import _iter_leaf_exceptions
 
 _TIMEOUT = 30
 
@@ -164,12 +165,3 @@ class TestLocalDiscoveryCapacity:
             for child in multiprocessing.active_children():
                 if child.pid not in before:
                     _ensure_killed(child.pid)
-
-
-def _iter_leaf_exceptions(exc: BaseException):
-    """Yield the non-group leaf exceptions of a (possibly nested) group."""
-    if isinstance(exc, BaseExceptionGroup):
-        for sub in exc.exceptions:
-            yield from _iter_leaf_exceptions(sub)
-    else:
-        yield exc

--- a/wool/tests/integration/test_local_discovery_lock_timeout.py
+++ b/wool/tests/integration/test_local_discovery_lock_timeout.py
@@ -1,0 +1,240 @@
+"""End-to-end tests for LocalDiscovery lock-timeout bounding (#316).
+
+These are targeted standalone tests rather than pairwise scenarios. A
+wedged discovery lock is a teardown/failure shape: the publish that
+contends it raises `TimeoutError`, aborting pool entry or logging a
+failed drop announcement. That would break the pairwise array's single
+dispatch-**success** oracle (`test_dispatch_pairwise`), exactly as
+capacity exhaustion does (see ``test_local_discovery_capacity.py``). The
+uncontended happy path — where the lock is always acquired on the first
+attempt and ``lock_timeout`` never fires — is already exercised through
+every HYBRID pairwise row with the default ``lock_timeout=30.0``, so a new
+`DiscoveryFactory` member would add no observable coverage.
+
+Genuine cross-process contention also requires a distinct interpreter: on
+POSIX, `fcntl`/`portalocker` advisory locks are per-process, so a second
+acquisition inside this process would not conflict. The `_HOLDER_SCRIPT`
+subprocess acquires the lock through the production `_lock` context manager
+itself, guaranteeing the same lock-file path (`_short_hash`) and mechanism
+(``portalocker.LOCK_EX | LOCK_NB``) the publisher waits on. Driving the
+private `_lock` this way is a deliberate exception to Test Guide §2's
+"no private references" rule: it is a cross-process harness to establish a
+genuinely held lock — no public API holds the discovery lock open across a
+wait — while every assertion targets public behavior, and reconstructing
+the lock-file path in the harness would duplicate more private detail and
+drift. Unit-level coverage of the timeout lives in
+``tests/runtime/discovery/test_local.py``.
+"""
+
+import asyncio
+import logging
+import multiprocessing
+import time
+import uuid
+
+import pytest
+
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.worker.metadata import WorkerMetadata
+from wool.runtime.worker.pool import WorkerPool
+
+from . import routines
+from .conftest import _ensure_killed
+from .conftest import _iter_leaf_exceptions
+from .conftest import _pid_alive
+from .conftest import release_subprocess
+from .conftest import spawn_script_subprocess
+
+_TIMEOUT = 30
+
+# Acquire the namespace's discovery lock in a separate interpreter and hold
+# it until released via stdin. Uses the production `_lock` so the held lock
+# is byte-for-byte the one a publisher contends — a same-process holder
+# cannot conflict on POSIX advisory locks.
+_HOLDER_SCRIPT = """
+import asyncio
+import sys
+
+from wool.runtime.discovery.local import _lock
+
+
+async def main():
+    namespace = sys.argv[1]
+    async with _lock(namespace, timeout=None):
+        print("locked", flush=True)
+        sys.stdin.readline()
+
+
+asyncio.run(main())
+"""
+
+
+@pytest.mark.integration
+class TestCrossProcessLockTimeout:
+    @pytest.mark.asyncio
+    async def test_publish_should_raise_timeout_error_when_holder_wedges_lock(self):
+        """Test a cross-process lock holder surfaces as a bounded TimeoutError.
+
+        Given:
+            An independent subprocess holding the namespace's discovery
+            lock, and a Publisher with a one-second lock_timeout
+        When:
+            The publisher publishes a worker while the holder still holds
+            the lock
+        Then:
+            It should raise TimeoutError after roughly the timeout rather
+            than hanging forever, proving real cross-process lock
+            arbitration is surfaced as a bounded failure.
+        """
+        # Arrange
+        namespace = f"lock-wedge-{uuid.uuid4().hex[:12]}"
+        metadata = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="localhost:50051",
+            pid=123,
+            version="1.0",
+        )
+        lock_timeout = 1.0
+        holder = spawn_script_subprocess(_HOLDER_SCRIPT, namespace, ready_line="locked")
+
+        # Act & assert
+        try:
+            publisher = LocalDiscovery.Publisher(namespace, lock_timeout=lock_timeout)
+            async with publisher:
+                start = time.monotonic()
+                with pytest.raises(TimeoutError):
+                    await asyncio.wait_for(
+                        publisher.publish("worker-added", metadata),
+                        timeout=lock_timeout + 5,
+                    )
+                elapsed = time.monotonic() - start
+
+            # Bounded, not instant and not forever: it genuinely waited on
+            # the contended lock (≥ half the timeout) and returned well
+            # before the wait_for safety net (< timeout + 4, itself under the
+            # timeout + 5 net), leaving slack for event-loop starvation on CI.
+            assert lock_timeout / 2 <= elapsed < lock_timeout + 4
+        finally:
+            release_subprocess(holder)
+
+
+@pytest.mark.integration
+class TestPoolTeardownLockTimeout:
+    @pytest.mark.asyncio
+    async def test___aexit___should_reap_worker_when_drop_announce_lock_wedged(
+        self, caplog
+    ):
+        """Test a wedged drop announcement still reaps under an unbounded exit.
+
+        Given:
+            A hybrid WorkerPool with a one-second discovery lock_timeout and
+            shutdown_timeout=None that has entered and dispatched a routine,
+            then an independent subprocess that wedges the discovery lock
+        When:
+            The pool exits so its worker-dropped announcement contends the
+            wedged lock
+        Then:
+            It should bound teardown by the lock timeout instead of hanging
+            forever, log that it could not announce the worker, and still
+            reap the worker process.
+        """
+        # Arrange
+        namespace = f"lock-teardown-{uuid.uuid4().hex[:12]}"
+        before = {child.pid for child in multiprocessing.active_children()}
+        holder = None
+        spawned = []
+
+        # Act
+        try:
+            with caplog.at_level(logging.ERROR, logger="wool.runtime.worker.pool"):
+                async with asyncio.timeout(_TIMEOUT):
+                    async with WorkerPool(
+                        spawn=1,
+                        discovery=LocalDiscovery(namespace, lock_timeout=1.0),
+                        shutdown_timeout=None,
+                    ):
+                        spawned = [
+                            child.pid
+                            for child in multiprocessing.active_children()
+                            if child.pid not in before
+                        ]
+                        assert await routines.add(1, 2) == 3
+                        # Wedge the lock only after the worker-added
+                        # announcement has already succeeded on a free lock.
+                        holder = await asyncio.to_thread(
+                            spawn_script_subprocess,
+                            _HOLDER_SCRIPT,
+                            namespace,
+                            ready_line="locked",
+                        )
+                    # Exiting here fires the worker-dropped announcement
+                    # against the wedged lock.
+
+            # Assert — join finished children so an exited-but-unreaped
+            # worker cannot masquerade as alive under os.kill(pid, 0).
+            multiprocessing.active_children()
+            assert spawned
+            for pid in spawned:
+                assert not _pid_alive(pid)
+            # Vacuity guard — the drop genuinely failed against the wedged
+            # lock, so the reap is not satisfied by a drop that succeeded.
+            assert any(
+                "could not announce" in record.getMessage() for record in caplog.records
+            )
+        finally:
+            release_subprocess(holder)
+            for child in multiprocessing.active_children():
+                if child.pid not in before:
+                    _ensure_killed(child.pid)
+
+
+@pytest.mark.integration
+class TestPoolEntryLockTimeout:
+    @pytest.mark.asyncio
+    async def test___aenter___should_abort_when_worker_announce_lock_wedged(self):
+        """Test pool entry aborts when the worker-added lock is wedged.
+
+        Given:
+            An independent subprocess holding the discovery lock before pool
+            entry, and a hybrid WorkerPool with a one-second lock_timeout
+        When:
+            The pool is entered so its worker-added announcement contends the
+            wedged lock
+        Then:
+            It should abort entry with an ExceptionGroup carrying a
+            TimeoutError and leave no worker process alive.
+        """
+        # Arrange
+        namespace = f"lock-entry-{uuid.uuid4().hex[:12]}"
+        before = {child.pid for child in multiprocessing.active_children()}
+        holder = spawn_script_subprocess(_HOLDER_SCRIPT, namespace, ready_line="locked")
+
+        # Act & assert
+        try:
+            with pytest.raises(ExceptionGroup) as excinfo:
+                async with asyncio.timeout(_TIMEOUT):
+                    async with WorkerPool(
+                        spawn=1,
+                        discovery=LocalDiscovery(namespace, lock_timeout=1.0),
+                    ):
+                        pass
+
+            leaves = list(_iter_leaf_exceptions(excinfo.value))
+            assert any(isinstance(leaf, TimeoutError) for leaf in leaves), (
+                f"expected a TimeoutError, got: {leaves!r}"
+            )
+
+            # Join finished children so an exited-but-unreaped worker cannot
+            # masquerade as alive.
+            multiprocessing.active_children()
+            leaked = [
+                child.pid
+                for child in multiprocessing.active_children()
+                if child.pid not in before
+            ]
+            assert leaked == []
+        finally:
+            release_subprocess(holder)
+            for child in multiprocessing.active_children():
+                if child.pid not in before:
+                    _ensure_killed(child.pid)

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -107,6 +107,44 @@ def unlink_schedule(mocker):
     return schedule
 
 
+@pytest.fixture
+def held_lock(mocker):
+    """Patch portalocker.lock to report the lock is permanently held.
+
+    Every acquisition attempt raises LockException, so a publish resolves
+    only through its lock_timeout deadline, never by acquiring.
+    """
+
+    def _held(fh, flags):
+        raise portalocker.LockException("Lock held")
+
+    mocker.patch.object(portalocker, "lock", side_effect=_held)
+
+
+@pytest.fixture
+def contending_lock(mocker):
+    """Return a factory patching portalocker.lock to fail its first n calls.
+
+    The returned callable installs a side effect that raises LockException
+    on the first n acquisition attempts and then delegates to the real
+    lock, returning the mock so a test can assert on its call count.
+    """
+    real_lock = portalocker.lock
+
+    def _make(n):
+        calls = {"count": 0}
+
+        def _contend(fh, flags):
+            calls["count"] += 1
+            if calls["count"] <= n:
+                raise portalocker.LockException("Lock held")
+            real_lock(fh, flags)
+
+        return mocker.patch.object(portalocker, "lock", side_effect=_contend)
+
+    return _make
+
+
 #: Same-namespace lifecycle forests: each node is one LocalDiscovery
 #: context; nesting models concurrently overlapping instances and
 #: siblings model teardown+respawn generations reusing the namespace.
@@ -274,6 +312,46 @@ class TestLocalDiscovery:
         # Assert
         assert isinstance(publisher, LocalDiscovery.Publisher)
         assert publisher.namespace == namespace
+
+    @pytest.mark.asyncio
+    async def test_publisher_should_propagate_lock_timeout(
+        self, namespace, metadata, held_lock
+    ):
+        """Test the publisher property plumbs lock_timeout to publish.
+
+        Given:
+            A LocalDiscovery constructed with a zero-second lock_timeout
+            and a file lock permanently held by another process
+        When:
+            A publisher obtained from the publisher property publishes
+        Then:
+            It should raise TimeoutError, proving lock_timeout reaches the
+            nested Publisher's lock acquisition.
+        """
+        # Act & assert
+        with LocalDiscovery(namespace, lock_timeout=0) as discovery:
+            async with discovery.publisher as publisher:
+                with pytest.raises(TimeoutError):
+                    await publisher.publish("worker-added", metadata)
+
+    def test_publisher_should_raise_when_lock_timeout_negative(self, namespace):
+        """Test the publisher property rejects a negative lock timeout lazily.
+
+        Given:
+            A LocalDiscovery constructed with a negative lock_timeout,
+            which does not validate at construction
+        When:
+            Its publisher property is accessed
+        Then:
+            It should raise ValueError, deferring lock_timeout validation
+            to the Publisher the property builds, mirroring block_size.
+        """
+        # Arrange
+        discovery = LocalDiscovery(namespace, lock_timeout=-1)
+
+        # Act & assert
+        with pytest.raises(ValueError, match="Lock timeout must be non-negative"):
+            discovery.publisher
 
     def test_subscriber_with_default_instance(self, namespace):
         """Test subscriber property returns Subscriber instance.
@@ -1273,6 +1351,58 @@ class TestLocalDiscoveryPublisher:
         with pytest.raises(ValueError, match="Block size must be positive"):
             LocalDiscovery.Publisher(namespace, block_size=-1)
 
+    def test___init___should_raise_when_lock_timeout_negative(self, namespace):
+        """Test Publisher rejects a negative lock timeout.
+
+        Given:
+            A negative lock_timeout
+        When:
+            Publisher is instantiated
+        Then:
+            It should raise ValueError.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="Lock timeout must be non-negative"):
+            LocalDiscovery.Publisher(namespace, lock_timeout=-1)
+
+    @given(
+        lock_timeout=st.one_of(
+            st.none(),
+            st.floats(min_value=0, allow_nan=False, allow_infinity=False),
+            st.floats(
+                max_value=0,
+                exclude_max=True,
+                allow_nan=False,
+                allow_infinity=False,
+            ),
+        )
+    )
+    @settings(
+        max_examples=50,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test___init___should_validate_lock_timeout_across_domain(
+        self, namespace, lock_timeout
+    ):
+        """Test Publisher validates lock_timeout across the float domain.
+
+        Given:
+            Any None or finite float lock_timeout.
+        When:
+            A Publisher is instantiated with it.
+        Then:
+            It should raise ValueError exactly when the value is a negative
+            float, and construct successfully for None and every
+            non-negative float.
+        """
+        # Act & assert
+        if lock_timeout is not None and lock_timeout < 0:
+            with pytest.raises(ValueError, match="Lock timeout must be non-negative"):
+                LocalDiscovery.Publisher(namespace, lock_timeout=lock_timeout)
+        else:
+            publisher = LocalDiscovery.Publisher(namespace, lock_timeout=lock_timeout)
+            assert publisher.namespace == namespace
+
     @pytest.mark.asyncio
     async def test___aenter___and___aexit___lifecycle(self, namespace):
         """Test Publisher async context manager lifecycle.
@@ -1974,7 +2104,7 @@ class TestLocalDiscoveryPublisher:
 
     @pytest.mark.asyncio
     async def test_publish_with_concurrent_lock_contention(
-        self, namespace, metadata, mocker
+        self, namespace, metadata, contending_lock
     ):
         """Test publish retries on concurrent lock contention.
 
@@ -1988,20 +2118,7 @@ class TestLocalDiscoveryPublisher:
             the lock is released.
         """
         # Arrange
-        original_lock = portalocker.lock
-        attempt = 0
-
-        def contending_lock(fh, flags):
-            nonlocal attempt
-            attempt += 1
-            if attempt == 1:
-                raise portalocker.LockException("Lock held")
-            original_lock(fh, flags)
-
-        mocker.patch(
-            "wool.runtime.discovery.local.portalocker.lock",
-            side_effect=contending_lock,
-        )
+        lock = contending_lock(1)
 
         with LocalDiscovery(namespace):
             publisher = LocalDiscovery.Publisher(namespace)
@@ -2011,7 +2128,234 @@ class TestLocalDiscoveryPublisher:
                 await publisher.publish("worker-added", metadata)
 
         # Assert
-        assert attempt == 2
+        assert lock.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_publish_should_poll_at_one_millisecond_when_lock_contended(
+        self, namespace, metadata, mocker, contending_lock
+    ):
+        """Test publish polls the file lock at the 1ms interval.
+
+        Given:
+            A file lock temporarily held by another process, with
+            asyncio.sleep wrapped in a recording pass-through
+        When:
+            publish("worker-added") retries lock acquisition
+        Then:
+            It should sleep 1ms between attempts rather than busy-spinning
+            on a zero-second yield.
+        """
+        # Arrange
+        contending_lock(1)
+
+        recorded: list[float | None] = []
+        real_sleep = asyncio.sleep
+
+        async def recording_sleep(delay, *args, **kwargs):
+            recorded.append(delay)
+            return await real_sleep(delay, *args, **kwargs)
+
+        mocker.patch.object(asyncio, "sleep", recording_sleep)
+
+        with LocalDiscovery(namespace):
+            publisher = LocalDiscovery.Publisher(namespace)
+
+            # Act
+            async with publisher:
+                await publisher.publish("worker-added", metadata)
+
+        # Assert — the retry polls at exactly 1ms and never busy-spins on a
+        # zero-second yield. Pinning the poll interval (an otherwise
+        # unobservable implementation constant) mirrors atexit_recorder's
+        # deliberate mechanism-pinning; a refactor of the retry is expected
+        # to rewrite this assertion.
+        assert 0.001 in recorded
+        assert 0 not in recorded
+
+    @pytest.mark.asyncio
+    async def test_publish_should_raise_timeout_error_when_lock_acquisition_times_out(
+        self, namespace, metadata, held_lock
+    ):
+        """Test publish surfaces a held lock as a bounded TimeoutError.
+
+        Given:
+            A file lock permanently held by another process and a
+            publisher with a zero-second lock timeout
+        When:
+            publish("worker-added") attempts lock acquisition
+        Then:
+            It should raise TimeoutError rather than waiting forever.
+        """
+        # Act & assert
+        with LocalDiscovery(namespace):
+            publisher = LocalDiscovery.Publisher(namespace, lock_timeout=0)
+
+            async with publisher:
+                with pytest.raises(TimeoutError):
+                    await publisher.publish("worker-added", metadata)
+
+    @pytest.mark.asyncio
+    async def test_publish_should_bound_a_held_lock_with_the_default_timeout(
+        self, namespace, metadata, mocker, held_lock
+    ):
+        """Test the default lock timeout bounds a permanently held lock.
+
+        Given:
+            A permanently held lock, a publisher constructed with the
+            default lock_timeout, and a clock advanced far past that
+            default on the first poll
+        When:
+            publish("worker-added", metadata) attempts lock acquisition
+        Then:
+            It should raise TimeoutError, proving the default timeout is
+            finite rather than an unbounded wait.
+        """
+        # Arrange
+        loop = asyncio.get_running_loop()
+        fake_now = loop.time()
+
+        async def jumping_sleep(delay, *args, **kwargs):
+            nonlocal fake_now
+            # Jump far past any finite timeout on the first poll so the
+            # default deadline expires without a real 30s wait.
+            fake_now += 1_000_000.0
+
+        mocker.patch.object(loop, "time", side_effect=lambda: fake_now)
+        mocker.patch.object(asyncio, "sleep", jumping_sleep)
+
+        with LocalDiscovery(namespace):
+            publisher = LocalDiscovery.Publisher(namespace)
+
+            # Act & assert
+            async with publisher:
+                with pytest.raises(TimeoutError, match="discovery lock"):
+                    await publisher.publish("worker-added", metadata)
+
+    @pytest.mark.asyncio
+    async def test_publish_should_retry_without_bound_when_lock_timeout_none(
+        self, namespace, metadata, mocker, contending_lock
+    ):
+        """Test a None lock timeout imposes no deadline as the clock advances.
+
+        Given:
+            A lock held across several attempts before release, a publisher
+            whose lock_timeout is None, and a clock that jumps far past any
+            finite timeout on every poll
+        When:
+            publish("worker-added") retries lock acquisition
+        Then:
+            It should keep polling until acquisition succeeds without ever
+            raising, where any finite timeout would already have expired.
+        """
+        # Arrange
+        lock = contending_lock(5)
+
+        loop = asyncio.get_running_loop()
+        fake_now = loop.time()
+
+        async def jumping_sleep(delay, *args, **kwargs):
+            nonlocal fake_now
+            # Each poll jumps far past any finite timeout; a None deadline
+            # never consults the clock, so acquisition still succeeds.
+            fake_now += 1_000_000.0
+
+        mocker.patch.object(loop, "time", side_effect=lambda: fake_now)
+        mocker.patch.object(asyncio, "sleep", jumping_sleep)
+
+        with LocalDiscovery(namespace):
+            publisher = LocalDiscovery.Publisher(namespace, lock_timeout=None)
+
+            # Act
+            async with publisher:
+                await publisher.publish("worker-added", metadata)
+
+        # Assert — reaching the sixth attempt proves no deadline fired
+        # despite the clock advancing past any finite timeout; a finite
+        # lock_timeout would have raised on the second poll.
+        assert lock.call_count == 6
+
+    @pytest.mark.asyncio
+    async def test_publish_should_acquire_when_lock_timeout_zero_and_uncontended(
+        self, namespace, metadata
+    ):
+        """Test a zero lock timeout still acquires an uncontended lock.
+
+        Given:
+            An owner LocalDiscovery and a Publisher with lock_timeout=0 on
+            an uncontended lock
+        When:
+            publish("worker-added", metadata) is called
+        Then:
+            It should acquire on the first attempt and publish the worker
+            so a subscriber discovers it, proving the timeout gates
+            contended acquisition only and never an uncontended acquire or
+            the held section.
+        """
+        # Arrange
+        events = []
+        event_received = asyncio.Event()
+
+        async def collect(subscriber):
+            async for event in subscriber:
+                events.append(event)
+                event_received.set()
+                break
+
+        with LocalDiscovery(namespace):
+            publisher = LocalDiscovery.Publisher(namespace, lock_timeout=0)
+            subscriber = LocalDiscovery.Subscriber(namespace, poll_interval=0.05)
+
+            # Act
+            async with publisher:
+                await publisher.publish("worker-added", metadata)
+
+                task = asyncio.create_task(collect(subscriber))
+                try:
+                    await asyncio.wait_for(event_received.wait(), timeout=2.0)
+                except asyncio.TimeoutError:
+                    pytest.fail("Worker not discovered within timeout")
+                finally:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+        # Assert
+        assert len(events) == 1
+        assert events[0].type == "worker-added"
+        assert events[0].metadata.uid == metadata.uid
+
+    @pytest.mark.asyncio
+    async def test_publish_should_name_timeout_and_namespace_in_timeout_error(
+        self, namespace, metadata, held_lock
+    ):
+        """Test an elapsed finite timeout raises a message naming the timeout.
+
+        Given:
+            A permanently held lock and a Publisher with a small finite
+            lock_timeout
+        When:
+            publish("worker-added", metadata) exhausts the timeout
+        Then:
+            It should raise TimeoutError whose message names both the
+            configured timeout and the namespace.
+        """
+
+        # Arrange
+        with LocalDiscovery(namespace):
+            publisher = LocalDiscovery.Publisher(namespace, lock_timeout=0.02)
+
+            # Act
+            async with publisher:
+                with pytest.raises(TimeoutError) as excinfo:
+                    await publisher.publish("worker-added", metadata)
+
+        # Assert
+        message = str(excinfo.value)
+        assert "0.02" in message
+        assert namespace in message
+        assert "discovery lock" in message
 
     @pytest.mark.asyncio
     async def test___aexit___should_disarm_atexit_fallbacks_when_workers_still_published(


### PR DESCRIPTION
## Summary

`LocalDiscovery`'s cross-process file lock had two compounding defects: it busy-spun on `asyncio.sleep(0)` while waiting — a hot spin that reissued an `fcntl` syscall every iteration and pinned a core while another process held the lock — and it looped forever with no timeout, so a holder that was alive but stuck wedged the caller indefinitely (reachable via `WorkerPool` teardown with `shutdown_timeout=None`).

Make the retry poll at the 1 ms interval the docstring already promised, and bound acquisition with a new `lock_timeout: float | None = 30.0` constructor kwarg (`None` preserves the historical wait-forever behavior), plumbed through to the nested `Publisher` exactly as `block_size` is. Expiry raises `TimeoutError`, which composes with pool teardown as-is: the publish raises, teardown logs it against the worker uid, and the worker is still reaped. The timeout bounds acquisition only, never the held section — interrupting a holder mid-write would corrupt the shared segment for every attached process.

Keep the validation lazy to mirror `block_size` (rejected in `Publisher`, deferred through the `publisher` property). A non-finite `lock_timeout` still yields an unbounded wait, noted as a possible follow-up.

Closes #316

## Proposed changes

### Bound and slow the lock retry (`_lock`)

Replace `await asyncio.sleep(0)` with `await asyncio.sleep(0.001)` and add a keyword-only `timeout: float | None = 30.0`. A `loop.time()` deadline raises the builtin `TimeoutError` once acquisition exhausts the timeout; `timeout=None` disables the deadline. The held section (the `yield`) sits outside the deadline logic, so a holder is never interrupted mid-write.

### Plumb `lock_timeout` through the public API

Add `lock_timeout: float | None = 30.0` to `LocalDiscovery.__init__` and `LocalDiscovery.Publisher.__init__`, forwarded through the `publisher` property alongside `block_size`. `Publisher.publish` passes `timeout=self._lock_timeout` to `_lock`. Reject a negative timeout in `Publisher.__init__` with `ValueError`, matching the existing `block_size` guard; `LocalDiscovery` defers that validation to the `Publisher` its property builds.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestLocalDiscoveryPublisher` | A lock held once then released | `publish` retries acquisition | Sleeps 1 ms between attempts | 1 ms poll, no busy-spin |
| 2 | `TestLocalDiscoveryPublisher` | A permanently held lock and `lock_timeout=0` | `publish` attempts acquisition | Raises `TimeoutError` | Bounded acquisition |
| 3 | `TestLocalDiscoveryPublisher` | A lock held several times then released with `lock_timeout=None` | `publish` retries | Succeeds without a deadline | `None` means wait-forever |
| 4 | `TestLocalDiscoveryPublisher` | An uncontended lock and `lock_timeout=0` | `publish` is called | Acquires and publishes so a subscriber discovers the worker | Timeout gates contention only, never the held section |
| 5 | `TestLocalDiscoveryPublisher` | A negative `lock_timeout` | A `Publisher` is constructed | Raises `ValueError` | Publisher timeout validation |
| 6 | `TestLocalDiscoveryPublisher` | Any `None` or finite float `lock_timeout` | A `Publisher` is constructed | Raises `ValueError` iff the value is negative | Validation across the float domain |
| 7 | `TestLocalDiscoveryPublisher` | A permanently held lock and a small finite `lock_timeout` | `publish` exhausts the timeout | Raises `TimeoutError` naming the timeout and namespace | Finite deadline and operator-facing message |
| 8 | `TestLocalDiscovery` | A `LocalDiscovery` with `lock_timeout=0` and a held lock | Its publisher publishes | Raises `TimeoutError` | Plumb-through to the nested Publisher |
| 9 | `TestLocalDiscovery` | A `LocalDiscovery` with a negative `lock_timeout` | Its `publisher` property is accessed | Raises `ValueError` | Lazy validation via the publisher property |
| 10 | `TestCrossProcessLockTimeout` | A separate process holding the discovery lock and a `Publisher` with a one-second `lock_timeout` | `publish` contends the wedged lock | Raises `TimeoutError` within a bounded window | Real cross-process contention surfaced as bounded |
| 11 | `TestPoolTeardownLockTimeout` | A `WorkerPool` with `shutdown_timeout=None` whose drop-announcement lock is wedged mid-teardown | The pool exits | Bounds teardown, logs the failed announcement, reaps the worker | Wedged teardown under an unbounded shutdown |
| 12 | `TestPoolEntryLockTimeout` | A held discovery lock before pool entry | The pool is entered | Aborts entry with an `ExceptionGroup` carrying a `TimeoutError`, leaks no worker | Wedged worker-added announcement at entry |
