### PR TITLE
Stop resource_tracker KeyError spam when attaching shared memory on Python below 3.13 — Closes #336

### DIFF
--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -315,9 +315,7 @@ class LocalDiscovery(Discovery):
             )
             self._owner = True
         except FileExistsError:
-            self._address_space = SharedMemory(
-                name=_short_hash(self._namespace), create=False
-            )
+            self._address_space = _attach(_short_hash(self._namespace))
             self._owner = False
 
         assert self._address_space.buf

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -6,6 +6,7 @@ import hashlib
 import struct
 import sys
 import tempfile
+import threading
 import warnings
 from contextlib import asynccontextmanager
 from contextlib import contextmanager
@@ -47,6 +48,12 @@ NULL_REF: Final = b"\x00" * REF_WIDTH
 DEFAULT_LOCK_TIMEOUT: Final[float] = 30.0
 _HEADER_MAGIC: Final = b"WLD1"
 _HEADER_SIZE: Final = REF_WIDTH
+# Serialises the resource-tracker rebind window in `_attach` below 3.13. Held
+# only across one `SharedMemory` constructor, never across a `_shared_memory`
+# body -- the module attaches a worker's block while an address-space attach is
+# already open, which a lock held that wide would deadlock on. Not reinitialised
+# after `fork`; wool starts workers with `spawn`, which inherits no lock state.
+_ATTACH_LOCK: Final = threading.Lock()
 
 
 class _Watchdog(FileSystemEventHandler):
@@ -984,18 +991,78 @@ def _short_hash(s: str, n: int = 30) -> str:
     return b64_str.rstrip("=")[:n]
 
 
+def _attach(name: str) -> SharedMemory:
+    """Map an existing shared memory segment without tracking it.
+
+    Only the process that created a segment may own its lifetime. Were an
+    attach-only mapping registered with this process's resource tracker, the
+    tracker would unlink the segment when this process exits, out from under
+    its owner (bpo-38119).
+
+    Python 3.13 says exactly that with ``track=False``. Below 3.13 there is
+    no such parameter, so the registration is instead suppressed at its
+    source for as long as the constructor runs. Undoing it afterwards --
+    registering, then unregistering -- is *not* equivalent: the tracker's
+    cache is a set shared by every process in the tree, so the first attach's
+    unregister discards the entry the creator made, and the creator's own
+    ``unlink`` later finds nothing to remove. That raises `KeyError` inside
+    the tracker process, which prints a traceback to stderr nothing in the
+    attaching process can intercept.
+
+    The suppression is as narrow as the failure allows. It matches on all
+    three of the calling thread, the resource type, and this segment's name,
+    and it lasts only as long as one constructor call -- so the sole call it
+    can ever swallow is the one made on our behalf from inside that
+    constructor. A ``create=True`` running concurrently on another thread is
+    still tracked, even for this same name. The lock serialises the rebind
+    itself, without which two overlapping attaches would restore each other's
+    shim and leave one installed for good.
+
+    `SharedMemory` compares names with a leading ``/`` on POSIX and without
+    it here, so both sides are stripped before matching.
+
+    A segment mapped through here MUST NOT be unlinked -- below 3.13
+    `SharedMemory.unlink` unregisters unconditionally, which would discard
+    the creator's entry after all. Teardown in this module unlinks only
+    segments it created; see `_unlink_quietly`.
+
+    :param name:
+        The name of the shared memory segment to map.
+    :returns:
+        An untracked SharedMemory instance mapped to the named segment.
+    """
+    if sys.version_info >= (3, 13):
+        return SharedMemory(name=name, track=False)
+
+    with _ATTACH_LOCK:
+        register = resource_tracker.register
+        attaching = threading.get_ident()
+        target = name.lstrip("/")
+
+        def _register(registered_name: str, rtype: str) -> None:
+            if (
+                threading.get_ident() == attaching
+                and rtype == "shared_memory"
+                and registered_name.lstrip("/") == target
+            ):
+                return
+            register(registered_name, rtype)
+
+        resource_tracker.register = _register
+        try:
+            return SharedMemory(name=name)
+        finally:
+            resource_tracker.register = register
+
+
 @contextmanager
 def _shared_memory(name):
     """Open an existing shared memory region by name.
 
     Context manager that opens a shared memory region for reading or writing
     and ensures it is properly closed on exit. Does not create new memory
-    regions (use SharedMemory with create=True for that).
-
-    The attachment is deliberately untracked: registering an attach-only
-    mapping with this process's resource tracker would unlink the segment
-    at this process's exit out from under its owner (bpo-38119). Only the
-    process that created a segment may own its lifetime.
+    regions (use SharedMemory with create=True for that). The mapping is
+    untracked -- see `_attach` for why, and for what that forbids.
 
     :param name:
         The name of the shared memory region to open.
@@ -1006,14 +1073,7 @@ def _shared_memory(name):
         Close errors are silently ignored to handle cases where the memory
         region has been unlinked by another process.
     """
-    if sys.version_info >= (3, 13):
-        shared_memory = SharedMemory(name=name, track=False)
-    else:  # pragma: no cover — bpo-38119 workaround predating track=False
-        shared_memory = SharedMemory(name=name)
-        resource_tracker.unregister(
-            shared_memory._name,  # type: ignore[attr-defined]
-            "shared_memory",
-        )
+    shared_memory = _attach(name)
     try:
         yield shared_memory
     finally:

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import atexit
 import hashlib
+import os
 import struct
 import sys
 import tempfile
@@ -48,12 +49,26 @@ NULL_REF: Final = b"\x00" * REF_WIDTH
 DEFAULT_LOCK_TIMEOUT: Final[float] = 30.0
 _HEADER_MAGIC: Final = b"WLD1"
 _HEADER_SIZE: Final = REF_WIDTH
-# Serialises the resource-tracker rebind window in `_attach` below 3.13. Held
-# only across one `SharedMemory` constructor, never across a `_shared_memory`
-# body -- the module attaches a worker's block while an address-space attach is
-# already open, which a lock held that wide would deadlock on. Not reinitialised
-# after `fork`; wool starts workers with `spawn`, which inherits no lock state.
-_ATTACH_LOCK: Final = threading.Lock()
+# Serialises the resource-tracker rebind window; see `_attach`. Held only
+# across one `SharedMemory` constructor, never across a `_shared_memory` body,
+# which would deadlock the nested attach `_add` performs.
+_attach_lock: threading.Lock = threading.Lock()
+
+
+def _reinit_attach_lock() -> None:  # pragma: no cover — fork-only path
+    """Replace the attach lock in a forked child.
+
+    A `fork` inside the rebind window copies the lock held, wedging every
+    later attach in the child. Wool starts its own workers with ``spawn``,
+    but `LocalDiscovery` is public and runs inside host processes that may
+    fork — the default start method on Linux below 3.14.
+    """
+    global _attach_lock
+    _attach_lock = threading.Lock()
+
+
+if hasattr(os, "register_at_fork"):  # pragma: no branch — POSIX-only guard
+    os.register_at_fork(after_in_child=_reinit_attach_lock)
 
 
 class _Watchdog(FileSystemEventHandler):
@@ -132,10 +147,11 @@ class _WorkerReference:
         self._uuid = uid
 
     def __str__(self) -> str:
-        """String representation (32-char hex) for :class:`SharedMemory` names.
+        """Return the `SharedMemory` name identifying this worker's block.
 
         :returns:
-            The UUID as a hex string without dashes.
+            The UUID abbreviated by `_short_hash` — 30 characters of
+            URL-safe base64, short enough for the platform name limit.
         """
         return _short_hash(self._uuid.hex)
 
@@ -300,8 +316,7 @@ class LocalDiscovery(Discovery):
             self._owner = True
         except FileExistsError:
             self._address_space = SharedMemory(
-                name=_short_hash(self._namespace),
-                create=False,
+                name=_short_hash(self._namespace), create=False
             )
             self._owner = False
 
@@ -994,65 +1009,94 @@ def _short_hash(s: str, n: int = 30) -> str:
 def _attach(name: str) -> SharedMemory:
     """Map an existing shared memory segment without tracking it.
 
-    Only the process that created a segment may own its lifetime. Were an
-    attach-only mapping registered with this process's resource tracker, the
-    tracker would unlink the segment when this process exits, out from under
-    its owner (bpo-38119).
+    Only the process that created a segment may own its lifetime. An
+    attach-only mapping registered with this process's resource tracker
+    would be unlinked when this process exits, out from under its owner
+    (bpo-38119), so this maps the segment without registering it.
 
-    Python 3.13 says exactly that with ``track=False``. Below 3.13 there is
-    no such parameter, so the registration is instead suppressed at its
-    source for as long as the constructor runs. Undoing it afterwards --
-    registering, then unregistering -- is *not* equivalent: the tracker's
-    cache is a set shared by every process in the tree, so the first attach's
-    unregister discards the entry the creator made, and the creator's own
-    ``unlink`` later finds nothing to remove. That raises `KeyError` inside
-    the tracker process, which prints a traceback to stderr nothing in the
-    attaching process can intercept.
-
-    The suppression is as narrow as the failure allows. It matches on all
-    three of the calling thread, the resource type, and this segment's name,
-    and it lasts only as long as one constructor call -- so the sole call it
-    can ever swallow is the one made on our behalf from inside that
-    constructor. A ``create=True`` running concurrently on another thread is
-    still tracked, even for this same name. The lock serialises the rebind
-    itself, without which two overlapping attaches would restore each other's
-    shim and leave one installed for good.
-
-    `SharedMemory` compares names with a leading ``/`` on POSIX and without
-    it here, so both sides are stripped before matching.
-
-    A segment mapped through here MUST NOT be unlinked -- below 3.13
-    `SharedMemory.unlink` unregisters unconditionally, which would discard
-    the creator's entry after all. Teardown in this module unlinks only
-    segments it created; see `_unlink_quietly`.
+    A segment mapped through here MUST NOT be unlinked. Where `track` is
+    unavailable `SharedMemory.unlink` unregisters unconditionally, which
+    would discard the creator's entry after all; teardown in this module
+    unlinks only segments it created, through `_unlink_quietly`.
 
     :param name:
         The name of the shared memory segment to map.
     :returns:
-        An untracked SharedMemory instance mapped to the named segment.
+        An untracked `SharedMemory` mapped to the named segment.
+    :raises FileNotFoundError:
+        If no segment of that name exists. The tracker hooks are restored
+        whether the mapping succeeds or raises.
+
+    .. rubric:: Implementation notes
+
+    Python 3.13 says this directly with ``track=False``. Below it there is
+    no such parameter, so the registration is suppressed at its source for
+    as long as the constructor runs. Undoing it afterwards, i.e. registering
+    and then unregistering, is *not* equivalent: the tracker's cache is a
+    set shared by every process in the tree, so the first attach's
+    unregister discards the entry the creator made, and the creator's own
+    unlink later finds nothing to remove — which raises `KeyError` inside
+    the tracker process and prints a traceback to stderr that nothing in the
+    attaching process can intercept.
+
+    Both hooks are rebound, not just `resource_tracker.register`: the
+    constructor wraps its own ``mmap`` in ``except OSError: self.unlink()``,
+    and that unlink issues the very unregister this function exists to
+    avoid. It also calls ``shm_unlink``, which is CPython's to own and
+    cannot be intercepted from here — a mid-construction `OSError` therefore
+    still destroys the segment.
+
+    The suppression matches on the calling thread, the resource type, and
+    this segment's name, and lasts only one constructor call, so the sole
+    call it can swallow is the one made on this function's behalf. A
+    ``create=True`` running concurrently on another thread stays tracked
+    even for the same name. `SharedMemory` registers names slash-prefixed
+    on POSIX while callers pass them bare, so both sides are stripped
+    before matching.
+
+    The lock serialises the rebind. Without it two overlapping attaches
+    would each capture the other's shim: the second attach's registration
+    would reach a shim whose thread does not match, be forwarded to the
+    real tracker, and be tracked after all — reinstating bpo-38119. That a
+    shim would also be left permanently installed is the lesser effect.
+    `os.register_at_fork` replaces the lock in a child, since a fork inside
+    the window would otherwise copy it held and wedge every later attach.
     """
     if sys.version_info >= (3, 13):
         return SharedMemory(name=name, track=False)
 
-    with _ATTACH_LOCK:
+    with _attach_lock:
         register = resource_tracker.register
+        unregister = resource_tracker.unregister
         attaching = threading.get_ident()
         target = name.lstrip("/")
 
-        def _register(registered_name: str, rtype: str) -> None:
-            if (
+        def _suppressed(name: str, rtype: str) -> bool:
+            return (
                 threading.get_ident() == attaching
                 and rtype == "shared_memory"
-                and registered_name.lstrip("/") == target
-            ):
-                return
-            register(registered_name, rtype)
+                and name.lstrip("/") == target
+            )
 
-        resource_tracker.register = _register
+        def _register(name: str, rtype: str) -> None:
+            if not _suppressed(name, rtype):
+                register(name, rtype)
+
+        def _unregister(name: str, rtype: str) -> None:
+            if not _suppressed(name, rtype):
+                unregister(name, rtype)
+
         try:
+            resource_tracker.register = _register
+            resource_tracker.unregister = _unregister
             return SharedMemory(name=name)
         finally:
-            resource_tracker.register = register
+            # Only restore what is still ours: a third party that rebound
+            # either hook inside the window keeps its wrapper.
+            if resource_tracker.register is _register:
+                resource_tracker.register = register
+            if resource_tracker.unregister is _unregister:
+                resource_tracker.unregister = unregister
 
 
 @contextmanager
@@ -1061,8 +1105,8 @@ def _shared_memory(name):
 
     Context manager that opens a shared memory region for reading or writing
     and ensures it is properly closed on exit. Does not create new memory
-    regions (use SharedMemory with create=True for that). The mapping is
-    untracked -- see `_attach` for why, and for what that forbids.
+    regions (use `SharedMemory` with ``create=True`` for that). The mapping
+    is untracked — see `_attach` for why, and for what that forbids.
 
     :param name:
         The name of the shared memory region to open.

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -54,17 +54,28 @@ _HEADER_SIZE: Final = REF_WIDTH
 # which would deadlock the nested attach `_add` performs.
 _attach_lock: threading.Lock = threading.Lock()
 
+# The tracker's own hooks, captured before anything can rebind them, so a
+# forked child can be put back to a known state.
+_tracker_register: Final = resource_tracker.register
+_tracker_unregister: Final = resource_tracker.unregister
+
 
 def _reinit_attach_lock() -> None:  # pragma: no cover — fork-only path
-    """Replace the attach lock in a forked child.
+    """Reset the attach state a forked child inherited mid-window.
 
-    A `fork` inside the rebind window copies the lock held, wedging every
+    A ``fork`` inside the rebind window copies the lock held, wedging every
     later attach in the child. Wool starts its own workers with ``spawn``,
     but `LocalDiscovery` is public and runs inside host processes that may
     fork — the default start method on Linux below 3.14.
+
+    The hooks are restored too: a fork inside the window leaves the child
+    holding this module's shims, since the frame that would have put them
+    back died with the parent's thread.
     """
     global _attach_lock
     _attach_lock = threading.Lock()
+    resource_tracker.register = _tracker_register
+    resource_tracker.unregister = _tracker_unregister
 
 
 if hasattr(os, "register_at_fork"):  # pragma: no branch — POSIX-only guard
@@ -1061,7 +1072,9 @@ def _attach(name: str) -> SharedMemory:
     the window would otherwise copy it held and wedge every later attach.
     """
     if sys.version_info >= (3, 13):
-        return SharedMemory(name=name, track=False)
+        # Unreachable below 3.13, where the parameter does not exist, so
+        # the 3.11 and 3.12 legs would otherwise report it missing.
+        return SharedMemory(name=name, track=False)  # pragma: no cover
 
     with _attach_lock:
         register = resource_tracker.register

--- a/wool/tests/integration/test_local_discovery_teardown.py
+++ b/wool/tests/integration/test_local_discovery_teardown.py
@@ -4,10 +4,9 @@ These are targeted standalone tests rather than pairwise scenarios:
 issue #291's reproduction shape — rapid same-namespace teardown and
 respawn with overlapping pool lifecycles — cannot be expressed through
 ``build_pool_from_scenario``'s single-yield nested-context contract,
-and the cross-process case needs independent interpreters whose
-multiprocessing resource trackers genuinely unlink the shared segment
-(CPython bpo-38119). Unit-level simulations of the same contracts live
-in ``tests/runtime/discovery/test_local.py``.
+and the cross-process case needs an independent interpreter to remove
+the shared segment out from under a live owner. Unit-level simulations
+of the same contracts live in ``tests/runtime/discovery/test_local.py``.
 """
 
 import asyncio
@@ -42,10 +41,19 @@ print("clean-exit", flush=True)
 _ATTACHER_SCRIPT = """
 import sys
 
-from wool.runtime.discovery.local import LocalDiscovery
+from multiprocessing.shared_memory import SharedMemory
 
-with LocalDiscovery(sys.argv[1]):
-    pass
+from wool.runtime.discovery.local import _short_hash
+
+# Remove the owner's segment out from under it. This used to be a side
+# effect of entering LocalDiscovery as a non-owner, whose tracked attach
+# had this interpreter's resource tracker reclaim the segment at exit;
+# that attach is untracked as of #336, so the removal is explicit here.
+# What these tests need is only that the segment vanishes externally.
+segment = SharedMemory(name=_short_hash(sys.argv[1]), create=False)
+segment.close()
+segment.unlink()
+print("unlinked", flush=True)
 """
 
 _LEAKED_OWNER_SCRIPT = """
@@ -353,12 +361,10 @@ class TestCrossProcessTeardown:
                 timeout=_TIMEOUT,
             )
             assert attacher.returncode == 0
-            # Vacuity guard — the attacher's tracker really unlinked
-            # the segment (warning about the leak) before the owner
-            # exits; if CPython ever stops tracking attaches this
-            # fails loudly instead of passing without exercising the
-            # fix.
-            assert "leaked shared_memory" in attacher.stderr
+            # Vacuity guard — the segment really did vanish before the
+            # owner exits, so the owner's teardown is exercised against a
+            # missing segment rather than passing on a live one.
+            assert "unlinked" in attacher.stdout
 
             # Act — release the owner to exit its context and shut
             # down its interpreter
@@ -411,9 +417,9 @@ class TestCrossProcessTeardown:
                 timeout=_TIMEOUT,
             )
             assert attacher.returncode == 0
-            # Vacuity guard — the attacher's tracker really unlinked
-            # the segment before the owner shuts down.
-            assert "leaked shared_memory" in attacher.stderr
+            # Vacuity guard — the segment really did vanish before the
+            # owner shuts down.
+            assert "unlinked" in attacher.stdout
 
             # Act — the owner returns from its script with the
             # context still open, so atexit fires the armed fallback

--- a/wool/tests/integration/test_local_discovery_tracker.py
+++ b/wool/tests/integration/test_local_discovery_tracker.py
@@ -49,7 +49,7 @@ if mode == "legacy":
     local.sys = SimpleNamespace(version_info=(3, 12, 0, "final", 0))
 
 # Report the path that actually ran, observed from the constructor's
-# arguments rather than by re-reading the version the override set --
+# arguments rather than by re-reading the version the override set:
 # only the modern path passes ``track``.
 _mapping = local.SharedMemory
 _paths = set()
@@ -113,7 +113,7 @@ print("done", flush=True)
 #: The superseded pattern, in pure standard library: attach to a segment
 #: this interpreter created, undo the attach's registration, then unlink.
 #: Deliberately independent of `wool`, so it keeps reproducing the fault
-#: however `local.py` is later refactored.
+#: however ``local.py`` is later refactored.
 _SUPERSEDED_SCRIPT = """
 import sys
 from multiprocessing import resource_tracker
@@ -153,50 +153,30 @@ def _run(script, *args):
 class TestCrossProcessTracker:
     """Pin tracker silence and segment ownership across a real process."""
 
-    def test_publish_should_emit_no_tracker_output_when_track_unsupported(self):
-        """Test a worker lifecycle below 3.13 leaves the tracker silent.
+    @pytest.mark.parametrize("mode", ["legacy", "native"])
+    def test_publish_should_emit_no_tracker_output_when_workers_cycle(self, mode):
+        """Test a worker lifecycle leaves the resource tracker silent.
 
         Given:
-            An independent interpreter forced onto the attach path taken
-            below 3.13, owning a namespace of its own.
+            An independent interpreter owning a namespace of its own, on
+            the attach path taken where ``track`` is unavailable or on
+            whichever path its own version selects.
         When:
             It announces, re-announces, updates, and drops three workers,
             then exits so its resource tracker drains.
         Then:
