### PR TITLE
Prevent SIGPIPE kills of tool subprocesses launched from workers — Closes #387

### DIFF
--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -245,6 +245,21 @@ Proxies on worker subprocesses are lazy by default — the `WorkerPool` propagat
 
 `wool.__proxy__` — the active proxy a nested `@wool.routine` reads to dispatch — is a plain `contextvars.ContextVar`, so it is invisible to the [chain-contention guard](../context/README.md#the-chain-contention-guard). To stop two tasks that share one `contextvars.Context` from silently clobbering each other's proxy (last-write-wins, so both dispatch through the wrong proxy), `WorkerProxy.__aenter__` arms a guarded marker (`WorkerProxy._armed`, a `wool.ContextVar`) before binding the proxy, so a contended second entry fails loud instead of corrupting the first task's dispatch — see `WorkerProxy.__aenter__` for the precise contract. A consequence is that entering a proxy with `async with` arms the chain, even when the routine sets no `wool.ContextVar` of its own. Only the `async with` path arms: the worker pool binds `wool.__proxy__` through `enter()` directly, which deliberately leaves the chain unarmed.
 
+### Subprocesses
+
+Routines are free to launch subprocesses, but the launch path CPython takes decides whether the worker's gRPC threads are involved.
+
+Wool spawns every worker with `GRPC_ENABLE_FORK_SUPPORT=0`; an embedder who sets the variable themselves keeps their value, since Wool only supplies the default. See `WorkerProcess` for why gRPC's atfork handlers are wrong for a spawned worker, and `~wool.runtime.worker.process._default_grpc_fork_support` for what the process hosting the pool sees while a spawn is in flight. The symptom the default suppresses is gRPC's postfork output surfacing inside a live subprocess's captured stderr (`ev_poll_posix.cc: FD from fork parent still in poll list`), observed on macOS.
+
+The launch path is the embedder's to choose, and it is worth knowing that on macOS there is effectively no choice. CPython takes the `posix_spawn` fast path only under the narrow set of conditions in `subprocess.Popen._execute_child`; among them, the executable must carry a directory component, `start_new_session` must be false, and `close_fds` must be false unless the platform has `os.POSIX_SPAWN_CLOSEFROM`. `close_fds` defaults to true and `asyncio` does not override it, and macOS has no `POSIX_SPAWN_CLOSEFROM`, so in practice every `asyncio.create_subprocess_exec` there goes through `_posixsubprocess.fork_exec` — a real `fork()` from a worker thread while the gRPC server's threads are live. A bare command name resolved through `PATH`, or `start_new_session=True`, disqualifies the fast path on every platform:
+
+```python
+# Always the forking path: new session, and a bare name resolved through PATH
+await asyncio.create_subprocess_exec("tabix", *args, start_new_session=True)
+```
+
+Because the fast path is out of reach on macOS, treat the forking path as the one a routine will take and rely on the fork-support default rather than trying to route around it. Where the fast path *is* reachable (Linux with glibc ≥ 2.34, given a directory-qualified executable, no new session, and `close_fds=False`), it runs no atfork handlers at all, at the cost of process-group semantics: `start_new_session=True` puts the child in its own process group, which is what makes group-wide signalling possible (e.g., cancelling a whole shell pipeline with one `killpg`), and the fast path leaves the child in the worker's group and gives that up.
+
 ## Connections
 
 `WorkerProxy` is the client-side bridge between routines and workers. It manages discovery, connection pooling, and load-balanced dispatch.

--- a/wool/src/wool/runtime/worker/process.py
+++ b/wool/src/wool/runtime/worker/process.py
@@ -66,6 +66,18 @@ _REAP_GRACE: Final[float] = 5.0
 # ceiling exceeds the advertised client concurrency gate.
 _SERVER_STREAM_CEILING_MULTIPLIER: Final[int] = 2
 
+#: Environment variable gating gRPC's POSIX fork handlers.
+_GRPC_FORK_SUPPORT_ENV: Final[str] = "GRPC_ENABLE_FORK_SUPPORT"
+
+# Guards the two counters below. Held only across their updates, never
+# across a spawn, so workers still fork in parallel.
+_spawn_lock: Final = threading.Lock()
+
+# How many spawns currently hold the fork-support default in place, and
+# whether wool is the one that installed it.
+_fork_support_holds: int = 0
+_fork_support_owned: bool = False
+
 
 class WorkerProcess(Process):
     """Subprocess hosting a gRPC worker server.
@@ -82,6 +94,12 @@ class WorkerProcess(Process):
     `concurrent.futures.ProcessPoolExecutor`), so a routine that must
     create them requires a non-daemonic worker; `subprocess` and
     `asyncio` subprocesses are unaffected.
+
+    Spawned with ``GRPC_ENABLE_FORK_SUPPORT=0`` unless the environment
+    already carries a value, which is left untouched — the supported way
+    to override the default. See `_default_grpc_fork_support` for what
+    the calling process's own environment sees while a spawn is in
+    flight.
 
     :param host:
         Host address to bind.
@@ -133,6 +151,22 @@ class WorkerProcess(Process):
     fire until the parent is already gone, so the join wedges
     interpreter exit. The watchdog covers the reverse case, where the
     parent dies first.
+
+    gRPC's atfork handlers exist so a process can survive a fork
+    *without* exec. A spawned worker never inherits gRPC across a fork,
+    so in the ordinary case its only forks are the immediately-exec'd
+    ones CPython performs to launch a subprocess, where the handlers can
+    only be useless or harmful — they have been observed reporting stale
+    descriptors against fd numbers asyncio has since reused for a live
+    subprocess's pipes. Hence the fork-support default. A non-daemonic
+    worker that forks `multiprocessing` children with the ``fork`` start
+    method is the exception: that is a fork without exec, and with the
+    handlers off gRPC makes no guarantee about the child.
+
+    The default has to ride the spawn from the parent's environment.
+    gRPC reads the variable once, as it initializes at import, and the
+    child imports this module — and through it `grpc.aio` — while
+    unpickling the process object, so `run` is already too late.
     """
 
     _port: int | None
@@ -232,9 +266,8 @@ class WorkerProcess(Process):
         """Start the worker process.
 
         Launches the worker process and waits until it has reported
-        its :class:`WorkerMetadata` back via pipe. After starting,
-        the :attr:`metadata` and :attr:`address` properties are
-        populated.
+        its `WorkerMetadata` back via pipe. After starting, the
+        `metadata` and `address` properties are populated.
 
         :param timeout:
             Maximum time in seconds to wait for worker process startup.
@@ -245,7 +278,8 @@ class WorkerProcess(Process):
         """
         if timeout is not None and timeout <= 0:
             raise ValueError("Timeout must be positive")
-        super().start()
+        with _default_grpc_fork_support():
+            super().start()
         if self._get_metadata.poll(timeout=timeout):
             self._metadata = WorkerMetadata.from_protobuf(
                 protocol.WorkerMetadata.FromString(self._get_metadata.recv())
@@ -562,6 +596,39 @@ class WorkerProcess(Process):
             Address string in "host:port" format.
         """
         return f"{host}:{port}"
+
+
+@contextmanager
+def _default_grpc_fork_support():
+    """Hold wool's gRPC fork-support default in place across a spawn.
+
+    An environment that already carries the variable is never written,
+    so an embedder who set it deliberately keeps their value. Otherwise
+    the variable is installed for as long as any hold is open and
+    removed when the last one closes, leaving the calling process's own
+    environment as it was found.
+
+    Holds nest and overlap: concurrent spawns each take one, the
+    variable is present from the first entry until the last exit, and no
+    exit can strip it from a spawn still in flight. The window is
+    process-global while it is open, so an unrelated subprocess launched
+    from another thread inherits the setting, and a host that first
+    imports gRPC during it latches the default too.
+    """
+    global _fork_support_holds, _fork_support_owned
+    with _spawn_lock:
+        if not _fork_support_holds and _GRPC_FORK_SUPPORT_ENV not in os.environ:
+            os.environ[_GRPC_FORK_SUPPORT_ENV] = "0"
+            _fork_support_owned = True
+        _fork_support_holds += 1
+    try:
+        yield
+    finally:
+        with _spawn_lock:
+            _fork_support_holds -= 1
+            if not _fork_support_holds and _fork_support_owned:
+                os.environ.pop(_GRPC_FORK_SUPPORT_ENV, None)
+                _fork_support_owned = False
 
 
 def _parent_watchdog(

--- a/wool/tests/integration/routines.py
+++ b/wool/tests/integration/routines.py
@@ -1672,3 +1672,37 @@ async def read_adopted_worker_ca() -> bytes:
     assert provider is not None
     material = await asyncio.to_thread(force_adoption, provider)
     return material.ca_cert
+
+
+@wool.routine
+async def read_grpc_fork_support() -> str | None:
+    """Report the gRPC fork-support setting the worker was spawned with.
+
+    Reads the child's own environment, so the value witnessed is the one
+    the spawn delivered.
+    """
+    return os.environ.get("GRPC_ENABLE_FORK_SUPPORT")
+
+
+@wool.routine
+async def probe_subprocess_stderr() -> list[tuple[int | None, str]]:
+    """Launch subprocesses on the fork path, reporting each rc and stderr.
+
+    The bare command name and ``start_new_session=True`` are what force
+    the forking launch path — see the worker README's Subprocesses
+    section. Three launches, because the atfork output depends on which
+    descriptors the fork happens to collide with.
+    """
+    results = []
+    for _ in range(3):
+        process = await asyncio.create_subprocess_exec(
+            "sh",
+            "-c",
+            "exit 0",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        _, stderr = await process.communicate()
+        results.append((process.returncode, stderr.decode()))
+    return results

--- a/wool/tests/integration/test_worker_fork_support.py
+++ b/wool/tests/integration/test_worker_fork_support.py
@@ -1,0 +1,147 @@
+"""End-to-end tests for gRPC fork-handler suppression in workers (#387).
+
+Targeted standalone tests rather than pairwise scenarios: the claims are
+properties of the spawn boundary, invariant across every composition
+axis the scenario matrix varies. The unit suite pins what wool puts into
+the environment around the spawn; only a real worker can witness that it
+arrived, for the import-time reason recorded in `WorkerProcess`.
+
+The two environment tests are the portable guard and are what CI checks.
+The stderr pair below them is a macOS-only observable — the suppressed
+output comes from gRPC's poll poller, which Linux does not select — so
+its anti-vacuity control runs on developer machines only.
+
+What these tests deliberately do not pin is the SIGPIPE kill the issue
+reports. That failure is machine-state-dependent, so a test for it would
+be silent on a clean machine and flaky on a loaded one. The gRPC atfork
+output leaking into a live subprocess's stderr pipe is deterministic,
+and is what is pinned here.
+"""
+
+import sys
+
+import pytest
+
+import wool
+
+from .routines import probe_subprocess_stderr
+from .routines import read_grpc_fork_support
+
+pytestmark = pytest.mark.integration
+
+# The suppressed line gRPC's postfork handler writes into whichever
+# descriptor it finds; matching it keeps the control test sensitive to
+# gRPC falling silent rather than to any stderr noise at all.
+_ATFORK_OUTPUT = "FD from fork parent still in poll list"
+
+
+class TestWorkerForkSupport:
+    @pytest.mark.asyncio
+    async def test_start_should_disable_grpc_fork_support_in_the_worker_process(
+        self, monkeypatch
+    ):
+        """Test a spawned worker runs with gRPC fork support disabled.
+
+        Given:
+            An environment carrying no GRPC_ENABLE_FORK_SUPPORT setting
+        When:
+            A routine dispatched to a real spawned worker reads the
+            variable from the worker process's own environment
+        Then:
+            It should report "0"
+        """
+        # Arrange
+        monkeypatch.delenv("GRPC_ENABLE_FORK_SUPPORT", raising=False)
+
+        # Act
+        async with wool.WorkerPool(spawn=1):
+            setting = await read_grpc_fork_support()
+
+        # Assert
+        assert setting == "0"
+
+    @pytest.mark.asyncio
+    async def test_start_should_hand_the_worker_the_embedder_s_setting(
+        self, monkeypatch
+    ):
+        """Test an embedder's setting rides the spawn into the worker.
+
+        Given:
+            An environment in which the embedder set
+            GRPC_ENABLE_FORK_SUPPORT
+        When:
+            A routine dispatched to a real spawned worker reads the
+            variable from the worker process's own environment
+        Then:
+            It should report that value rather than wool's default
+        """
+        # Arrange
+        monkeypatch.setenv("GRPC_ENABLE_FORK_SUPPORT", "1")
+
+        # Act
+        async with wool.WorkerPool(spawn=1):
+            setting = await read_grpc_fork_support()
+
+        # Assert
+        assert setting == "1"
+
+    @pytest.mark.asyncio
+    async def test_start_should_keep_subprocess_stderr_free_of_grpc_output(
+        self, monkeypatch
+    ):
+        """Test subprocesses launched from a routine own their stderr.
+
+        Given:
+            A default worker pool, so the worker runs with gRPC's fork
+            handlers disabled, and gRPC logging left at info
+        When:
+            A routine launches subprocesses on the forking launch path
+            and captures each one's stderr
+        Then:
+            Every launch should exit 0 with nothing on stderr
+        """
+        # Arrange
+        monkeypatch.delenv("GRPC_ENABLE_FORK_SUPPORT", raising=False)
+        monkeypatch.setenv("GRPC_VERBOSITY", "info")
+
+        # Act
+        async with wool.WorkerPool(spawn=1):
+            results = await probe_subprocess_stderr()
+
+        # Assert
+        assert results
+        assert all(result == (0, "") for result in results), results
+
+    @pytest.mark.skipif(
+        sys.platform != "darwin",
+        reason="the poll poller's atfork logging is the macOS observable (#387)",
+    )
+    @pytest.mark.asyncio
+    async def test_start_should_leak_grpc_output_when_embedder_enables_fork_support(
+        self, monkeypatch
+    ):
+        """Test the suppressed gRPC output is real and still reachable.
+
+        Given:
+            An embedder who set GRPC_ENABLE_FORK_SUPPORT=1, so the
+            worker keeps gRPC's fork handlers armed, and gRPC logging
+            left at info
+        When:
+            A routine launches subprocesses on the forking launch path
+            and captures each one's stderr
+        Then:
+            At least one launch should carry gRPC's postfork output
+        """
+        # Arrange
+        monkeypatch.setenv("GRPC_ENABLE_FORK_SUPPORT", "1")
+        monkeypatch.setenv("GRPC_VERBOSITY", "info")
+
+        # Act
+        async with wool.WorkerPool(spawn=1):
+            results = await probe_subprocess_stderr()
+
+        # Assert
+        # The returncode is deliberately unasserted: armed handlers
+        # recreate the descriptor race, so a killed child here is the
+        # bug being demonstrated, not a test failure.
+        assert any(_ATFORK_OUTPUT in stderr for _, stderr in results), results

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -98,6 +98,25 @@ def metadata_pipe(mocker):
 
 
 @pytest.fixture
+def spawn_env(mocker):
+    """Stub the spawn and record the environment each one is handed.
+
+    Patches the spawn seam with a side effect that samples
+    GRPC_ENABLE_FORK_SUPPORT as the real fork/exec would read it, and
+    returns the list those samples land in. The context manager restores
+    the variable before start() returns, so sampling inside the spawn is
+    the only window onto it.
+    """
+    observed = []
+    mocker.patch.object(
+        process_module.Process,
+        "start",
+        side_effect=lambda: observed.append(os.environ.get("GRPC_ENABLE_FORK_SUPPORT")),
+    )
+    return observed
+
+
+@pytest.fixture
 def run_harness(mocker):
     """Stub the run() lifecycle collaborators behind one seam.
 
@@ -852,7 +871,7 @@ class TestWorkerProcess:
         with pytest.raises(ValueError, match="Proxy pool TTL must be positive"):
             WorkerProcess(proxy_pool_ttl=ttl)
 
-    def test_start_raises_error_for_non_positive_timeout(self):
+    def test_start_should_raise_when_the_timeout_is_not_positive(self):
         """Test start raises ValueError for non-positive timeout.
 
         Given:
@@ -869,15 +888,15 @@ class TestWorkerProcess:
         with pytest.raises(ValueError, match="Timeout must be positive"):
             process.start(timeout=0)
 
-    def test_start_calls_parent_start(self, mocker, metadata_pipe):
-        """Test start method calls parent Process.start.
+    def test_start_should_spawn_the_worker_process(self, mocker, metadata_pipe):
+        """Test start delegates the spawn to Process.start.
 
         Given:
             A WorkerProcess with mocked parent start and pipe
         When:
             start() is called
         Then:
-            It should call Process.start
+            It should call Process.start once
         """
         # Arrange
         mock_parent_start = mocker.patch.object(process_module.Process, "start")
@@ -885,15 +904,38 @@ class TestWorkerProcess:
         process = WorkerProcess()
 
         # Act
-        process.start(timeout=60.0)
+        process.start()
 
         # Assert
         mock_parent_start.assert_called_once()
+
+    def test_start_should_wait_for_metadata_up_to_the_given_timeout(
+        self, mocker, metadata_pipe
+    ):
+        """Test start polls the metadata pipe with the caller's timeout.
+
+        Given:
+            A WorkerProcess and an explicit startup timeout
+        When:
+            start() is called with that timeout
+        Then:
+            It should poll the metadata pipe once with it
+        """
+        # Arrange
+        mocker.patch.object(process_module.Process, "start")
+
+        process = WorkerProcess()
+
+        # Act
+        process.start(timeout=60.0)
+
+        # Assert
         metadata_pipe.poll.assert_called_once_with(timeout=60.0)
         metadata_pipe.recv.assert_called_once()
-        metadata_pipe.close.assert_called_once()
 
-    def test_start_receives_port_from_pipe(self, mocker, metadata_pipe):
+    def test_start_should_adopt_the_address_reported_by_the_child(
+        self, mocker, metadata_pipe
+    ):
         """Test start receives port from pipe and updates address.
 
         Given:
@@ -904,6 +946,7 @@ class TestWorkerProcess:
             It should receive the port and provide correct address
         """
         # Arrange
+        metadata_pipe.recv.return_value = _metadata_bytes(address="127.0.0.1:50051")
         mocker.patch.object(process_module.Process, "start")
 
         process = WorkerProcess()
@@ -915,7 +958,9 @@ class TestWorkerProcess:
         assert process.port == 50051
         assert process.address == "127.0.0.1:50051"
 
-    def test_start_raises_runtime_error_on_timeout(self, mocker, metadata_pipe):
+    def test_start_should_raise_and_reap_when_metadata_never_arrives(
+        self, mocker, metadata_pipe
+    ):
         """Test start raises RuntimeError when process fails to start in time.
 
         Given:
@@ -940,7 +985,9 @@ class TestWorkerProcess:
 
         mock_reap.assert_called_once_with(timeout=0)
 
-    def test_start_closes_pipe_after_receiving_port(self, mocker, metadata_pipe):
+    def test_start_should_close_the_metadata_pipe_when_metadata_arrives(
+        self, mocker, metadata_pipe
+    ):
         """Test start closes the pipe connection after receiving port.
 
         Given:
@@ -961,7 +1008,7 @@ class TestWorkerProcess:
         # Assert
         metadata_pipe.close.assert_called_once()
 
-    def test_start_deserializes_metadata_with_extra_from_pipe(
+    def test_start_should_populate_extra_and_tags_from_the_reported_metadata(
         self, mocker, metadata_pipe
     ):
         """Test start deserializes metadata with extra and tags from pipe.
@@ -990,6 +1037,225 @@ class TestWorkerProcess:
         assert process.metadata.extra == MappingProxyType({"key": "value"})
         assert isinstance(process.metadata.extra, MappingProxyType)
         assert process.metadata.tags == frozenset({"gpu"})
+
+    def test_start_should_disable_grpc_fork_support_for_the_child_when_unset(
+        self, monkeypatch, metadata_pipe, spawn_env
+    ):
+        """Test start hands the spawned child disabled gRPC fork support.
+
+        Given:
+            A WorkerProcess and an environment carrying no
+            GRPC_ENABLE_FORK_SUPPORT setting
+        When:
+            start() is called
+        Then:
+            It should scope GRPC_ENABLE_FORK_SUPPORT="0" to the spawn
+        """
+        # Arrange
+        monkeypatch.delenv("GRPC_ENABLE_FORK_SUPPORT", raising=False)
+
+        process = WorkerProcess()
+
+        # Act
+        process.start()
+
+        # Assert
+        assert spawn_env == ["0"]
+        assert "GRPC_ENABLE_FORK_SUPPORT" not in os.environ
+
+    @pytest.mark.parametrize("preset", ["1", "0", ""])
+    def test_start_should_preserve_grpc_fork_support_when_already_set(
+        self, monkeypatch, metadata_pipe, spawn_env, preset
+    ):
+        """Test start leaves a deliberate fork-support setting intact.
+
+        Given:
+            An environment in which the embedder set
+            GRPC_ENABLE_FORK_SUPPORT, including to a falsy value
+        When:
+            start() is called
+        Then:
+            It should expose that exact value to the spawn and leave it
+            set
+        """
+        # Arrange
+        monkeypatch.setenv("GRPC_ENABLE_FORK_SUPPORT", preset)
+
+        process = WorkerProcess()
+
+        # Act
+        process.start()
+
+        # Assert
+        assert spawn_env == [preset]
+        assert os.environ["GRPC_ENABLE_FORK_SUPPORT"] == preset
+
+    @given(
+        preset=st.text().filter(lambda value: "\x00" not in value and "=" not in value)
+    )
+    @settings(
+        max_examples=50,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    def test_start_should_preserve_any_value_the_embedder_set(
+        self, mocker, monkeypatch, preset
+    ):
+        """Test the preserved value is carried verbatim, whatever it is.
+
+        Given:
+            Any string the embedder may have put in
+            GRPC_ENABLE_FORK_SUPPORT
+        When:
+            start() is called
+        Then:
+            It should expose that exact value to the spawn and leave it
+            set
+        """
+        # Arrange
+        monkeypatch.setenv("GRPC_ENABLE_FORK_SUPPORT", preset)
+        receiver = mocker.MagicMock()
+        receiver.poll.return_value = True
+        receiver.recv.return_value = _metadata_bytes()
+        mocker.patch.object(
+            process_module, "Pipe", return_value=(receiver, mocker.MagicMock())
+        )
+        observed = []
+        mocker.patch.object(
+            process_module.Process,
+            "start",
+            side_effect=lambda: observed.append(
+                os.environ.get("GRPC_ENABLE_FORK_SUPPORT")
+            ),
+        )
+
+        process = WorkerProcess()
+
+        # Act
+        process.start()
+
+        # Assert
+        assert observed == [preset]
+        assert os.environ["GRPC_ENABLE_FORK_SUPPORT"] == preset
+
+    def test_start_should_restore_the_environment_when_the_spawn_fails(
+        self, mocker, monkeypatch, metadata_pipe
+    ):
+        """Test a failed spawn leaves no fork-support setting behind.
+
+        Given:
+            An environment carrying no GRPC_ENABLE_FORK_SUPPORT and a
+            spawn that raises
+        When:
+            start() is called
+        Then:
+            It should propagate the error and leave the variable unset
+        """
+        # Arrange
+        monkeypatch.delenv("GRPC_ENABLE_FORK_SUPPORT", raising=False)
+        mocker.patch.object(
+            process_module.Process, "start", side_effect=OSError("spawn failed")
+        )
+
+        process = WorkerProcess()
+
+        # Act & assert
+        with pytest.raises(OSError, match="spawn failed"):
+            process.start()
+
+        assert "GRPC_ENABLE_FORK_SUPPORT" not in os.environ
+
+    def test_start_should_spawn_again_when_an_earlier_spawn_failed(
+        self, mocker, monkeypatch, metadata_pipe
+    ):
+        """Test a failed spawn releases the hold for the next start.
+
+        Given:
+            A WorkerProcess whose spawn raised, after which the
+            environment is clean again
+        When:
+            A second WorkerProcess is started
+        Then:
+            It should spawn without wedging and observe
+            GRPC_ENABLE_FORK_SUPPORT="0"
+        """
+        # Arrange
+        monkeypatch.delenv("GRPC_ENABLE_FORK_SUPPORT", raising=False)
+        observed = []
+
+        def spawn():
+            observed.append(os.environ.get("GRPC_ENABLE_FORK_SUPPORT"))
+            if len(observed) == 1:
+                raise OSError("spawn failed")
+
+        mocker.patch.object(process_module.Process, "start", side_effect=spawn)
+        with pytest.raises(OSError, match="spawn failed"):
+            WorkerProcess().start()
+        # Distinguishes a released hold from a leaked one: a leaked
+        # setting would satisfy the spawn assertion below just as a
+        # restored environment does.
+        assert "GRPC_ENABLE_FORK_SUPPORT" not in os.environ
+
+        # Act
+        second = threading.Thread(target=lambda: WorkerProcess().start())
+        second.start()
+        second.join(timeout=10.0)
+
+        # Assert
+        assert not second.is_alive()
+        assert observed == ["0", "0"]
+
+    def test_start_should_disable_grpc_fork_support_for_every_concurrent_spawn(
+        self, mocker, monkeypatch, metadata_pipe
+    ):
+        """Test overlapping spawns each see fork support disabled.
+
+        Given:
+            An environment carrying no GRPC_ENABLE_FORK_SUPPORT and
+            eight workers started from their own threads
+        When:
+            Their spawns are all in flight at once
+        Then:
+            Every spawn should observe "0", and the environment should
+            be clean once the last one returns
+        """
+        # Arrange
+        monkeypatch.delenv("GRPC_ENABLE_FORK_SUPPORT", raising=False)
+        spawns = 8
+        # The barrier is the overlap proof: it releases only once all
+        # eight spawns are inside, so a design that serialized them
+        # would time out here rather than pass.
+        rendezvous = threading.Barrier(spawns, timeout=10.0)
+        observed = []
+        errors = []
+        recorded = threading.Lock()
+
+        def spawn():
+            rendezvous.wait()
+            value = os.environ.get("GRPC_ENABLE_FORK_SUPPORT")
+            with recorded:
+                observed.append(value)
+
+        def start():
+            try:
+                WorkerProcess().start()
+            except BaseException as error:  # noqa: BLE001 - reported below
+                with recorded:
+                    errors.append(error)
+
+        mocker.patch.object(process_module.Process, "start", side_effect=spawn)
+        threads = [threading.Thread(target=start) for _ in range(spawns)]
+
+        # Act
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=15.0)
+
+        # Assert
+        assert not errors
+        assert not any(thread.is_alive() for thread in threads)
+        assert observed == ["0"] * spawns
+        assert "GRPC_ENABLE_FORK_SUPPORT" not in os.environ
 
     def test_run_sets_up_proxy_pool_and_starts_server(self, mocker):
         """Test run method sets up proxy pool and starts gRPC server.

--- a/wool/tests/runtime/worker/test_process.py
+++ b/wool/tests/runtime/worker/test_process.py
@@ -67,6 +67,36 @@ def watchdog_env(mocker):
     return mock_parent, mock_exit, exited
 
 
+def _metadata_bytes(**overrides):
+    """Serialize a WorkerMetadata payload the way the child sends it."""
+    fields = {
+        "uid": uuid.uuid4(),
+        "address": "127.0.0.1:50051",
+        "pid": 12345,
+        "version": "1.0.0",
+    }
+    fields.update(overrides)
+    return WorkerMetadata(**fields).to_protobuf().SerializeToString()
+
+
+@pytest.fixture
+def metadata_pipe(mocker):
+    """Stub the metadata pipe and return its receiving end.
+
+    Patches the Pipe seam so a constructed WorkerProcess gets mock pipe
+    ends, and primes the receiving end to deliver one WorkerMetadata
+    payload. Tests that need a different payload — or a startup that
+    never reports one — reshape the returned mock's recv and poll.
+    """
+    receiver = mocker.MagicMock()
+    receiver.poll.return_value = True
+    receiver.recv.return_value = _metadata_bytes()
+    mocker.patch.object(
+        process_module, "Pipe", return_value=(receiver, mocker.MagicMock())
+    )
+    return receiver
+
+
 @pytest.fixture
 def run_harness(mocker):
     """Stub the run() lifecycle collaborators behind one seam.
@@ -839,7 +869,7 @@ class TestWorkerProcess:
         with pytest.raises(ValueError, match="Timeout must be positive"):
             process.start(timeout=0)
 
-    def test_start_calls_parent_start(self, mocker):
+    def test_start_calls_parent_start(self, mocker, metadata_pipe):
         """Test start method calls parent Process.start.
 
         Given:
@@ -850,24 +880,6 @@ class TestWorkerProcess:
             It should call Process.start
         """
         # Arrange
-        mock_get_meta = mocker.MagicMock()
-        mock_get_meta.poll.return_value = True
-        mock_get_meta.recv.return_value = (
-            WorkerMetadata(
-                uid=uuid.uuid4(),
-                address="127.0.0.1:50051",
-                pid=12345,
-                version="1.0.0",
-            )
-            .to_protobuf()
-            .SerializeToString()
-        )
-        mock_set_meta = mocker.MagicMock()
-        mocker.patch(
-            "wool.runtime.worker.process.Pipe",
-            return_value=(mock_get_meta, mock_set_meta),
-        )
-
         mock_parent_start = mocker.patch.object(process_module.Process, "start")
 
         process = WorkerProcess()
@@ -877,11 +889,11 @@ class TestWorkerProcess:
 
         # Assert
         mock_parent_start.assert_called_once()
-        mock_get_meta.poll.assert_called_once_with(timeout=60.0)
-        mock_get_meta.recv.assert_called_once()
-        mock_get_meta.close.assert_called_once()
+        metadata_pipe.poll.assert_called_once_with(timeout=60.0)
+        metadata_pipe.recv.assert_called_once()
+        metadata_pipe.close.assert_called_once()
 
-    def test_start_receives_port_from_pipe(self, mocker):
+    def test_start_receives_port_from_pipe(self, mocker, metadata_pipe):
         """Test start receives port from pipe and updates address.
 
         Given:
@@ -892,24 +904,6 @@ class TestWorkerProcess:
             It should receive the port and provide correct address
         """
         # Arrange
-        mock_get_meta = mocker.MagicMock()
-        mock_get_meta.poll.return_value = True
-        mock_get_meta.recv.return_value = (
-            WorkerMetadata(
-                uid=uuid.uuid4(),
-                address="127.0.0.1:50051",
-                pid=12345,
-                version="1.0.0",
-            )
-            .to_protobuf()
-            .SerializeToString()
-        )
-        mock_set_meta = mocker.MagicMock()
-        mocker.patch(
-            "wool.runtime.worker.process.Pipe",
-            return_value=(mock_get_meta, mock_set_meta),
-        )
-
         mocker.patch.object(process_module.Process, "start")
 
         process = WorkerProcess()
@@ -921,7 +915,7 @@ class TestWorkerProcess:
         assert process.port == 50051
         assert process.address == "127.0.0.1:50051"
 
-    def test_start_raises_runtime_error_on_timeout(self, mocker):
+    def test_start_raises_runtime_error_on_timeout(self, mocker, metadata_pipe):
         """Test start raises RuntimeError when process fails to start in time.
 
         Given:
@@ -932,14 +926,7 @@ class TestWorkerProcess:
             It should raise RuntimeError and reap the process
         """
         # Arrange
-        mock_get_meta = mocker.MagicMock()
-        mock_get_meta.poll.return_value = False
-        mock_set_meta = mocker.MagicMock()
-        mocker.patch(
-            "wool.runtime.worker.process.Pipe",
-            return_value=(mock_get_meta, mock_set_meta),
-        )
-
+        metadata_pipe.poll.return_value = False
         mocker.patch.object(process_module.Process, "start")
 
         process = WorkerProcess()
@@ -953,7 +940,7 @@ class TestWorkerProcess:
 
         mock_reap.assert_called_once_with(timeout=0)
 
-    def test_start_closes_pipe_after_receiving_port(self, mocker):
+    def test_start_closes_pipe_after_receiving_port(self, mocker, metadata_pipe):
         """Test start closes the pipe connection after receiving port.
 
         Given:
@@ -964,24 +951,6 @@ class TestWorkerProcess:
             It should close the pipe connection
         """
         # Arrange
-        mock_get_meta = mocker.MagicMock()
-        mock_get_meta.poll.return_value = True
-        mock_get_meta.recv.return_value = (
-            WorkerMetadata(
-                uid=uuid.uuid4(),
-                address="127.0.0.1:50051",
-                pid=12345,
-                version="1.0.0",
-            )
-            .to_protobuf()
-            .SerializeToString()
-        )
-        mock_set_meta = mocker.MagicMock()
-        mocker.patch(
-            "wool.runtime.worker.process.Pipe",
-            return_value=(mock_get_meta, mock_set_meta),
-        )
-
         mocker.patch.object(process_module.Process, "start")
 
         process = WorkerProcess()
@@ -990,9 +959,11 @@ class TestWorkerProcess:
         process.start()
 
         # Assert
-        mock_get_meta.close.assert_called_once()
+        metadata_pipe.close.assert_called_once()
 
-    def test_start_deserializes_metadata_with_extra_from_pipe(self, mocker):
+    def test_start_deserializes_metadata_with_extra_from_pipe(
+        self, mocker, metadata_pipe
+    ):
         """Test start deserializes metadata with extra and tags from pipe.
 
         Given:
@@ -1004,28 +975,10 @@ class TestWorkerProcess:
             and metadata.tags as frozenset
         """
         # Arrange
-        metadata_bytes = (
-            WorkerMetadata(
-                uid=uuid.uuid4(),
-                address="127.0.0.1:50051",
-                pid=12345,
-                version="1.0.0",
-                tags=frozenset({"gpu"}),
-                extra=MappingProxyType({"key": "value"}),
-            )
-            .to_protobuf()
-            .SerializeToString()
+        metadata_pipe.recv.return_value = _metadata_bytes(
+            tags=frozenset({"gpu"}),
+            extra=MappingProxyType({"key": "value"}),
         )
-
-        mock_get_meta = mocker.MagicMock()
-        mock_get_meta.poll.return_value = True
-        mock_get_meta.recv.return_value = metadata_bytes
-        mock_set_meta = mocker.MagicMock()
-        mocker.patch(
-            "wool.runtime.worker.process.Pipe",
-            return_value=(mock_get_meta, mock_set_meta),
-        )
-
         mocker.patch.object(process_module.Process, "start")
 
         process = WorkerProcess()


### PR DESCRIPTION
## Summary

Tool subprocesses launched from inside a `@wool.routine` intermittently die with returncode -13 on macOS, killed by SIGPIPE. Hand every spawned worker `GRPC_ENABLE_FORK_SUPPORT=0` so gRPC's atfork handlers never run on a worker's subprocess launches, and document which launch paths involve those handlers at all.

The mechanism reproduces locally on macOS with grpcio 1.83.1. A `grpc.aio` server plus `asyncio.create_subprocess_exec(..., start_new_session=True)` emits `fork_posix.cc: Other threads are currently calling into gRPC, skipping fork() handlers` and leaks `ev_poll_posix.cc: FD from fork parent still in poll list: fd(N, generation: 1)` into the child's own stderr pipe — the fingerprint captured in the issue's failure. With fork support disabled, both vanish.

Two facts constrain where the variable can be set. gRPC reads it once, as it initializes at import: setting it after `import grpc.aio` leaves the handlers firing. And the spawn child imports `wool.runtime.worker.process` — which imports `grpc.aio` at module scope — while unpickling the process object, so `WorkerProcess.run` is already too late. The setting therefore rides the spawn from the parent's environment, which is the plain inheritance path the issue verified.

Concurrency is handled with a reference-counted hold rather than mutual exclusion. `WorkerPool` gathers one task per worker and `LocalWorker._start` offloads to `run_in_executor`, so `spawn=N` runs N concurrent starts on N threads. Each start takes a hold: the variable is installed on the first and removed when the last closes, so it is present for every fork in flight and no exit can strip it from a spawn still running. The lock spans only the two counter updates, never the spawn, so workers still fork in parallel. The variable is set only when absent, so an embedder who set it deliberately keeps their value, and the window is process-global while open — documented on the context manager.

This does not prove the SIGPIPE causal chain. The issue's controlled campaign never produced a firing baseline, so the fix is validated as suppressing the observed FD entanglement, not as eliminating the flake. Confirming causality still needs the paired-arm campaign the issue describes.

Closes #387

## Proposed changes

### Disable gRPC fork support in spawned workers

`WorkerProcess.start` wraps `super().start()` in `_default_grpc_fork_support()`, a reference-counted hold on `GRPC_ENABLE_FORK_SUPPORT=0`. The guard is a membership test rather than a truthiness check, so an embedder's empty-string value is preserved rather than overwritten and then deleted, and the restore is a `pop` so a third party clearing the variable inside the window cannot mask the spawn's own exception.

The class docstring states the caller-facing contract; the implementation-notes rubric records why a spawned worker's forks are ordinarily immediately-exec'd subprocess launches (naming the non-daemonic `fork` start method as the exception), and why the setting cannot be applied in the child.

### Extract a shared metadata-pipe fixture

Five `start` tests each inlined the same metadata-pipe arrangement, differing only in the payload delivered and whether the pipe becomes readable. A `metadata_pipe` fixture and a `_metadata_bytes` helper replace the duplication, so each test states only the part of the arrangement it cares about. No test gains or loses an assertion.

### Document subprocess launch paths

The worker README gains a `Subprocesses` section covering why wool disables the handlers, that an embedder's own setting wins, and how `start_new_session=True` and a bare command name each disqualify CPython's `posix_spawn` fast path and route a launch through `_posixsubprocess.fork_exec`. It states the trade-off plainly: `posix_spawn` runs no atfork handlers at all, at the cost of the process-group semantics that make group-wide cancellation of a pipeline possible.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestWorkerProcess` | An environment carrying no `GRPC_ENABLE_FORK_SUPPORT` | `start()` is called | The spawn observes `"0"` and the caller's environment is left unchanged | Default arm and restore ordering |
| 2 | `TestWorkerProcess` | An embedder setting the variable to `"1"`, `"0"`, the empty string, or any generated string | `start()` is called | The spawn observes that exact value and it remains set | Membership guard rather than truthiness |
| 3 | `TestWorkerProcess` | No setting present and a spawn that raises | `start()` is called | The error propagates and the variable is absent afterwards | Restoration on the failure path |
| 4 | `TestWorkerProcess` | A `WorkerProcess` whose spawn raised | A second worker is started | It spawns and observes `"0"` | Lock release after a failed spawn |
| 5 | `TestWorkerProcess` | No setting present and eight workers started from their own threads | All eight spawns rendezvous on a barrier, proving they are in flight together | Every spawn observes `"0"` and the environment is left clean | Reference-counted hold, and that spawns are not serialized |
| 6 | `TestWorkerForkSupport` | An environment carrying no setting, then one where the embedder set `"1"` | A routine on a real spawned worker reads the variable | It reports `"0"`, then `"1"` | Inheritance across the spawn boundary, both arms |
| 7 | `TestWorkerForkSupport` | A default worker pool | A routine launches subprocesses on the `fork_exec` path | Every launch exits 0 with nothing on stderr | Absence of gRPC output in a live child's pipe |
| 8 | `TestWorkerForkSupport` | An embedder who set `GRPC_ENABLE_FORK_SUPPORT=1`, on macOS | The same routine runs | At least one launch carries gRPC's postfork output on stderr | Anti-vacuity sentinel for case 7 |
