### PR TITLE
Unblock the release pipeline from actions/checkout's pull_request_target guardrail — Closes #332

### DIFF
--- a/.github/actions/build-release/action.yaml
+++ b/.github/actions/build-release/action.yaml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-tags: true
         persist-credentials: false

--- a/.github/actions/get-touched-files/action.yaml
+++ b/.github/actions/get-touched-files/action.yaml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
         persist-credentials: false

--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: main
       - name: Get touched files
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - uses: ./.github/actions/get-wool-labs-app-token
@@ -78,7 +78,7 @@ jobs:
           echo "Release candidate: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
       - name: Checkout release
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: release
           token: ${{ steps.get-wool-labs-app-token.outputs.access-token }}
@@ -114,7 +114,7 @@ jobs:
       matrix:
         source: [wool]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/build-release
         with:
           source: ${{ matrix.source }}
@@ -156,7 +156,7 @@ jobs:
       matrix:
         source: [wool]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/publish-github-release
         with:
           source: ${{ matrix.source }}
@@ -174,7 +174,7 @@ jobs:
       matrix:
         source: [wool]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/publish-pypi-release
         with:
           source: ${{ matrix.source }}

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -60,7 +60,7 @@ jobs:
       version: ${{ steps.bump-version.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.inputs.commit }}
           fetch-depth: 0
@@ -92,7 +92,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/get-wool-labs-app-token
@@ -123,7 +123,7 @@ jobs:
       matrix:
         source: [wool]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/build-release
@@ -164,7 +164,7 @@ jobs:
       matrix:
         source: [wool]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/publish-github-release
@@ -185,7 +185,7 @@ jobs:
       matrix:
         source: [wool]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.inputs.commit }}
       - uses: ./.github/actions/publish-pypi-release

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -31,7 +31,7 @@ jobs:
       version: ${{ steps.bump-version.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/get-wool-labs-app-token
         id: get-wool-labs-app-token
         with:
@@ -93,7 +93,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
       - uses: ./.github/actions/get-wool-labs-app-token
@@ -125,7 +125,7 @@ jobs:
       matrix:
         source: [wool]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/build-release
         with:
           source: ${{ matrix.source }}
@@ -170,7 +170,7 @@ jobs:
       matrix:
         source: [wool]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/publish-github-release
         with:
           source: ${{ matrix.source }}
@@ -189,7 +189,7 @@ jobs:
       matrix:
         source: [wool]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/publish-pypi-release
         with:
           source: ${{ matrix.source }}
@@ -214,7 +214,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/get-wool-labs-app-token
         id: get-wool-labs-app-token
         with:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -92,10 +92,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      # No `ref:` here. Under `pull_request_target` on a fork PR,
+      # actions/checkout refuses any PR-associated ref (see
+      # allow-unsafe-pr-checkout). The base branch is trusted and is all
+      # this job needs: the composite action below runs from the checked
+      # out tree, and the tag is created through the API at TARGET_SHA.
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
       - uses: ./.github/actions/get-wool-labs-app-token
         id: get-wool-labs-app-token
         with:
@@ -108,11 +111,12 @@ jobs:
           GH_TOKEN: ${{ steps.get-wool-labs-app-token.outputs.access-token }}
           REPO: ${{ github.repository }}
           NEW_VERSION: ${{ needs.bump-version.outputs.version }}
+          TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
         run: |
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
-          echo "Tagging $NEW_VERSION"
-          git tag "$NEW_VERSION"
-          git push origin "$NEW_VERSION"
+          echo "Tagging $NEW_VERSION at $TARGET_SHA"
+          gh api "repos/$REPO/git/refs" \
+            -f ref="refs/tags/$NEW_VERSION" \
+            -f sha="$TARGET_SHA"
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
   build-release:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -19,7 +19,7 @@ jobs:
       has_code_changes: ${{ steps.get-touched-files.outputs.touched && 'true' || 'false' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Get touched files
         id: get-touched-files
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install uv and prepare python
         uses: astral-sh/setup-uv@v5
@@ -61,7 +61,7 @@ jobs:
         namespace: ['wool']
         python-version: ['3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/run-tests
         with:
           python-version: ${{ matrix.python-version }}
@@ -79,7 +79,7 @@ jobs:
         namespace: ['wool']
         python-version: ['3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/run-tests
         with:
           python-version: ${{ matrix.python-version }}
@@ -97,7 +97,7 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install uv and prepare python
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/sync-branches.yaml
+++ b/.github/workflows/sync-branches.yaml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/get-wool-labs-app-token
         id: get-wool-labs-app-token
         with:


### PR DESCRIPTION
## Summary

Restore the release pipeline, which has been fully blocked since `actions/checkout` v4.4.0 backported `allow-unsafe-pr-checkout` with a default of `false`. The workflows tracked the floating `@v4` tag, so the breaking change arrived with no commit of our own in between.

Fix the `tag-version` job by removing its need to check out PR-associated code at all, rather than opting out of the guardrail, and pin `actions/checkout` repo-wide so a future upstream release cannot change release behavior silently.

Closes #332

## Proposed changes

### Create the release tag through the API

`tag-version` checked out `github.event.pull_request.merge_commit_sha`. Under `pull_request_target` on a fork pull request, `actions/checkout` now refuses any PR-associated ref. Development happens from a personal fork, so every release PR is cross-repository and this failed on every release, taking the build and publish jobs down with it.

The job never needed the merge commit in the working tree. It now checks out the base branch — which the guardrail permits, and which the `get-wool-labs-app-token` composite action requires in order to resolve — and creates the tag ref through the API at the merge SHA, passed explicitly as `TARGET_SHA`. The tag still lands on the same commit. The `git remote set-url` credential-injection line goes away, since no git write is performed any more.

Setting `allow-unsafe-pr-checkout: true` was rejected. The job runs a composite action from the checked-out tree while holding the app's private key — the exact shape the guardrail exists to catch. The trust boundary here is merge review, and opting out would make that permanent and silent.

### Pin actions/checkout to a release SHA

Replace all 25 `actions/checkout@v4` references across 5 workflows and 2 composite actions with `actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0`. The effective version is unchanged, so the new guardrail stays in force rather than being rolled back.

`tag-version` is the only site the guardrail actually broke — `sync-branches.yaml` is also `pull_request_target` but passes no explicit `ref:`, `cut-release.yaml` and `manual-release.yaml` are `workflow_dispatch`, and `run-tests.yaml` is `pull_request` rather than `pull_request_target`. The other 24 pins are preventative.

## Test cases

No automated tests apply — this PR changes only CI configuration. `sdlc_guides_for(kind="test")` returns no guides for these paths, and no test suite covers workflow YAML.

Verification performed instead:

| # | Check | Result |
|---|-------|--------|
| 1 | `actionlint` per-file, pre-change vs post-change | 17 findings before, 17 after; identical set, only line numbers shift by +4 in `publish-release.yaml` |
| 2 | Floating `actions/checkout@v4` references remaining | None |
| 3 | SHA-pinned `actions/checkout` references | 25, matching the pre-change count |
| 4 | Explicit `ref:` in `tag-version` | Removed |

All 17 `actionlint` findings are pre-existing schema complaints (`description:` at workflow level, `type:` in composite-action inputs) that this PR neither introduces nor resolves.

End-to-end verification is only possible on the next real release merge. Do not smoke-test via `workflow_dispatch` — under that trigger `merge_commit_sha` is empty and `github.sha` takes over, so the run would cut a genuine tag, GitHub release, and PyPI publish.