-            It should exit 0 having taken that path, with no tracker
-            traceback on stderr — the failure no exit code reflects.
+            It should exit 0 with no tracker traceback on stderr — the
+            failure no exit code reflects. Below 3.13 the unforced case
+            exercises the reported conditions with nothing simulated.
         """
         # Act
-        result = _run(_PUBLISH_SCRIPT, "legacy", f"tracker-{uuid.uuid4().hex[:12]}")
-
-        # Assert
-        assert result.returncode == 0, result.stderr
-        assert "path=legacy" in result.stdout, result.stdout
-        assert "done" in result.stdout, result.stdout
-        assert "KeyError" not in result.stderr, result.stderr
-        assert "Traceback" not in result.stderr, result.stderr
-        assert "resource_tracker" not in result.stderr, result.stderr
-
-    def test_publish_should_emit_no_tracker_output_on_the_running_interpreter(self):
-        """Test a worker lifecycle leaves the tracker silent as shipped.
-
-        Given:
-            An independent interpreter taking whichever attach path its
-            own version selects, owning a namespace of its own.
-        When:
-            It announces, re-announces, updates, and drops three workers,
-            then exits so its resource tracker drains.
-        Then:
-            It should exit 0 with no tracker traceback on stderr — on an
-            interpreter below 3.13 this exercises the reported failure's
-            conditions with nothing forced.
-        """
-        # Act
-        result = _run(_PUBLISH_SCRIPT, "native", f"tracker-{uuid.uuid4().hex[:12]}")
+        result = _run(_PUBLISH_SCRIPT, mode, f"tracker-{uuid.uuid4().hex[:12]}")
 
         # Assert
         assert result.returncode == 0, result.stderr
         assert "done" in result.stdout, result.stdout
+        if mode == "legacy":
+            assert "path=legacy" in result.stdout, result.stdout
         assert "KeyError" not in result.stderr, result.stderr
         assert "Traceback" not in result.stderr, result.stderr
         assert "resource_tracker" not in result.stderr, result.stderr

--- a/wool/tests/integration/test_local_discovery_tracker.py
+++ b/wool/tests/integration/test_local_discovery_tracker.py
@@ -1,0 +1,187 @@
+"""End-to-end tests for resource-tracker silence during attach (#336).
+
+These are targeted standalone tests rather than pairwise scenarios. The
+symptom is a traceback printed by the ``multiprocessing`` resource
+tracker — a *separate* process that inherits the interpreter's stderr and
+outlives the work — while the interpreter itself exits 0. Neither half of
+that observable is reachable from ``build_pool_from_scenario``, which
+yields a running system inside the pytest process with no subprocess
+stderr to inspect and a dispatch oracle that stays green throughout. The
+attach path is also an interpreter-global property, not a dimension the
+``Scenario`` model can vary.
+
+Reading stderr must run to EOF, which is why every test here uses
+``subprocess.run``: the pipe's write end is held by the tracker as well
+as the child, so EOF is the only point at which the tracker's output is
+guaranteed flushed. ``proc.wait()`` followed by a read would race.
+
+Coverage of the sub-3.13 branch lives in
+``tests/runtime/discovery/test_local.py`` — a ``subprocess`` child is
+invisible to ``coverage``, whose ``concurrency = multiprocessing``
+instruments ``multiprocessing.Process`` rather than ``subprocess.Popen``.
+These tests are behavioral evidence, not coverage.
+"""
+
+import subprocess
+import sys
+import uuid
+
+import pytest
+
+from .conftest import _TIMEOUT
+
+#: Announce, re-announce, update, and drop workers on a namespace this
+#: interpreter owns, so the same segments are attached repeatedly and
+#: then unlinked by their creator — the sequence that faults. ``mode``
+#: selects the attach path; "legacy" forces the branch interpreters
+#: below 3.13 take, which is otherwise unreachable on 3.13.
+_PUBLISH_SCRIPT = """
+import asyncio
+import sys
+import uuid
+from types import SimpleNamespace
+
+import wool.runtime.discovery.local as local
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.worker.metadata import WorkerMetadata
+
+mode, namespace = sys.argv[1:3]
+if mode == "legacy":
+    local.sys = SimpleNamespace(version_info=(3, 12, 0, "final", 0))
+
+print(
+    "branch=" + ("native" if local.sys.version_info >= (3, 13) else "legacy"),
+    flush=True,
+)
+
+
+async def main():
+    workers = [
+        WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="localhost:5005%d" % i,
+            pid=100 + i,
+            version="1.0",
+        )
+        for i in range(3)
+    ]
+    with LocalDiscovery(namespace):
+        async with LocalDiscovery.Publisher(namespace) as publisher:
+            for worker in workers:
+                await publisher.publish("worker-added", worker)
+                await publisher.publish("worker-added", worker)
+                await publisher.publish("worker-updated", worker)
+            for worker in workers:
+                await publisher.publish("worker-dropped", worker)
+    print("segments=%d" % (len(workers) + 1), flush=True)
+
+
+asyncio.run(main())
+print("done", flush=True)
+"""
+
+#: The superseded pattern, in pure standard library: attach to a segment
+#: this interpreter created, undo the attach's registration, then unlink.
+#: Deliberately independent of `wool`, so it keeps reproducing the fault
+#: however `local.py` is later refactored.
+_SUPERSEDED_SCRIPT = """
+import sys
+from multiprocessing import resource_tracker
+from multiprocessing.shared_memory import SharedMemory
+
+name = sys.argv[1]
+creator = SharedMemory(name=name, create=True, size=64)
+try:
+    for _ in range(3):
+        attached = SharedMemory(name=name)
+        resource_tracker.unregister(attached._name, "shared_memory")
+        attached.close()
+finally:
+    creator.close()
+    creator.unlink()
+print("done", flush=True)
+"""
+
+
+def _run(script, *args):
+    """Run script in a fresh interpreter, returning the completed process."""
+    return subprocess.run(
+        [sys.executable, "-c", script, *args],
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+    )
+
+
+@pytest.mark.integration
+class TestCrossProcessTracker:
+    def test_publish_should_emit_no_tracker_output_when_track_unsupported(self):
+        """Test a worker lifecycle below 3.13 leaves the tracker silent.
+
+        Given:
+            An independent interpreter forced onto the attach path taken
+            below 3.13, owning a namespace of its own.
+        When:
+            It announces, re-announces, updates, and drops three workers,
+            then exits so its resource tracker drains.
+        Then:
+            It should exit 0 having taken that path, with no tracker
+            traceback on stderr — the failure no exit code reflects.
+        """
+        # Act
+        result = _run(_PUBLISH_SCRIPT, "legacy", f"tracker-{uuid.uuid4().hex[:12]}")
+
+        # Assert
+        assert result.returncode == 0, result.stderr
+        assert "branch=legacy" in result.stdout, result.stdout
+        assert "done" in result.stdout, result.stdout
+        assert "KeyError" not in result.stderr, result.stderr
+        assert "Traceback" not in result.stderr, result.stderr
+        assert "resource_tracker" not in result.stderr, result.stderr
+
+    def test_publish_should_emit_no_tracker_output_on_the_running_interpreter(self):
+        """Test a worker lifecycle leaves the tracker silent as shipped.
+
+        Given:
+            An independent interpreter taking whichever attach path its
+            own version selects, owning a namespace of its own.
+        When:
+            It announces, re-announces, updates, and drops three workers,
+            then exits so its resource tracker drains.
+        Then:
+            It should exit 0 with no tracker traceback on stderr — on an
+            interpreter below 3.13 this reproduces the reported failure
+            with nothing forced.
+        """
+        # Act
+        result = _run(_PUBLISH_SCRIPT, "native", f"tracker-{uuid.uuid4().hex[:12]}")
+
+        # Assert
+        assert result.returncode == 0, result.stderr
+        assert "done" in result.stdout, result.stdout
+        assert "KeyError" not in result.stderr, result.stderr
+        assert "Traceback" not in result.stderr, result.stderr
+        assert "resource_tracker" not in result.stderr, result.stderr
+
+    def test_unregister_should_emit_tracker_output_when_an_attach_undoes_it(self):
+        """Test the superseded pattern still faults, so silence means something.
+
+        Given:
+            An independent interpreter reproducing the pattern this fix
+            replaced — attach, undo the attach's registration, unlink —
+            against a segment it created itself.
+        When:
+            It runs to completion and its resource tracker drains.
+        Then:
+            It should exit 0 yet print a tracker KeyError, proving these
+            tests observe the fault they assert the absence of, and that
+            an exit code alone cannot detect it.
+        """
+        # Act
+        result = _run(_SUPERSEDED_SCRIPT, f"tracker-{uuid.uuid4().hex[:12]}")
+
+        # Assert
+        assert result.returncode == 0, result.stderr
+        assert "done" in result.stdout, result.stdout
+        assert "KeyError" in result.stderr, result.stderr
+        assert "resource_tracker" in result.stderr, result.stderr

--- a/wool/tests/integration/test_local_discovery_tracker.py
+++ b/wool/tests/integration/test_local_discovery_tracker.py
@@ -1,32 +1,31 @@
 """End-to-end tests for resource-tracker silence during attach (#336).
 
 These are targeted standalone tests rather than pairwise scenarios. The
-symptom is a traceback printed by the ``multiprocessing`` resource
-tracker — a *separate* process that inherits the interpreter's stderr and
+symptom `_attach` documents is emitted by the `multiprocessing` resource
+tracker — a separate process that inherits the interpreter's stderr and
 outlives the work — while the interpreter itself exits 0. Neither half of
-that observable is reachable from ``build_pool_from_scenario``, which
+that observable is reachable from `build_pool_from_scenario`, which
 yields a running system inside the pytest process with no subprocess
 stderr to inspect and a dispatch oracle that stays green throughout. The
 attach path is also an interpreter-global property, not a dimension the
-``Scenario`` model can vary.
-
-Reading stderr must run to EOF, which is why every test here uses
-``subprocess.run``: the pipe's write end is held by the tracker as well
-as the child, so EOF is the only point at which the tracker's output is
-guaranteed flushed. ``proc.wait()`` followed by a read would race.
+`Scenario` model can vary.
 
 Coverage of the sub-3.13 branch lives in
-``tests/runtime/discovery/test_local.py`` — a ``subprocess`` child is
-invisible to ``coverage``, whose ``concurrency = multiprocessing``
-instruments ``multiprocessing.Process`` rather than ``subprocess.Popen``.
+``tests/runtime/discovery/test_local.py`` — a subprocess child is
+invisible to coverage, whose ``concurrency = multiprocessing`` setting
+instruments `multiprocessing.Process` rather than `subprocess.Popen`.
 These tests are behavioral evidence, not coverage.
 """
 
 import subprocess
 import sys
 import uuid
+from multiprocessing.shared_memory import SharedMemory
 
 import pytest
+
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.discovery.local import _short_hash
 
 from .conftest import _TIMEOUT
 
@@ -49,10 +48,20 @@ mode, namespace = sys.argv[1:3]
 if mode == "legacy":
     local.sys = SimpleNamespace(version_info=(3, 12, 0, "final", 0))
 
-print(
-    "branch=" + ("native" if local.sys.version_info >= (3, 13) else "legacy"),
-    flush=True,
-)
+# Report the path that actually ran, observed from the constructor's
+# arguments rather than by re-reading the version the override set --
+# only the modern path passes ``track``.
+_mapping = local.SharedMemory
+_paths = set()
+
+
+def _observing(*args, **kwargs):
+    if not kwargs.get("create"):
+        _paths.add("native" if "track" in kwargs else "legacy")
+    return _mapping(*args, **kwargs)
+
+
+local.SharedMemory = _observing
 
 
 async def main():
@@ -77,6 +86,27 @@ async def main():
 
 
 asyncio.run(main())
+print("path=" + ",".join(sorted(_paths)), flush=True)
+print("done", flush=True)
+"""
+
+#: Attach to a namespace this interpreter does not own, then exit. The
+#: creating process must still find its segment afterwards: only a creator
+#: may unlink, and a tracked attach would have this process's tracker do it
+#: on the way out (bpo-38119).
+_ATTACHER_SCRIPT = """
+import sys
+from types import SimpleNamespace
+
+import wool.runtime.discovery.local as local
+from wool.runtime.discovery.local import LocalDiscovery
+
+mode, namespace = sys.argv[1:3]
+if mode == "legacy":
+    local.sys = SimpleNamespace(version_info=(3, 12, 0, "final", 0))
+
+with LocalDiscovery(namespace):
+    print("attached", flush=True)
 print("done", flush=True)
 """
 
@@ -104,7 +134,13 @@ print("done", flush=True)
 
 
 def _run(script, *args):
-    """Run script in a fresh interpreter, returning the completed process."""
+    """Run script in a fresh interpreter, returning the completed process.
+
+    `subprocess.run` reads stderr to EOF, which matters here: the pipe's
+    write end is held by the resource tracker as well as the child, so EOF
+    is the only point at which the tracker's output is guaranteed flushed.
+    A `subprocess.Popen.wait` followed by a read would race it.
+    """
     return subprocess.run(
         [sys.executable, "-c", script, *args],
         capture_output=True,
@@ -115,6 +151,8 @@ def _run(script, *args):
 
 @pytest.mark.integration
 class TestCrossProcessTracker:
+    """Pin tracker silence and segment ownership across a real process."""
+
     def test_publish_should_emit_no_tracker_output_when_track_unsupported(self):
         """Test a worker lifecycle below 3.13 leaves the tracker silent.
 
@@ -133,7 +171,7 @@ class TestCrossProcessTracker:
 
         # Assert
         assert result.returncode == 0, result.stderr
-        assert "branch=legacy" in result.stdout, result.stdout
+        assert "path=legacy" in result.stdout, result.stdout
         assert "done" in result.stdout, result.stdout
         assert "KeyError" not in result.stderr, result.stderr
         assert "Traceback" not in result.stderr, result.stderr
@@ -150,8 +188,8 @@ class TestCrossProcessTracker:
             then exits so its resource tracker drains.
         Then:
             It should exit 0 with no tracker traceback on stderr — on an
-            interpreter below 3.13 this reproduces the reported failure
-            with nothing forced.
+            interpreter below 3.13 this exercises the reported failure's
+            conditions with nothing forced.
         """
         # Act
         result = _run(_PUBLISH_SCRIPT, "native", f"tracker-{uuid.uuid4().hex[:12]}")
@@ -162,6 +200,37 @@ class TestCrossProcessTracker:
         assert "KeyError" not in result.stderr, result.stderr
         assert "Traceback" not in result.stderr, result.stderr
         assert "resource_tracker" not in result.stderr, result.stderr
+
+    @pytest.mark.parametrize("mode", ["legacy", "native"])
+    def test___enter___should_keep_the_segment_when_an_attacher_exits(self, mode):
+        """Test a non-owner's exit leaves the owner's segment mapped.
+
+        Given:
+            A namespace this process created, and an independent
+            interpreter that enters and leaves it as a non-owner on either
+            attach path.
+        When:
+            That interpreter exits and its resource tracker drains.
+        Then:
+            It should leave the segment mapped and warn about no leak —
+            only the process that created a segment may unlink it, and a
+            tracked attach would have the attacher reclaim it instead
+            (bpo-38119).
+        """
+        # Arrange
+        namespace = f"tracker-{uuid.uuid4().hex[:12]}"
+
+        # Act
+        with LocalDiscovery(namespace):
+            result = _run(_ATTACHER_SCRIPT, mode, namespace)
+
+            # Assert — the owner is still inside its context, so the
+            # segment must still be there for it to map.
+            assert result.returncode == 0, result.stderr
+            assert "attached" in result.stdout, result.stdout
+            assert "leaked shared_memory" not in result.stderr, result.stderr
+            assert "KeyError" not in result.stderr, result.stderr
+            SharedMemory(name=_short_hash(namespace)).close()
 
     def test_unregister_should_emit_tracker_output_when_an_attach_undoes_it(self):
         """Test the superseded pattern still faults, so silence means something.

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -1,12 +1,16 @@
 import asyncio
 import atexit
 import pickle
+import sys
+import threading
 import uuid
 from collections import Counter
 from contextlib import ExitStack
 from contextlib import asynccontextmanager
+from multiprocessing import resource_tracker
 from multiprocessing.shared_memory import SharedMemory
 from types import MappingProxyType
+from types import SimpleNamespace
 
 import portalocker
 import pytest
@@ -15,6 +19,7 @@ from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
 
+from wool.runtime.discovery import local
 from wool.runtime.discovery.base import DiscoverySubscriberLike
 from wool.runtime.discovery.exceptions import DiscoveryBlockExhausted
 from wool.runtime.discovery.exceptions import DiscoveryCapacityExhausted
@@ -110,6 +115,80 @@ def unlink_schedule(mocker):
 
 
 @pytest.fixture
+def tracker_ledger(mocker):
+    """Mirrors the resource tracker's cache in-process, recording violations.
+
+    Wraps ``resource_tracker.register``/``unregister`` in pass-throughs, so
+    the real tracker stays authoritative and no segment leaks, while
+    replaying the tracker's own bookkeeping locally: a per-type **set**,
+    added to on register and removed from on unregister.
+
+    The set is the whole point. Registrations of one name collapse to a
+    single entry while every unregister attempts its own removal, so
+    counting calls does not detect #336 -- register/unregister counts stay
+    perfectly balanced while the tracker faults. What faults is a removal
+    of a name the cache no longer holds, which the real tracker answers
+    with a `KeyError` traceback in a process no test can observe. Here it
+    lands in ``violations``.
+
+    Only names first registered inside this fixture's window can be
+    recorded as violations, so a segment that outlived an earlier test
+    cannot produce a false one.
+    """
+    ledger = SimpleNamespace(registered=[], unregistered=[], violations=[])
+    cache: set[tuple[str, str]] = set()
+    seen: set[tuple[str, str]] = set()
+    real_register = resource_tracker.register
+    real_unregister = resource_tracker.unregister
+
+    def register(name, rtype):
+        key = (rtype, name.lstrip("/"))
+        ledger.registered.append(key)
+        cache.add(key)
+        seen.add(key)
+        return real_register(name, rtype)
+
+    def unregister(name, rtype):
+        key = (rtype, name.lstrip("/"))
+        ledger.unregistered.append(key)
+        if key in cache:
+            cache.discard(key)
+        elif key in seen:
+            ledger.violations.append(key)
+        return real_unregister(name, rtype)
+
+    mocker.patch.object(resource_tracker, "register", register)
+    mocker.patch.object(resource_tracker, "unregister", unregister)
+    ledger.residual = cache
+    return ledger
+
+
+@pytest.fixture
+def attach_fallback(mocker):
+    """Force the attach path taken by interpreters below 3.13.
+
+    The package supports 3.11 and up, so most supported interpreters take
+    the fallback -- but the development interpreter is 3.13, where it is
+    unreachable. Since that branch no longer carries ``# pragma: no
+    cover``, forcing it is what covers it on the 3.13 CI leg; on the 3.11
+    and 3.12 legs the override is a no-op against the natural branch.
+
+    The module reads ``sys`` at exactly one place, so replacing its own
+    reference is narrower than patching the real ``sys.version_info``,
+    which every module in the interpreter would see. Should another
+    ``sys`` attribute ever be used here, this raises ``AttributeError``
+    rather than silently steering nothing.
+
+    Forcing *down* is always safe. Forcing up is not: ``track=False`` does
+    not exist below 3.13, so a test that wants the modern path must skip
+    rather than override.
+    """
+    mocker.patch.object(
+        local, "sys", SimpleNamespace(version_info=(3, 12, 0, "final", 0))
+    )
+
+
+@pytest.fixture
 def held_lock(mocker):
     """Patch portalocker.lock to report the lock is permanently held.
 
@@ -175,6 +254,219 @@ _LIFECYCLE_FORESTS = st.recursive(
     lambda children: st.lists(children, max_size=3),
     max_leaves=6,
 )
+
+
+@asynccontextmanager
+async def _segment(name):
+    """Create a shared memory segment by name, unlinking it on exit."""
+    created = SharedMemory(name=name, create=True, size=64)
+    try:
+        yield created
+    finally:
+        created.close()
+        created.unlink()
+
+
+def _segment_name():
+    """Return a fresh segment name short enough for macOS's 31-char limit."""
+    return f"wool-336-{uuid.uuid4().hex[:16]}"
+
+
+# Attaching to an existing segment is reached only through private helpers,
+# so the behavioral coverage below drives it through publish and __aiter__.
+# These four cases cannot: nothing else registers a resource during the
+# fallback's rebind window in real use, and a restore that failed would be
+# invisible until some later, unrelated attach. They follow the private
+# import idiom of TestWorkerReference.
+
+
+def test_attach_should_not_register_the_segment_when_track_unsupported(
+    attach_fallback, tracker_ledger
+):
+    """Test an attach below 3.13 leaves the resource tracker untouched.
+
+    Given:
+        An existing shared memory segment and an interpreter reporting a
+        version below 3.13, where SharedMemory has no track parameter.
+    When:
+        The segment is attached by name.
+    Then:
+        It should register nothing further for that segment, leaving the
+        creator's registration to answer the creator's own unlink.
+    """
+    # Arrange
+    from wool.runtime.discovery.local import _attach
+
+    name = _segment_name()
+    created = SharedMemory(name=name, create=True, size=64)
+    before = tracker_ledger.registered.count(("shared_memory", name))
+
+    # Act
+    try:
+        attached = _attach(name)
+        attached.close()
+    finally:
+        created.close()
+        created.unlink()
+
+    # Assert
+    assert tracker_ledger.registered.count(("shared_memory", name)) == before
+    assert tracker_ledger.violations == []
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 13), reason="track=False requires Python 3.13"
+)
+def test_attach_should_not_register_the_segment_when_track_supported(tracker_ledger):
+    """Test an attach on 3.13 and above leaves the resource tracker untouched.
+
+    Given:
+        An existing shared memory segment and an interpreter whose
+        SharedMemory accepts track=False.
+    When:
+        The segment is attached by name.
+    Then:
+        It should register nothing further for that segment — the same
+        observable the pre-3.13 fallback produces.
+    """
+    # Arrange
+    from wool.runtime.discovery.local import _attach
+
+    name = _segment_name()
+    created = SharedMemory(name=name, create=True, size=64)
+    before = tracker_ledger.registered.count(("shared_memory", name))
+
+    # Act
+    try:
+        attached = _attach(name)
+        attached.close()
+    finally:
+        created.close()
+        created.unlink()
+
+    # Assert
+    assert tracker_ledger.registered.count(("shared_memory", name)) == before
+    assert tracker_ledger.violations == []
+
+
+def test_attach_should_register_other_resources_when_track_unsupported(
+    mocker, attach_fallback, tracker_ledger
+):
+    """Test the fallback suppresses only the segment it is attaching.
+
+    Given:
+        An interpreter reporting a version below 3.13 and a mapping that
+        registers an unrelated segment and a non-segment resource while
+        it is being constructed.
+    When:
+        A segment is attached by name.
+    Then:
+        It should pass both foreign registrations through to the tracker,
+        narrowing the suppression to this segment and this resource type.
+    """
+    # Arrange
+    from wool.runtime.discovery.local import _attach
+
+    name = _segment_name()
+    other = _segment_name()
+    mapping = local.SharedMemory
+
+    def constructing(*args, **kwargs):
+        resource_tracker.register(f"/{other}", "shared_memory")
+        resource_tracker.register(f"/{other}", "semaphore")
+        return mapping(*args, **kwargs)
+
+    mocker.patch.object(local, "SharedMemory", constructing)
+    created = SharedMemory(name=name, create=True, size=64)
+    before = tracker_ledger.registered.count(("shared_memory", name))
+
+    # Act
+    try:
+        attached = _attach(name)
+        attached.close()
+    finally:
+        created.close()
+        created.unlink()
+        resource_tracker.unregister(f"/{other}", "shared_memory")
+        resource_tracker.unregister(f"/{other}", "semaphore")
+
+    # Assert
+    assert ("shared_memory", other) in tracker_ledger.registered
+    assert ("semaphore", other) in tracker_ledger.registered
+    assert tracker_ledger.registered.count(("shared_memory", name)) == before
+
+
+def test_attach_should_register_the_segment_when_another_thread_creates_it(
+    mocker, attach_fallback, tracker_ledger
+):
+    """Test the fallback suppresses only its own thread's registration.
+
+    Given:
+        An interpreter reporting a version below 3.13 and a second thread
+        registering the very segment being attached, from inside the
+        window in which the attach has the registration hook rebound.
+    When:
+        The segment is attached by name.
+    Then:
+        It should let that thread's registration reach the tracker — a
+        concurrent creator keeps ownership of the segment it created.
+    """
+    # Arrange
+    from wool.runtime.discovery.local import _attach
+
+    name = _segment_name()
+    mapping = local.SharedMemory
+
+    def constructing(*args, **kwargs):
+        creator = threading.Thread(
+            target=resource_tracker.register, args=(f"/{name}", "shared_memory")
+        )
+        creator.start()
+        creator.join(timeout=5)
+        assert not creator.is_alive()
+        return mapping(*args, **kwargs)
+
+    mocker.patch.object(local, "SharedMemory", constructing)
+    created = SharedMemory(name=name, create=True, size=64)
+    before = tracker_ledger.registered.count(("shared_memory", name))
+
+    # Act
+    try:
+        attached = _attach(name)
+        attached.close()
+    finally:
+        created.close()
+        created.unlink()
+
+    # Assert
+    assert tracker_ledger.registered.count(("shared_memory", name)) == before + 1
+
+
+def test_attach_should_restore_the_registration_hook_when_the_segment_is_gone(
+    attach_fallback,
+):
+    """Test a failed attach below 3.13 restores the registration hook.
+
+    Given:
+        An interpreter reporting a version below 3.13 and a segment name
+        that does not exist.
+    When:
+        The segment is attached by name and the mapping fails.
+    Then:
+        It should propagate FileNotFoundError having rebound the tracker's
+        registration hook to what it found — a hook left installed would
+        silently stop tracking that name for the rest of the process.
+    """
+    # Arrange
+    from wool.runtime.discovery.local import _attach
+
+    original = resource_tracker.register
+
+    # Act & assert
+    with pytest.raises(FileNotFoundError):
+        _attach(_segment_name())
+
+    assert resource_tracker.register is original
 
 
 class TestLocalDiscovery:
