### PR TITLE
Rename the worker idle_time surface to idle — Closes #368

### DIFF
--- a/wool/proto/wire.proto
+++ b/wool/proto/wire.proto
@@ -104,7 +104,7 @@ message Nack {
 service Worker {
     rpc dispatch (stream Request) returns (stream Response);
     rpc stop (StopRequest) returns (Void);
-    rpc idle (Void) returns (IdleTime);
+    rpc idle (Void) returns (Idle);
 }
 
 message Request {
@@ -136,7 +136,7 @@ message StopRequest {
     float timeout = 1;
 }
 
-message IdleTime {
+message Idle {
     // Seconds the worker has been continuously idle: time since the
     // in-flight task set last emptied (startup counts as empty).
     // 0 while any task is in flight; measured on a monotonic clock.

--- a/wool/src/wool/protocol/__init__.py
+++ b/wool/src/wool/protocol/__init__.py
@@ -13,7 +13,7 @@ from wool.protocol._wire import (
 from wool.protocol._wire import ChainManifest as ChainManifest
 from wool.protocol._wire import ChannelOptions as ChannelOptions
 from wool.protocol._wire import ContextVar as ContextVar
-from wool.protocol._wire import IdleTime as IdleTime
+from wool.protocol._wire import Idle as Idle
 from wool.protocol._wire import Message as Message
 from wool.protocol._wire import Nack as Nack
 from wool.protocol._wire import Request as Request
@@ -36,7 +36,7 @@ __all__ = [
     "ChainManifest",
     "ChannelOptions",
     "ContextVar",
-    "IdleTime",
+    "Idle",
     "Message",
     "Nack",
     "Request",

--- a/wool/src/wool/protocol/_wire.py
+++ b/wool/src/wool/protocol/_wire.py
@@ -14,7 +14,7 @@ try:
     from wool.protocol.wire_pb2 import ChainManifest
     from wool.protocol.wire_pb2 import ChannelOptions
     from wool.protocol.wire_pb2 import ContextVar
-    from wool.protocol.wire_pb2 import IdleTime
+    from wool.protocol.wire_pb2 import Idle
     from wool.protocol.wire_pb2 import Message
     from wool.protocol.wire_pb2 import Nack
     from wool.protocol.wire_pb2 import Request
@@ -58,7 +58,7 @@ __all__ = [
     "ChainManifest",
     "ChannelOptions",
     "ContextVar",
-    "IdleTime",
+    "Idle",
     "Message",
     "Nack",
     "Request",

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -206,13 +206,12 @@ class IdleUnavailable(WoolError):
     """Raised when a worker does not implement the idle RPC.
 
     A worker that predates the idle capability answers the idle RPC
-    with gRPC ``UNIMPLEMENTED``; `WorkerConnection.idle_time`
-    translates that into this typed signal so a polling client can
-    detect an old worker and treat idle reporting as unavailable,
-    distinct from a transient hiccup or an unhealthy peer. It descends
-    from `wool.WoolError` — not `RpcError` — because an absent
-    capability is not an RPC-health fault, so ``except RpcError`` does
-    not catch it.
+    with gRPC ``UNIMPLEMENTED``; `WorkerConnection.idle` translates
+    that into this typed signal so a polling client can detect an old
+    worker and treat idle reporting as unavailable, distinct from a
+    transient hiccup or an unhealthy peer. It descends from
+    `wool.WoolError` — not `RpcError` — because an absent capability is
+    not an RPC-health fault, so ``except RpcError`` does not catch it.
     """
 
 
@@ -220,7 +219,7 @@ class IdleUnavailable(WoolError):
 class WorkerConnection:
     """Direct single-worker control surface over a pooled gRPC channel.
 
-    Exposes `dispatch` (task execution), `idle_time` (poll the worker's
+    Exposes `dispatch` (task execution), `idle` (poll the worker's
     continuous idle duration), and `stop` (shut the remote worker
     down). ``close`` is distinct: it releases this connection's local
     pooled channel, whereas `stop` terminates the remote worker.
@@ -487,7 +486,7 @@ class WorkerConnection:
         if self._uds_key is not None:
             await _channel_pool.expire(self._uds_key)
 
-    async def idle_time(self, *, timeout: float | None = None) -> float:
+    async def idle(self, *, timeout: float | None = None) -> float:
         """Query how long the remote worker has been continuously idle.
 
         Returns the worker's reported continuous idle duration; see

--- a/wool/src/wool/runtime/worker/service.py
+++ b/wool/src/wool/runtime/worker/service.py
@@ -582,7 +582,7 @@ class WorkerService(protocol.WorkerServicer):
         self,
         request: protocol.Void,
         context: ServicerContext | None,
-    ) -> protocol.IdleTime:
+    ) -> protocol.Idle:
         """Report how long the worker has been continuously idle.
 
         Idle is the number of seconds since the in-flight task set
@@ -600,13 +600,13 @@ class WorkerService(protocol.WorkerServicer):
         :param context:
             The `grpc.aio.ServicerContext` for this request.
         :returns:
-            An `IdleTime` carrying the continuous idle duration in
+            An `Idle` carrying the continuous idle duration in
             seconds.
         """
         seconds = (
             0.0 if self._idle_since is None else time.monotonic() - self._idle_since
         )
-        return protocol.IdleTime(seconds=seconds)
+        return protocol.Idle(seconds=seconds)
 
     @staticmethod
     def _create_worker_loop(

--- a/wool/tests/integration/test_worker_idle.py
+++ b/wool/tests/integration/test_worker_idle.py
@@ -109,7 +109,7 @@ class TestWorkerIdleReporting:
         "cred",
         [CredentialType.INSECURE, CredentialType.MTLS, CredentialType.ONE_WAY],
     )
-    async def test_idle_time_should_accrue_from_startup_over_the_real_wire(
+    async def test_idle_should_accrue_from_startup_over_the_real_wire(
         self, credentials_map, retry_grpc_internal, cred
     ):
         """Test idle accrues from startup, over each transport.
@@ -133,9 +133,9 @@ class TestWorkerIdleReporting:
                 conn = connect()
 
                 # Act
-                first = await conn.idle_time()
+                first = await conn.idle()
                 await asyncio.sleep(0.1)
-                second = await conn.idle_time()
+                second = await conn.idle()
 
                 # Assert
                 assert first >= 0.0
@@ -145,7 +145,7 @@ class TestWorkerIdleReporting:
         await retry_grpc_internal(body)
 
     @pytest.mark.asyncio
-    async def test_idle_time_should_report_zero_while_a_task_is_in_flight(
+    async def test_idle_should_report_zero_while_a_task_is_in_flight(
         self, credentials_map, retry_grpc_internal, tmp_path
     ):
         """Test idle is zero while a dispatched routine runs on the worker.
@@ -177,7 +177,7 @@ class TestWorkerIdleReporting:
                     )
 
                     # Act & assert
-                    assert await conn.idle_time() == 0.0
+                    assert await conn.idle() == 0.0
                 finally:
                     dispatch.cancel()
                     with contextlib.suppress(BaseException):
@@ -186,7 +186,7 @@ class TestWorkerIdleReporting:
         await retry_grpc_internal(body)
 
     @pytest.mark.asyncio
-    async def test_idle_time_should_reset_after_the_in_flight_set_drains(
+    async def test_idle_should_reset_after_the_in_flight_set_drains(
         self, credentials_map, retry_grpc_internal, tmp_path
     ):
         """Test idle resets once the worker's in-flight set drains.
@@ -210,7 +210,7 @@ class TestWorkerIdleReporting:
             ):
                 conn = connect()
                 await asyncio.sleep(0.2)
-                before = await conn.idle_time()
+                before = await conn.idle()
 
                 # Act
                 sentinel = tmp_path / "drain.txt"
@@ -219,10 +219,10 @@ class TestWorkerIdleReporting:
                 # Wait for the docket-drain to be reflected (idle > 0),
                 # then confirm it counts from the drain, not from startup.
                 async def _reset():
-                    return await conn.idle_time() > 0.0
+                    return await conn.idle() > 0.0
 
                 await _poll_coro(_reset)
-                after = await conn.idle_time()
+                after = await conn.idle()
 
                 # Assert
                 assert before > 0.0
@@ -231,7 +231,7 @@ class TestWorkerIdleReporting:
         await retry_grpc_internal(body)
 
     @pytest.mark.asyncio
-    async def test_idle_time_should_raise_idle_unavailable_for_a_legacy_worker(
+    async def test_idle_should_raise_idle_unavailable_for_a_legacy_worker(
         self, retry_grpc_internal
     ):
         """Test idle surfaces IdleUnavailable against a legacy worker.
@@ -257,7 +257,7 @@ class TestWorkerIdleReporting:
             try:
                 # Act & assert
                 with pytest.raises(IdleUnavailable) as exc_info:
-                    await conn.idle_time()
+                    await conn.idle()
                 assert not isinstance(exc_info.value, RpcError)
             finally:
                 await conn.close()
@@ -287,7 +287,7 @@ class TestWorkerControlSurface:
             # Arrange
             async with _bare_worker(credentials_map[cred]) as (worker, connect):
                 conn = connect()
-                assert await conn.idle_time() >= 0.0
+                assert await conn.idle() >= 0.0
 
                 # Act
                 await conn.stop()
@@ -295,7 +295,7 @@ class TestWorkerControlSurface:
                 # Assert
                 async def _unreachable():
                     try:
-                        await conn.idle_time()
+                        await conn.idle()
                         return False
                     except TransientRpcError:
                         return True

--- a/wool/tests/protocol/test_wire.py
+++ b/wool/tests/protocol/test_wire.py
@@ -8,7 +8,7 @@ from wool import protocol
 EXPECTED_MESSAGE_EXPORTS = [
     "Ack",
     "ChainManifest",
-    "IdleTime",
+    "Idle",
     "Message",
     "Nack",
     "Request",
@@ -273,38 +273,38 @@ class TestMessageConstruction:
         parsed.ParseFromString(nack.SerializeToString())
         assert parsed.HasField("exception") is False
 
-    def test_idle_time_fields(self):
-        """Test IdleTime carries the idle duration in seconds.
+    def test_idle_fields(self):
+        """Test Idle carries the idle duration in seconds.
 
         Given:
             A seconds value, and the default construction.
         When:
-            An IdleTime message is constructed with and without a value.
+            An Idle message is constructed with and without a value.
         Then:
             The seconds field should hold the value and default to 0.0.
         """
         # Arrange, act, & assert
-        assert protocol.IdleTime(seconds=42.5).seconds == 42.5
-        assert protocol.IdleTime().seconds == 0.0
+        assert protocol.Idle(seconds=42.5).seconds == 42.5
+        assert protocol.Idle().seconds == 0.0
 
     @settings(max_examples=100)
     @given(seconds=st.floats(width=64, allow_nan=False, allow_infinity=False))
-    def test_idle_time_roundtrip(self, seconds):
-        """Test IdleTime.seconds survives the wire-format round-trip.
+    def test_idle_roundtrip(self, seconds):
+        """Test Idle.seconds survives the wire-format round-trip.
 
         Given:
             Any finite double value for the idle duration.
         When:
-            An IdleTime message is serialized and re-parsed.
+            An Idle message is serialized and re-parsed.
         Then:
             The seconds field should equal the original exactly — a
             proto double round-trips losslessly.
         """
         # Arrange
-        message = protocol.IdleTime(seconds=seconds)
+        message = protocol.Idle(seconds=seconds)
 
         # Act
-        parsed = protocol.IdleTime()
+        parsed = protocol.Idle()
         parsed.ParseFromString(message.SerializeToString())
 
         # Assert

--- a/wool/tests/runtime/worker/test_connection.py
+++ b/wool/tests/runtime/worker/test_connection.py
@@ -1473,14 +1473,13 @@ class TestWorkerConnection:
         await connection.close()
 
     @pytest.mark.asyncio
-    async def test_idle_time_should_return_seconds_when_worker_responds(
+    async def test_idle_should_return_seconds_when_worker_responds(
         self, mocker: MockerFixture
     ):
         """Test idle returns the worker's reported idle seconds.
 
         Given:
-            A connection whose worker answers the idle RPC with an
-            IdleTime
+            A connection whose worker answers the idle RPC with an Idle
         When:
             idle is awaited
         Then:
@@ -1488,19 +1487,19 @@ class TestWorkerConnection:
         """
         # Arrange
         mock_stub = mocker.MagicMock()
-        mock_stub.idle = mocker.AsyncMock(return_value=protocol.IdleTime(seconds=42.5))
+        mock_stub.idle = mocker.AsyncMock(return_value=protocol.Idle(seconds=42.5))
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
         connection = WorkerConnection("localhost:50051")
 
         # Act
-        result = await connection.idle_time()
+        result = await connection.idle()
 
         # Assert
         assert result == 42.5
         mock_stub.idle.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_idle_time_should_raise_idle_unavailable_when_unimplemented(
+    async def test_idle_should_raise_idle_unavailable_when_unimplemented(
         self, mocker: MockerFixture
     ):
         """Test idle surfaces IdleUnavailable for a worker without the RPC.
@@ -1530,7 +1529,7 @@ class TestWorkerConnection:
 
         # Act & assert
         with pytest.raises(IdleUnavailable):
-            await connection.idle_time()
+            await connection.idle()
 
     @pytest.mark.asyncio
     @settings(
@@ -1544,7 +1543,7 @@ class TestWorkerConnection:
         ),
         details=st.one_of(st.none(), st.just(""), st.text()),
     )
-    async def test_idle_time_should_map_status_code_to_typed_exception(
+    async def test_idle_should_map_status_code_to_typed_exception(
         self, mocker: MockerFixture, code: grpc.StatusCode, details: str | None
     ):
         """Test idle maps every gRPC status code to the right exception.
@@ -1574,7 +1573,7 @@ class TestWorkerConnection:
 
         # Act
         with pytest.raises(Exception) as exc_info:
-            await connection.idle_time()
+            await connection.idle()
 
         # Assert
         raised = exc_info.value
@@ -1598,23 +1597,23 @@ class TestWorkerConnection:
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
     @given(timeout=st.floats(max_value=0.0, allow_nan=False, allow_infinity=False))
-    async def test_idle_time_should_reject_non_positive_timeout(
+    async def test_idle_should_reject_non_positive_timeout(
         self, mocker: MockerFixture, timeout: float
     ):
-        """Test idle_time rejects a non-positive timeout with ValueError.
+        """Test idle rejects a non-positive timeout with ValueError.
 
         Given:
             A connection whose worker answers the idle RPC, and any
             non-positive timeout
         When:
-            idle_time is awaited with that timeout
+            idle is awaited with that timeout
         Then:
             It should raise ValueError without calling the stub, matching
             dispatch's timeout validation.
         """
         # Arrange
         mock_stub = mocker.MagicMock()
-        mock_stub.idle = mocker.AsyncMock(return_value=protocol.IdleTime(seconds=1.0))
+        mock_stub.idle = mocker.AsyncMock(return_value=protocol.Idle(seconds=1.0))
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
         connection = WorkerConnection("localhost:50051")
         # Fresh channel per example (see idle-map note above).
@@ -1622,7 +1621,7 @@ class TestWorkerConnection:
 
         # Act & assert
         with pytest.raises(ValueError):
-            await connection.idle_time(timeout=timeout)
+            await connection.idle(timeout=timeout)
         mock_stub.idle.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -1642,30 +1641,30 @@ class TestWorkerConnection:
             ),
         )
     )
-    async def test_idle_time_should_forward_positive_timeout(
+    async def test_idle_should_forward_positive_timeout(
         self, mocker: MockerFixture, timeout: float | None
     ):
-        """Test idle_time forwards None or a positive timeout to the stub.
+        """Test idle forwards None or a positive timeout to the stub.
 
         Given:
             A connection whose worker answers the idle RPC, and None or
             any positive timeout
         When:
-            idle_time is awaited with that timeout
+            idle is awaited with that timeout
         Then:
             It should call the stub with a Void request and that timeout
             as the gRPC deadline.
         """
         # Arrange
         mock_stub = mocker.MagicMock()
-        mock_stub.idle = mocker.AsyncMock(return_value=protocol.IdleTime(seconds=1.0))
+        mock_stub.idle = mocker.AsyncMock(return_value=protocol.Idle(seconds=1.0))
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
         connection = WorkerConnection("localhost:50051")
         # Fresh channel per example (see idle-map note above).
         await clear_channel_pool()
 
         # Act
-        result = await connection.idle_time(timeout=timeout)
+        result = await connection.idle(timeout=timeout)
 
         # Assert
         assert result == 1.0
@@ -1681,7 +1680,7 @@ class TestWorkerConnection:
         suppress_health_check=[HealthCheck.function_scoped_fixture],
     )
     @given(seconds=st.floats(width=64, allow_nan=False, allow_infinity=False))
-    async def test_idle_time_should_return_reported_seconds_verbatim(
+    async def test_idle_should_return_reported_seconds_verbatim(
         self, mocker: MockerFixture, seconds: float
     ):
         """Test idle returns the worker's reported seconds losslessly.
@@ -1696,16 +1695,14 @@ class TestWorkerConnection:
         """
         # Arrange
         mock_stub = mocker.MagicMock()
-        mock_stub.idle = mocker.AsyncMock(
-            return_value=protocol.IdleTime(seconds=seconds)
-        )
+        mock_stub.idle = mocker.AsyncMock(return_value=protocol.Idle(seconds=seconds))
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
         connection = WorkerConnection("localhost:50051")
         # Fresh channel per example (see idle-map note above).
         await clear_channel_pool()
 
         # Act
-        result = await connection.idle_time()
+        result = await connection.idle()
 
         # Assert
         assert result == seconds


### PR DESCRIPTION
## Summary

Unify the worker idle-reporting surface introduced by #253 on the single name `idle`. The surface spelled one concept three ways: the wire RPC and the service handler said `idle`, the caller-facing method said `idle_time`, and the message said `IdleTime`. `WorkerConnection.idle` now mirrors the RPC it wraps, and the unit stays explicit where it matters — the message's `seconds` field and the method docstring. `IdleUnavailable` keeps its name.

The RPC name itself is untouched, so the gRPC method path is identical and `seconds` keeps tag 1. The surface has only shipped in `v0.14.0-rc0`, so renaming the Python API before `v0.14.0` avoids a deprecation cycle.

Behavior is unchanged — this is a pure rename, so it adds no tests. The 17 existing tests that exercise the idle surface all still apply and none became stale; twelve were renamed to track the method name, and the five in `test_service.py` needed no edit at all because they drive the handler through `stub.idle(protocol.Void())` and never name the renamed message.

Closes #368

## Proposed changes

### Rename the wire message

Rename `message IdleTime` to `message Idle` in `wool/proto/wire.proto`, so the service reads `rpc idle (Void) returns (Idle)`. The `seconds` field, its tag, and its comment are unchanged — the message name carries the concept and the field carries the unit. Generated stubs are gitignored and rebuilt by the `hatch-protobuf` build hook, so no generated artifact is committed.

### Rename the protocol re-export

Re-export the message as `wool.protocol.Idle` from `_wire.py` and `protocol/__init__.py`, in both the import block and each `__all__`. Both keep their alphabetical slot, so the diff is one line per list.

### Rename the connection method

Rename `WorkerConnection.idle_time` to `WorkerConnection.idle`. The body is untouched: the timeout validation, the channel acquisition, and the mapping of `UNIMPLEMENTED` to `IdleUnavailable` and of transient codes to `TransientRpcError` all behave exactly as before. Update the docstring references in the `IdleUnavailable` and `WorkerConnection` class docstrings, and reflow the two paragraphs the shorter name left ragged.

### Update the service handler

Point `WorkerService.idle` at the renamed message — the return annotation, the constructed response, and the `:returns:` docstring line. The handler name, its idle accounting, and its monotonic-clock measurement are unchanged.

### Track the rename through the tests

Update the three test files that named the old symbols: the export list and two message tests in `test_wire.py`, six method tests in `test_connection.py`, and the call sites and names in the integration suite. Test names follow the method's `__name__`, so `test_idle_time_should_*` becomes `test_idle_should_*`.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestExports` | The expected message export list naming `Idle` | Each name is looked up on `wool.protocol` | The attribute should resolve and appear in `__all__` | Renamed export surface |
| 2 | `TestMessageConstruction` | A seconds value, and the default construction | An `Idle` message is constructed with and without a value | The seconds field should hold the value and default to `0.0` | Renamed message fields |
| 3 | `TestMessageConstruction` | Any finite double for the idle duration | An `Idle` message is serialized and re-parsed | The seconds field should equal the original exactly | Wire-format round-trip |
| 4 | `TestWorkerConnection` | A connection whose worker answers the idle RPC with an `Idle` | `idle` is awaited | It should return the reported seconds as a float | Renamed method, happy path |
| 5 | `TestWorkerConnection` | A worker answering the idle RPC with gRPC `UNIMPLEMENTED` | `idle` is awaited | It should raise `IdleUnavailable` | Absent-capability signal |
| 6 | `TestWorkerConnection` | Any gRPC error status code and any details | `idle` is awaited | It should raise `IdleUnavailable`, `TransientRpcError`, or `RpcError` per the code, carrying details | Status-code mapping |
| 7 | `TestWorkerConnection` | Any non-positive timeout | `idle` is awaited with that timeout | It should raise `ValueError` without calling the stub | Timeout validation |
| 8 | `TestWorkerConnection` | `None` or any positive timeout | `idle` is awaited with that timeout | It should call the stub with a `Void` request and that deadline | Timeout forwarding |
| 9 | `TestWorkerConnection` | A worker answering with any double value | `idle` is awaited | It should return exactly that value | Lossless seconds |
| 10 | `TestWorkerIdleReporting` | A real worker over each transport, freshly started | `idle` is polled twice with a wait between | It should report a positive, non-decreasing duration | Renamed method over the real wire |
| 11 | `TestWorkerIdleReporting` | A real worker executing a dispatched routine | `idle` is polled | It should report zero while the task is in flight | In-flight reporting |
| 12 | `TestWorkerIdleReporting` | A real worker whose in-flight set drains | `idle` is polled before and after the drain | It should count from the drain, not from startup | Drain reset |
| 13 | `TestWorkerIdleReporting` | A real server whose servicer does not implement idle | `idle` is polled against it | It should raise `IdleUnavailable` and not an `RpcError` | Legacy-worker path |
| 14 | `TestWorkerControlSurface` | A real worker polled for idle then stopped | `idle` is polled again after the stop | It should become unreachable with a `TransientRpcError` | Poll-then-retire flow |
