### PR TITLE
Stop a failed shared-memory create from emitting a stray resource_tracker unregister — Closes #106, #340

### DIFF
--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -229,9 +229,12 @@ class LocalDiscovery(Discovery):
 
     **Lifecycle.** An instance is single-use: it may be entered once, and a
     second entry raises `RuntimeError` whether or not the first has exited.
-    Use a fresh instance per ``with`` block. The guard binds to the instance,
-    so distinct instances sharing a namespace — which compare equal — are
-    unaffected by each other.
+    An entry that *failed* also counts — a create that raises `OSError`
+    leaves nothing behind, but the instance is spent, so recovering from a
+    transient failure means retrying with a fresh instance rather than the
+    same one. Use a fresh instance per ``with`` block. The guard binds to
+    the instance, so distinct instances sharing a namespace — which compare
+    equal — are unaffected by each other.
 
     The owner's exit unlinks the segment out from under every still-attached
     peer, while a non-owner's exit only closes its own mapping; a non-owner
@@ -323,15 +326,18 @@ class LocalDiscovery(Discovery):
         :returns:
             This instance.
         :raises RuntimeError:
-            If this instance has already been entered.
+            If this instance has already been entered — including by an
+            entry that raised, which still consumes the instance.
+        :raises OSError:
+            If the namespace's segment can neither be created nor
+            attached. Transient at the OS level, but recovery needs a
+            fresh instance; see `LocalDiscovery` for why.
+        :raises TimeoutError:
+            If the tracker rebind window cannot be entered; see `_create`.
         """
         size = _HEADER_SIZE + self._capacity * REF_WIDTH
         try:
-            self._address_space = SharedMemory(
-                name=_short_hash(self._namespace),
-                create=True,
-                size=size,
-            )
+            self._address_space = _create(_short_hash(self._namespace), size)
             self._owner = True
         except FileExistsError:
             self._address_space = _attach(_short_hash(self._namespace))
@@ -547,7 +553,14 @@ class LocalDiscovery(Discovery):
                 registration is restored before the error propagates.
             :raises TimeoutError:
                 If the cross-process file lock is not acquired within this
-                publisher's ``lock_timeout``.
+                publisher's ``lock_timeout``, or the tracker rebind window
+                within `DEFAULT_LOCK_TIMEOUT`; see `_create` for the
+                distinction.
+            :raises OSError:
+                For ``worker-added``, if the worker's block cannot be
+                created — e.g. an exhausted ``/dev/shm``. Nothing is
+                registered and the publisher stays usable, so a retry may
+                succeed.
             """
             async with _lock(self._namespace, timeout=self._lock_timeout):
                 with _shared_memory(_short_hash(self._namespace)) as address_space:
@@ -686,13 +699,12 @@ class LocalDiscovery(Discovery):
                 The name for the shared memory block (typically a worker UUID
                 hex string).
             :returns:
-                A new SharedMemory instance.
+                A new SharedMemory instance, tracked by this process.
+            :raises OSError:
+                If the segment cannot be created. The creation goes through
+                `_create`; see it for the tracker and failure semantics.
             """
-            shared_memory = SharedMemory(
-                name=name,
-                create=True,
-                size=self._block_size,
-            )
+            shared_memory = _create(name, self._block_size)
 
             def cleanup():  # pragma: no cover
                 _unlink_quietly(shared_memory)
@@ -1146,6 +1158,63 @@ def _suppressing(
         lock.release()
 
 
+def _create(name: str, size: int) -> SharedMemory:
+    """Create a shared memory segment, tracked by this process.
+
+    This process owns the segment, and the registration this makes is what
+    its own later `unlink` removes. Only the tracker call a *failed*
+    construction would make is silenced.
+
+    :param name:
+        The name of the shared memory segment to create.
+    :param size:
+        The size of the segment, in bytes.
+    :returns:
+        A tracked `SharedMemory` mapped to a newly created segment.
+    :raises FileExistsError:
+        If a segment of that name already exists. Raised before anything
+        is mapped, so nothing is left behind; `LocalDiscovery.__enter__`
+        routes this case to `_attach`.
+    :raises OSError:
+        If the truncation, stat or mapping fails partway through
+        construction — ``ENOSPC`` on an exhausted ``/dev/shm``, ``ENOMEM``
+        on the mapping. The segment is destroyed by the constructor's own
+        handler before the error escapes, so the caller has nothing to
+        clean up; this is the failure the suppression exists for.
+    :raises TimeoutError:
+        If the rebind window cannot be entered within
+        `DEFAULT_LOCK_TIMEOUT`. This bound is the module's own, not the
+        ``lock_timeout`` a caller configures — the two locks guard
+        different things.
+
+    .. rubric:: Implementation notes
+
+    `SharedMemory.__init__` registers the name *after* the block that
+    truncates, stats and maps it, but unlinks from inside that block's
+    ``except OSError`` handler. Below 3.13 `SharedMemory.unlink`
+    unregisters unconditionally; on 3.13 and up it unregisters whenever
+    ``track`` is set, which it is here. So on every supported version a
+    construction that fails mid-way unregisters a name that was never
+    registered — the tracker fault `_suppressing` describes, reached from
+    the owning side rather than the attaching one.
+
+    Only failures raised *inside* that block reach the handler. A
+    ``shm_open`` failure — ``EEXIST``, ``EMFILE``, ``ENOENT`` — raises
+    ahead of it and needs no suppression, which is what makes
+    `LocalDiscovery.__enter__`'s `FileExistsError` fallback safe.
+
+    Unlike the attach case, the ``shm_unlink`` that same handler performs
+    is correct here — the segment it destroys is the one this call just
+    created — so nothing is left for CPython to fix.
+
+    There is no version fast path. `_attach` can ask for ``track=False``
+    on 3.13 and skip the window entirely; nothing equivalent exists for a
+    create, so this rebinds the tracker hook on every supported version.
+    """
+    with _suppressing(name, register=False):
+        return SharedMemory(name=name, create=True, size=size)
+
+
 def _attach(name: str) -> SharedMemory:
     """Map an existing shared memory segment without tracking it.
 
@@ -1164,27 +1233,26 @@ def _attach(name: str) -> SharedMemory:
     :returns:
         An untracked `SharedMemory` mapped to the named segment.
     :raises FileNotFoundError:
-        If no segment of that name exists. The tracker hooks are restored
-        whether the mapping succeeds or raises.
+        If no segment of that name exists.
 
     .. rubric:: Implementation notes
 
     Python 3.13 says this directly with ``track=False``. Below it there is
     no such parameter, so the registration is suppressed at its source for
     as long as the constructor runs. Undoing it afterwards, i.e. registering
-    and then unregistering, is *not* equivalent: the tracker's cache is a
-    set shared by every process in the tree, so the first attach's
-    unregister discards the entry the creator made, and the creator's own
-    unlink later finds nothing to remove — which raises `KeyError` inside
-    the tracker process and prints a traceback to stderr that nothing in the
-    attaching process can intercept.
+    and then unregistering, is *not* equivalent: the tracker's cache is
+    shared by every process in the tree, so the first attach's unregister
+    discards the entry the creator made and the creator's own unlink later
+    finds nothing to remove.
 
-    Both hooks are rebound, not just `resource_tracker.register`: the
+    Both hooks are suppressed, not just `resource_tracker.register`: the
     constructor wraps its own ``mmap`` in ``except OSError: self.unlink()``,
     and that unlink issues the very unregister this function exists to
     avoid. It also calls ``shm_unlink``, which is CPython's to own and
     cannot be intercepted from here — a mid-construction `OSError` therefore
-    still destroys the segment.
+    still destroys a segment this process does not own. `_create` covers
+    the same handler on the owning side, where only the unregister is
+    wrong.
 
     See `_suppressing` for how the window is scoped and serialised, and
     for the tracker behaviour both callers are working around.
@@ -1204,8 +1272,9 @@ def _shared_memory(name):
 
     Context manager that opens a shared memory region for reading or writing
     and ensures it is properly closed on exit. Does not create new memory
-    regions (use `SharedMemory` with ``create=True`` for that). The mapping
-    is untracked — see `_attach` for why, and for what that forbids.
+    regions (use `_create` for that, which is the module's only sanctioned
+    creation path). The mapping is untracked — see `_attach` for why, and
+    for what that forbids.
 
     :param name:
         The name of the shared memory region to open.

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -18,6 +18,7 @@ from typing import AsyncGenerator
 from typing import AsyncIterator
 from typing import Callable
 from typing import Final
+from typing import Generator
 from typing import Iterator
 from typing import Self
 from uuid import UUID