@@ -3715,6 +4007,107 @@ class TestLocalDiscoveryPublisher:
                         publisher = registrar.pop(index)
                         await publisher.publish("worker-dropped", roster[index])
 
+    @pytest.mark.asyncio
+    async def test_publish_should_leave_the_tracker_balanced_when_worker_readded(
+        self, namespace, attach_fallback, tracker_ledger
+    ):
+        """Test a re-announced worker never unregisters an untracked name.
+
+        Given:
+            An owned namespace on an interpreter reporting a version
+            below 3.13, and a worker announced more than once — the shape
+            49c4f2e made routine, which attaches a live block on every
+            announcement.
+        When:
+            The worker is added, re-added, updated, and dropped, and the
+            namespace's owner exits.
+        Then:
+            It should never unregister a name the tracker is not holding,
+            and should leave nothing registered — every attach preserved
+            the registration its creator's unlink depends on.
+        """
+        # Arrange
+        worker = WorkerMetadata(
+            uid=uuid.uuid4(), address="localhost:50051", pid=123, version="1.0"
+        )
+
+        # Act
+        with LocalDiscovery(namespace):
+            async with LocalDiscovery.Publisher(namespace) as publisher:
+                await publisher.publish("worker-added", worker)
+                await publisher.publish("worker-added", worker)
+                await publisher.publish("worker-updated", worker)
+                await publisher.publish("worker-dropped", worker)
+
+        # Assert
+        assert tracker_ledger.violations == []
+        assert tracker_ledger.residual == set()
+
+    @given(
+        ops=st.lists(
+            st.tuples(
+                st.sampled_from(["add", "update", "drop"]),
+                st.integers(min_value=0, max_value=2),
+            ),
+            min_size=1,
+            max_size=12,
+        )
+    )
+    @settings(
+        max_examples=15,
+        deadline=5000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @pytest.mark.asyncio
+    async def test_publish_should_leave_the_tracker_balanced_across_event_sequences(
+        self, namespace, attach_fallback, tracker_ledger, ops
+    ):
+        """Test the tracker stays consistent however segments are reattached.
+
+        Given:
+            An owned namespace on an interpreter reporting a version
+            below 3.13, a three-worker roster, and an arbitrary sequence
+            of add, update, and drop events over it.
+        When:
+            The sequence is published serially and the owner exits.
+        Then:
+            It should never unregister a name the tracker is not holding,
+            whatever the order and however many times one segment is
+            attached.
+        """
+        # Arrange — a per-example namespace so shared-memory state does
+        # not carry across Hypothesis examples, and a per-example ledger
+        # so one example's imbalance cannot be attributed to the next.
+        example_ns = f"{namespace}-{uuid.uuid4().hex[:8]}"
+        tracker_ledger.violations.clear()
+        roster = [
+            WorkerMetadata(
+                uid=uuid.uuid4(),
+                address=f"localhost:{50051 + i}",
+                pid=100 + i,
+                version="1.0",
+            )
+            for i in range(3)
+        ]
+        live: set[int] = set()
+
+        # Act
+        with LocalDiscovery(example_ns):
+            async with LocalDiscovery.Publisher(example_ns) as publisher:
+                for action, index in ops:
+                    if action == "add":
+                        await publisher.publish("worker-added", roster[index])
+                        live.add(index)
+                    elif index in live:
+                        if action == "update":
+                            await publisher.publish("worker-updated", roster[index])
+                        else:
+                            await publisher.publish("worker-dropped", roster[index])
+                            live.discard(index)
+
+        # Assert
+        assert tracker_ledger.violations == []
+
 
 class TestWorkerReference:
     """Tests for the internal _WorkerReference value object."""
@@ -4591,6 +4984,54 @@ class TestLocalDiscoverySubscriber:
         # Assert
         assert len(events) == 1
         assert events[0].metadata.uid == metadata.uid
+
+    @pytest.mark.asyncio
+    async def test___aiter___should_leave_the_tracker_balanced_when_polling(
+        self, namespace, metadata, attach_fallback, tracker_ledger
+    ):
+        """Test repeated read-side attaches leave the tracker consistent.
+
+        Given:
+            An owned namespace holding one worker, on an interpreter
+            reporting a version below 3.13, and a subscriber polling it —
+            the most frequent attach in the system, since every poll
+            reattaches the address space and each worker's block.
+        When:
+            The subscriber discovers the worker across several poll
+            cycles and the worker is then dropped.
+        Then:
+            It should never unregister a name the tracker is not holding
+            — a reader must not consume the registration the writer's
+            unlink depends on.
+        """
+        # Arrange
+        received = asyncio.Event()
+        polls = 0
+
+        async def collect(subscriber):
+            nonlocal polls
+            async for event in subscriber:
+                if event.metadata.uid == metadata.uid:
+                    polls += 1
+                    if polls >= 1:
+                        received.set()
+
+        # Act
+        with LocalDiscovery(namespace) as discovery:
+            async with LocalDiscovery.Publisher(namespace) as publisher:
+                await publisher.publish("worker-added", metadata)
+                subscriber = discovery.subscribe(poll_interval=0.02)
+                async with _collecting(subscriber, collect):
+                    await asyncio.wait_for(received.wait(), timeout=5.0)
+                    # Let the poll loop reattach the same segments a few
+                    # more times before teardown.
+                    await asyncio.sleep(0.1)
+                await publisher.publish("worker-dropped", metadata)
+
+        # Assert
+        assert polls >= 1
+        assert tracker_ledger.violations == []
+        assert tracker_ledger.residual == set()
 
 
 def _enter_lifecycle_forest(namespace, forest):

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -410,8 +410,7 @@ def test__attach_should_register_the_segment_when_another_thread_registers_it(
     When:
         The segment is attached by name.
     Then:
-        It should let that thread's registration reach the tracker — a
-        concurrent creator keeps ownership of what it created.
+        It should let that thread's registration reach the tracker.
     """
     # Arrange
     name = _segment_name()

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -1,5 +1,8 @@
 import asyncio
 import atexit
+import contextlib
+import errno
+import mmap
 import pickle
 import sys
 import threading
@@ -7,6 +10,7 @@ import uuid
 from collections import Counter
 from contextlib import ExitStack
 from contextlib import asynccontextmanager
+from contextlib import contextmanager
 from multiprocessing import resource_tracker
 from multiprocessing.shared_memory import SharedMemory
 from types import MappingProxyType
@@ -15,6 +19,7 @@ from types import SimpleNamespace
 import portalocker
 import pytest
 from hypothesis import HealthCheck
+from hypothesis import assume
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
@@ -116,26 +121,29 @@ def unlink_schedule(mocker):
 
 @pytest.fixture
 def tracker_ledger(mocker):
-    """Mirrors the resource tracker's cache in-process, recording violations.
+    """Mirror the resource tracker's cache in-process, recording violations.
 
-    Wraps ``resource_tracker.register``/``unregister`` in pass-throughs, so
-    the real tracker stays authoritative and no segment leaks, while
+    Wraps `resource_tracker.register` and `resource_tracker.unregister`,
     replaying the tracker's own bookkeeping locally: a per-type **set**,
     added to on register and removed from on unregister.
 
     The set is the whole point. Registrations of one name collapse to a
     single entry while every unregister attempts its own removal, so
-    counting calls does not detect #336 -- register/unregister counts stay
-    perfectly balanced while the tracker faults. What faults is a removal
-    of a name the cache no longer holds, which the real tracker answers
-    with a `KeyError` traceback in a process no test can observe. Here it
-    lands in ``violations``.
+    counting calls does not detect the fault `_attach` documents — the
+    counts stay perfectly balanced while the tracker raises. What raises is
+    a removal of a name the cache no longer holds; here it lands in
+    ``violations`` instead of a traceback no test can observe.
+
+    A violating unregister is recorded and *not* forwarded. Forwarding it
+    would corrupt the real tracker's session-global cache and reproduce
+    that traceback inside this suite, misattributed to whichever test ran
+    last. Every other call passes through, so real segments stay tracked.
 
     Only names first registered inside this fixture's window can be
     recorded as violations, so a segment that outlived an earlier test
     cannot produce a false one.
     """
-    ledger = SimpleNamespace(registered=[], unregistered=[], violations=[])
+    ledger = SimpleNamespace(registered=[], violations=[])
     cache: set[tuple[str, str]] = set()
     seen: set[tuple[str, str]] = set()
     real_register = resource_tracker.register
@@ -150,42 +158,69 @@ def tracker_ledger(mocker):
 
     def unregister(name, rtype):
         key = (rtype, name.lstrip("/"))
-        ledger.unregistered.append(key)
         if key in cache:
             cache.discard(key)
         elif key in seen:
             ledger.violations.append(key)
+            return None
         return real_unregister(name, rtype)
+
+    def reset():
+        ledger.registered.clear()
+        ledger.violations.clear()
+        cache.clear()
+        seen.clear()
 
     mocker.patch.object(resource_tracker, "register", register)
     mocker.patch.object(resource_tracker, "unregister", unregister)
     ledger.residual = cache
+    ledger.reset = reset
     return ledger
 
 
 @pytest.fixture
 def attach_fallback(mocker):
-    """Force the attach path taken by interpreters below 3.13.
+    """Force the attach path taken where `SharedMemory` has no ``track``.
 
     The package supports 3.11 and up, so most supported interpreters take
-    the fallback -- but the development interpreter is 3.13, where it is
-    unreachable. Since that branch no longer carries ``# pragma: no
-    cover``, forcing it is what covers it on the 3.13 CI leg; on the 3.11
-    and 3.12 legs the override is a no-op against the natural branch.
+    that path — but the development interpreter is 3.13, where it is
+    unreachable. The branch is measured rather than pragma-excluded, so
+    forcing it is what covers it there; where the interpreter is already
+    below 3.13 the override is a no-op against the natural branch.
 
-    The module reads ``sys`` at exactly one place, so replacing its own
-    reference is narrower than patching the real ``sys.version_info``,
-    which every module in the interpreter would see. Should another
-    ``sys`` attribute ever be used here, this raises ``AttributeError``
-    rather than silently steering nothing.
+    The module reads `sys` at exactly one place, so replacing its own
+    reference is narrower than patching the real `sys.version_info`, which
+    every module in the interpreter would see. Should another `sys`
+    attribute ever be used there, this raises `AttributeError` rather than
+    silently steering nothing.
 
     Forcing *down* is always safe. Forcing up is not: ``track=False`` does
-    not exist below 3.13, so a test that wants the modern path must skip
+    not exist below 3.13, so a test wanting the modern path must skip
     rather than override.
     """
     mocker.patch.object(
         local, "sys", SimpleNamespace(version_info=(3, 12, 0, "final", 0))
     )
+
+
+@pytest.fixture
+def attach_calls(mocker):
+    """Record the keyword arguments of every `SharedMemory` construction.
+
+    Observes which attach path ran, rather than trusting the version the
+    `attach_fallback` fixture reports: only the modern path passes
+    ``track``. Without this, inverting the version predicate leaves the
+    suite green while every test silently exercises the other branch.
+    """
+    calls = []
+    mapping = local.SharedMemory
+
+    def constructing(*args, **kwargs):
+        calls.append(kwargs)
+        return mapping(*args, **kwargs)
+
+    mocker.patch.object(local, "SharedMemory", constructing)
+    return calls
 
 
 @pytest.fixture
@@ -256,8 +291,8 @@ _LIFECYCLE_FORESTS = st.recursive(
 )
 
 
-@asynccontextmanager
-async def _segment(name):
+@contextmanager
+def _segment(name):
     """Create a shared memory segment by name, unlinking it on exit."""
     created = SharedMemory(name=name, create=True, size=64)
     try:
@@ -272,180 +307,224 @@ def _segment_name():
     return f"wool-336-{uuid.uuid4().hex[:16]}"
 
 
-# Attaching to an existing segment is reached only through private helpers,
-# so the behavioral coverage below drives it through publish and __aiter__.
-# These four cases cannot: nothing else registers a resource during the
-# fallback's rebind window in real use, and a restore that failed would be
-# invisible until some later, unrelated attach. They follow the private
-# import idiom of TestWorkerReference.
+@pytest.fixture(params=["fallback", "native"])
+def attach_path(request, mocker):
+    """Select an attach path, skipping the modern one where it cannot run.
+
+    Forcing the fallback is safe on every interpreter. Forcing the modern
+    path is not — ``track=False`` does not exist below 3.13 — so that case
+    skips rather than overrides.
+    """
+    if request.param == "fallback":
+        mocker.patch.object(
+            local, "sys", SimpleNamespace(version_info=(3, 12, 0, "final", 0))
+        )
+    elif sys.version_info < (3, 13):
+        pytest.skip("track=False requires Python 3.13")
+    return request.param
 
 
-def test_attach_should_not_register_the_segment_when_track_unsupported(
-    attach_fallback, tracker_ledger
+def test__attach_should_not_register_the_segment(
+    attach_path, attach_calls, tracker_ledger
 ):
-    """Test an attach below 3.13 leaves the resource tracker untouched.
+    """Test attaching to a segment leaves the resource tracker untouched.
 
     Given:
-        An existing shared memory segment and an interpreter reporting a
-        version below 3.13, where SharedMemory has no track parameter.
+        An existing shared memory segment, on either attach path.
     When:
         The segment is attached by name.
     Then:
         It should register nothing further for that segment, leaving the
-        creator's registration to answer the creator's own unlink.
+        creator's registration to answer the creator's own unlink — the
+        same observable on both paths.
     """
     # Arrange
-    from wool.runtime.discovery.local import _attach
-
     name = _segment_name()
-    created = SharedMemory(name=name, create=True, size=64)
-    before = tracker_ledger.registered.count(("shared_memory", name))
 
     # Act
-    try:
-        attached = _attach(name)
+    with _segment(name):
+        before = tracker_ledger.registered.count(("shared_memory", name))
+        attached = local._attach(name)
         attached.close()
-    finally:
-        created.close()
-        created.unlink()
 
     # Assert
     assert tracker_ledger.registered.count(("shared_memory", name)) == before
     assert tracker_ledger.violations == []
+    # Pin which path ran: only the modern one passes track.
+    assert ("track" in attach_calls[-1]) == (attach_path == "native")
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 13), reason="track=False requires Python 3.13"
-)
-def test_attach_should_not_register_the_segment_when_track_supported(tracker_ledger):
-    """Test an attach on 3.13 and above leaves the resource tracker untouched.
+def test__attach_should_register_other_resources_when_track_unsupported(
+    mocker, attach_fallback, tracker_ledger
+):
+    """Test the fallback suppresses only this segment and this resource type.
 
     Given:
-        An existing shared memory segment and an interpreter whose
-        SharedMemory accepts track=False.
+        An interpreter reporting a version below 3.13, and a mapping that
+        registers an unrelated segment and a semaphore of the very name
+        being attached while the constructor runs.
     When:
         The segment is attached by name.
     Then:
-        It should register nothing further for that segment — the same
-        observable the pre-3.13 fallback produces.
+        It should pass both registrations through — narrowing the
+        suppression to one segment and one resource type, not to the name
+        alone.
     """
     # Arrange
-    from wool.runtime.discovery.local import _attach
-
-    name = _segment_name()
-    created = SharedMemory(name=name, create=True, size=64)
-    before = tracker_ledger.registered.count(("shared_memory", name))
-
-    # Act
-    try:
-        attached = _attach(name)
-        attached.close()
-    finally:
-        created.close()
-        created.unlink()
-
-    # Assert
-    assert tracker_ledger.registered.count(("shared_memory", name)) == before
-    assert tracker_ledger.violations == []
-
-
-def test_attach_should_register_other_resources_when_track_unsupported(
-    mocker, attach_fallback, tracker_ledger
-):
-    """Test the fallback suppresses only the segment it is attaching.
-
-    Given:
-        An interpreter reporting a version below 3.13 and a mapping that
-        registers an unrelated segment and a non-segment resource while
-        it is being constructed.
-    When:
-        A segment is attached by name.
-    Then:
-        It should pass both foreign registrations through to the tracker,
-        narrowing the suppression to this segment and this resource type.
-    """
-    # Arrange
-    from wool.runtime.discovery.local import _attach
-
     name = _segment_name()
     other = _segment_name()
     mapping = local.SharedMemory
 
     def constructing(*args, **kwargs):
         resource_tracker.register(f"/{other}", "shared_memory")
-        resource_tracker.register(f"/{other}", "semaphore")
+        resource_tracker.register(f"/{name}", "semaphore")
         return mapping(*args, **kwargs)
 
     mocker.patch.object(local, "SharedMemory", constructing)
-    created = SharedMemory(name=name, create=True, size=64)
-    before = tracker_ledger.registered.count(("shared_memory", name))
 
     # Act
-    try:
-        attached = _attach(name)
-        attached.close()
-    finally:
-        created.close()
-        created.unlink()
-        resource_tracker.unregister(f"/{other}", "shared_memory")
-        resource_tracker.unregister(f"/{other}", "semaphore")
+    with _segment(name):
+        before = tracker_ledger.registered.count(("shared_memory", name))
+        try:
+            attached = local._attach(name)
+            attached.close()
+        finally:
+            resource_tracker.unregister(f"/{other}", "shared_memory")
+            resource_tracker.unregister(f"/{name}", "semaphore")
 
     # Assert
     assert ("shared_memory", other) in tracker_ledger.registered
-    assert ("semaphore", other) in tracker_ledger.registered
+    assert ("semaphore", name) in tracker_ledger.registered
     assert tracker_ledger.registered.count(("shared_memory", name)) == before
 
 
-def test_attach_should_register_the_segment_when_another_thread_creates_it(
+def test__attach_should_register_the_segment_when_another_thread_registers_it(
     mocker, attach_fallback, tracker_ledger
 ):
     """Test the fallback suppresses only its own thread's registration.
 
     Given:
-        An interpreter reporting a version below 3.13 and a second thread
-        registering the very segment being attached, from inside the
-        window in which the attach has the registration hook rebound.
+        An interpreter reporting a version below 3.13, and a second thread
+        registering the very segment being attached from inside the window
+        in which the attach has the tracker's hooks rebound.
     When:
         The segment is attached by name.
     Then:
         It should let that thread's registration reach the tracker — a
-        concurrent creator keeps ownership of the segment it created.
+        concurrent creator keeps ownership of what it created.
     """
     # Arrange
-    from wool.runtime.discovery.local import _attach
-
     name = _segment_name()
     mapping = local.SharedMemory
 
     def constructing(*args, **kwargs):
-        creator = threading.Thread(
+        registrar = threading.Thread(
             target=resource_tracker.register, args=(f"/{name}", "shared_memory")
         )
-        creator.start()
-        creator.join(timeout=5)
-        assert not creator.is_alive()
+        registrar.start()
+        registrar.join(timeout=5)
+        assert not registrar.is_alive()
         return mapping(*args, **kwargs)
 
     mocker.patch.object(local, "SharedMemory", constructing)
-    created = SharedMemory(name=name, create=True, size=64)
-    before = tracker_ledger.registered.count(("shared_memory", name))
 
     # Act
-    try:
-        attached = _attach(name)
+    with _segment(name):
+        before = tracker_ledger.registered.count(("shared_memory", name))
+        attached = local._attach(name)
         attached.close()
-    finally:
-        created.close()
-        created.unlink()
 
     # Assert
     assert tracker_ledger.registered.count(("shared_memory", name)) == before + 1
 
 
-def test_attach_should_restore_the_registration_hook_when_the_segment_is_gone(
-    attach_fallback,
+def test__attach_should_serialise_overlapping_attaches(
+    mocker, attach_fallback, tracker_ledger
 ):
-    """Test a failed attach below 3.13 restores the registration hook.
+    """Test one attach's rebind window excludes another thread's.
+
+    Given:
+        An interpreter reporting a version below 3.13, and a second thread
+        attaching a different segment while the first attach holds the
+        window open.
+    When:
+        The first attach is in its constructor.
+    Then:
+        It should keep the second thread waiting until the window closes —
+        two overlapping rebinds would capture each other's shim, letting an
+        attach's own registration escape suppression.
+    """
+    # Arrange
+    first = _segment_name()
+    second = _segment_name()
+    mapping = local.SharedMemory
+    contender_ran = threading.Event()
+
+    def constructing(*args, **kwargs):
+        if kwargs.get("name") == first:
+
+            def contend():
+                local._attach(second).close()
+                contender_ran.set()
+
+            contender = threading.Thread(target=contend, daemon=True)
+            contender.start()
+            # The contender cannot enter its own window while this one is
+            # open, so it is still blocked here.
+            assert not contender_ran.wait(timeout=0.5)
+        return mapping(*args, **kwargs)
+
+    mocker.patch.object(local, "SharedMemory", constructing)
+
+    # Act
+    with _segment(first), _segment(second):
+        local._attach(first).close()
+
+        # Assert
+        assert contender_ran.wait(timeout=5)
+        assert tracker_ledger.violations == []
+
+
+def test__attach_should_suppress_the_unregister_when_the_mapping_fails(
+    mocker, attach_fallback, tracker_ledger
+):
+    """Test a mapping that fails mid-construction issues no unregister.
+
+    Given:
+        An interpreter reporting a version below 3.13, where the memory
+        mapping raises after the segment is opened — the path on which
+        `SharedMemory` unlinks what it opened before returning.
+    When:
+        The segment is attached by name.
+    Then:
+        It should propagate the error without unregistering a name it
+        never registered, which would discard the creator's entry exactly
+        as the superseded pattern did.
+    """
+    # Arrange — create first, then break the mapping, so only the attach
+    # takes the constructor's failure path.
+    name = _segment_name()
+    created = SharedMemory(name=name, create=True, size=64)
+    mocker.patch.object(mmap, "mmap", side_effect=OSError(errno.ENOMEM, "no memory"))
+
+    # Act & assert
+    try:
+        with pytest.raises(OSError):
+            local._attach(name)
+
+        assert tracker_ledger.violations == []
+    finally:
+        created.close()
+        # The failed attach unlinks what it opened, so the segment may
+        # already be gone; that part is CPython's and not ours to prevent.
+        with contextlib.suppress(FileNotFoundError):
+            created.unlink()
+
+
+def test__attach_should_restore_the_tracker_hooks_when_the_segment_is_gone(
+    attach_fallback, tracker_ledger
+):
+    """Test a failed attach still unwinds the tracker suppression.
 
     Given:
         An interpreter reporting a version below 3.13 and a segment name
@@ -453,20 +532,21 @@ def test_attach_should_restore_the_registration_hook_when_the_segment_is_gone(
     When:
         The segment is attached by name and the mapping fails.
     Then:
-        It should propagate FileNotFoundError having rebound the tracker's
-        registration hook to what it found — a hook left installed would
+        It should propagate FileNotFoundError and leave a later, unrelated
+        segment tracked normally — suppression left installed would
         silently stop tracking that name for the rest of the process.
     """
     # Arrange
