### PR TITLE
Fix release signing broken by the sigstore action's unpinned dependencies — Closes #383

### DIFF
--- a/.github/actions/publish-github-release/action.yaml
+++ b/.github/actions/publish-github-release/action.yaml
@@ -19,7 +19,7 @@ runs:
         path: ${{ inputs.source }}-dist-${{ inputs.version }}/
 
     - name: Sign the artifacts with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      uses: sigstore/gh-action-sigstore-python@790bc6befb9d733738f18d8f895854b453640ec9 # v3.5.0
       with:
         inputs: ./${{ inputs.source }}-dist-${{ inputs.version }}/*.tar.gz ./${{ inputs.source }}-dist-${{ inputs.version }}/*.whl
  


### PR DESCRIPTION
## Summary

Pin `sigstore/gh-action-sigstore-python` by commit SHA to v3.5.0 in the publish-github-release composite action. The v3.0.0 pin declares only `sigstore ~= 3.0` and resolves transitive dependencies fresh on every run, which let an upstream PyPI upload break release signing overnight with no change on our side: securesystemslib 1.5.0 requires cryptography >= 48 through an extras declaration the tuf → sigstore dependency chain never selects ([sigstore/sigstore-python#1887](https://github.com/sigstore/sigstore-python/issues/1887)), so the resolver paired it with an older cryptography, TUF root verification silently degraded, and the [v0.15.0-rc0 signing job](https://github.com/wool-labs/wool/actions/runs/33554371606/job/100011699569) failed with `root was signed by 0/3 keys` after the GitHub release and PyPI upload had already landed. v3.5.0 hash-pins its entire environment — `sigstore==4.5.0`, `cryptography==49.0.0`, `securesystemslib==1.4.0` — so no future upload can perturb the signing step.

Closes #383

## Proposed changes

### Pin the sigstore action to an immutable, hash-locked release

Replace `sigstore/gh-action-sigstore-python@v3.0.0` with `@790bc6befb9d733738f18d8f895854b453640ec9 # v3.5.0` in `.github/actions/publish-github-release/action.yaml` — the only reference to the action in the repository. Pinning by commit SHA rather than tag matches the existing `actions/checkout@<sha> # v4.4.0` convention in the release workflows and removes the last mutable reference in the signing path: the action's own environment is hash-locked, and the action itself now is too. The v3.5.0 `inputs` parameter is unchanged and the new `rekor-version` input defaults to 1, so signing behavior is otherwise identical.

## Test cases

No test coverage applies — composite actions have no local test harness. End-to-end proof is the next release run's Publish release to GitHub job signing against the locked environment.