@@ -49,37 +50,44 @@ NULL_REF: Final = b"\x00" * REF_WIDTH
 DEFAULT_LOCK_TIMEOUT: Final[float] = 30.0
 _HEADER_MAGIC: Final = b"WLD1"
 _HEADER_SIZE: Final = REF_WIDTH
-# Serialises the resource-tracker rebind window; see `_attach`. Held only
-# across one `SharedMemory` constructor, never across a `_shared_memory` body,
-# which would deadlock the nested attach `_add` performs.
-_attach_lock: threading.Lock = threading.Lock()
+# Serialises the resource-tracker rebind window; see `_suppressing` for the
+# scoping constraint that makes it safe. Taken by every construction this
+# module performs, create and attach alike, and on every Python version —
+# `_attach` skips it only where `track` makes the window unnecessary.
+_tracker_lock: threading.Lock = threading.Lock()
 
-# The tracker's own hooks, captured before anything can rebind them, so a
-# forked child can be put back to a known state.
-_tracker_register: Final = resource_tracker.register
-_tracker_unregister: Final = resource_tracker.unregister
+# The shims an open window has installed, keyed by hook name, each paired
+# with the hook it displaced. Written only under `_tracker_lock`, so a
+# forked child can restore precisely what this module changed and nothing
+# else.
+_shims: dict[str, tuple[Callable, Callable]] = {}
 
 
-def _reinit_attach_lock() -> None:  # pragma: no cover — fork-only path
-    """Reset the attach state a forked child inherited mid-window.
+def _reinit_tracker_state() -> None:  # pragma: no cover — fork-only path
+    """Reset the suppression state a forked child inherited mid-window.
 
     A ``fork`` inside the rebind window copies the lock held, wedging every
-    later attach in the child. Wool starts its own workers with ``spawn``,
-    but `LocalDiscovery` is public and runs inside host processes that may
-    fork — the default start method on Linux below 3.14.
+    later attach or create in the child. Wool starts its own workers with
+    ``spawn``, but `LocalDiscovery` is public and runs inside host processes
+    that may fork — the default start method on Linux below 3.14.
 
-    The hooks are restored too: a fork inside the window leaves the child
-    holding this module's shims, since the frame that would have put them
-    back died with the parent's thread.
+    The shims are unwound too: a fork inside the window leaves the child
+    holding them, since the frame that would have put them back died with
+    the parent's thread. Each is replaced by the hook it displaced rather
+    than by a snapshot taken at import, so a child forked with no window
+    open changes nothing, and instrumentation another library installed
+    after this module was imported survives.
     """
-    global _attach_lock
-    _attach_lock = threading.Lock()
-    resource_tracker.register = _tracker_register
-    resource_tracker.unregister = _tracker_unregister
+    global _tracker_lock
+    _tracker_lock = threading.Lock()
+    for hook, (shim, forward) in _shims.items():
+        if getattr(resource_tracker, hook) is shim:
+            setattr(resource_tracker, hook, forward)
+    _shims.clear()
 
 
 if hasattr(os, "register_at_fork"):  # pragma: no branch — POSIX-only guard
-    os.register_at_fork(after_in_child=_reinit_attach_lock)
+    os.register_at_fork(after_in_child=_reinit_tracker_state)
 
 
 class _Watchdog(FileSystemEventHandler):
@@ -1015,6 +1023,129 @@ def _short_hash(s: str, n: int = 30) -> str:
     return b64_str.rstrip("=")[:n]
 
 
+@contextmanager
+def _suppressing(
+    name: str, *, register: bool, unregister: bool = True
+) -> Generator[None, None, None]:
+    """Silence the tracker calls one `SharedMemory` constructor would make.
+
+    Rebinds the named `resource_tracker` hooks for the duration of the
+    block, so the calls `SharedMemory.__init__` makes on this module's
+    behalf never reach the tracker process. Suppressing ``unregister`` is
+    always right: the constructor's own failure handler issues one whether
+    or not the name was ever registered. Suppressing ``register`` too is
+    right only where the mapping must not be tracked at all — a
+    construction that creates the segment leaves it set, so the entry its
+    own later `SharedMemory.unlink` needs is made.
+
+    .. important::
+        The block MUST contain exactly one `SharedMemory` construction and
+        nothing that constructs shared memory transitively. `_tracker_lock`
+        is not reentrant, so widening the window — across a
+        ``try``/``except`` that falls back to another construction, or
+        across a `_shared_memory` body whose nested attach `_add`
+        performs — deadlocks the process with nothing to diagnose from.
+
+    :param name:
+        The segment name whose tracker calls are suppressed. Callers pass
+        it bare; `SharedMemory` registers names slash-prefixed on POSIX,
+        so both sides are stripped before matching.
+    :param register:
+        Whether to suppress `resource_tracker.register`.
+    :param unregister:
+        Whether to suppress `resource_tracker.unregister`.
+    :yields:
+        Nothing. The block runs with the hooks installed, and they are
+        restored whether it returns or raises.
+    :raises TimeoutError:
+        If the lock cannot be acquired within `DEFAULT_LOCK_TIMEOUT`.
+
+    .. rubric:: Implementation notes
+
+    Rebinding works because `SharedMemory` resolves ``register`` and
+    ``unregister`` as attributes of the `resource_tracker` *module* at call
+    time, on every supported version. A future CPython that imported them
+    by value instead would leave these shims installed and consulted by
+    nobody — silently, in production. What catches that is
+    ``tests/integration/test_local_discovery_tracker.py``: its controls
+    assert the unguarded fault still reproduces, so a CPython that fixed or
+    restructured this turns that suite red rather than turning the guard
+    into a no-op.
+
+    The tracker keeps a per-resource-type `set`, so removing a name it does
+    not hold raises `KeyError` in its main loop. That traceback is printed
+    by the tracker process to the stderr it inherited, after the
+    interpreter that caused it has already exited 0 — nothing in this
+    process can intercept it, which is why suppression at the source is
+    the only remedy available.
+
+    The suppression matches on the calling thread, the resource type, and
+    this segment's name, so the only calls it can swallow are the ones made
+    on the wrapped construction's behalf. A construction running
+    concurrently on another thread stays tracked even for the same name.
+
+    The lock serialises the rebind. Without it two overlapping windows
+    would each capture the other's shim: the second window's call would
+    reach a shim whose thread does not match, be forwarded to the real
+    tracker, and take effect after all — reinstating for an attach the
+    registration bpo-38119 makes fatal, and for a create the stray
+    unregister. That a shim would also be left permanently installed is the
+    lesser effect. Acquisition is bounded rather than indefinite, so a
+    holder that wedges surfaces as an attributable error instead of a
+    process-wide stall.
+    """
+    lock = _tracker_lock
+    if not lock.acquire(timeout=DEFAULT_LOCK_TIMEOUT):
+        raise TimeoutError(
+            f"Timed out acquiring the resource-tracker suppression lock "
+            f"after {DEFAULT_LOCK_TIMEOUT}s"
+        )
+    constructing = threading.get_ident()
+    target = name.lstrip("/")
+    installed: list[str] = []
+    active = True
+
+    def _matches(name: str, rtype: str) -> bool:
+        return (
+            active
+            and threading.get_ident() == constructing
+            and rtype == "shared_memory"
+            and name.lstrip("/") == target
+        )
+
+    def _install(hook: str) -> None:
+        forward = getattr(resource_tracker, hook)
+
+        def _suppressed(name: str, rtype: str) -> None:
+            if not _matches(name, rtype):
+                forward(name, rtype)
+
+        setattr(resource_tracker, hook, _suppressed)
+        _shims[hook] = (_suppressed, forward)
+        installed.append(hook)
+
+    try:
+        if register:
+            _install("register")
+        if unregister:
+            _install("unregister")
+        yield
+    finally:
+        # Neutralise before unwinding. A shim a third party wrapped stays
+        # in their delegation chain for the life of the process, where it
+        # would otherwise keep matching this segment's name against a
+        # thread ident the interpreter is free to reuse once this thread
+        # dies — swallowing a later, legitimate call for the same name.
+        active = False
+        for hook in installed:
+            shim, forward = _shims.pop(hook)
+            # Only restore what is still ours: a third party that rebound
+            # this hook inside the window keeps its wrapper.
+            if getattr(resource_tracker, hook) is shim:
+                setattr(resource_tracker, hook, forward)
+        lock.release()
+
+
 def _attach(name: str) -> SharedMemory:
     """Map an existing shared memory segment without tracking it.
 
