### PR TITLE
Close the dispatch stream when a coroutine routine takes its result — Closes #390

### DIFF
--- a/wool/src/wool/runtime/routine/wrapper.py
+++ b/wool/src/wool/runtime/routine/wrapper.py
@@ -347,4 +347,11 @@ async def _execute(fn, *args, **kwargs):
 
 
 async def _stream_to_coroutine(stream):
-    return await anext(stream, None)
+    # A coroutine routine yields one result frame. Close the stream once it
+    # is taken so the dispatch releases its pooled channel before the call
+    # returns, rather than whenever garbage collection finalizes the
+    # generator.
+    try:
+        return await anext(stream, None)
+    finally:
+        await stream.aclose()

--- a/wool/src/wool/runtime/routine/wrapper.py
+++ b/wool/src/wool/runtime/routine/wrapper.py
@@ -82,6 +82,15 @@ def routine(fn: C) -> C:
       Calling ``aclose()`` or breaking out of iteration properly cancels
       the remote worker task
 
+    **Dispatch cleanup:**
+
+    A completed dispatch releases its transport resources before control
+    returns to the caller — for a coroutine routine when the ``await``
+    returns, for an async generator on exhaustion or ``aclose()``.
+    Release is never deferred to garbage collection, so a routine
+    awaited on a loop that stops immediately afterwards strands nothing
+    on that loop.
+
     Best practices and considerations for designing tasks:
 
     1. **Picklability**: Arguments, return values, and yielded values
@@ -347,10 +356,18 @@ async def _execute(fn, *args, **kwargs):
 
 
 async def _stream_to_coroutine(stream):
-    # A coroutine routine yields one result frame. Close the stream once it
-    # is taken so the dispatch releases its pooled channel before the call
-    # returns, rather than whenever garbage collection finalizes the
-    # generator.
+    """Take a coroutine routine's single result frame and close the stream.
+
+    .. rubric:: Implementation notes
+
+    A coroutine dispatch yields exactly one result frame, leaving the
+    dispatch generator suspended at its yield. Closing it in a
+    ``finally`` — on every exit path, not only when a frame is taken —
+    drives the teardown `WorkerConnection._execute` pins on its exit
+    stack, binding release to this call returning rather than to the
+    event loop's async-generator finalizer, which a loop that stops
+    first never runs.
+    """
     try:
         return await anext(stream, None)
     finally:

--- a/wool/tests/runtime/routine/test_wrapper.py
+++ b/wool/tests/runtime/routine/test_wrapper.py
@@ -383,6 +383,42 @@ async def test_routine_with_various_function_types(
             assert result == expected
 
 
+@pytest.mark.asyncio
+async def test_routine_should_close_dispatch_stream_when_coroutine_result_taken(
+    mocker: MockerFixture, mock_proxy_context
+):
+    """Test a coroutine routine closes its dispatch stream once the result is taken.
+
+    Given:
+        A proxy in context whose dispatch returns a result stream that
+        records when it is closed.
+    When:
+        A coroutine routine is awaited under dispatch.
+    Then:
+        It should return the first result and have closed the stream
+        before returning.
+    """
+    # Arrange
+    closed = False
+
+    async def dispatch_stream():
+        nonlocal closed
+        try:
+            yield 8
+            yield 9  # pragma: no cover — never reached
+        finally:
+            closed = True
+
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=dispatch_stream())
+
+    # Act
+    result = await foo(5, 3)
+
+    # Assert
+    assert result == 8
+    assert closed is True
+
+
 @settings(
     max_examples=20,
     deadline=None,

--- a/wool/tests/runtime/routine/test_wrapper.py
+++ b/wool/tests/runtime/routine/test_wrapper.py
@@ -395,27 +395,29 @@ async def test_routine_should_close_dispatch_stream_when_coroutine_result_taken(
     When:
         A coroutine routine is awaited under dispatch.
     Then:
-        It should return the first result and have closed the stream
-        before returning.
+        It should have closed the stream before returning the result.
     """
     # Arrange
     closed = False
 
-    async def dispatch_stream():
+    async def mock_dispatch_stream():
         nonlocal closed
         try:
-            yield 8
-            yield 9  # pragma: no cover — never reached
+            yield 42
+            yield 43  # pragma: no cover — never reached
         finally:
             closed = True
 
-    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=dispatch_stream())
+    # Construct the stream eagerly so the mock holds a reference to it.
+    # Built lazily, it could be finalized by the event loop's
+    # async-generator hook, masking a missing aclose().
+    mock_proxy_context.dispatch = mocker.AsyncMock(return_value=mock_dispatch_stream())
 
     # Act
     result = await foo(5, 3)
 
     # Assert
-    assert result == 8
+    assert result == 42
     assert closed is True
 
 


### PR DESCRIPTION
## Summary

Close the dispatch stream in the coroutine routine driver so a completed dispatch releases its pooled gRPC channel before the routine call returns.

`_stream_to_coroutine` took the single result frame with `anext` and left the dispatch async generator suspended at its yield. That generator's teardown is what unwinds the dispatch `AsyncExitStack` in `WorkerConnection._execute`, releasing the pooled channel reference, releasing the concurrency permit, and cancelling the in-flight gRPC call. With the generator never closed, teardown ran only once garbage collection finalized it and the loop's async-generator finalizer scheduled `aclose()` — one loop iteration later at best, and never on a loop that stopped first, which discards that callback and strands the channel as referenced.

Wrapping the `anext` in `try`/`finally: await stream.aclose()` brings the coroutine driver into parity with the sibling async-generator driver, which already closed its stream the same way.

Closes #390

## Proposed changes

### Close the dispatch stream once the coroutine result is taken

`wool/src/wool/runtime/routine/wrapper.py` — `_stream_to_coroutine` now closes the stream in a `finally`, so release is bound to the call returning rather than to garbage collection.

The fix is deliberately confined to the driver rather than the connection layer. `_execute` already owns every resource on a single exit stack and already releases each exactly once on any unwind — it was correct. The defect was that nothing drove the unwind on the coroutine path, and the async-generator path next door already demonstrated the right shape.

Only one path through the function changes behavior: the stream yielded a value and is left suspended at the yield. When the stream is empty or raises, the generator has already terminated and run its own teardown, so `aclose()` is a documented no-op there.

### Document when a completed dispatch releases its resources

Release timing is caller-observable — the bug's own reproduction surfaces as a `RuntimeWarning` under a plain `asyncio.run(main())` — so the `routine` docstring now states the guarantee for both driver shapes, beside the cleanup guarantee it already published for the generator path. The mechanism moved out of a body comment into a docstring on `_stream_to_coroutine`, which points at the teardown `WorkerConnection._execute` owns rather than restating it. The replaced comment was also inaccurate: it described a conditional close when the `finally` closes on every exit path, and credited garbage collection when deferral is actually the event loop's async-generator finalizer.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `test_wrapper` | A proxy in context whose dispatch returns a result stream that records when it is closed | A coroutine routine is awaited under dispatch | Has closed the stream before returning the result | `_stream_to_coroutine` teardown — the regression guard for this fix |
