### PR TITLE
Fix release-workflow authenticating as github-actions — Closes #364

### DIFF
--- a/.github/workflows/cut-release.yaml
+++ b/.github/workflows/cut-release.yaml
@@ -69,6 +69,7 @@ jobs:
           APP_TOKEN: ${{ steps.get-wool-labs-app-token.outputs.access-token }}
           REPO: ${{ github.repository }}
         run: |
+          git config --local --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPO}.git"
       - name: Create release branch
         id: cut-release-branch

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -72,6 +72,7 @@ jobs:
           INPUT_VERSION: ${{ github.event.inputs.version }}
           VERSION_SEGMENT: ${{ steps.determine-version-segment.outputs.segment }}
         run: |
+          git config --local --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
           if [[ "$INPUT_VERSION" != "" ]]; then
             new_version="$INPUT_VERSION"
@@ -230,7 +231,8 @@ jobs:
           GH_TOKEN: ${{ steps.get-wool-labs-app-token.outputs.access-token }}
           REPO: ${{ github.repository }}
         run: |
-          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $(echo -n "x-access-token:${GH_TOKEN}" | base64)"
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
           git fetch --unshallow
           if [[ -n $(git ls-remote --heads origin release) ]]; then
             git push origin --delete release


### PR DESCRIPTION
## Summary

Clear `actions/checkout`'s persisted credentials before installing the app credential at every git-auth site in the release workflows, so pushes authenticate as the wool-labs app rather than `github-actions[bot]`. #362 switched cut-release to a credentialed remote URL, but checkout's persisted `GITHUB_TOKEN` extraheader remains in `.git/config` and curl's custom-header precedence overrides URL credentials — so the release-branch push authenticated as `github-actions[bot]`, which holds no bypass on the `Lockdown` ruleset, and was rejected with `GH013` ([run 31413786993](https://github.com/wool-labs/wool/actions/runs/31413786993)). The pre-#362 code was immune only by accident: writing the same config key replaced checkout's header.

Closes #364

## Proposed changes

### Unset the persisted extraheader before `set-url` (cut-release, publish-release "Bump version")

Add `git config --local --unset-all http.https://github.com/.extraheader || true` ahead of the existing `git remote set-url` lines, making the app's URL credential the only identity in play (`|| true` because `--unset-all` exits non-zero on an absent key under `bash -e`).

### Convert publish-release's "Drop release branch" off the wrap-prone base64 header

This step still used the `echo -n … | base64` extraheader pattern from #361 — the same token-length landmine #362 removed from cut-release — and it deletes the `release` branch, which exercises `Lockdown`'s `deletion` rule where app identity is equally required. Replace it with the unset + credentialed-URL pair, unifying all three auth sites on one idiom.