### PR TITLE
Reject a zero LocalDiscovery block size at construction instead of failing at first publish — Closes #346

### DIFF
--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -263,6 +263,9 @@ class LocalDiscovery(Discovery):
         file lock; see `LocalDiscovery.Publisher` for the acquisition
         contract. Plumbed through to each `Publisher`. Defaults to
         `DEFAULT_LOCK_TIMEOUT`.
+    :raises ValueError:
+        If ``capacity`` or ``block_size`` is less than 1, or
+        ``lock_timeout`` is negative.
 
     Example — publish workers:
 
@@ -302,6 +305,9 @@ class LocalDiscovery(Discovery):
     ):
         if capacity < 1:
             raise ValueError(f"Expected capacity of at least 1, got {capacity}")
+        _validate_block_size(block_size)
+        if lock_timeout is not None and lock_timeout < 0:
+            raise ValueError("Lock timeout must be non-negative")
         self._namespace = namespace or f"workerpool-{uuid4()}"
         self._filter = filter
         self._capacity = capacity
@@ -451,7 +457,8 @@ class LocalDiscovery(Discovery):
             raising `TimeoutError`. ``None`` waits forever. Defaults to
             `DEFAULT_LOCK_TIMEOUT`.
         :raises ValueError:
-            If ``block_size`` is negative, or ``lock_timeout`` is negative.
+            If ``block_size`` is less than 1, or ``lock_timeout`` is
+            negative.
         """
 
         _block_size: int
@@ -472,8 +479,7 @@ class LocalDiscovery(Discovery):
             block_size: int = 1024,
             lock_timeout: float | None = DEFAULT_LOCK_TIMEOUT,
         ):
-            if block_size < 0:
-                raise ValueError("Block size must be positive")
+            _validate_block_size(block_size)
             if lock_timeout is not None and lock_timeout < 0:
                 raise ValueError("Lock timeout must be non-negative")
             self._namespace = namespace
@@ -890,6 +896,16 @@ class LocalDiscovery(Discovery):
                     "worker-updated", metadata=discovered_workers[uid]
                 )
                 yield event
+
+
+def _validate_block_size(block_size: int) -> None:
+    """Reject a block size below one.
+
+    :raises ValueError:
+        If ``block_size`` is less than 1.
+    """
+    if block_size < 1:
+        raise ValueError(f"Expected block size of at least 1, got {block_size}")
 
 
 def _read_capacity(buf: memoryview) -> int | None:

--- a/wool/src/wool/runtime/discovery/local.py
+++ b/wool/src/wool/runtime/discovery/local.py
@@ -254,8 +254,10 @@ class LocalDiscovery(Discovery):
         `LocalDiscovery.Publisher.publish` for the full contract.
         Defaults to 128.
     :param block_size:
-        Size in bytes for each worker's serialized data block.
-        Defaults to 1024.
+        Size in bytes for each worker's serialized data block. Each
+        block spends 4 bytes on a length prefix, leaving
+        ``block_size - 4`` for the serialized metadata. Defaults to
+        1024.
     :param lock_timeout:
         Maximum seconds a publisher waits to acquire the cross-process
         file lock; see `LocalDiscovery.Publisher` for the acquisition
@@ -439,8 +441,10 @@ class LocalDiscovery(Discovery):
         :param namespace:
             The namespace identifier for the shared memory region.
         :param block_size:
-            Size in bytes for worker metadata storage blocks. Defaults
-            to 512 bytes, which accommodates typical worker
+            Size in bytes for worker metadata storage blocks. Each
+            block spends 4 bytes on a length prefix, leaving
+            ``block_size - 4`` for the serialized metadata. Defaults
+            to 1024 bytes, which accommodates typical worker
             metadata including tags and extra metadata.
         :param lock_timeout:
             Maximum seconds to wait for the cross-process file lock before

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -20,6 +20,7 @@ import portalocker
 import pytest
 from hypothesis import HealthCheck
 from hypothesis import assume
+from hypothesis import example
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
@@ -46,6 +47,23 @@ def metadata():
         address="localhost:50051",
         pid=12345,
         version="1.0.0",
+    )
+
+
+@pytest.fixture
+def oversized_metadata():
+    """Provides WorkerMetadata whose serialization overflows small blocks.
+
+    The extra payload serializes to roughly 20 KB — larger than the
+    default block size and any page-rounded small block — so publishes
+    against modest block sizes deterministically overflow.
+    """
+    return WorkerMetadata(
+        uid=uuid.uuid4(),
+        address="localhost:50051",
+        pid=123,
+        version="1.0",
+        extra=MappingProxyType({"data": "x" * 20000}),
     )
 
 
@@ -619,6 +637,34 @@ class TestLocalDiscovery:
         with pytest.raises(ValueError, match="Expected block size of at least 1"):
             LocalDiscovery("ns", block_size=block_size)
 
+    @given(block_size=st.integers())
+    @settings(max_examples=50)
+    @example(block_size=1)
+    @example(block_size=0)
+    @example(block_size=-1)
+    def test___init___should_validate_block_size_across_domain(self, block_size):
+        """Test LocalDiscovery validates block_size across the integer domain.
+
+        Given:
+            Any integer block_size.
+        When:
+            LocalDiscovery is instantiated with it.
+        Then:
+            It should raise ValueError naming the offending value exactly
+            when the value is below one, and construct successfully for
+            every value of at least one.
+        """
+        # Act & assert
+        if block_size < 1:
+            with pytest.raises(
+                ValueError,
+                match=f"Expected block size of at least 1, got {block_size}",
+            ):
+                LocalDiscovery("ns", block_size=block_size)
+        else:
+            discovery = LocalDiscovery("ns", block_size=block_size)
+            assert discovery.namespace == "ns"
+
     def test___init___should_raise_when_lock_timeout_negative(self):
         """Test LocalDiscovery rejects a negative lock timeout.
 