-    from wool.runtime.discovery.local import _attach
+    missing = _segment_name()
+    later = _segment_name()
 
-    original = resource_tracker.register
-
-    # Act & assert
+    # Act
     with pytest.raises(FileNotFoundError):
-        _attach(_segment_name())
+        local._attach(missing)
 
-    assert resource_tracker.register is original
+    # Assert — the observable consequence, not the hook's identity.
+    with _segment(later):
+        assert ("shared_memory", later) in tracker_ledger.registered
 
 
 class TestLocalDiscovery:
@@ -4015,9 +4095,8 @@ class TestLocalDiscoveryPublisher:
 
         Given:
             An owned namespace on an interpreter reporting a version
-            below 3.13, and a worker announced more than once — the shape
-            49c4f2e made routine, which attaches a live block on every
-            announcement.
+            below 3.13, and a worker announced more than once, which
+            attaches a live block on every announcement.
         When:
             The worker is added, re-added, updated, and dropped, and the
             namespace's owner exits.
@@ -4075,11 +4154,12 @@ class TestLocalDiscoveryPublisher:
             whatever the order and however many times one segment is
             attached.
         """
-        # Arrange — a per-example namespace so shared-memory state does
-        # not carry across Hypothesis examples, and a per-example ledger
-        # so one example's imbalance cannot be attributed to the next.
+        # Arrange — a per-example namespace and ledger, so neither
+        # shared-memory state nor one example's imbalance carries into the
+        # next; the fixture itself is function-scoped, not example-scoped.
         example_ns = f"{namespace}-{uuid.uuid4().hex[:8]}"
-        tracker_ledger.violations.clear()
+        tracker_ledger.reset()
+        assume(any(action == "add" for action, _ in ops))
         roster = [
             WorkerMetadata(
                 uid=uuid.uuid4(),
@@ -4107,6 +4187,7 @@ class TestLocalDiscoveryPublisher:
 
         # Assert
         assert tracker_ledger.violations == []
+        assert tracker_ledger.residual == set()
 
 
 class TestWorkerReference:
@@ -4987,7 +5068,7 @@ class TestLocalDiscoverySubscriber:
 
     @pytest.mark.asyncio
     async def test___aiter___should_leave_the_tracker_balanced_when_polling(
-        self, namespace, metadata, attach_fallback, tracker_ledger
+        self, namespace, attach_fallback, attach_calls, tracker_ledger
     ):
         """Test repeated read-side attaches leave the tracker consistent.
 
