### PR TITLE
Keep the token registry's finalizer off the registry lock — Closes #397

### DIFF
--- a/wool/pyproject.toml
+++ b/wool/pyproject.toml
@@ -101,6 +101,7 @@ faulthandler_timeout = 300
 markers = [
     "integration: end-to-end integration tests against real WorkerPool",
     "stdlib_parity: stdlib contextvars propagation parity pins",
+    "subprocess_probe: unit regressions that spawn an interpreter to contain a hang",
 ]
 
 [tool.ruff]

--- a/wool/src/wool/runtime/context/token.py
+++ b/wool/src/wool/runtime/context/token.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import contextvars
 import threading
 import weakref
+from collections import deque
 from collections.abc import Generator
 from collections.abc import Iterable
 from contextlib import contextmanager
@@ -67,13 +68,21 @@ _token_sink: Final[contextvars.ContextVar[list["Token"] | None]] = (
 
 #: Count of live `Token` instances per ID, consulted by
 #: `~wool.runtime.context.chain.Chain`'s ledger reap to bound ``spent_tokens``
-#: to token lifespan (see `_register_token` and `dead_token_ids`).
+#: to token lifespan.
 _token_counts: Final[dict[str, int]] = {}
 
-#: Serialises the read-modify-write on `_token_counts` so a register on one
-#: thread and a `weakref.finalize` release on another (finalizers fire during
-#: GC on whatever thread drops the token) cannot lose an increment — a lost
+#: IDs of collected `Token` instances whose decrement of `_token_counts` is
+#: still pending, applied by `_drain_released`. A `collections.deque` is the
+#: queue because the release path must stay off `_token_lock` (see
+#: `_release_token`).
+_released_token_ids: Final[deque[str]] = deque()
+
+#: Serialises the drain and read-modify-write on `_token_counts` so a register
+#: on one thread and a drain on another cannot lose an increment — a lost
 #: increment could zero a count early and reap an ID whose token is still live.
+#: Nothing run under it may mint or release a token: it is not re-entrant, so a
+#: second acquisition on the holding thread blocks that thread forever (see
+#: `_release_token`).
 _token_lock: Final[threading.Lock] = threading.Lock()
 
 
@@ -97,23 +106,72 @@ def _register_token(token: Token) -> None:
     """Record *token* as a live instance of its ID for ledger reaping.
 
     Increments the ID's live-instance count and attaches a `weakref.finalize`
-    that decrements it when this instance is collected. Counts each instance
-    rather than a single canonical one, so coexisting copies of one ID (a
-    returned clone alongside its origin, or a token both held and re-decoded)
-    keep the ID live until the last is collected.
+    that releases the ID when this instance is collected (see
+    `_release_token`). Counts each instance rather than a single canonical one,
+    so coexisting copies of one ID (a returned clone alongside its origin, or a
+    token both held and re-decoded) keep the ID live until the last is
+    collected.
+
+    .. rubric:: Implementation notes
+
+    The drain is here to bound `_released_token_ids` in a process that mints
+    and drops tokens without ever reaching a reap. Its position within the
+    block carries no correctness weight: each queued release matches exactly
+    one earlier increment, so draining before or after this one settles the
+    count alike. That makes the bound the drain's only effect here, and a
+    memory property no test can observe without reading the queue itself, so
+    it rests on this note rather than on a pin.
     """
     with _token_lock:
+        _drain_released()
         _token_counts[token._id] = _token_counts.get(token._id, 0) + 1
     weakref.finalize(token, _release_token, token._id)
 
 
 def _release_token(token_id: str) -> None:
-    """Decrement *token_id*'s live-instance count, dropping the key at zero.
+    """Queue *token_id* for a decrement of its live-instance count.
 
-    The `weakref.finalize` callback `_register_token` attaches to each instance;
-    it fires during garbage collection when that instance is reclaimed.
+    The `weakref.finalize` callback attached to each minted instance; it fires
+    when that instance is reclaimed, on whichever thread drops the last
+    reference.
+
+    .. rubric:: Implementation notes
+
+    Takes no lock, and that is the point. A finalizer runs wherever the
+    collector or a refcount drop happens to be, including inside
+    `_token_lock`'s own critical section on the thread already holding it,
+    where acquiring a `threading.Lock` a second time blocks that thread on
+    itself forever. Queuing the ID instead keeps the release path off the lock
+    entirely: a `collections.deque` append is a single atomic C-level
+    operation, so it cannot corrupt a concurrent drain, and it allocates
+    nothing the collector tracks, so it cannot start a collection of its own.
+
+    Deferral is safe in one direction only, and that is the direction the reap
+    needs: between drains a count can only be too high, so an ID is retained
+    one mount longer, never reaped early.
+
+    Survives as a named function rather than collapsing into a bound
+    ``append`` because it is the one home for the constraint above, and
+    because a named callback keeps the finalizer legible in a development-mode
+    traceback.
     """
-    with _token_lock:
+    _released_token_ids.append(token_id)
+
+
+def _drain_released() -> None:
+    """Apply the queued releases to `_token_counts`, dropping keys at zero.
+
+    Requires `_token_lock` held.
+
+    .. rubric:: Implementation notes
+
+    Only a lock holder pops, so nothing can empty the queue between the
+    emptiness test and the `collections.deque.popleft`. A finalizer firing
+    mid-drain only ever appends, so its release can be neither corrupted nor
+    lost: it is picked up by this drain or the next.
+    """
+    while _released_token_ids:
+        token_id = _released_token_ids.popleft()
         remaining = _token_counts.get(token_id, 0) - 1
         if remaining > 0:
             _token_counts[token_id] = remaining
@@ -128,13 +186,21 @@ def dead_token_ids(ids: Iterable[str]) -> frozenset[str]:
     from `_token_counts` has no surviving instance, so nothing local can reset
     or forward it and its consumed-token entry can be dropped. Keeps the
     registry encapsulated here: callers pass the spent IDs and get back the
-    dead ones.
+    dead ones. Reaping may lag by one mount: an instance collected concurrently
+    with this call is accounted for on the next query, never reported dead
+    while one lives.
 
     .. rubric:: Implementation notes
 
-    The membership read needs no lock: a transient miscount can only retain an
-    ID one mount longer, never reap one early.
+    Applies the queued releases first, so a release that landed before this
+    call is accounted for here rather than a mount later. The membership read
+    itself needs no lock, and is kept outside it: *ids* is caller-supplied, and
+    driving an arbitrary iterable under a lock no finalizer may take would put
+    back the hazard this queue exists to remove. A transient miscount is
+    harmless in the only direction it can go (see `_release_token`).
     """
+    with _token_lock:
+        _drain_released()
     return frozenset(id for id in ids if id not in _token_counts)
 
 
@@ -333,8 +399,7 @@ class Token(Generic[T]):
         dispatch reconstitution (`_reconstitute`) — building the token from its
         wire and anchor state directly rather than through the refusing
         ``__init__``. Every minted instance is counted for ledger reaping via
-        `_register_token`, so a consumed ID is reclaimed once no instance of it
-        remains live in this process.
+        `_register_token`, which owns the retention semantics that follow.
         """
         token: Token[T] = object.__new__(cls)
         token._var = var
@@ -370,9 +435,9 @@ def _reconstitute(
     method that fails cloudpickle's identity check, forcing a by-value pickle
     that would capture this module's `~wool.runtime.context.registry.lock`.
 
-    `Token._mint` counts this instance in `_token_counts`, so while the
-    reconstituted token lives its ID's consumed-token entry is retained for
-    reaping (see `dead_token_ids`) and reclaimed once it is collected.
+    `Token._mint` counts this instance for ledger reaping, so this token's
+    ID is retained while it lives; see `_register_token` for the retention
+    semantics.
     """
     token = Token._mint(
         var=var,

--- a/wool/tests/runtime/context/_finalizer_reentry_probe.py
+++ b/wool/tests/runtime/context/_finalizer_reentry_probe.py
@@ -1,0 +1,74 @@
+"""Out-of-process probe for the token registry's finalizer re-entrancy.
+
+NOT a test module — no ``test_`` prefix — so pytest does not collect it. It is
+run in a subprocess by the re-entrancy regression in ``test_token.py``, whose
+docstring owns the scenario. It lives out of process because a regression hangs
+while holding the token registry's lock, which would strand every later test in
+the interpreter rather than failing one.
+"""
+
+import sys
+import uuid
+
+import wool
+from wool.runtime.context.token import dead_token_ids
+from wool.runtime.context.var import ContextVar
+
+#: Holds the token whose release must fire inside the critical section, so the
+#: profile hook can drop its last reference from there.
+_victim: list = []
+
+
+def _fail(message: str) -> None:
+    """Exit non-zero with *message*.
+
+    Used in place of ``assert``, which the interpreter strips under ``-O`` —
+    inherited from the parent environment, that would let this probe report
+    success without checking anything.
+    """
+    raise SystemExit(message)
+
+
+def _drop_victim_inside_critical_section(frame, event, arg) -> None:
+    """Drop the victim's last reference from inside the registry's lock.
+
+    Anchored on the registry's drain, whose documented precondition is that
+    callers hold the registry lock, so landing inside the critical section is
+    structural rather than incidental to whichever C call happens to run there.
+
+    Naming a private function is a deliberate, reviewed waiver of the test
+    guide's rule against referencing private symbols. No public anchor exists:
+    the critical section runs no user-controllable callback, garbage-collection
+    stress never reproduced the interleaving across thousands of rounds, and an
+    ungated ``gc.callbacks`` drop always fired before the lock was taken.
+    """
+    if event == "call" and frame.f_code.co_name == "_drain_released":
+        sys.setprofile(None)
+        _victim.clear()
+
+
+def main() -> None:
+    """Register a token while another token's release fires under the lock."""
+    victim_var = ContextVar(f"probe_victim_{uuid.uuid4().hex}")
+    trigger_var = ContextVar(f"probe_trigger_{uuid.uuid4().hex}")
+    key = (victim_var.namespace, victim_var.name)
+
+    _victim.append(victim_var.set("victim"))
+    manifest = wool.__chain__.get().to_manifest()
+    victim_id = next(iter(manifest.unspent_tokens[key]))
+
+    sys.setprofile(_drop_victim_inside_critical_section)
+    try:
+        trigger_var.set("trigger")
+    finally:
+        sys.setprofile(None)
+
+    if _victim:
+        _fail("the probe never reached the token registry's critical section")
+    if dead_token_ids({victim_id}) != frozenset({victim_id}):
+        _fail("the release fired under the lock but its decrement was lost")
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/wool/tests/runtime/context/test_token.py
+++ b/wool/tests/runtime/context/test_token.py
@@ -1,6 +1,8 @@
 import copy
 import gc
 import pickle
+import subprocess
+import sys
 import uuid
 
 import cloudpickle
@@ -11,6 +13,7 @@ from hypothesis import strategies as st
 
 import wool
 from tests.helpers import scoped_context
+from tests.runtime.context import _finalizer_reentry_probe
 from wool.runtime.context.token import Token
 from wool.runtime.context.token import dead_token_ids
 from wool.runtime.context.token import token_sink
@@ -27,6 +30,11 @@ loads = cloudpickle.loads
 # Sentinel distinguishing "the variable was never set" from a drawn prior
 # value of None in the roundtrip property below.
 _UNSET = object()
+
+#: Wall-clock bound on the out-of-process finalizer probe. Generous enough to
+#: absorb interpreter startup on a loaded CI runner, while still turning a
+#: re-entrant registry deadlock into a bounded failure.
+_PROBE_TIMEOUT = 60
 
 
 def _unique(stem: str) -> str:
@@ -487,6 +495,21 @@ def test_token_sink_should_scope_wire_token_capture_to_the_decode():
     assert not any(outside is captured for captured in collected)
 
 
+def test_dead_token_ids_should_return_empty_when_given_no_ids():
+    """Test dead_token_ids over no ids returns an empty set.
+
+    Given:
+        No token ids — the degenerate empty input the reap passes on every
+        mount of a chain that carries no spent tokens.
+    When:
+        dead_token_ids is queried with an empty iterable.
+    Then:
+        It should return an empty frozenset without error.
+    """
+    # Arrange, act, & assert
+    assert dead_token_ids(frozenset()) == frozenset()
+
+
 def test_dead_token_ids_should_report_only_ids_with_no_live_instance():
     """Test dead_token_ids returns exactly the ids whose tokens are gone.
 
@@ -522,16 +545,140 @@ def test_dead_token_ids_should_report_only_ids_with_no_live_instance():
         assert isinstance(held, Token)  # keep the held instance alive
 
 
-def test_dead_token_ids_should_return_empty_when_given_no_ids():
-    """Test dead_token_ids over no ids returns an empty set.
+def test_dead_token_ids_should_not_report_an_id_when_a_round_trip_clone_lives():
+    """Test a shared id stays live while one of its two instances survives.
 
     Given:
-        No token ids — the degenerate empty input the reap passes on every
-        mount of a chain that carries no spent tokens.
+        A set token and its dispatch round-trip clone — two instances sharing
+        one id — with the original dropped and collected, leaving the clone's
+        instance the only live one.
     When:
-        dead_token_ids is queried with an empty iterable.
+        dead_token_ids is queried with the shared id.
     Then:
-        It should return an empty frozenset without error.
+        It should report nothing dead — releasing one instance decrements the
+        id's count without zeroing it, so a surviving instance is never reaped
+        out from under a caller that can still reset or forward it.
     """
-    # Arrange, act, & assert
-    assert dead_token_ids(frozenset()) == frozenset()
+    # Arrange
+    var = ContextVar(_unique("clone_liveness"))
+    key = (var.namespace, var.name)
+    with scoped_context():
+        origin = var.set("x")
+        token_id = next(iter(wool.__chain__.get().to_manifest().unspent_tokens[key]))
+        clone = loads(dumps(origin))
+        del origin
+        gc.collect()
+
+        # Act
+        result = dead_token_ids({token_id})
+
+        # Assert
+        assert result == frozenset()
+        assert isinstance(clone, Token)  # keep the surviving instance alive
+
+
+def test_dead_token_ids_should_report_every_id_when_many_released_at_once():
+    """Test one query applies every release queued since the previous query.
+
+    Given:
+        Eight live token instances under one key, their ids read from the
+        public chain manifest, all dropped and collected together with no
+        registration in between.
+    When:
+        dead_token_ids is queried once with all eight ids.
+    Then:
+        It should report every one of them dead — a query applies the whole
+        backlog of releases, so a batch of collections cannot strand ids in the
+        ledger for the life of the chain.
+    """
+    # Arrange
+    var = ContextVar(_unique("release_backlog"))
+    key = (var.namespace, var.name)
+    with scoped_context():
+        tokens = [var.set(value) for value in range(8)]
+        token_ids = wool.__chain__.get().to_manifest().unspent_tokens[key]
+        assert len(token_ids) == len(tokens), (
+            "the manifest yielded no ids, which would vacate the assertion below"
+        )
+        tokens.clear()
+        gc.collect()
+
+        # Act
+        result = dead_token_ids(token_ids)
+
+        # Assert
+        assert result == token_ids
+
+
+@settings(max_examples=25, deadline=None)
+@given(instances=st.integers(min_value=1, max_value=6), data=st.data())
+def test_dead_token_ids_should_report_a_shared_id_only_when_no_instance_lives(
+    instances, data
+):
+    """Test a shared id is reported dead exactly when its last instance goes.
+
+    Given:
+        Any number of instances of one token id — an origin plus dispatch
+        round-trip clones — of which any number are dropped and collected.
+    When:
+        dead_token_ids is queried with the shared id.
+    Then:
+        It should report the id dead if and only if every instance was
+        released, since a deferred release may leave a count too high between
+        drains but never too low.
+    """
+    # Arrange
+    released = data.draw(st.integers(min_value=0, max_value=instances))
+    var = ContextVar(_unique("shared_id_liveness"))
+    key = (var.namespace, var.name)
+    with scoped_context():
+        origin = var.set("x")
+        token_id = next(iter(wool.__chain__.get().to_manifest().unspent_tokens[key]))
+        payload = dumps(origin)
+        live = [origin] + [loads(payload) for _ in range(instances - 1)]
+        del origin
+        del live[:released]
+        gc.collect()
+
+        # Act
+        result = dead_token_ids({token_id})
+
+        # Assert
+        assert (result == frozenset({token_id})) is (released == instances)
+        assert len(live) == instances - released  # keep the survivors alive
+
+
+@pytest.mark.subprocess_probe
+def test_dead_token_ids_should_report_an_id_when_released_inside_a_registration():
+    """Test a release firing inside a registration is neither blocked nor lost.
+
+    Given:
+        A token whose last reference is dropped from inside the registry's
+        read-modify-write for another token's registration, so its finalizer
+        runs on the registering thread while the registry is mid-update.
+    When:
+        dead_token_ids is queried for the dropped token's id.
+    Then:
+        It should report the id dead within the bound — a finalizer must never
+        wait on the thread that is already registering, and deferring its
+        decrement must not drop it.
+    """
+    # Arrange
+    probe = _finalizer_reentry_probe.__file__
+
+    # Act & assert
+    try:
+        result = subprocess.run(
+            [sys.executable, probe],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            f"token registration did not complete within {_PROBE_TIMEOUT}s: a "
+            "finalizer firing inside the token registry's critical section "
+            "blocked the registering thread"
+        )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout


### PR DESCRIPTION
## Summary

Take the registry lock out of the token finalizer path, so a token collected at any moment — on any thread, including in the middle of another token's registration — is accounted for without the registering thread waiting on it.

`_release_token` is a `weakref.finalize` callback, and a finalizer runs wherever the collector or a refcount drop happens to be. It took `_token_lock`, a plain non-reentrant `threading.Lock`, which the register path holds across its read-modify-write on `_token_counts`. Evaluating that increment allocates, which can start a collection; if the collection reclaims a dead `Token`, the finalizer re-enters the lock on the thread already holding it and that thread blocks on itself forever. CI hit this twice on the Python 3.12 integration job for #395, at the same point with the same stack, and the job ran to the workflow limit.

The release path now appends the id to a module-level `deque` and takes no lock at all. `_register_token` and `dead_token_ids` apply the queued decrements under `_token_lock` before they increment or read. Deferral is safe in one direction only, and it is the direction the reap needs: between drains a count can only be too high, so an id is retained one mount longer and is never reaped early — the same asymmetry the module's docstring already accepted for its unlocked membership read.

Trade-offs worth noting. An `RLock` would also clear the deadlock, but would leave a lock in a finalizer and open a narrow lost-decrement window, so it was rejected. Reap promptness is unchanged: the drain runs ahead of the membership read, so a finalizer that has already fired is accounted for on the very next mount. The reap's membership read stays outside the lock, where it already was — its ids are caller-supplied, and driving an arbitrary iterable under a lock no finalizer may take would reintroduce the hazard the queue exists to remove.

Closes #397

## Proposed changes

### Queue releases instead of applying them under the lock

`_release_token` becomes a single `_released_token_ids.append(token_id)`. The append is a single atomic C-level operation, so it cannot corrupt a concurrent drain, and it allocates nothing the collector tracks, so it cannot start a collection of its own — which is what makes it safe to run from inside the critical section it used to contend for. Its `Implementation notes` rubric is the single home for the deferral invariant; the `_token_lock` and `_released_token_ids` declarations carry only their own claim and point at it.

### Drain under the lock at both registry entry points

A new `_drain_released()` helper applies the queued decrements, dropping a key at zero. `_register_token` calls it before its increment; `dead_token_ids` calls it before its membership read. Only a lock holder pops, so nothing can empty the queue between the emptiness test and the `popleft`, and a finalizer firing mid-drain only ever appends — its release is picked up by that drain or the next.

The drain inside `_register_token` carries no correctness weight: each queued release matches exactly one earlier increment, so draining before or after the increment settles the count alike. It is there to bound the queue in a process that mints and drops tokens without ever reaching a reap — a memory property no test can observe without reading the queue itself, so the rubric records it rather than a pin.

### Documentation

The `_token_lock` declaration states what it serialises and that nothing run under it may mint or release a token. `_release_token`'s summary no longer claims the callback fires "during garbage collection" — it fires on whichever thread drops the last reference, which is exactly what this PR's own probe relies on. `dead_token_ids` carries the one-mount reaping lag above its rubric, where a caller reasoning about the reap will find it. `Chain`'s ledger-reap documentation needs no change: it claims a spent id is reaped once no live instance remains, and the drain preserves exactly that.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `test_token.py` | No token ids — the degenerate empty input the reap passes on every mount of a chain carrying no spent tokens | `dead_token_ids` is queried with an empty iterable | Returns an empty frozenset without error | The drain-then-read path on its degenerate input |
| 2 | `test_token.py` | Two set tokens under distinct keys, one held and one dropped and collected | `dead_token_ids` is queried with both ids | Reports the dropped id and not the held one | The reap oracle's baseline liveness discrimination |
| 3 | `test_token.py` | A set token and its dispatch round-trip clone — two instances sharing one id — with the original dropped and collected | `dead_token_ids` is queried with the shared id | Reports nothing dead | Releasing one instance decrements a shared id without zeroing it |
| 4 | `test_token.py` | Eight live token instances under one key, all dropped and collected together with no registration in between | `dead_token_ids` is queried once with all eight ids | Reports every one of them dead | A query applies the whole backlog of releases, not only the head of the queue |
| 5 | `test_token.py` | Any number of instances of one token id, of which any number are dropped and collected | `dead_token_ids` is queried with the shared id | Reports the id dead if and only if every instance was released | The module's central invariant, over the instance and release domain rather than at two sampled points |
| 6 | `test_token.py` | A token whose last reference is dropped from inside the registry's read-modify-write for another token's registration | `dead_token_ids` is queried for the dropped token's id, out of process under a wall-clock bound | Reports the id dead within the bound | The #397 regression: a finalizer never blocks the registering thread, and deferring its decrement does not drop it |

Test 6 runs out of process because a regression hangs while holding the registry lock, which would strand every later test in the interpreter rather than failing one; it carries a registered `subprocess_probe` marker so CI can deselect it, while staying in the fast lane where the hang originated. Its hook anchors on the drain rather than on a dictionary lookup, so landing inside the critical section follows from the drain's own documented precondition instead of from whichever C call happens to run there. Naming a private function is a deliberate waiver recorded at the hook: the critical section runs no user-controllable callback, garbage-collection stress never reproduced the interleaving across thousands of rounds, and an ungated `gc.callbacks` drop always fired before the lock was taken. The probe lives in its own non-collected module so ruff and pyright see it, and reports failure by exit status rather than by `assert`, which the interpreter strips under `-O`.

Verified against a restored pre-fix registry: the probe hangs and is killed at the bound, and passes in 0.16s after. A benign refactor that reads the count before taking the lock — which defeated an earlier anchor — still trips it. Renaming the drain fails it loudly rather than passing silently. Mutation-checked: a no-op drain, a head-only drain, a drain that pops the key regardless of the remaining count, and a reap that skips the drain are each caught by two or more of these tests.

The pre-existing reap suite in `test_chain.py` continues to pin the chain-level consequences unchanged, including cross-thread release, wire reconstitution of a released id, and the bounded-ledger property.