@@ -754,6 +800,28 @@ class TestLocalDiscovery:
             async with discovery.publisher as publisher:
                 with pytest.raises(TimeoutError):
                     await publisher.publish("worker-added", metadata)
+
+    @pytest.mark.asyncio
+    async def test_publisher_should_propagate_block_size(
+        self, namespace, oversized_metadata
+    ):
+        """Test the publisher property plumbs block_size to publish.
+
+        Given:
+            A LocalDiscovery constructed with a block_size larger than
+            the Publisher default and worker metadata whose serialization
+            exceeds any default-sized block
+        When:
+            A publisher obtained from the publisher property publishes it
+        Then:
+            It should publish successfully, proving the constructor's
+            block_size governs the nested Publisher — a default-sized
+            block could not hold the metadata.
+        """
+        # Act & assert — success is only possible if block_size propagated
+        with LocalDiscovery(namespace, block_size=65536) as discovery:
+            async with discovery.publisher as publisher:
+                await publisher.publish("worker-added", oversized_metadata)
 
     def test_subscriber_with_default_instance(self, namespace):
         """Test subscriber property returns Subscriber instance.
@@ -1706,39 +1774,6 @@ class TestLocalDiscoveryPublisher:
     wool.runtime.discovery.local.LocalDiscovery.Publisher
     """
 
