### PR TITLE
Fix the release workflows' auth header breaking when the app token exceeds base64's wrap column — Closes #361

### DIFF
--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -67,8 +67,9 @@ jobs:
       - name: Configure git with app token
         env:
           APP_TOKEN: ${{ steps.get-wool-labs-app-token.outputs.access-token }}
+          REPO: ${{ github.repository }}
         run: |
-          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${APP_TOKEN}" | base64)"
+          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPO}.git"
       - name: Create release branch
         id: cut-release-branch
         env:


### PR DESCRIPTION
## Summary

Replace the cut-release workflow's hand-built basic-auth extraheader with a credentialed remote URL — the idiom `publish-release.yaml` already uses on master. The old step piped the app token through GNU `base64`, which wraps at 76 columns: a classic 40-char installation token encoded to exactly 76 chars (a single line with zero slack), and GitHub's lengthened token format pushed the encoding onto a second line, embedding a newline in the header value and making libcurl fail every subsequent git network operation instantly with `Failed sending HTTP request` ([run 31411865456](https://github.com/wool-labs/wool/actions/runs/31411865456)).

Closes #361

## Proposed changes

### Use a credentialed remote URL in "Configure git with app token"

Set `origin` to `https://x-access-token:${APP_TOKEN}@github.com/${REPO}.git` instead of writing `http.https://github.com/.extraheader` with a hand-rolled base64 value, mirroring `publish-release.yaml`. Every subsequent git operation in the job — the release script's fetch and pull (whose identical failure was previously swallowed by output suppression) and the `release` branch push — authenticates via the URL with no wrap-sensitive encoding involved.

Merging to master propagates to main via the sync-branches workflow (triggered on merged PRs to master), which also carries master's already-migrated publish-release line down to main — after which re-dispatching Cut release from main should succeed.