@@ -1055,59 +1186,16 @@ def _attach(name: str) -> SharedMemory:
     cannot be intercepted from here — a mid-construction `OSError` therefore
     still destroys the segment.
 
-    The suppression matches on the calling thread, the resource type, and
-    this segment's name, and lasts only one constructor call, so the sole
-    call it can swallow is the one made on this function's behalf. A
-    ``create=True`` running concurrently on another thread stays tracked
-    even for the same name. `SharedMemory` registers names slash-prefixed
-    on POSIX while callers pass them bare, so both sides are stripped
-    before matching.
-
-    The lock serialises the rebind. Without it two overlapping attaches
-    would each capture the other's shim: the second attach's registration
-    would reach a shim whose thread does not match, be forwarded to the
-    real tracker, and be tracked after all — reinstating bpo-38119. That a
-    shim would also be left permanently installed is the lesser effect.
-    `os.register_at_fork` replaces the lock in a child, since a fork inside
-    the window would otherwise copy it held and wedge every later attach.
+    See `_suppressing` for how the window is scoped and serialised, and
+    for the tracker behaviour both callers are working around.
     """
     if sys.version_info >= (3, 13):
         # Unreachable below 3.13, where the parameter does not exist, so
         # the 3.11 and 3.12 legs would otherwise report it missing.
         return SharedMemory(name=name, track=False)  # pragma: no cover
 
-    with _attach_lock:
-        register = resource_tracker.register
-        unregister = resource_tracker.unregister
-        attaching = threading.get_ident()
-        target = name.lstrip("/")
-
-        def _suppressed(name: str, rtype: str) -> bool:
-            return (
-                threading.get_ident() == attaching
-                and rtype == "shared_memory"
-                and name.lstrip("/") == target
-            )
-
-        def _register(name: str, rtype: str) -> None:
-            if not _suppressed(name, rtype):
-                register(name, rtype)
-
-        def _unregister(name: str, rtype: str) -> None:
-            if not _suppressed(name, rtype):
-                unregister(name, rtype)
-
-        try:
-            resource_tracker.register = _register
-            resource_tracker.unregister = _unregister
-            return SharedMemory(name=name)
-        finally:
-            # Only restore what is still ours: a third party that rebound
-            # either hook inside the window keeps its wrapper.
-            if resource_tracker.register is _register:
-                resource_tracker.register = register
-            if resource_tracker.unregister is _unregister:
-                resource_tracker.unregister = unregister
+    with _suppressing(name, register=True):
+        return SharedMemory(name=name)
 
 
 @contextmanager

--- a/wool/tests/integration/test_local_discovery_tracker.py
+++ b/wool/tests/integration/test_local_discovery_tracker.py
@@ -1,22 +1,41 @@
-"""End-to-end tests for resource-tracker silence during attach (#336).
+"""End-to-end tests for resource-tracker silence around shared memory.
+
+Covers both construction paths: an attach must not register the segment
+it maps (#336), and a create that fails partway through must not
+unregister a name it never registered (#340).
 
 These are targeted standalone tests rather than pairwise scenarios. The
-symptom `_attach` documents is emitted by the `multiprocessing` resource
-tracker — a separate process that inherits the interpreter's stderr and
-outlives the work — while the interpreter itself exits 0. Neither half of
-that observable is reachable from `build_pool_from_scenario`, which
-yields a running system inside the pytest process with no subprocess
-stderr to inspect and a dispatch oracle that stays green throughout. The
-attach path is also an interpreter-global property, not a dimension the
-`Scenario` model can vary.
+symptom `_attach` and `_create` document is emitted by the
+`multiprocessing` resource tracker — a separate process that inherits the
+interpreter's stderr and outlives the work — while the interpreter itself
+exits 0. Neither half of that observable is reachable from
+`build_pool_from_scenario`, which yields a running system inside the
+pytest process with no subprocess stderr to inspect and a dispatch oracle
+that stays green throughout. Both paths are also interpreter-global
+properties, not dimensions the `Scenario` model can vary.
 
-Coverage of the sub-3.13 branch lives in
-``tests/runtime/discovery/test_local.py`` — a subprocess child is
-invisible to coverage, whose ``concurrency = multiprocessing`` setting
-instruments `multiprocessing.Process` rather than `subprocess.Popen`.
-These tests are behavioral evidence, not coverage.
+Only the attach tests carry a ``mode`` parametrization. `_attach` really
+does branch on the interpreter version, and forcing the sub-3.13 leg is
+the only way to reach it from 3.13. `_create` has no such branch: the
+stray unregister reproduces unpatched on every supported version, because
+3.13's ``self._track`` guard on `SharedMemory.unlink` is satisfied for a
+segment created with the default ``track=True``. Splitting those tests by
+version would run identical code twice and assert a version-conditionality
+that does not exist.
+
+Coverage of both paths lives in ``tests/runtime/discovery/test_local.py``
+— a subprocess child is invisible to coverage, whose `multiprocessing`
+concurrency support instruments `multiprocessing.Process` and not
+`subprocess.Popen`. These tests are behavioral evidence, not coverage.
+
+Liveness properties belong here for a second reason. The lock both
+construction paths take is process-global, so a test that wedges it inside
+the pytest process strands every later test in the session; run in a
+child, the same wedge is reaped by `_run`'s timeout and reported against
+the one test that caused it.
 """
 
+import os
 import subprocess
 import sys
 import uuid
@@ -133,6 +152,179 @@ print("done", flush=True)
 """
 
 
+#: Fail the truncation a ``create=True`` construction performs, so it
+#: reaches the constructor's ``except OSError: self.unlink()`` handler
+#: with the name never registered. ``site`` selects which of Wool's two
+#: create sites is broken: the namespace segment `LocalDiscovery` owns,
+#: or a worker's metadata block. Truncation is the injection point
+#: because only a create truncates — an attach skips it — so the
+#: address-space remap every publish performs keeps working. The errno is
+#: reported back, not just the exception class, so the assertion pins the
+#: failure this script injected rather than any `OSError` the child might
+#: raise for an unrelated reason.
+_CREATE_SCRIPT = """
+import asyncio
+import errno
+import os
+import sys
+import uuid
+
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.worker.metadata import WorkerMetadata
+
+site, namespace = sys.argv[1:3]
+_real_ftruncate = os.ftruncate
+
+
+def _enospc(fd, length):
+    raise OSError(errno.ENOSPC, "No space left on device")
+
+
+def _reported(error):
+    return "raised=" + errno.errorcode.get(error.errno, str(error.errno))
+
+
+async def main():
+    if site == "owner":
+        os.ftruncate = _enospc
+        try:
+            with LocalDiscovery(namespace):
+                return "unexpectedly-entered"
+        except OSError as error:
+            return _reported(error)
+        finally:
+            os.ftruncate = _real_ftruncate
+
+    worker = WorkerMetadata(
+        uid=uuid.uuid4(),
+        address="localhost:50051",
+        pid=101,
+        version="1.0",
+    )
+    with LocalDiscovery(namespace):
+        async with LocalDiscovery.Publisher(namespace) as publisher:
+            os.ftruncate = _enospc
+            try:
+                await publisher.publish("worker-added", worker)
+                return "unexpectedly-published"
+            except OSError as error:
+                return _reported(error)
+            finally:
+                os.ftruncate = _real_ftruncate
+
+
+print(asyncio.run(main()), flush=True)
+print("done", flush=True)
+"""
+
+#: The create fault, in pure standard library and with nothing patched: a
+#: ``create=True`` construction for more memory than any machine can back,
+#: so the failure is the operating system's rather than a simulation. The
+#: constructor then unlinks — and unregisters — a name
+#: `resource_tracker.register` never reached, since the registration
+#: happens after the block that unlinks. Independent of `wool` *and* of
+#: the injection technique the rest of this file uses, so it keeps
+#: reproducing the fault however ``local.py`` is refactored and however
+#: that technique is later changed.
+#:
+#: 2**48 bytes fails on both supported platforms, though at different
+#: syscalls: the mapping on macOS, which truncates sparsely (``ENOMEM``),
+#: and the truncation on Linux, whose ``/dev/shm`` is a bounded tmpfs
+#: (``ENOSPC``). Both raise inside the constructor's guarded block, which
+#: is the only property this control depends on.
+_UNGUARDED_CREATE_SCRIPT = """
+import sys
+from multiprocessing.shared_memory import SharedMemory
+
+name = sys.argv[1]
+try:
+    SharedMemory(name=name, create=True, size=2 ** 48)
+    print("unexpectedly-created", flush=True)
+except OSError:
+    print("raised", flush=True)
+print("done", flush=True)
+"""
+
+#: Enter a namespace this interpreter does not own, losing the create race
+#: and falling back to an attach. The two constructions take the same
+#: non-reentrant lock, so a suppression window widened across
+#: `LocalDiscovery.__enter__`'s ``try``/``except`` wedges here — and a
+#: wedge in a child is reaped by `_run`'s timeout, where the same wedge on
+#: a daemon thread inside pytest would strand the lock and hang every
+#: later test in the session.
+_LOSER_SCRIPT = """
+import sys
+from types import SimpleNamespace
+
+import wool.runtime.discovery.local as local
+from wool.runtime.discovery.local import LocalDiscovery
+
+mode, namespace = sys.argv[1:3]
+if mode == "legacy":
+    # Below 3.13 the attach takes the lock too, which is the only
+    # configuration in which the two constructions can contend.
+    local.sys = SimpleNamespace(version_info=(3, 12, 0, "final", 0))
+
+with LocalDiscovery(namespace):
+    print("attached", flush=True)
+print("done", flush=True)
+"""
+
+#: Fork from inside an open suppression window and have the child create a
+#: segment of its own. The child inherits the lock held and the shims
+#: installed, so without `os.register_at_fork` restoring both it wedges on
+#: the first construction and never prints its marker.
+_FORK_SCRIPT = """
+import os
+import sys
+import threading
+
+import wool.runtime.discovery.local as local
+from wool.runtime.discovery.local import LocalDiscovery
+
+namespace = sys.argv[1]
+inside = threading.Event()
+release = threading.Event()
+_mapping = local.SharedMemory
+
+
+def _blocking(*args, **kwargs):
+    # Park inside the window, so the fork below copies the lock held.
+    inside.set()
+    release.wait(10)
+    return _mapping(*args, **kwargs)
+
+
+def _hold():
+    local.SharedMemory = _blocking
+    try:
+        with LocalDiscovery(namespace + "-held"):
+            pass
+    finally:
+        local.SharedMemory = _mapping
+
+
+holder = threading.Thread(target=_hold, daemon=True)
+holder.start()
+inside.wait(10)
+
+pid = os.fork()
+if pid == 0:
+    try:
+        with LocalDiscovery(namespace + "-child"):
+            print("child-entered", flush=True)
+        os._exit(0)
+    except BaseException:
+        os._exit(3)
+
+_, status = os.waitpid(pid, 0)
+print("child-status=%d" % (status >> 8), flush=True)
+release.set()
+holder.join(10)
+print("done", flush=True)
+"""
+
+
 def _run(script, *args):
     """Run script in a fresh interpreter, returning the completed process.
 
@@ -211,6 +403,138 @@ class TestCrossProcessTracker:
             assert "leaked shared_memory" not in result.stderr, result.stderr
             assert "KeyError" not in result.stderr, result.stderr
             SharedMemory(name=_short_hash(namespace)).close()
+
+    def test___enter___should_emit_no_tracker_output_when_the_create_fails(self):
+        """Test a failed namespace create leaves the resource tracker silent.
+
+        Given:
+            An independent interpreter whose filesystem fails the
+            truncation every shared-memory create performs, entering a
+            namespace it would own.
+        When:
+            The entry raises, the interpreter exits, and its resource
+            tracker drains.
+        Then:
+            It should exit 0 with no tracker traceback on stderr — the
+            constructor's own unlink issues an unregister for a name it
+            never registered, and the exit code does not reflect it.
+        """
+        # Act
+        result = _run(_CREATE_SCRIPT, "owner", f"tracker-{uuid.uuid4().hex[:12]}")
+
+        # Assert — the errno marker rules out a vacuous pass: silence
+        # proves nothing if the child never reached a failing create, and
+        # the exception class alone would accept any stray `OSError`.
+        assert result.returncode == 0, result.stderr
+        assert "raised=ENOSPC" in result.stdout, result.stdout
+        assert "done" in result.stdout, result.stdout
+        assert "KeyError" not in result.stderr, result.stderr
+        assert "Traceback" not in result.stderr, result.stderr
+        assert "resource_tracker" not in result.stderr, result.stderr
+
+    def test_publish_should_emit_no_tracker_output_when_a_block_create_fails(self):
+        """Test a failed block create leaves the resource tracker silent.
+
+        Given:
+            An independent interpreter owning a namespace of its own,
+            whose filesystem fails the truncation for the duration of one
+            worker announcement.
+        When:
+            The publish raises, the interpreter exits, and its resource
+            tracker drains.
+        Then:
+            It should exit 0 with no tracker traceback on stderr, covering
+            the pool's create site as well as the namespace's.
+        """
+        # Act
+        result = _run(_CREATE_SCRIPT, "publisher", f"tracker-{uuid.uuid4().hex[:12]}")
+
+        # Assert
+        assert result.returncode == 0, result.stderr
+        assert "raised=ENOSPC" in result.stdout, result.stdout
+        assert "done" in result.stdout, result.stdout
+        assert "KeyError" not in result.stderr, result.stderr
+        assert "Traceback" not in result.stderr, result.stderr
+        assert "resource_tracker" not in result.stderr, result.stderr
+
+    @pytest.mark.parametrize("mode", ["legacy", "native"])
+    def test___enter___should_admit_the_attach_when_the_create_loses(self, mode):
+        """Test losing the create race still admits the attach that follows.
+
+        Given:
+            A namespace this process owns, and an independent interpreter
+            entering it as a non-owner — on the attach path that takes the
+            same lock the create does, or on whichever path its own
+            version selects.
+        When:
+            That interpreter's create raises FileExistsError and the
+            attach runs from the handler.
+        Then:
+            It should attach and exit within the bound — a suppression
+            window held open across the handler would wedge on a lock its
+            own frame still owns, and running it in a child keeps that
+            wedge from stranding the lock for the rest of this session.
+        """
+        # Arrange
+        namespace = f"tracker-{uuid.uuid4().hex[:12]}"
+
+        # Act
+        with LocalDiscovery(namespace):
+            result = _run(_LOSER_SCRIPT, mode, namespace)
+
+            # Assert
+            assert result.returncode == 0, result.stderr
+            assert "attached" in result.stdout, result.stdout
+            assert "done" in result.stdout, result.stdout
+
+    @pytest.mark.skipif(not hasattr(os, "register_at_fork"), reason="POSIX-only guard")
+    def test___enter___should_admit_a_create_in_a_child_forked_mid_window(self):
+        """Test a child forked inside the suppression window can still create.
+
+        Given:
+            An independent interpreter with one thread parked inside an
+            open suppression window, so a fork copies the lock held and
+            the shims installed.
+        When:
+            It forks and the child enters a namespace of its own.
+        Then:
+            It should report the child entering and exiting 0 — the
+            at-fork handler replaces the inherited lock and unwinds the
+            inherited shims, without which the child wedges on its first
+            construction.
+        """
+        # Act
+        result = _run(_FORK_SCRIPT, f"tracker-{uuid.uuid4().hex[:12]}")
+
+        # Assert
+        assert result.returncode == 0, result.stderr
+        assert "child-entered" in result.stdout, result.stdout
+        assert "child-status=0" in result.stdout, result.stdout
+        assert "done" in result.stdout, result.stdout
+
+    def test_unlink_should_emit_tracker_output_when_a_create_fails(self):
+        """Test an unguarded failed create faults, so silence means something.
+
+        Given:
+            An independent interpreter creating a segment larger than the
+            system can back, using the standard library alone and patching
+            nothing, so the constructor unlinks a name it never registered.
+        When:
+            It runs to completion and its resource tracker drains.
+        Then:
+            It should exit 0 yet print a tracker KeyError, proving these
+            tests observe the fault they assert the absence of, and that
+            an exit code alone cannot detect it.
+        """
+        # Act
+        result = _run(_UNGUARDED_CREATE_SCRIPT, f"tracker-{uuid.uuid4().hex[:12]}")
+
+        # Assert
+        assert result.returncode == 0, result.stderr
+        assert "raised" in result.stdout, result.stdout
+        assert "done" in result.stdout, result.stdout
+        assert "KeyError" in result.stderr, result.stderr
+        assert "resource_tracker" in result.stderr, result.stderr
 
     def test_unregister_should_emit_tracker_output_when_an_attach_undoes_it(self):
         """Test the superseded pattern still faults, so silence means something.

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -511,6 +511,12 @@ def test__attach_should_suppress_the_unregister_when_the_mapping_fails(
         with pytest.raises(OSError):
             local._attach(name)
 
+        # `violations` alone does not discriminate here: the creator's
+        # entry is live, so an unsuppressed unregister is absorbed as an
+        # ordinary discard and records nothing. Surviving in `residual`
+        # is what says the entry the creator's unlink needs is still
+        # there.
+        assert tracker_ledger.residual == {("shared_memory", name)}
         assert tracker_ledger.violations == []
     finally:
         created.close()

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -3,6 +3,7 @@ import atexit
 import contextlib
 import errno
 import mmap
+import os
 import pickle
 import sys
 import threading
@@ -20,6 +21,7 @@ import portalocker
 import pytest
 from hypothesis import HealthCheck
 from hypothesis import assume
+from hypothesis import example
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
@@ -179,6 +181,39 @@ def tracker_ledger(mocker):
 
 
 @pytest.fixture
+def broken_ftruncate(mocker):
+    """Return a toggle making `os.ftruncate` raise ENOSPC while it is set.
+
+    A create is the only `SharedMemory` construction that truncates —
+    ``if create and size`` guards the call, so an attach skips it — which
+    makes this the one injection point that breaks a create and leaves
+    every attach in the arrangement working. That matters wherever the
+    arrangement attaches before it creates: `~LocalDiscovery.Publisher`
+    remaps the address space on every publish, and a failure planted in
+    the mapping itself would break that remap instead of the block
+    creation under test.
+
+    The truncation runs inside the constructor's ``try``, so failing it
+    reaches the ``except OSError: self.unlink()`` handler that emits the
+    stray unregister — the fault itself, not an approximation of it.
+
+    A toggle rather than a plain patch, so a test can arrange with the
+    syscall working, fail exactly one construction, and then restore it
+    to observe what the failure left behind.
+    """
+    failing = {"now": False}
+    real_ftruncate = os.ftruncate
+
+    def ftruncate(fd, length):
+        if failing["now"]:
+            raise OSError(errno.ENOSPC, "no space left on device")
+        return real_ftruncate(fd, length)
+
+    mocker.patch.object(os, "ftruncate", ftruncate)
+    return failing
+
+
+@pytest.fixture
 def attach_fallback(mocker):
     """Force the attach path taken where `SharedMemory` has no ``track``.
 
@@ -307,6 +342,15 @@ def _segment_name():
     return f"wool-336-{uuid.uuid4().hex[:16]}"
 
 
+#: The largest capacity whose address space still fits in a single page.
+#: Below it a segment created short still maps a whole page, so every slot
+#: lands anyway and an under-sized request is invisible; above it the
+#: mapping is genuinely too small. Derived rather than hard-coded because
+#: the page size is 4 KiB on Linux x86-64 and 16 KiB on macOS arm64, and a
+#: constant tuned to either is a no-op on the other.
+_PAGE_CAPACITY = (mmap.PAGESIZE - local._HEADER_SIZE) // local.REF_WIDTH
+
+
 @pytest.fixture(params=["fallback", "native"])
 def attach_path(request, mocker):
     """Select an attach path, skipping the modern one where it cannot run.
@@ -322,6 +366,201 @@ def attach_path(request, mocker):
     elif sys.version_info < (3, 13):
         pytest.skip("track=False requires Python 3.13")
     return request.param
+
+
+@pytest.mark.parametrize("suppress_register", [False, True])
+@given(
+    rtype=st.sampled_from(["shared_memory", "semaphore"]),
+    same_name=st.booleans(),
+    other=st.text(
+        alphabet="abcdefghijklmnopqrstuvwxyz0123456789", min_size=1, max_size=12
+    ),
+)
+@settings(
+    max_examples=25,
+    deadline=5000,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+def test__suppressing_should_forward_every_call_but_its_own(
+    tracker_ledger, suppress_register, rtype, same_name, other
+):
+    """Test the window silences one segment's calls and nothing else.
+
+    Given:
+        An open suppression window over one segment name, in either
+        configuration, and any other resource the tracker may be asked
+        about from the same thread — differing in name, in resource type,
+        or in both.
+    When:
+        That resource is registered and unregistered inside the window.
+    Then:
+        It should let both calls through. Only an exact match on name
+        *and* resource type is suppressed, so a construction narrows the
+        tracker rather than silencing it — a window that matched on the
+        name alone would swallow this segment's semaphore traffic too.
+    """
+    # Arrange — register and unregister within the example, so the real
+    # tracker stays balanced however many examples Hypothesis draws. The
+    # exact-match case is excluded here and covered by the tests that
+    # drive a real construction through the window.
+    target = _segment_name()
+    name = target if same_name else other
+    assume(not (same_name and rtype == "shared_memory"))
+    assume(name != target or rtype != "shared_memory")
+    tracker_ledger.reset()
+    key = (rtype, name)
+
+    # Act
+    with local._suppressing(target, register=suppress_register):
+        resource_tracker.register(f"/{name}", rtype)
+        resource_tracker.unregister(f"/{name}", rtype)
+
+    # Assert
+    assert key in tracker_ledger.registered
+    assert tracker_ledger.residual == set()
+    assert tracker_ledger.violations == []
+
+
+def test__suppressing_should_raise_when_the_lock_is_held_too_long(mocker):
+    """Test a wedged holder surfaces as an error, not a stalled process.
+
+    Given:
+        Another thread holding the rebind lock, and a short bound on how
+        long an acquisition waits for it.
+    When:
+        A second window is opened.
+    Then:
+        It should raise TimeoutError naming the wait — an unbounded
+        acquire would block the caller for the life of the holder, and
+        the caller is often an event-loop thread with no way to time out
+        a `threading.Lock` from the outside.
+    """
+    # Arrange
+    mocker.patch.object(local, "DEFAULT_LOCK_TIMEOUT", 0.05)
+    holder_ready = threading.Event()
+    release = threading.Event()
+
+    def hold():
+        with local._tracker_lock:
+            holder_ready.set()
+            release.wait(10)
+
+    holder = threading.Thread(target=hold, daemon=True)
+    holder.start()
+    assert holder_ready.wait(timeout=10)
+
+    # Act & assert
+    try:
+        with pytest.raises(TimeoutError, match="0.05"):
+            with local._suppressing(_segment_name(), register=False):
+                pass  # pragma: no cover — the acquire never succeeds
+    finally:
+        release.set()
+        holder.join(timeout=10)
+        assert not holder.is_alive()
+
+
+def test__suppressing_should_keep_a_wrapper_a_third_party_installed(
+    tracker_ledger,
+):
+    """Test the window yields the hook to anyone who rebound it.
+
+    Given:
+        An open suppression window whose block rebinds the tracker's
+        unregister hook, as an instrumenting library would.
+    When:
+        The window closes.
+    Then:
+        It should leave that wrapper installed rather than overwrite it
+        with the hook it displaced — restoring unconditionally would
+        silently uninstall another library's instrumentation, and the
+        shim the wrapper now delegates to is inert once the window ends.
+    """
+    # Arrange
+    target = _segment_name()
+    ledger_hook = resource_tracker.unregister
+
+    def third_party(name, rtype):  # pragma: no cover — identity only
+        raise AssertionError("not called")
+
+    # Act
+    with local._suppressing(target, register=False):
+        resource_tracker.unregister = third_party
+
+    # Assert
+    try:
+        assert resource_tracker.unregister is third_party
+    finally:
+        # The ledger's own patch was displaced; put it back so this
+        # test's teardown observes the fixture, not the sentinel.
+        resource_tracker.unregister = ledger_hook
+
+
+def test__create_should_track_the_segment_after_a_failed_attach(
+    attach_fallback, tracker_ledger
+):
+    """Test a create still registers a name a failed attach was scoped to.
+
+    Given:
+        An attach of a name no segment holds, on an interpreter reporting
+        a version below 3.13 so the attach opens a suppression window,
+        and the same name created afterwards on the same thread.
+    When:
+        The attach raises and the create follows.
+    Then:
+        It should track the created segment. The attach suppresses the
+        registration this create then depends on, and both are scoped to
+        one name and one thread — so a window that failed to unwind is
+        invisible to every name except this one.
+    """
+    # Arrange
+    name = _segment_name()
+    with pytest.raises(FileNotFoundError):
+        local._attach(name)
+
+    # Act
+    created = local._create(name, 64)
+
+    # Assert
+    try:
+        assert ("shared_memory", name) in tracker_ledger.registered
+        assert ("shared_memory", name) in tracker_ledger.residual
+    finally:
+        created.close()
+        created.unlink()
+
+
+def test__suppressing_should_restore_the_hooks_when_the_block_raises(
+    tracker_ledger,
+):
+    """Test the window unwinds even when its block does not return.
+
+    Given:
+        An open suppression window whose block raises.
+    When:
+        The exception propagates out of the context manager.
+    Then:
+        It should leave a later, unrelated segment tracked normally —
+        restoration that only ran on the returning path would strand the
+        shim for the rest of the process.
+    """
+    # Arrange
+    target = _segment_name()
+    later = _segment_name()
+
+    # Act
+    with pytest.raises(RuntimeError):
+        with local._suppressing(target, register=True):
+            raise RuntimeError("block failed")
+
+    # Assert — the observable consequence, not the hook's identity.
+    with _segment(later):
+        assert ("shared_memory", later) in tracker_ledger.registered
+
+    # No window is open, so the module must be holding no shim to unwind.
+    # A stale entry here is what a forked child would act on, restoring a
+    # hook that is no longer this module's to restore.
+    assert local._shims == {}
 
 
 def test__attach_should_not_register_the_segment(
@@ -1165,6 +1404,222 @@ class TestLocalDiscovery:
         # Act & assert
         with second as entered:
             assert entered is second
+
+    def test___enter___should_track_the_segment_when_it_is_created(
+        self, namespace, tracker_ledger
+    ):
+        """Test a created segment is registered with this process's tracker.
+
+        Given:
+            A namespace no process currently owns.
+        When:
+            An owner enters its context and leaves it.
+        Then:
+            It should hold exactly one tracked segment for the life of
+            the context and none after it — a segment this process
+            created is the one its own unlink must find registered, so
+            only the failure path may be silenced.
+        """
+        # Act & assert
+        with LocalDiscovery(namespace):
+            assert len(tracker_ledger.residual) == 1
+
+        assert tracker_ledger.residual == set()
+        assert tracker_ledger.violations == []
+
+    def test___enter___should_not_unregister_when_the_create_fails(
+        self, namespace, tracker_ledger, broken_ftruncate
+    ):
+        """Test a create that fails mid-construction unregisters nothing.
+
+        Given:
+            A namespace an owner has already entered and left, so the
+            tracker has held its segment before, and a filesystem that
+            fails the truncation every create performs.
+        When:
+            A fresh owner enters that namespace.
+        Then:
+            It should propagate the error without unregistering a name
+            the tracker is not holding — the removal that raises
+            KeyError inside the tracker process and prints a traceback
+            nothing here can intercept.
+        """
+        # Arrange — the completed cycle is load-bearing, not incidental.
+        # It puts this segment's name into the ledger's history; without
+        # it a stray unregister names something the ledger never saw,
+        # is forwarded to the real tracker unclassified, and leaves this
+        # test green against the very fault it is named for.
+        with LocalDiscovery(namespace):
+            pass
+        assert len(tracker_ledger.registered) == 1
+        assert tracker_ledger.residual == set()
+        broken_ftruncate["now"] = True
+
+        # Act
+        try:
+            with pytest.raises(OSError) as excinfo:
+                with LocalDiscovery(namespace):
+                    pass
+        finally:
+            broken_ftruncate["now"] = False
+
+        # Assert — ENOSPC, not the FileExistsError that is also an OSError.
+        assert excinfo.value.errno == errno.ENOSPC
+        assert tracker_ledger.violations == []
+
+    def test___enter___should_track_the_segment_when_a_retry_follows_a_failure(
+        self, namespace, tracker_ledger, broken_ftruncate
+    ):
+        """Test retrying the same namespace after a failed create tracks it.
+
+        Given:
+            A namespace whose create already failed mid-construction, and
+            a filesystem that has since recovered.
+        When:
+            That same namespace is entered again and left.
+        Then:
+            It should track the retried segment and release it on exit.
+            The same name is what discriminates: a shim left installed
+            keeps matching only the name and thread it was scoped to, so
+            it is invisible to any later segment except this one — whose
+            registration it would swallow, leaving the exit unlink to
+            remove a name the tracker is not holding.
+        """
+        # Arrange
+        broken_ftruncate["now"] = True
+        try:
+            with pytest.raises(OSError):
+                with LocalDiscovery(namespace):
+                    pass
+        finally:
+            broken_ftruncate["now"] = False
+        tracker_ledger.reset()
+
+        # Act & assert
+        with LocalDiscovery(namespace):
+            assert len(tracker_ledger.residual) == 1
+
+        assert tracker_ledger.residual == set()
+        assert tracker_ledger.violations == []
+
+    def test___enter___should_track_a_later_segment_when_a_create_failed(
+        self, namespace, tracker_ledger, broken_ftruncate
+    ):
+        """Test a failed create leaves the tracker suppression unwound.
+
+        Given:
+            An owner whose create already failed mid-construction, and a
+            filesystem that has since recovered.
+        When:
+            A second, unrelated namespace is entered and left.
+        Then:
+            It should track that segment and release it on exit —
+            suppression left installed for every name, rather than the
+            one it was scoped to, would stop tracking process-wide.
+        """
+        # Arrange
+        broken_ftruncate["now"] = True
+        try:
+            with pytest.raises(OSError):
+                with LocalDiscovery(namespace):
+                    pass
+        finally:
+            broken_ftruncate["now"] = False
+        tracker_ledger.reset()
+
+        # Act & assert — the observable consequence, not the hook's identity.
+        with LocalDiscovery(f"{namespace}-later"):
+            assert len(tracker_ledger.residual) == 1
+
+        assert tracker_ledger.residual == set()
+        assert tracker_ledger.violations == []
+
+    @given(capacity=st.integers(min_value=1, max_value=2 * _PAGE_CAPACITY))
+    @settings(
+        max_examples=20,
+        deadline=5000,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    # The page boundary, pinned rather than left to the draw: Hypothesis
+    # biases toward small values, and every capacity below `_PAGE_CAPACITY`
+    # maps a whole page regardless of the size requested, so a run that
+    # never crosses it cannot see an under-sized segment at all.
+    @example(capacity=_PAGE_CAPACITY)
+    @example(capacity=_PAGE_CAPACITY + 1)
+    @example(capacity=2 * _PAGE_CAPACITY)
+    def test___enter___should_map_every_slot_it_declares_capacity_for(
+        self, namespace, capacity
+    ):
+        """Test the created segment spans the capacity it was sized for.
+
+        Given:
+            Any capacity a caller may ask a namespace to hold, spanning
+            the point at which its address space outgrows one page.
+        When:
+            The namespace is entered and every slot it declares is
+            written and read back.
+        Then:
+            It should map the whole address space, whatever the capacity —
+            a size computed short, by a dropped header or a truncating
+            division, maps the same page below that boundary and is only
+            observable above it.
+        """
+        # Arrange — a per-example namespace, so one example's segment
+        # cannot be reused by the next under a different capacity.
+        example_ns = f"{namespace}-{capacity}"
+
+        # Act & assert
+        header, width = local._HEADER_SIZE, local.REF_WIDTH
+        with LocalDiscovery(example_ns, capacity=capacity) as discovery:
+            buffer = discovery._address_space.buf
+            assert buffer is not None
+            assert len(buffer) >= header + capacity * width
+            for slot in range(capacity):
+                offset = header + slot * width
+                buffer[offset : offset + width] = bytes([slot % 256]) * width
+            for slot in range(capacity):
+                offset = header + slot * width
+                assert bytes(buffer[offset : offset + width]) == (
+                    bytes([slot % 256]) * width
+                )
+
+    def test___enter___should_forward_other_unregisters_while_creating(
+        self, namespace, tracker_ledger, mocker
+    ):
+        """Test the create window suppresses one segment, not the tracker.
+
+        Given:
+            A construction that registers and then unregisters an
+            unrelated segment while the create's suppression window is
+            open, from the creating thread.
+        When:
+            An owner enters its context.
+        Then:
+            It should let that unrelated unregister reach the tracker,
+            narrowing the suppression to the one segment being created
+            rather than silencing the hook outright.
+        """
+        # Arrange — act on the unrelated name from inside the window,
+        # which is open for the duration of the create's constructor.
+        other = _segment_name()
+        constructing = local.SharedMemory
+
+        def interposed(*args, **kwargs):
+            if kwargs.get("create"):
+                resource_tracker.register(f"/{other}", "shared_memory")
+                resource_tracker.unregister(f"/{other}", "shared_memory")
+            return constructing(*args, **kwargs)
+
+        mocker.patch.object(local, "SharedMemory", interposed)
+
+        # Act
+        with LocalDiscovery(namespace):
+            pass
+
+        # Assert
+        assert ("shared_memory", other) in tracker_ledger.registered
+        assert ("shared_memory", other) not in tracker_ledger.residual
+        assert tracker_ledger.violations == []
 
     def test___exit___should_disarm_atexit_fallback_when_reentry_is_rejected(
         self, namespace, atexit_recorder
@@ -4093,6 +4548,77 @@ class TestLocalDiscoveryPublisher:
                         await publisher.publish("worker-dropped", roster[index])
 
     @pytest.mark.asyncio
+    async def test_publish_should_track_the_block_when_a_worker_is_added(
+        self, namespace, metadata, tracker_ledger
+    ):
+        """Test a worker's block is registered with this process's tracker.
+
+        Given:
+            An owned namespace and a publisher on it.
+        When:
+            A worker is added and then dropped.
+        Then:
+            It should track the block alongside the address space while
+            the worker is registered and release it on the drop — the
+            publisher creates that block, so its own unlink must find it
+            registered.
+        """
+        # Act & assert
+        with LocalDiscovery(namespace):
+            async with LocalDiscovery.Publisher(namespace) as publisher:
+                await publisher.publish("worker-added", metadata)
+                assert len(tracker_ledger.residual) == 2
+
+                await publisher.publish("worker-dropped", metadata)
+                assert len(tracker_ledger.residual) == 1
+
+        assert tracker_ledger.residual == set()
+        assert tracker_ledger.violations == []
+
+    @pytest.mark.asyncio
+    async def test_publish_should_not_unregister_when_a_block_create_fails(
+        self, namespace, metadata, tracker_ledger, broken_ftruncate
+    ):
+        """Test a block create that fails mid-construction unregisters nothing.
+
+        Given:
+            An owned namespace, a worker already added and dropped so
+            the tracker has held its block before, and a filesystem that
+            fails the truncation every create performs.
+        When:
+            That worker is added again.
+        Then:
+            It should propagate the error without unregistering a name
+            the tracker is not holding, leaving the tracker exactly as
+            the failed block found it.
+        """
+        # Arrange — the add/drop cycle puts the block's name into the
+        # ledger's history, so a stray unregister is classified rather
+        # than forwarded unseen; without it this test is green whether or
+        # not the suppression is there. Failing the truncation only
+        # afterwards leaves every attach this publish performs, including
+        # the address-space remap, working normally.
+        block = local._short_hash(metadata.uid.hex)
+        with LocalDiscovery(namespace):
+            async with LocalDiscovery.Publisher(namespace) as publisher:
+                await publisher.publish("worker-added", metadata)
+                await publisher.publish("worker-dropped", metadata)
+                assert ("shared_memory", block) in tracker_ledger.registered
+                broken_ftruncate["now"] = True
+
+                # Act
+                try:
+                    with pytest.raises(OSError) as excinfo:
+                        await publisher.publish("worker-added", metadata)
+                finally:
+                    broken_ftruncate["now"] = False
+
+        # Assert
+        assert excinfo.value.errno == errno.ENOSPC
+        assert tracker_ledger.violations == []
+        assert tracker_ledger.residual == set()
+
+    @pytest.mark.asyncio
     async def test_publish_should_leave_the_tracker_balanced_when_worker_readded(
         self, namespace, attach_fallback, tracker_ledger
     ):
@@ -4135,29 +4661,32 @@ class TestLocalDiscoveryPublisher:
             ),
             min_size=1,
             max_size=12,
-        )
+        ),
+        failures=st.sets(st.integers(min_value=0, max_value=11), max_size=4),
     )
     @settings(
-        max_examples=15,
+        max_examples=20,
         deadline=5000,
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
     @pytest.mark.asyncio
     async def test_publish_should_leave_the_tracker_balanced_across_event_sequences(
-        self, namespace, attach_fallback, tracker_ledger, ops
+        self, namespace, attach_fallback, tracker_ledger, broken_ftruncate, ops, failures
     ):
-        """Test the tracker stays consistent however segments are reattached.
+        """Test the tracker stays consistent however segments fail or reattach.
 
         Given:
             An owned namespace on an interpreter reporting a version
-            below 3.13, a three-worker roster, and an arbitrary sequence
-            of add, update, and drop events over it.
+            below 3.13, a three-worker roster, an arbitrary sequence of
+            add, update, and drop events over it, and an arbitrary subset
+            of those events whose block creation fails mid-construction.
         When:
             The sequence is published serially and the owner exits.
         Then:
             It should never unregister a name the tracker is not holding,
-            whatever the order and however many times one segment is
-            attached.
+            whatever the order, however many times one segment is
+            attached, and whichever creates failed — including a create
+            that fails and is then retried for the same worker.
         """
         # Arrange — a per-example namespace and ledger, so neither
         # shared-memory state nor one example's imbalance carries into the
@@ -4179,16 +4708,32 @@ class TestLocalDiscoveryPublisher:
         # Act
         with LocalDiscovery(example_ns):
             async with LocalDiscovery.Publisher(example_ns) as publisher:
-                for action, index in ops:
-                    if action == "add":
-                        await publisher.publish("worker-added", roster[index])
-                        live.add(index)
-                    elif index in live:
-                        if action == "update":
-                            await publisher.publish("worker-updated", roster[index])
-                        else:
-                            await publisher.publish("worker-dropped", roster[index])
-                            live.discard(index)
+                for step, (action, index) in enumerate(ops):
+                    # Only an add for a worker that is not already live
+                    # reaches a block create: a re-add refreshes the block
+                    # the pool still holds, and update and drop only
+                    # attach. Arming the toggle over any of those would
+                    # break an attach instead of the create under test.
+                    failing = step in failures and action == "add" and index not in live
+                    broken_ftruncate["now"] = failing
+                    try:
+                        if action == "add":
+                            if failing:
+                                with pytest.raises(OSError):
+                                    await publisher.publish(
+                                        "worker-added", roster[index]
+                                    )
+                            else:
+                                await publisher.publish("worker-added", roster[index])
+                                live.add(index)
+                        elif index in live:
+                            if action == "update":
+                                await publisher.publish("worker-updated", roster[index])
+                            else:
+                                await publisher.publish("worker-dropped", roster[index])
+                                live.discard(index)
+                    finally:
+                        broken_ftruncate["now"] = False
 
         # Assert
         assert tracker_ledger.violations == []


### PR DESCRIPTION
## Summary

Route Wool's two `SharedMemory(create=True)` sites through a helper that suppresses the stray `resource_tracker.unregister` a construction emits when it fails partway through.

`SharedMemory.__init__` unlinks from inside the `except OSError` handler wrapping the block that truncates, stats and maps the segment, and `register` runs *after* that block. Below 3.13 `unlink` unregisters unconditionally; on 3.13 and up it unregisters whenever `track` is set, which it is for a create. So a construction that fails mid-way unregisters a name that was never registered. The tracker's per-type cache is a set, so removing an absent name raises `KeyError` in the tracker process, which prints a traceback to stderr and sets an exit code nothing waits on — the same observable #336 removed from the attach path, reached instead by the truncation or the mapping failing.

**This corrects the issue's stated scope**, and #340 has been corrected in place. The issue said 3.13 was unaffected because `unlink` is guarded by `self._track`. That guard does not help a create: `track` defaults to `True`, so it is satisfied. Probed directly on all three supported interpreters:

| | 3.11.12 | 3.12.10 | 3.13.3 |
|---|---|---|---|
| failed create emits a stray unregister | yes | yes | **yes** |
| tracker `KeyError` traceback on stderr | yes | yes | yes |

The fix therefore carries **no version gate**, unlike #336's attach fix. That is also its best CI property: the new code runs on every matrix leg with no fixture forcing a version the interpreter is not on.

The `shm_unlink` half that #336 had to leave to CPython (bpo-38119) has no counterpart here. On an attach it destroys a segment the process does not own; on a create it destroys the one the call just made, which is correct. Nothing is left over.

Closes #106 
Closes #340

## Proposed changes

### Extract the suppression window from `_attach`

`_attach` rebound both tracker hooks for one constructor call. A create needs the same window but a different policy — the segment must stay *registered* on success, since that entry is what its own `unlink` removes; only the failure path is wrong.

Move the machinery into a `_suppressing(name, *, register, unregister=True)` context manager. Name the parameters for the hooks rather than switching on a single boolean, so both call sites read without consulting the callee. Leave `_attach` a two-line caller that keeps its version gate. Rename `_attach_lock` and `_reinit_attach_lock` to `_tracker_lock` and `_reinit_tracker_state`, since they no longer serve attaches alone. Committed separately as a behaviour-preserving refactor.

### Harden the window against three hazards review surfaced

- **Restore what this module displaced, not an import-time snapshot.** The at-fork handler previously reset the hooks unconditionally, so *any* fork in a process that had imported Wool clobbered instrumentation another library installed after import — even with no window ever opened. Track each shim with the hook it displaced and restore only that.
- **Neutralise a shim before unwinding.** A third party that wraps the hook inside the window keeps our shim in its delegation chain for the life of the process, where it would go on matching this segment's name against a thread ident the interpreter is free to reuse. A liveness flag makes a stranded shim a pass-through.
- **Bound the acquisition.** `DEFAULT_LOCK_TIMEOUT` already governs this module's other lock, and #316 bounded that one for the same reason. An unbounded acquire turns a wedged holder into a process-wide stall with nothing to diagnose.

### Add `_create` and route both call sites

`_create(name, size)` opens the window over `unregister` only. `LocalDiscovery.__enter__` and `LocalDiscovery.Publisher._shared_memory_factory` both use it.

`__enter__`'s `FileExistsError` fallback to `_attach` is unaffected: the exception propagates out of the context manager, releasing the non-reentrant lock, before the handler runs. Pin that with a subprocess test rather than leaving it to inspection — a refactor that widened the window across the whole `try`/`except` deadlocks rather than fails, and three of the fifteen reviewers independently wrote exactly that refactor while reviewing.

### Give the existing attach assertion teeth

`test__attach_should_suppress_the_unregister_when_the_mapping_fails` asserted only that the ledger recorded no violation — and **passed with the suppression removed entirely**. The creator's entry is live at that point, so an unsuppressed unregister is absorbed as an ordinary discard and records nothing. Assert on the residual set instead, where the creator's registration either survives or does not.

### Test design notes

**Inject at `os.ftruncate`, not `mmap.mmap`.** Only a create truncates, so failing it breaks creates and leaves every attach working. That matters because `publish` remaps the address space *before* reaching the block factory; a broken mapping would take out the arrangement rather than the target.

**Seed the name before every failure test.** The `tracker_ledger` fixture classifies an unregister only for a name it has seen registered. A first-time failed create names something it never saw, so the stray is forwarded unclassified — leaving the assertion green whether or not the fix is present, while planting a real `KeyError` in the session's tracker.

**Run the liveness properties in a subprocess.** The lock is process-global, so a wedge inside pytest strands every later test in the session; a wedge in a child is reaped by the harness timeout and reported against the test that caused it.

**Derive the page boundary rather than hard-coding it.** The capacity property crosses the point where a segment outgrows one page, which is where an under-sized request first becomes observable. That point is capacity 255 on Linux's 4 KiB pages and 1023 on macOS arm64's 16 KiB pages, so a fixed example tuned to either is a no-op on the other.

**Carry no version dimension on the create tests.** The fault reproduces unpatched on every supported version, so a legacy/native split would run identical code twice and encode a conditionality that does not exist.

### Mutation results

Each mutant, and the tests that caught it:

| Mutant | Caught by |
|---|---|
| Create suppression removed | 2 unit + 2 integration |
| `register` suppressed on the create path | 7 unit |
| Unregister shim forwards unconditionally | 6 unit, incl. the strengthened #336 test |
| `__enter__` site left unrouted | 1 unit + 1 integration |
| Block site left unrouted | 1 unit + 1 integration |
| Name clause dropped from the match | 4 unit |
| Resource-type clause dropped from the match | 3 unit |
| Restore only on the returning path | whole suite wedges — the lock is never released |
| Restore only one of the two hooks | 1 unit |
| Identity guard dropped from the restore | 1 unit |
| Segment created one byte long | 1 unit |
| `__enter__` halves the size it requests | 1 unit |
| Suppression window widened across the fallback | 1 integration |
| At-fork registration deleted | 1 integration |
| At-fork handler stops replacing the lock | 1 integration |

The last eight all survived the first round of tests; review found them, and they now fail. Both unrouted-site mutants are caught by exactly one unit test and one integration test each, so the two call sites have independent guards.

### Coverage

Unit 98.86% against a floor of 98; integration 86.46% against 70. `local.py` holds at 6 missed lines — the same pre-existing set as before this change, with the `_unregister` pass-through gap inherited from #336 now covered and the new bounded-acquire path covered by a test rather than a pragma. No `pragma` added or removed.

Subprocess children earn no coverage credit, so the integration tests are behavioural evidence and the unit suite carries the coverage. That division is stated in the integration module docstring.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestLocalDiscovery` | A namespace no process currently owns | An owner enters its context and leaves it | It should hold exactly one tracked segment for the life of the context and none after it | Create success path; registration deliberately not suppressed |
| 2 | `TestLocalDiscovery` | A namespace an owner has already entered and left, and a filesystem that fails the truncation | A fresh owner enters that namespace | It should propagate the error without unregistering a name the tracker is not holding | Create failure path at `LocalDiscovery.__enter__` |
| 3 | `TestLocalDiscovery` | A namespace whose create already failed, and a filesystem that has since recovered | That same namespace is entered again | It should track the retried segment — the same name is what a stranded shim would still match | Hook restoration, scoped to the failed name |
| 4 | `TestLocalDiscovery` | An owner whose create already failed | A second, unrelated namespace is entered and left | It should track that segment and release it on exit | Restoration is not name-wide |
| 5 | `TestLocalDiscovery` | Any capacity spanning the point at which the address space outgrows one page | The namespace is entered and every declared slot is written and read back | It should map the whole address space, whatever the capacity | `_create`'s `size` argument |
| 6 | `TestLocalDiscovery` | A construction that unregisters an unrelated segment while the window is open | An owner enters its context | It should let that unregister reach the tracker | Suppression narrowed to one segment |
| 7 | `TestLocalDiscoveryPublisher` | An owned namespace and a publisher on it | A worker is added and then dropped | It should track the block alongside the address space and release it on the drop | Create success path at the pool factory |
| 8 | `TestLocalDiscoveryPublisher` | An owned namespace, a worker already added and dropped, and a filesystem that fails the truncation | That worker is added again | It should propagate the error without unregistering a name the tracker is not holding | Create failure path at the pool factory |
| 9 | `TestLocalDiscoveryPublisher` | An arbitrary sequence of add, update and drop events, and an arbitrary subset of them whose block creation fails | The sequence is published serially and the owner exits | It should never unregister a name the tracker is not holding, whichever creates failed | The balance invariant, now including failures |
| 10 | Module-level `_suppressing` | An open window, and any resource differing in name, in type, or in both | That resource is registered and unregistered inside the window | It should let both calls through | Narrowing on name and resource type, both configurations |
| 11 | Module-level `_suppressing` | An open window whose block raises | The exception propagates | It should leave a later segment tracked and hold no shim | Restoration on the raising path |
| 12 | Module-level `_suppressing` | An open window whose block rebinds the tracker's hook | The window closes | It should leave that wrapper installed | The identity guard's documented promise |
| 13 | Module-level `_suppressing` | Another thread holding the lock, and a short bound | A second window is opened | It should raise `TimeoutError` naming the wait | The bounded acquisition |
| 14 | Module-level `_create` | An attach of a name no segment holds, followed by a create of that same name | The attach raises and the create follows | It should track the created segment | Cross-path interaction on one name |
| 15 | `TestCrossProcessTracker` | An independent interpreter whose filesystem fails the truncation | It fails to create the namespace segment and exits | It should exit 0 with no tracker traceback on stderr | `__enter__`, across a real process boundary |
| 16 | `TestCrossProcessTracker` | The same, failing one worker announcement | The publish raises and the interpreter exits | It should exit 0 with no tracker traceback on stderr | The pool factory, across a real process boundary |
| 17 | `TestCrossProcessTracker` | A namespace this process owns, and an interpreter entering it as a non-owner | Its create raises `FileExistsError` and the attach runs | It should attach and exit within the bound | The lock is released before the fallback |
| 18 | `TestCrossProcessTracker` | An interpreter with a thread parked inside an open window | It forks and the child enters a namespace of its own | It should report the child entering and exiting 0 | The at-fork handler |
| 19 | `TestCrossProcessTracker` | An interpreter creating a segment larger than the system can back, patching nothing | It runs to completion and its tracker drains | It should exit 0 yet print a tracker `KeyError` | Negative control, independent of both Wool and the injection technique |
| 20 | Module-level `_attach` | A segment created by this process and a mapping that raises after it is opened | The segment is attached by name | It should leave the creator's registration in the tracker's cache | Strengthened #336 assertion, now shared with the create path |