@@ -4997,39 +5078,44 @@ class TestLocalDiscoverySubscriber:
             the most frequent attach in the system, since every poll
             reattaches the address space and each worker's block.
         When:
-            The subscriber discovers the worker across several poll
-            cycles and the worker is then dropped.
+            The subscriber discovers the worker, the poll loop reattaches
+            those segments several times, and the worker is dropped.
         Then:
             It should never unregister a name the tracker is not holding
-            — a reader must not consume the registration the writer's
-            unlink depends on.
+            and should leave nothing registered — a reader must not consume
+            the registration the writer's unlink depends on.
         """
-        # Arrange
+        # Arrange — a unique uid, so a segment left by a concurrent run of
+        # this test cannot collide on the name derived from it.
+        worker = WorkerMetadata(
+            uid=uuid.uuid4(), address="localhost:50051", pid=123, version="1.0"
+        )
         received = asyncio.Event()
-        polls = 0
 
         async def collect(subscriber):
-            nonlocal polls
             async for event in subscriber:
-                if event.metadata.uid == metadata.uid:
-                    polls += 1
-                    if polls >= 1:
-                        received.set()
+                if event.metadata.uid == worker.uid:
+                    received.set()
 
         # Act
         with LocalDiscovery(namespace) as discovery:
             async with LocalDiscovery.Publisher(namespace) as publisher:
-                await publisher.publish("worker-added", metadata)
+                await publisher.publish("worker-added", worker)
                 subscriber = discovery.subscribe(poll_interval=0.02)
                 async with _collecting(subscriber, collect):
                     await asyncio.wait_for(received.wait(), timeout=5.0)
-                    # Let the poll loop reattach the same segments a few
-                    # more times before teardown.
-                    await asyncio.sleep(0.1)
-                await publisher.publish("worker-dropped", metadata)
+                    attaches = len(attach_calls)
+                    # Count reattachments rather than trusting elapsed time:
+                    # the poll loop remaps the same segments every cycle.
+                    deadline = asyncio.get_running_loop().time() + 5.0
+                    while len(attach_calls) < attaches + 4:
+                        assert asyncio.get_running_loop().time() < deadline, (
+                            "poll loop stopped reattaching"
+                        )
+                        await asyncio.sleep(0.02)
+                await publisher.publish("worker-dropped", worker)
 
         # Assert
-        assert polls >= 1
         assert tracker_ledger.violations == []
         assert tracker_ledger.residual == set()
 


### PR DESCRIPTION
## Summary

Suppress the resource-tracker registration when attaching to an existing shared-memory segment on Python versions below 3.13, rather than registering and then unregistering it.

The two are not equivalent, which is the whole of the bug. The tracker's cache is a set shared by every process in the tree, so the first attach's unregister discards the entry the *creator* made. The creator's own unlink then finds nothing to remove and raises `KeyError` inside the tracker process, which prints a traceback to stderr that nothing in the attaching process can intercept and no exit code reflects. The re-add path added for #321 made re-attaching routine, turning a rare fault into ~2 tracebacks per worker.

The issue proposed making the unregister idempotent. Unfortunately, that doesn't work — a *single* unregister is enough to destroy the creator's entry, so deduplicating per attaching process cannot help. The other variant the issue suggests — guarding against a name that is not currently tracked — is not implementable at all, because the cache lives in the tracker process behind a write-only pipe with no query primitive. Suppressing at the source is what `track=False` does on 3.13, and is the correct remediation.

### Upstream

This is CPython [gh-82300](https://github.com/python/cpython/issues/82300) (originally [bpo-38119](https://bugs.python.org/issue38119)), *"resource tracker destroys shared memory segments when other processes should still have valid access"* — open since 2019, with [bpo-39959](https://bugs.python.org/issue39959), [bpo-41447](https://bugs.python.org/issue41447), and [bpo-45209](https://bugs.python.org/issue45209) as duplicates of the same root cause.

`track` was added in 3.13 to resolve it, and the [stdlib documentation](https://docs.python.org/3/library/multiprocessing.shared_memory.html) prescribes this project's exact situation:

> Python processes created in any other way will receive their own resource tracker when accessing shared memory with *track* enabled. This will cause the shared memory to be deleted by the resource tracker of the first process that terminates. To avoid this issue, users of `subprocess` or standalone Python processes should set *track* to `False` when there is already another process in place that does the bookkeeping.

Below 3.13 the accepted workaround is to rebind `resource_tracker.register` and `unregister` — see [`mprt_monkeypatch.py`](https://bugs.python.org/file49859/mprt_monkeypatch.py), attached to the bug itself. This PR uses that mechanism but narrows it: the published workaround filters on resource *type* alone and installs permanently, which untracks segments this process **creates** as well. Wool wants those tracked, since the tracker is the backstop when `atexit` does not run. The suppression here matches on type, name, and calling thread, and lasts one constructor call.

Closes #336

## Proposed changes

### Extract the attach into `_attach`, and suppress rather than undo

`_shared_memory` now delegates its mapping to a new `_attach` helper. On 3.13 and above nothing changes. Below 3.13 the helper temporarily rebinds `resource_tracker.register` for the duration of one constructor call, so the registration never happens in the first place.

The rebind works because CPython resolves `resource_tracker.register` as a module attribute at call time — verified against the 3.11, 3.12 and 3.13 sources, not assumed. If that ever changes to a `from ... import register` at module scope, the tests fail on the effect rather than staying green on a mechanism that stopped working.

The suppression matches on three things: the calling thread, the resource type, and the segment name. Thread identity is what makes it airtight — the only call it can swallow is the one made on our behalf from inside that constructor, so a `create=True` running concurrently on another thread stays tracked even for the same name. Without it, a same-name concurrent create silently loses its registration and leaks, reintroducing the same class of fault. `SharedMemory` stores POSIX names with a leading `/` and callers pass them without, so both sides are stripped before matching.

`_ATTACH_LOCK` serialises the rebind itself. It is not there for mutual exclusion of attaches — without it, two overlapping attaches would restore each other's shim and leave one installed permanently. It is deliberately held only across the constructor, never across a `_shared_memory` body: the module attaches a worker's block while an address-space attach is already open, and a lock held that wide would deadlock on the first re-add.

### Remove the `# pragma: no cover`

The branch every supported interpreter below 3.13 takes is now measured and covered. `local.py` moves from 95.50% to 98.42%, and the unit suite total from 98.62% to 98.85% against a 98 gate.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | Module level | An existing segment and an interpreter reporting a version below 3.13 | The segment is attached by name | It registers nothing further for that segment | The fallback's suppression |
| 2 | Module level | An existing segment and an interpreter whose `SharedMemory` accepts `track=False` | The segment is attached by name | It registers nothing further for that segment | Version parity — both branches share one observable |
| 3 | Module level | A mapping that registers an unrelated segment and a non-segment resource while it is constructed | A segment is attached by name | It passes both foreign registrations through | The delegate-through arm, unreachable in real use |
| 4 | Module level | A second thread registering the very segment being attached, from inside the rebind window | The segment is attached by name | It lets that thread's registration reach the tracker | Thread-scoping — a concurrent creator keeps ownership |
| 5 | Module level | A segment name that does not exist | The segment is attached and the mapping fails | It propagates `FileNotFoundError` with the registration hook restored | The `finally` restore |
| 6 | `TestLocalDiscoveryPublisher` | An owned namespace below 3.13 and a worker announced more than once | The worker is added, re-added, updated, dropped, and the owner exits | It never unregisters an untracked name and leaves nothing registered | The regression proper |
| 7 | `TestLocalDiscoveryPublisher` | An arbitrary sequence of add, update, and drop events over a three-worker roster | The sequence is published serially and the owner exits | It never unregisters an untracked name, whatever the order | Hypothesis — arbitrary attach and detach orderings |
| 8 | `TestLocalDiscoverySubscriber` | An owned namespace holding one worker, below 3.13, and a subscriber polling it | The worker is discovered across several poll cycles and then dropped | It never unregisters an untracked name | The subscriber, the highest-frequency attach site |
| 9 | `TestCrossProcessTracker` | An independent interpreter forced onto the attach path taken below 3.13 | It cycles three workers through add, re-add, update, and drop, then exits | It exits 0 with no tracker traceback on stderr | End-to-end silence on the forced branch |
| 10 | `TestCrossProcessTracker` | An independent interpreter taking whichever path its own version selects | It cycles three workers and exits | It exits 0 with no tracker traceback on stderr | The natural branch, unmocked, on the 3.11 and 3.12 legs |
| 11 | `TestCrossProcessTracker` | An independent interpreter reproducing the superseded pattern in pure standard library | It runs to completion and its tracker drains | It exits 0 yet prints a tracker `KeyError` | Positive control — silence elsewhere means something |

Three things drove the shape of these tests, each of which invalidates the obvious approach:

**Counting registrations does not detect the fault.** Register and unregister counts stay perfectly balanced against the buggy code, because the cache is a set — repeated registrations of one name collapse to a single entry while every unregister attempts its own removal. The ledger fixture mirrors that set and records removals of a name it no longer holds.

**The fault fires at the creator's unlink, not at any attach.** A test that attaches in a loop without running the segment through to teardown reproduces nothing.

**Subprocess children earn no coverage credit,** since `.coveragerc`'s `concurrency = multiprocessing` instruments `multiprocessing.Process` rather than `subprocess.Popen`. The `# pragma: no cover` removal is therefore satisfiable only by the in-process unit tests; the integration tests are behavioural evidence. Unit tests force the sub-3.13 path because the development interpreter is 3.13 and CI measures coverage per matrix leg. Forcing down is safe on every leg; forcing up is not, as `track=False` does not exist below 3.13, so the modern path is pinned with a skip.

Reverting `_attach` to its previous body turns 6 of the 8 unit tests and the forced-branch integration test red, with real `KeyError` tracebacks captured — so these tests discriminate rather than merely pass. The two that stay green are the ones that should: the 3.13 parity pin and the restore-hook test, neither of which the old code could break.