-    def test_bind_host_with_default_value(self, namespace):
-        """Test bind_host prescribes the loopback address.
-
-        Given:
-            A LocalDiscovery Publisher
-        When:
-            The bind_host attribute is accessed
-        Then:
-            It should be "127.0.0.1" since shared-memory announcements
-            are only discoverable same-host.
-        """
-        # Act
-        publisher = LocalDiscovery.Publisher(namespace)
-
-        # Assert
-        assert publisher.bind_host == "127.0.0.1"
-
-    def test_namespace_with_provided_value(self, namespace):
-        """Test Publisher.namespace property returns provided value.
-
-        Given:
-            A namespace string
-        When:
-            Publisher is instantiated
-        Then:
-            It should return the provided namespace.
-        """
-        # Act
-        publisher = LocalDiscovery.Publisher(namespace)
-
-        # Assert
-        assert publisher.namespace == namespace
-
     @pytest.mark.parametrize("block_size", [0, -1])
     def test___init___should_raise_when_block_size_below_one(
         self, namespace, block_size
@@ -1755,6 +1790,39 @@ class TestLocalDiscoveryPublisher:
         # Act & assert
         with pytest.raises(ValueError, match="Expected block size of at least 1"):
             LocalDiscovery.Publisher(namespace, block_size=block_size)
+
+    @given(block_size=st.integers())
+    @settings(
+        max_examples=50,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @example(block_size=1)
+    @example(block_size=0)
+    @example(block_size=-1)
+    def test___init___should_validate_block_size_across_domain(
+        self, namespace, block_size
+    ):
+        """Test Publisher validates block_size across the integer domain.
+
+        Given:
+            Any integer block_size.
+        When:
+            A Publisher is instantiated with it.
+        Then:
+            It should raise ValueError naming the offending value exactly
+            when the value is below one, and construct successfully for
+            every value of at least one.
+        """
+        # Act & assert
+        if block_size < 1:
+            with pytest.raises(
+                ValueError,
+                match=f"Expected block size of at least 1, got {block_size}",
+            ):
+                LocalDiscovery.Publisher(namespace, block_size=block_size)
+        else:
+            publisher = LocalDiscovery.Publisher(namespace, block_size=block_size)
+            assert publisher.namespace == namespace
 
     def test___init___should_raise_when_lock_timeout_negative(self, namespace):
         """Test Publisher rejects a negative lock timeout.
@@ -1807,6 +1875,39 @@ class TestLocalDiscoveryPublisher:
         else:
             publisher = LocalDiscovery.Publisher(namespace, lock_timeout=lock_timeout)
             assert publisher.namespace == namespace
+
+    def test_bind_host_with_default_value(self, namespace):
+        """Test bind_host prescribes the loopback address.
+
+        Given:
+            A LocalDiscovery Publisher
+        When:
+            The bind_host attribute is accessed
+        Then:
+            It should be "127.0.0.1" since shared-memory announcements
+            are only discoverable same-host.
+        """
+        # Act
+        publisher = LocalDiscovery.Publisher(namespace)
+
+        # Assert
+        assert publisher.bind_host == "127.0.0.1"
+
+    def test_namespace_with_provided_value(self, namespace):
+        """Test Publisher.namespace property returns provided value.
+
+        Given:
+            A namespace string
+        When:
+            Publisher is instantiated
+        Then:
+            It should return the provided namespace.
+        """
+        # Act
+        publisher = LocalDiscovery.Publisher(namespace)
+
+        # Assert
+        assert publisher.namespace == namespace
 
     @pytest.mark.asyncio
     async def test___aenter___and___aexit___lifecycle(self, namespace):

--- a/wool/tests/runtime/discovery/test_local.py
+++ b/wool/tests/runtime/discovery/test_local.py
@@ -603,6 +603,36 @@ class TestLocalDiscovery:
         with pytest.raises(ValueError, match="Expected capacity of at least 1"):
             LocalDiscovery("ns", capacity=capacity)
 
+    @pytest.mark.parametrize("block_size", [0, -1])
+    def test___init___should_raise_when_block_size_below_one(self, block_size):
+        """Test LocalDiscovery rejects a block size below one.
+
+        Given:
+            A block_size of zero or a negative block_size
+        When:
+            LocalDiscovery is instantiated
+        Then:
+            It should raise ValueError, since a block smaller than one
+            byte can never hold a worker's serialized metadata.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="Expected block size of at least 1"):
+            LocalDiscovery("ns", block_size=block_size)
+
+    def test___init___should_raise_when_lock_timeout_negative(self):
+        """Test LocalDiscovery rejects a negative lock timeout.
+
+        Given:
+            A negative lock_timeout
+        When:
+            LocalDiscovery is instantiated
+        Then:
+            It should raise ValueError at construction.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="Lock timeout must be non-negative"):
+            LocalDiscovery("ns", lock_timeout=-1)
+
     def test___hash___with_same_namespace(self):
         """Test hash equality for same namespace.
 
@@ -724,25 +754,6 @@ class TestLocalDiscovery:
             async with discovery.publisher as publisher:
                 with pytest.raises(TimeoutError):
                     await publisher.publish("worker-added", metadata)
-
-    def test_publisher_should_raise_when_lock_timeout_negative(self, namespace):
-        """Test the publisher property rejects a negative lock timeout lazily.
-
-        Given:
-            A LocalDiscovery constructed with a negative lock_timeout,
-            which does not validate at construction
-        When:
-            Its publisher property is accessed
-        Then:
-            It should raise ValueError, deferring lock_timeout validation
-            to the Publisher the property builds, mirroring block_size.
-        """
-        # Arrange
-        discovery = LocalDiscovery(namespace, lock_timeout=-1)
-
-        # Act & assert
-        with pytest.raises(ValueError, match="Lock timeout must be non-negative"):
-            discovery.publisher
 
     def test_subscriber_with_default_instance(self, namespace):
         """Test subscriber property returns Subscriber instance.
@@ -1728,19 +1739,22 @@ class TestLocalDiscoveryPublisher:
         # Assert
         assert publisher.namespace == namespace
 
-    def test___init___with_negative_block_size(self, namespace):
-        """Test Publisher rejects negative block sizes.
+    @pytest.mark.parametrize("block_size", [0, -1])
+    def test___init___should_raise_when_block_size_below_one(
+        self, namespace, block_size
+    ):
+        """Test Publisher rejects a block size below one.
 
         Given:
-            A negative block_size
+            A block_size of zero or a negative block_size
         When:
             Publisher is instantiated
         Then:
-            It should raise ValueError.
+            It should raise ValueError at construction.
         """
         # Act & assert
-        with pytest.raises(ValueError, match="Block size must be positive"):
-            LocalDiscovery.Publisher(namespace, block_size=-1)
+        with pytest.raises(ValueError, match="Expected block size of at least 1"):
+            LocalDiscovery.Publisher(namespace, block_size=block_size)
 
     def test___init___should_raise_when_lock_timeout_negative(self, namespace):
         """Test Publisher rejects a negative lock timeout.


### PR DESCRIPTION
## Summary

`LocalDiscovery(block_size=0)` constructed cleanly and failed at the first publish, inside CPython's `SharedMemory` constructor, with an error naming no Wool parameter. The guard in `Publisher.__init__` rejected only negatives — its message already stated the intended contract; the predicate didn't implement it — and `LocalDiscovery.__init__` forwarded `block_size` to its publishers without validating it at all. Reject values below one at construction in both classes through a single shared validator, in the capacity guard's diagnostic style: name the parameter, report the offending value. Validate `lock_timeout` at construction as well, giving the constructor one validation contract — an argument that can never produce a working publisher is rejected where it is supplied. This is a diagnostic-quality fix; at `size=0` CPython raised before `shm_open`, so nothing ever leaked. Closes #346

## Proposed changes

### Construction-time validation

A module-private `_validate_block_size` owns the predicate and the message; both `LocalDiscovery.__init__` and `Publisher.__init__` call it. One owner means the message cannot drift from the predicate again — that drift is how the original guard came to say "must be positive" while accepting zero. `LocalDiscovery.__init__` also rejects a negative `lock_timeout` at construction; previously it constructed successfully and raised only at first `publisher` property access, the same accept-now-fail-later shape this change removes for `block_size`.

### Documented contract

Both class docstrings state the tightened contract: `:raises ValueError:` covers `capacity` and `block_size` below one and a negative `lock_timeout`, and both `block_size` parameter docs state the block layout's overhead — each block spends 4 bytes on a length prefix, leaving `block_size - 4` for serialized metadata. The floor stays at 1, the bound of the layer beneath; an undersized-but-positive block fails at publish through the documented `DiscoveryBlockExhausted` channel. The Publisher docstring's stale 512-byte default claim now reads 1024, matching the signature.

### Tests

Hypothesis sweeps `block_size` across the integer domain for both constructors, with the boundary pinned deterministically by `@example` at -1, 0, and 1 and the raising branch matching the full diagnostic including the offending value. The propagation test proves the constructor's `block_size` governs the nested Publisher by direction of success: a publisher built by the `publisher` property with `block_size=65536` publishes metadata that overflows any default-sized block, so the publish completes only if the value propagated. An `oversized_metadata` fixture carries the overflow payload, and constructor validation tests precede tests requiring a constructed instance in the Publisher suite.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestLocalDiscovery` | A block_size of zero or a negative block_size | `LocalDiscovery` is instantiated | Raises ValueError at construction with Wool's own message | Eager rejection in `LocalDiscovery.__init__` |
| 2 | `TestLocalDiscovery` | Any integer block_size drawn by Hypothesis, with -1, 0, and 1 pinned as examples | `LocalDiscovery` is instantiated with it | Raises ValueError reporting the offending value exactly when below one, and constructs otherwise | Full integer-domain invariant of the guard |
| 3 | `TestLocalDiscovery` | A negative lock_timeout | `LocalDiscovery` is instantiated | Raises ValueError at construction | Eager lock_timeout rejection |
| 4 | `TestLocalDiscovery` | A block_size of 65536 and metadata overflowing any default-sized block | A publisher obtained from the `publisher` property publishes | The publish succeeds | Constructor block_size governs the nested Publisher |
| 5 | `TestLocalDiscoveryPublisher` | A block_size of zero or a negative block_size | `Publisher` is instantiated | Raises ValueError at construction | Eager rejection in `Publisher.__init__` |
| 6 | `TestLocalDiscoveryPublisher` | Any integer block_size drawn by Hypothesis, with -1, 0, and 1 pinned as examples | `Publisher` is instantiated with it | Raises ValueError reporting the offending value exactly when below one, and constructs otherwise | Full integer-domain invariant of the guard |