### PR TITLE
Derive release versions from the tag reachable on the target branch — Closes #400

### DIFF
--- a/.github/actions/build-release/action.yaml
+++ b/.github/actions/build-release/action.yaml
@@ -14,6 +14,10 @@ runs:
     - name: Checkout code
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
+        # Full history: the metadata hook derives the package version from
+        # the tag `git describe` reaches at HEAD, which a shallow checkout
+        # cannot answer.
+        fetch-depth: 0
         fetch-tags: true
         persist-credentials: false
         ref: ${{ inputs.version }}

--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -24,8 +24,17 @@ case $1 in
         ;;
 esac
 
-# Determine release cycle
+# Evaluate version
 VERSION=$2
+if ! [[ "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-(a|b|rc)[0-9]+)?$ ]]; then
+    # Without this the arithmetic below fails on stderr, echoes the version
+    # back unchanged and still exits 0, which publishes whatever it was given.
+    echo "ERROR: Invalid version: $VERSION" >&2
+    echo "$USAGE" >&2
+    exit 1
+fi
+
+# Determine release cycle
 case $VERSION in
     *-a*)
         CYCLE="-a"
@@ -51,7 +60,7 @@ if [ "$PRE_RELEASE" = true ] && [[ "$SEGMENT" == "major" ]]; then
 fi
 
 #Split version
-read MAJOR MINOR PATCH <<< $(.github/scripts/split-version.sh $VERSION)
+read MAJOR MINOR PATCH <<< $("$(dirname "${BASH_SOURCE[0]}")/split-version.sh" $VERSION)
 
 case $SEGMENT in
     major)

--- a/.github/scripts/cut-release.sh
+++ b/.github/scripts/cut-release.sh
@@ -36,8 +36,8 @@ if git show-ref --verify --quiet refs/heads/$BRANCH; then
     exit 1
 fi
 
-# Get the latest version tag, default to 0.0.0
-VERSION=$(git describe --tags --abbrev=0)
+# Get the latest version tag reachable from main, default to 0.0.0
+VERSION=$("$(dirname "${BASH_SOURCE[0]}")/latest-version.sh" any)
 
 # Verify no active release candidates exist
 if [[ $VERSION == *-rc* ]]; then
@@ -45,7 +45,7 @@ if [[ $VERSION == *-rc* ]]; then
     exit 1
 fi
 
-read MAJOR MINOR PATCH <<< $(.github/scripts/split-version.sh $VERSION)
+read MAJOR MINOR PATCH <<< $("$(dirname "${BASH_SOURCE[0]}")/split-version.sh" $VERSION)
 
 # Bump the version
 case $RELEASE_TYPE in

--- a/.github/scripts/latest-version.sh
+++ b/.github/scripts/latest-version.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+USAGE="Usage: $0 production|candidate|any [REF=HEAD]"
+
+# Evaluate release channel. Each channel matches the whole tag rather than
+# excluding cycle markers, so a tag that is not a version this tooling
+# produces -- a "nightly-2026-01-01", a "docs-rc-cleanup" -- can never be
+# bumped and published as one.
+case $1 in
+    production)
+        PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+$'
+        ;;
+    candidate)
+        PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$'
+        ;;
+    any)
+        PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+(-(a|b|rc)[0-9]+)?$'
+        ;;
+    *)
+        echo "ERROR: Invalid release channel: $1" >&2
+        echo "$USAGE" >&2
+        exit 1
+        ;;
+esac
+
+# Evaluate arguments
+case $# in
+    1)
+        REF="HEAD"
+        ;;
+    2)
+        REF=$2
+        ;;
+    *)
+        echo "$USAGE" >&2
+        exit 1
+        ;;
+esac
+
+# An unresolvable ref is an error, not an empty channel. Reporting v0.0.0
+# for a ref that does not exist would bump to v0.0.1 and publish it.
+if ! git rev-parse --verify --quiet "${REF}^{commit}" >/dev/null 2>&1; then
+    echo "ERROR: Cannot resolve ref: $REF" >&2
+    echo "$USAGE" >&2
+    exit 1
+fi
+
+# The highest version of the channel reachable from REF -- deliberately not
+# the nearest. `git describe` ranks candidate tags by a commit-distance
+# metric that a merge from an older fork point inverts, which would hand
+# back a tag below one already released and publish a version regression.
+# Tags outside the channel are filtered before the sort, so a commit that
+# reaches both a production tag and a candidate resolves by pattern rather
+# than by tie-breaking. The suffix settings order a pre-release below the
+# version it is a candidate for, which `git`'s version sort otherwise
+# inverts.
+VERSION=$(
+    git -c versionsort.suffix=-a \
+        -c versionsort.suffix=-b \
+        -c versionsort.suffix=-rc \
+        tag --merged "$REF" --sort=-v:refname |
+        grep -E "$PATTERN" |
+        head -1
+)
+
+echo "${VERSION:-v0.0.0}"

--- a/.github/scripts/version-segment.sh
+++ b/.github/scripts/version-segment.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+USAGE="Usage: $0 BASE_REF HEAD_REF"
+
+# Evaluate arguments
+case $# in
+    2)
+        BASE_REF=$1
+        HEAD_REF=$2
+        ;;
+    *)
+        echo "$USAGE" >&2
+        exit 1
+        ;;
+esac
+
+# The branch pair fixes both which segment moves and which release channel
+# the version it moves is read from. `master` is the production line, so a
+# fix merged into it patches the last production release; `release` carries
+# the pending candidate, so merges into it advance that candidate; and
+# finalizing `release` into `master` promotes the candidate by consuming its
+# release cycle.
+case $BASE_REF in
+    master)
+        case $HEAD_REF in
+            release)
+                SEGMENT="minor"
+                CHANNEL="candidate"
+                ;;
+            *)
+                SEGMENT="patch"
+                CHANNEL="production"
+                ;;
+        esac
+        ;;
+    release)
+        SEGMENT="patch"
+        CHANNEL="candidate"
+        ;;
+    *)
+        echo "ERROR: Unsupported base branch $BASE_REF" >&2
+        exit 1
+        ;;
+esac
+
+echo "segment=$SEGMENT"
+echo "channel=$CHANNEL"

--- a/.github/workflows/manual-release.yaml
+++ b/.github/workflows/manual-release.yaml
@@ -79,7 +79,15 @@ jobs:
         run: |
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
           git fetch --tags
-          old_version=$(git describe --tags $(git rev-list --tags --max-count=1))
+          # The same rule the merge path applies, for the branch this commit
+          # is on. `validate-inputs` requires the commit to be a head of
+          # `master`, the production line, so the version moves from the last
+          # production release reachable at that commit -- for a minor as
+          # well as a patch. Reading the candidate channel here would move
+          # from a candidate `master` has already consumed and produce a
+          # version that is already tagged. The checkout is at the requested
+          # commit, so HEAD is its lineage.
+          old_version=$(.github/scripts/latest-version.sh production HEAD)
           new_version=$(.github/scripts/bump-version.sh "$BUMP" "$old_version")
           echo "Bumping $old_version to $new_version"
           echo "version=$new_version" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -30,8 +30,15 @@ jobs:
     outputs:
       version: ${{ steps.bump-version.outputs.version }}
     steps:
+      # No `ref:` here, for the reason spelled out in `tag-version` below.
+      # `fetch-depth: 0` gives the tag history `git describe` walks; the
+      # merge commit itself is fetched explicitly in the bump step, since
+      # `github.sha` under `pull_request_target` is only documented as the
+      # last commit on the base branch, not as the merge commit.
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/get-wool-labs-app-token
         id: get-wool-labs-app-token
         with:
@@ -45,32 +52,17 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           HEAD_REF: ${{ github.head_ref }}
         run: |
-          case "$BASE_REF" in
-            master)
-              case "$HEAD_REF" in
-                release)
-                  echo "segment=minor" >> $GITHUB_OUTPUT
-                  ;;
-                *)
-                  echo "segment=patch" >> $GITHUB_OUTPUT
-                  ;;
-              esac
-              ;;
-            release)
-              echo "segment=patch" >> $GITHUB_OUTPUT
-              ;;
-            *)
-              echo "Error: Unsupported base branch $BASE_REF" >&2
-              exit 1
-              ;;
-          esac
+          .github/scripts/version-segment.sh "$BASE_REF" "$HEAD_REF" >> $GITHUB_OUTPUT
       - name: Bump version
         id: bump-version
         env:
           GH_TOKEN: ${{ steps.get-wool-labs-app-token.outputs.access-token }}
           REPO: ${{ github.repository }}
+          BASE_REF: ${{ github.base_ref }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           VERSION_SEGMENT: ${{ steps.determine-version-segment.outputs.segment }}
+          VERSION_CHANNEL: ${{ steps.determine-version-segment.outputs.channel }}
         run: |
           git config --local --unset-all http.https://github.com/.extraheader || true
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
@@ -78,8 +70,16 @@ jobs:
             new_version="$INPUT_VERSION"
             echo "Using manually specified version: $new_version"
           else
-            git fetch --unshallow
-            old_version=$(git describe --tags $(git rev-list --tags --max-count=1))
+            # The version is read from the lineage of the commit that
+            # `tag-version` tags, so the tag it lands beside is the tag it
+            # was derived from. Falling back to the base branch tip covers
+            # a merge commit the API did not report.
+            git fetch --tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+            describe_ref="$MERGE_SHA"
+            if ! git cat-file -e "${describe_ref}^{commit}" 2>/dev/null; then
+              describe_ref="origin/${BASE_REF}"
+            fi
+            old_version=$(.github/scripts/latest-version.sh "$VERSION_CHANNEL" "$describe_ref")
             new_version=$(.github/scripts/bump-version.sh "$VERSION_SEGMENT" "$old_version")
             echo "Bumping $old_version to $new_version"
           fi

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -26,7 +26,7 @@ jobs:
         id: get-touched-files
         uses: ./.github/actions/get-touched-files
         with:
-          pathspec: 'wool/src/ wool/tests/ wool/pyproject.toml proto/ .github/'
+          pathspec: 'wool/src/ wool/tests/ wool/pyproject.toml proto/ .github/ build-hooks/'
 
   lint:
     name: Lint / pyright

--- a/build-hooks/_git.py
+++ b/build-hooks/_git.py
@@ -1,5 +1,5 @@
 import git
-from _version import SemanticVersion, parser
+from _version import parser
 
 
 @parser("git")
@@ -7,31 +7,39 @@ def parse() -> str:
     """
     Parses the current git repository to generate a version string.
 
+    A commit that carries a tag is versioned as that tag, so a release
+    artifact is labelled with the version it was cut as. Any other commit is
+    versioned as the nearest tag reachable from it -- tags on branches the
+    commit does not reach are invisible, so a pending release candidate never
+    labels a build of the production line -- qualified by a local identifier
+    naming the commit, and further qualified as ``dirty`` when the worktree
+    carries uncommitted changes. A commit with no tag in its lineage is
+    versioned as ``0.0.0``.
+
     Returns:
-        A version string based on the latest tag, commit hash, and uncommitted
-        changes.
+        A version string based on the tag reachable at HEAD, the commit hash,
+        and uncommitted changes.
 
     Raises:
-        RuntimeError: If the repository is empty.
+        RuntimeError: If the repository is bare.
     """
     repo = git.Repo(search_parent_directories=True)
     if repo.bare:
         raise RuntimeError(f"The repo at '{repo.working_dir}' cannot be empty!")
-    head_commit = repo.head.commit
     try:
-        tag = max(repo.tags, key=lambda t: SemanticVersion.parse(str(t)))
-    except ValueError:
-        tag_name = "0.0.0"
-        tag_commit = None
+        tag_name = repo.git.describe("--tags", "--exact-match")
+    except git.GitCommandError:
+        exact = False
+        try:
+            tag_name = repo.git.describe("--tags", "--abbrev=0")
+        except git.GitCommandError:
+            tag_name = "0.0.0"
     else:
-        tag_name = tag.name
-        tag_commit = tag.commit
+        exact = True
     public, *local = tag_name.split("+")
-    if head_commit != tag_commit:
-        commit_label = repo.git.rev_parse(head_commit.hexsha, short=True)
-        local.append(commit_label)
-    dirty = repo.index.diff(None) or repo.untracked_files
-    if dirty:
+    if not exact:
+        local.append(repo.git.rev_parse(repo.head.commit.hexsha, short=True))
+    if repo.is_dirty(untracked_files=True):
         local.append("dirty")
     local = "-".join(local)
     return f"{public}+{local}" if local else public

--- a/wool/pyproject.toml
+++ b/wool/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "allpairspy",
     "cryptography",
     "debugpy",
+    "gitpython",
     "hypothesis",
     "pyright",
     "pytest",
@@ -49,6 +50,7 @@ dev = [
     "pytest-cov",
     "pytest-grpc-aio~=0.3.0",
     "pytest-mock",
+    "pyyaml",
     "ruff",
     "uvloop",
 ]

--- a/wool/tests/cicd/conftest.py
+++ b/wool/tests/cicd/conftest.py
@@ -1,0 +1,151 @@
+"""Fixtures for the release-tooling tests.
+
+The release scripts and the build metadata hook both answer questions about
+a git repository, so the units under test are exercised against throwaway
+repositories with synthetic histories rather than against this checkout.
+"""
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+from collections.abc import Callable
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+SCRIPTS = REPO_ROOT / ".github" / "scripts"
+
+BUILD_HOOKS = REPO_ROOT / "build-hooks"
+
+
+class Repository:
+    """A throwaway git repository under construction.
+
+    Wraps the handful of plumbing commands the histories in this package are
+    built from, so a test reads as the topology it describes.
+    """
+
+    def __init__(self, path: pathlib.Path) -> None:
+        self.path = path
+        self._commits = 0
+
+    def git(self, *arguments: str) -> str:
+        """Run a git command in the repository and return its output."""
+        return subprocess.run(
+            ("git", *arguments),
+            capture_output=True,
+            check=True,
+            cwd=self.path,
+            text=True,
+        ).stdout.strip()
+
+    def commit(self, message: str = "") -> str:
+        """Add an empty commit and return its full hash.
+
+        The default message is numbered because two empty commits sharing a
+        parent, a tree, a message and a one-second timestamp are the same git
+        object: sibling branches would silently collapse onto one commit and
+        a merge between them would be a no-op.
+        """
+        self._commits += 1
+        self.git("commit", "--allow-empty", "--message", message or f"c{self._commits}")
+        return self.git("rev-parse", "HEAD")
+
+    def tag(self, name: str) -> None:
+        """Tag the current commit."""
+        self.git("tag", name)
+
+    def branch(self, name: str) -> None:
+        """Create a branch at the current commit and check it out."""
+        self.git("checkout", "-b", name)
+
+    def checkout(self, *arguments: str) -> None:
+        """Check out a branch, a tag, or a commit."""
+        self.git("checkout", *arguments)
+
+    def merge(self, name: str, message: str = "merge") -> str:
+        """Merge a branch with an explicit merge commit and return its hash.
+
+        The parent count is asserted because ``git merge`` reports success
+        when it has nothing to do, which would leave a test that means to
+        exercise a merge commit asserting against a linear history.
+        """
+        self.git("merge", "--no-ff", name, "--message", message)
+        head = self.git("rev-parse", "HEAD")
+        parents = self.git("rev-list", "--parents", "--max-count", "1", "HEAD")
+        assert len(parents.split()) == 3, f"expected a merge commit, got {parents}"
+        return head
+
+
+@pytest.fixture
+def repository(tmp_path: pathlib.Path) -> Repository:
+    """An initialized git repository with no commits, on ``master``."""
+    repository = Repository(tmp_path / "repository")
+    repository.path.mkdir()
+    repository.git("init", "--initial-branch", "master")
+    repository.git("config", "user.email", "tests@wool.io")
+    repository.git("config", "user.name", "Tests")
+    repository.git("config", "commit.gpgsign", "false")
+    repository.git("config", "tag.gpgsign", "false")
+    return repository
+
+
+@pytest.fixture
+def script(repository: Repository) -> Callable[..., subprocess.CompletedProcess]:
+    """Run one of the release scripts with the repository as its directory.
+
+    The repository is never this checkout, so a script that resolves a
+    sibling script relative to the working directory fails these tests.
+    """
+
+    def run(
+        name: str, *arguments: str, cwd: pathlib.Path | None = None
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            (str(SCRIPTS / name), *arguments),
+            capture_output=True,
+            cwd=cwd or repository.path,
+            text=True,
+        )
+
+    return run
+
+
+def _load(name: str) -> ModuleType:
+    """Import a build hook module by path, under a name of this suite's own.
+
+    ``build-hooks`` holds modules named ``build`` and ``metadata``; putting
+    it on ``sys.path`` would shadow those names for every test that runs
+    afterward.
+    """
+    if (module := sys.modules.get(name)) is not None:
+        return module
+    specification = importlib.util.spec_from_file_location(
+        name, BUILD_HOOKS / f"{name.rpartition('.')[2]}.py"
+    )
+    assert specification and specification.loader
+    module = importlib.util.module_from_spec(specification)
+    # Registered before execution so the hook's own ``from _version import``
+    # resolves to this module rather than re-executing it under that name.
+    sys.modules[name] = module
+    specification.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="session")
+def semantic_version() -> type:
+    """The version model the release tooling's output is parsed against."""
+    return _load("_version").SemanticVersion
+
+
+@pytest.fixture
+def version(semantic_version: type, repository: Repository, monkeypatch) -> Callable:
+    """Render the build metadata hook's version for the repository."""
+    monkeypatch.chdir(repository.path)
+    # Importing the hook registers it with the version parser registry,
+    # which is what makes it reachable as ``parse.git``.
+    _load("_git")
+    return lambda: semantic_version.parse.git()

--- a/wool/tests/cicd/test_bump_version.py
+++ b/wool/tests/cicd/test_bump_version.py
@@ -1,0 +1,167 @@
+import pytest
+from hypothesis import HealthCheck
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
+
+#: Release cycles in ascending order, production last.
+_CYCLES = [None, "a", "b", "rc"]
+
+
+@pytest.mark.parametrize(
+    ("segment", "old_version", "new_version"),
+    [
+        ("patch", "v0.14.0", "v0.14.1"),
+        ("patch", "v0.15.0-rc2", "v0.15.0-rc3"),
+        ("patch", "v0.0.0", "v0.0.1"),
+        ("minor", "v0.14.0", "v0.15.0"),
+        ("minor", "v0.15.0-rc2", "v0.15.0"),
+        ("minor", "v0.15.0-a1", "v0.15.0-b0"),
+        ("minor", "v0.15.0-b1", "v0.15.0-rc0"),
+        ("major", "v0.14.0", "v1.0.0"),
+    ],
+)
+def test_bump_version_should_return_the_bumped_version(
+    script, segment, old_version, new_version
+):
+    """Test the version transitions the release workflows depend on.
+
+    Given:
+        A version and the segment to move.
+    When:
+        The version is bumped.
+    Then:
+        It should return the next version of that segment.
+    """
+    # Act
+    result = script("bump-version.sh", segment, old_version)
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == new_version
+
+
+def test_bump_version_should_exit_nonzero_when_bumping_a_prerelease_major(script):
+    """Test the major bump's rejection of a pre-release version.
+
+    Given:
+        A release candidate version.
+    When:
+        Its major segment is bumped.
+    Then:
+        It should exit non-zero and report the rejected bump.
+    """
+    # Act
+    result = script("bump-version.sh", "major", "v0.15.0-rc2")
+
+    # Assert
+    assert result.returncode != 0
+    assert "Cannot bump major version segment" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "version", ["v1.0.0-rc.1", "v1.0.0-alpha.1", "v1.0.0+build.5", "nightly", ""]
+)
+def test_bump_version_should_exit_nonzero_when_the_version_is_malformed(script, version):
+    """Test the version argument's validation.
+
+    Given:
+        A string that is not a version this tooling produces.
+    When:
+        Its patch segment is bumped.
+    Then:
+        It should exit non-zero rather than return the string unchanged.
+    """
+    # Act
+    result = script("bump-version.sh", "patch", version)
+
+    # Assert
+    assert result.returncode != 0
+    assert "Invalid version" in result.stderr
+
+
+# The repository the script fixture runs in is arrangement Hypothesis has no
+# reason to redraw between examples -- bump-version.sh reads its arguments,
+# not the repository -- so re-using it across examples is safe. The deadline
+# is lifted because each example spawns two shells, which a loaded CI runner
+# can take longer over than Hypothesis's default allows.
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    segment=st.sampled_from(["patch", "minor"]),
+    major=st.integers(min_value=0, max_value=99),
+    minor=st.integers(min_value=0, max_value=99),
+    patch=st.integers(min_value=0, max_value=99),
+    cycle=st.sampled_from(_CYCLES),
+)
+def test_bump_version_should_return_a_greater_version(
+    script, segment, major, minor, patch, cycle
+):
+    """Test the ordering invariant every release bump rests on.
+
+    Given:
+        Any production or pre-release version and a patch or minor segment.
+    When:
+        The version is bumped.
+    Then:
+        It should return a version that ranks above the original.
+    """
+    # Arrange
+    if cycle:
+        old_version = f"v{major}.{minor}.0-{cycle}{patch}"
+    else:
+        old_version = f"v{major}.{minor}.{patch}"
+
+    # Act
+    result = script("bump-version.sh", segment, old_version)
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+    bumped = result.stdout.strip()
+    # Ranked on the segments themselves rather than through SemanticVersion,
+    # whose pre-release ordering compares "rc10" against "rc9" as text.
+    assert _rank(bumped) > _rank(old_version)
+
+
+def _rank(version: str) -> tuple:
+    """Order a version by its numeric segments and its release cycle."""
+    core, _, pre = version.lstrip("v").partition("-")
+    major, minor, patch = (int(segment) for segment in core.split("."))
+    if pre:
+        cycle = pre.rstrip("0123456789")
+        return (major, minor, patch, _CYCLES.index(cycle), int(pre[len(cycle) :]))
+    return (major, minor, patch, len(_CYCLES), 0)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="SemanticVersion compares pre-release identifiers as text, so "
+    "rc10 ranks below rc9. Unreachable from the release path, which no "
+    "longer orders versions, but the model still reports it.",
+)
+def test_bump_version_should_return_a_version_semantic_version_ranks_above(
+    script, semantic_version
+):
+    """Test the version model's ordering of a two-digit release candidate.
+
+    Given:
+        A release candidate whose next patch carries a two-digit cycle.
+    When:
+        The candidate's patch segment is bumped.
+    Then:
+        It should return a version the version model ranks above it.
+    """
+    # Arrange
+    old_version = "v0.15.0-rc9"
+
+    # Act
+    result = script("bump-version.sh", "patch", old_version)
+
+    # Assert
+    assert result.stdout.strip() == "v0.15.0-rc10"
+    assert semantic_version.parse(result.stdout.strip()) > semantic_version.parse(
+        old_version
+    )

--- a/wool/tests/cicd/test_cut_release.py
+++ b/wool/tests/cicd/test_cut_release.py
@@ -1,0 +1,127 @@
+import pytest
+
+
+@pytest.fixture
+def published(repository, tmp_path):
+    """A repository on ``main`` with an ``origin`` it can push to."""
+    origin = tmp_path / "origin.git"
+    repository.git("init", "--bare", "--initial-branch", "master", str(origin))
+    repository.git("remote", "add", "origin", str(origin))
+    repository.commit()
+    repository.branch("main")
+    repository.git("push", "--quiet", "--set-upstream", "origin", "main")
+    return repository
+
+
+def test_cut_release_should_return_the_next_candidate(published, script):
+    """Test the candidate a minor release is cut as.
+
+    Given:
+        A main branch reaching a production tag.
+    When:
+        A minor release is cut.
+    Then:
+        It should return the next minor's first candidate and push the branch.
+    """
+    # Arrange
+    published.tag("v0.14.0")
+
+    # Act
+    result = script("cut-release.sh", "minor")
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "v0.15.0-rc0"
+    assert "release" in published.git("branch", "--list", "release")
+    assert "release" in published.git("ls-remote", "--heads", "origin", "release")
+
+
+def test_cut_release_should_return_the_first_candidate_when_there_are_no_tags(
+    published, script
+):
+    """Test the candidate cut from an untagged history.
+
+    Given:
+        A main branch with no tags.
+    When:
+        A minor release is cut.
+    Then:
+        It should return the first candidate of the zero version's next minor.
+    """
+    # Act
+    result = script("cut-release.sh", "minor")
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "v0.1.0-rc0"
+
+
+def test_cut_release_should_exit_nonzero_when_a_candidate_is_pending(published, script):
+    """Test the guard against cutting over a pending candidate.
+
+    Given:
+        A main branch reaching a candidate tag.
+    When:
+        A minor release is cut.
+    Then:
+        It should exit non-zero and name the pending candidate.
+    """
+    # Arrange
+    published.tag("v0.14.0")
+    published.commit()
+    published.tag("v0.15.0-rc0")
+
+    # Act
+    result = script("cut-release.sh", "minor")
+
+    # Assert
+    assert result.returncode != 0
+    assert "An active release candidate already exists: v0.15.0-rc0" in result.stderr
+
+
+def test_cut_release_should_cut_again_once_the_candidate_is_promoted(published, script):
+    """Test the cut following a finalized release.
+
+    Given:
+        A main branch reaching a candidate and the release it was promoted to.
+    When:
+        A minor release is cut.
+    Then:
+        It should return the next minor's first candidate.
+    """
+    # Arrange
+    published.tag("v0.15.0-rc0")
+    published.commit()
+    published.tag("v0.15.0")
+
+    # Act
+    result = script("cut-release.sh", "minor")
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "v0.16.0-rc0"
+
+
+def test_cut_release_should_exit_nonzero_when_the_branch_already_exists(
+    published, script
+):
+    """Test the guard against cutting over an existing release branch.
+
+    Given:
+        A repository that already has a release branch.
+    When:
+        A minor release is cut.
+    Then:
+        It should exit non-zero and report the existing branch.
+    """
+    # Arrange
+    published.tag("v0.14.0")
+    published.branch("release")
+    published.checkout("main")
+
+    # Act
+    result = script("cut-release.sh", "minor")
+
+    # Assert
+    assert result.returncode != 0
+    assert "already exists" in result.stderr

--- a/wool/tests/cicd/test_git.py
+++ b/wool/tests/cicd/test_git.py
@@ -1,0 +1,289 @@
+def test_parse_git_should_return_the_tag_when_head_is_tagged(repository, version):
+    """Test the version of a commit that carries a tag.
+
+    Given:
+        A repository whose head commit is tagged.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the tag, with no local identifier.
+    """
+    # Arrange
+    repository.commit()
+    # A higher tag on an ancestor: the version is a property of the commit,
+    # not the highest version in the repository.
+    repository.tag("v0.15.0-rc2")
+    repository.commit()
+    repository.tag("v0.14.1")
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == "0.14.1"
+    assert result.build is None
+
+
+def test_parse_git_should_append_commit_hash_when_head_is_not_tagged(
+    repository, version
+):
+    """Test the version of a commit that carries no tag.
+
+    Given:
+        A repository whose head commit follows a tagged commit.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the nearest tag qualified by the commit hash.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.branch("release")
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+    repository.checkout("master")
+    repository.commit()
+    commit = repository.git("rev-parse", "--short", "HEAD")
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == f"0.14.0+{commit}"
+    # The commit belongs in the local identifier: a describe suffix parsed
+    # as a pre-release would sort the build below the tag it followed.
+    assert result.pre_release is None
+
+
+def test_parse_git_should_ignore_tags_off_the_head_lineage(repository, version):
+    """Test the version of a commit a higher tag does not reach.
+
+    Given:
+        A repository with a higher tag on a branch head does not reach.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the tag reachable from head.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.branch("release")
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+    repository.checkout("master")
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == "0.14.0"
+
+
+def test_parse_git_should_append_dirty_when_a_change_is_staged(repository, version):
+    """Test the version of a worktree with uncommitted changes.
+
+    Given:
+        A repository whose head commit is tagged and whose index carries a
+        staged modification.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the tag qualified as dirty.
+    """
+    # Arrange
+    tracked = repository.path / "tracked.txt"
+    tracked.write_text("committed")
+    repository.git("add", "tracked.txt")
+    repository.commit()
+    repository.tag("v0.14.0")
+    tracked.write_text("modified")
+    repository.git("add", "tracked.txt")
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == "0.14.0+dirty"
+
+
+def test_parse_git_should_append_dirty_when_the_worktree_has_untracked_files(
+    repository, version
+):
+    """Test the version of a worktree with untracked files.
+
+    Given:
+        A repository whose head commit is tagged and whose worktree has an
+        untracked file.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the tag qualified as dirty.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    (repository.path / "untracked.txt").write_text("untracked")
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == "0.14.0+dirty"
+
+
+def test_parse_git_should_return_zero_version_when_repository_has_no_tags(
+    repository, version
+):
+    """Test the version of a repository with no tags.
+
+    Given:
+        A repository with a commit and no tags.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the zero version qualified by the commit hash.
+    """
+    # Arrange
+    repository.commit()
+    commit = repository.git("rev-parse", "--short", "HEAD")
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == f"0.0.0+{commit}"
+
+
+def test_parse_git_should_return_the_candidate_tag_when_head_is_a_candidate(
+    repository, version
+):
+    """Test the version of a commit tagged as a release candidate.
+
+    Given:
+        A repository whose head commit carries a candidate tag.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the candidate, with no local identifier.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == "0.15.0-rc2"
+    assert result.build is None
+
+
+def test_parse_git_should_prefer_the_nearest_tag_when_a_merge_reaches_both(
+    repository, version
+):
+    """Test the version of a merge commit reaching both release channels.
+
+    Given:
+        A commit past a merge that reaches a production tag and a higher
+        candidate tag.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the production tag qualified by the commit hash.
+    """
+    # Arrange
+    repository.commit()
+    repository.branch("release")
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+    repository.checkout("master")
+    repository.commit()
+    repository.tag("v0.14.1")
+    repository.merge("release")
+    commit = repository.git("rev-parse", "--short", "HEAD")
+
+    # Act
+    result = version()
+
+    # Assert
+    # The wheel of a v0.14.1 build must not be labelled 0.15.0-rc2.
+    assert str(result) == f"0.14.1+{commit}"
+
+
+def test_parse_git_should_append_both_identifiers_when_untagged_and_dirty(
+    repository, version
+):
+    """Test the version of an untagged commit in a dirty worktree.
+
+    Given:
+        A repository past a tagged commit with an untracked file.
+    When:
+        The version is parsed from git.
+    Then:
+        It should carry the commit hash and the dirty marker, in that order.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.commit()
+    commit = repository.git("rev-parse", "--short", "HEAD")
+    (repository.path / "untracked.txt").write_text("untracked")
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == f"0.14.0+{commit}-dirty"
+
+
+def test_parse_git_should_return_the_tag_when_head_is_detached(repository, version):
+    """Test the version of a detached head at a tag.
+
+    Given:
+        A repository with a later commit, checked out at an earlier tag.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the tag.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.commit()
+    repository.tag("v0.14.1")
+    # The state `build-release` produces: `ref:` a tag, so HEAD detaches.
+    repository.checkout("v0.14.0")
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == "0.14.0"
+
+
+def test_parse_git_should_return_the_tag_when_invoked_from_a_subdirectory(
+    repository, version, monkeypatch
+):
+    """Test the version resolved from below the repository root.
+
+    Given:
+        A tagged repository and a working directory inside it.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the tag.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    # Hatch invokes the hook from the package directory, never the root.
+    (package := repository.path / "wool").mkdir()
+    monkeypatch.chdir(package)
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == "0.14.0"

--- a/wool/tests/cicd/test_latest_version.py
+++ b/wool/tests/cicd/test_latest_version.py
@@ -1,0 +1,447 @@
+import pytest
+
+
+def test_latest_version_should_return_production_tag_when_candidate_is_nearer(
+    repository, script
+):
+    """Test the production lookup against a pending release candidate.
+
+    Given:
+        A production tag with a nearer candidate tag on the same branch.
+    When:
+        The production channel is queried.
+    Then:
+        It should return the production tag.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.commit()
+    repository.tag("v0.15.0-rc1")
+
+    # Act
+    result = script("latest-version.sh", "production")
+
+    # Assert
+    assert result.stdout.strip() == "v0.14.0"
+
+
+def test_latest_version_should_return_candidate_tag_when_production_is_nearer(
+    repository, script
+):
+    """Test the candidate lookup against a nearer production tag.
+
+    Given:
+        A candidate tag with a nearer production tag on the same branch.
+    When:
+        The candidate channel is queried.
+    Then:
+        It should return the candidate tag.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+    repository.commit()
+    repository.tag("v0.14.1")
+
+    # Act
+    result = script("latest-version.sh", "candidate")
+
+    # Assert
+    assert result.stdout.strip() == "v0.15.0-rc2"
+
+
+def test_latest_version_should_ignore_tags_off_the_ref(repository, script):
+    """Test that the lookup is scoped to the ref's own lineage.
+
+    Given:
+        A tag on a branch the queried ref does not reach.
+    When:
+        The production channel is queried for that ref.
+    Then:
+        It should return the tag reachable from the ref.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.branch("main")
+    repository.commit()
+    repository.tag("v0.16.0")
+    repository.checkout("master")
+
+    # Act
+    result = script("latest-version.sh", "production", "master")
+
+    # Assert
+    assert result.stdout.strip() == "v0.14.0"
+
+
+def test_latest_version_should_resolve_by_pattern_when_merge_reaches_both_channels(
+    repository, script
+):
+    """Test the lookup on a merge commit reaching both release channels.
+
+    Given:
+        A merge commit reaching both a production tag and a candidate tag.
+    When:
+        Each channel is queried for that merge commit.
+    Then:
+        It should return the tag matching the queried channel.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.branch("release")
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+    repository.checkout("master")
+    repository.commit()
+    repository.tag("v0.14.1")
+    merge = repository.merge("release")
+
+    # Act
+    production = script("latest-version.sh", "production", merge)
+    candidate = script("latest-version.sh", "candidate", merge)
+
+    # Assert
+    assert production.stdout.strip() == "v0.14.1"
+    assert candidate.stdout.strip() == "v0.15.0-rc2"
+
+
+def test_latest_version_should_exclude_alpha_and_beta_from_production(
+    repository, script
+):
+    """Test the production lookup against alpha and beta cycle tags.
+
+    Given:
+        A production tag followed by alpha and beta cycle tags.
+    When:
+        The production channel is queried.
+    Then:
+        It should return the production tag.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.commit()
+    repository.tag("v0.15.0-a1")
+    repository.commit()
+    repository.tag("v0.15.0-b1")
+
+    # Act
+    result = script("latest-version.sh", "production")
+
+    # Assert
+    assert result.stdout.strip() == "v0.14.0"
+
+
+def test_latest_version_should_return_nearest_tag_when_channel_is_any(
+    repository, script
+):
+    """Test the unscoped lookup.
+
+    Given:
+        A production tag with a nearer candidate tag.
+    When:
+        The any channel is queried.
+    Then:
+        It should return the nearest tag of either channel.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.commit()
+    repository.tag("v0.15.0-rc1")
+
+    # Act
+    result = script("latest-version.sh", "any")
+
+    # Assert
+    assert result.stdout.strip() == "v0.15.0-rc1"
+
+
+def test_latest_version_should_return_zero_version_when_no_tag_matches(
+    repository, script
+):
+    """Test the lookup against a lineage with no tag of the channel.
+
+    Given:
+        A repository whose only tag is a candidate.
+    When:
+        The production channel is queried.
+    Then:
+        It should return the zero version.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.15.0-rc1")
+
+    # Act
+    result = script("latest-version.sh", "production")
+
+    # Assert
+    assert result.returncode == 0
+    assert result.stdout.strip() == "v0.0.0"
+
+
+def test_latest_version_should_return_zero_version_when_repository_has_no_tags(
+    repository, script
+):
+    """Test the lookup against an untagged repository.
+
+    Given:
+        A repository with a commit and no tags.
+    When:
+        Any channel is queried.
+    Then:
+        It should return the zero version.
+    """
+    # Arrange
+    repository.commit()
+
+    # Act
+    result = script("latest-version.sh", "any")
+
+    # Assert
+    assert result.returncode == 0
+    assert result.stdout.strip() == "v0.0.0"
+
+
+def test_latest_version_should_default_to_head_when_ref_omitted(repository, script):
+    """Test the default ref.
+
+    Given:
+        A checked-out branch carrying a tag its sibling does not reach.
+    When:
+        The production channel is queried without a ref.
+    Then:
+        It should return the tag reachable from the checked-out branch.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.branch("main")
+    repository.commit()
+    repository.tag("v0.16.0")
+
+    # Act
+    result = script("latest-version.sh", "production")
+
+    # Assert
+    assert result.stdout.strip() == "v0.16.0"
+
+
+def test_latest_version_should_exit_nonzero_when_channel_invalid(repository, script):
+    """Test the channel argument's validation.
+
+    Given:
+        A repository with a tagged commit.
+    When:
+        An unrecognized channel is queried.
+    Then:
+        It should exit non-zero and report the invalid channel.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+
+    # Act
+    result = script("latest-version.sh", "stable")
+
+    # Assert
+    assert result.returncode != 0
+    assert "Invalid release channel: stable" in result.stderr
+
+
+def test_latest_version_should_return_the_highest_reachable_tag(repository, script):
+    """Test the lookup against a lower tag on a shorter path.
+
+    Given:
+        A merge whose other parent forks before the highest production tag.
+    When:
+        The production channel is queried.
+    Then:
+        It should return the highest reachable production tag.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.13.1")
+    fork = repository.git("rev-parse", "HEAD")
+    repository.commit()
+    repository.tag("v0.14.0")
+    for _ in range(8):
+        repository.commit()
+    repository.checkout("-b", "feature", fork)
+    repository.commit()
+    repository.checkout("master")
+    repository.merge("feature")
+
+    # Assert
+    # Commit distance ranks v0.13.1 nearer here, and bumping it would
+    # publish a version below one already released.
+    assert script("latest-version.sh", "production").stdout.strip() == "v0.14.0"
+
+
+def test_latest_version_should_return_the_highest_candidate_when_cycles_are_two_digit(
+    repository, script
+):
+    """Test the candidate lookup across a two-digit release cycle.
+
+    Given:
+        Release candidates whose cycle numbers span one and two digits.
+    When:
+        The candidate channel is queried.
+    Then:
+        It should return the numerically highest candidate.
+    """
+    # Arrange
+    for tag in ("v0.15.0-rc2", "v0.15.0-rc9", "v0.15.0-rc10"):
+        repository.commit()
+        repository.tag(tag)
+
+    # Assert
+    assert script("latest-version.sh", "candidate").stdout.strip() == "v0.15.0-rc10"
+
+
+def test_latest_version_should_rank_a_release_above_its_candidate(repository, script):
+    """Test the unscoped lookup across a consumed release cycle.
+
+    Given:
+        A release and the candidate it was promoted from.
+    When:
+        The any channel is queried.
+    Then:
+        It should return the release rather than its candidate.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+    repository.commit()
+    repository.tag("v0.15.0")
+
+    # Assert
+    assert script("latest-version.sh", "any").stdout.strip() == "v0.15.0"
+
+
+def test_latest_version_should_resolve_both_channels_when_one_commit_carries_both(
+    repository, script
+):
+    """Test the lookup on a commit tagged in both release channels.
+
+    Given:
+        A single commit carrying a production tag and a candidate tag.
+    When:
+        Each channel is queried.
+    Then:
+        It should return the tag matching the queried channel.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.16.0")
+    repository.tag("v0.16.0-rc9")
+
+    # Assert
+    assert script("latest-version.sh", "production").stdout.strip() == "v0.16.0"
+    assert script("latest-version.sh", "candidate").stdout.strip() == "v0.16.0-rc9"
+
+
+@pytest.mark.parametrize("channel", ["production", "candidate", "any"])
+def test_latest_version_should_ignore_tags_that_are_not_versions(
+    repository, script, channel
+):
+    """Test the lookup against tags outside the versioning scheme.
+
+    Given:
+        Non-version tags nearer than the version tags.
+    When:
+        Any channel is queried.
+    Then:
+        It should never return a non-version tag.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+    repository.commit()
+    repository.tag("nightly-2026-01-01")
+    repository.tag("docs-rc-cleanup")
+    repository.tag("release-2026")
+
+    # Act
+    result = script("latest-version.sh", channel)
+
+    # Assert
+    assert result.stdout.strip() in {"v0.14.0", "v0.15.0-rc2"}
+
+
+def test_latest_version_should_exit_nonzero_when_the_ref_cannot_be_resolved(
+    repository, script
+):
+    """Test the lookup against a ref that does not exist.
+
+    Given:
+        A repository with a tagged commit.
+    When:
+        A ref that does not resolve is queried.
+    Then:
+        It should exit non-zero rather than report the zero version.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+
+    # Act
+    result = script("latest-version.sh", "production", "origin/master")
+
+    # Assert
+    # Reporting v0.0.0 here would bump to v0.0.1 and publish it.
+    assert result.returncode != 0
+    assert "origin/master" in result.stderr
+
+
+def test_latest_version_should_exit_nonzero_when_run_outside_a_repository(
+    tmp_path, script
+):
+    """Test the lookup outside a git repository.
+
+    Given:
+        A working directory that is not a git repository.
+    When:
+        Any channel is queried.
+    Then:
+        It should exit non-zero rather than report the zero version.
+    """
+    # Act
+    result = script("latest-version.sh", "any", cwd=tmp_path)
+
+    # Assert
+    assert result.returncode != 0
+
+
+def test_latest_version_should_exit_nonzero_when_given_extra_arguments(
+    repository, script
+):
+    """Test the argument count's validation.
+
+    Given:
+        A repository with a tagged commit.
+    When:
+        The lookup is invoked with a third argument.
+    Then:
+        It should exit non-zero and print the usage line intact.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    # A bracket expression in the usage line globs against the working
+    # directory unless it is quoted.
+    (repository.path / "R").write_text("")
+    (repository.path / "H").write_text("")
+
+    # Act
+    result = script("latest-version.sh", "production", "HEAD", "extra")
+
+    # Assert
+    assert result.returncode != 0
+    assert "[REF=HEAD]" in result.stderr

--- a/wool/tests/cicd/test_version_segment.py
+++ b/wool/tests/cicd/test_version_segment.py
@@ -1,0 +1,167 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("base_ref", "head_ref", "segment", "channel"),
+    [
+        ("master", "400-release-version-lookup", "patch", "production"),
+        ("master", "release", "minor", "candidate"),
+        ("release", "master", "patch", "candidate"),
+        ("release", "401-fix", "patch", "candidate"),
+    ],
+)
+def test_version_segment_should_report_the_segment_and_channel_of_the_branch_pair(
+    script, base_ref, head_ref, segment, channel
+):
+    """Test the release contract each merge is resolved through.
+
+    Given:
+        The base and head branches of a merged pull request.
+    When:
+        The version segment is determined.
+    Then:
+        It should report the segment to move and the channel to move it from.
+    """
+    # Act
+    result = script("version-segment.sh", base_ref, head_ref)
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == [f"segment={segment}", f"channel={channel}"]
+
+
+def test_version_segment_should_exit_nonzero_when_the_base_branch_is_unsupported(
+    script,
+):
+    """Test the base branch's validation.
+
+    Given:
+        A base branch that is not a release line.
+    When:
+        The version segment is determined.
+    Then:
+        It should exit non-zero and name the unsupported branch.
+    """
+    # Act
+    result = script("version-segment.sh", "main", "401-fix")
+
+    # Assert
+    assert result.returncode != 0
+    assert "Unsupported base branch main" in result.stderr
+
+
+def test_version_segment_should_exit_nonzero_when_a_branch_is_missing(script):
+    """Test the argument count's validation.
+
+    Given:
+        Only a base branch.
+    When:
+        The version segment is determined.
+    Then:
+        It should exit non-zero and print the usage line.
+    """
+    # Act
+    result = script("version-segment.sh", "master")
+
+    # Assert
+    assert result.returncode != 0
+    assert "Usage:" in result.stderr
+
+
+def test_a_fix_merged_into_master_should_patch_the_last_production_release(
+    repository, script
+):
+    """Test the release the issue exists to make possible.
+
+    Given:
+        A master reaching a production tag with a stray candidate on its head.
+    When:
+        A fix branch is merged and the resulting version is derived.
+    Then:
+        It should patch the production tag rather than advance the candidate.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.branch("fix")
+    repository.commit()
+    repository.checkout("master")
+    # The stray candidate PR #395's merge left on master's head.
+    repository.commit()
+    repository.tag("v0.15.0-rc1")
+    merge = repository.merge("fix")
+
+    # Act
+    version = _derive(script, "master", "fix", merge)
+
+    # Assert
+    assert version == "v0.14.1"
+
+
+def test_a_release_merged_into_master_should_promote_the_reachable_candidate(
+    repository, script
+):
+    """Test the version a finalized release is published as.
+
+    Given:
+        A release branch carrying the pending candidate.
+    When:
+        It is merged into master and the resulting version is derived.
+    Then:
+        It should promote the candidate to its production version.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.1")
+    repository.branch("release")
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+    repository.checkout("master")
+    merge = repository.merge("release")
+
+    # Act
+    version = _derive(script, "master", "release", merge)
+
+    # Assert
+    # The production tag the merge also reaches must not leak in.
+    assert version == "v0.15.0"
+
+
+def test_a_sync_merged_into_release_should_advance_the_reachable_candidate(
+    repository, script
+):
+    """Test the version a sync into the release branch is published as.
+
+    Given:
+        A release branch carrying a candidate, synced from master.
+    When:
+        The sync is merged and the resulting version is derived.
+    Then:
+        It should advance the candidate.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.1")
+    repository.branch("release")
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+    repository.checkout("master")
+    repository.commit()
+    repository.checkout("release")
+    merge = repository.merge("master")
+
+    # Act
+    version = _derive(script, "release", "master", merge)
+
+    # Assert
+    assert version == "v0.15.0-rc3"
+
+
+def _derive(script, base_ref: str, head_ref: str, ref: str) -> str:
+    """Resolve the version a merge publishes, as the workflow composes it."""
+    segment, channel = (
+        line.split("=", 1)[1]
+        for line in script("version-segment.sh", base_ref, head_ref).stdout.split()
+    )
+    old_version = script("latest-version.sh", channel, ref).stdout.strip()
+    return script("bump-version.sh", segment, old_version).stdout.strip()

--- a/wool/tests/cicd/test_workflows.py
+++ b/wool/tests/cicd/test_workflows.py
@@ -1,0 +1,118 @@
+import os
+import pathlib
+import re
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+ACTIONS = REPO_ROOT / ".github" / "actions"
+
+#: Every `.github/scripts/<name>.sh` reference in a workflow or action body.
+SCRIPT_REFERENCE = re.compile(r"\.github/scripts/[\w-]+\.sh")
+
+
+def checkouts(definition: dict) -> list:
+    """Every ``actions/checkout`` step in a workflow or composite action."""
+    jobs = definition.get("jobs", {}).values()
+    steps = definition.get("runs", {}).get("steps", [])
+    for job in jobs:
+        steps = [*steps, *job.get("steps", [])]
+    return [step for step in steps if "actions/checkout" in step.get("uses", "")]
+
+
+def test_build_release_should_check_out_the_full_history():
+    """Test the checkout the release build derives its version from.
+
+    Given:
+        The build-release action.
+    When:
+        Its checkout step is read.
+    Then:
+        It should fetch the full history and the tags.
+    """
+    # Arrange
+    definition = yaml.safe_load((ACTIONS / "build-release" / "action.yaml").read_text())
+
+    # Act
+    step = checkouts(definition)[0]
+
+    # Assert
+    # Without the full history the metadata hook cannot describe the tag it
+    # was checked out at, and the wheel is labelled 0.0.0 instead.
+    assert step["with"]["fetch-depth"] == 0
+    assert step["with"]["fetch-tags"] is True
+
+
+def test_publish_release_should_check_out_the_full_history_before_bumping():
+    """Test the checkout the published version is derived from.
+
+    Given:
+        The publish-release workflow.
+    When:
+        The bump-version job's checkout step is read.
+    Then:
+        It should fetch the full history.
+    """
+    # Arrange
+    definition = yaml.safe_load((WORKFLOWS / "publish-release.yaml").read_text())
+
+    # Act
+    job = definition["jobs"]["bump-version"]
+
+    # Assert
+    assert checkouts({"jobs": {"bump-version": job}})[0]["with"]["fetch-depth"] == 0
+
+
+def test_publish_release_should_not_be_triggered_by_this_suite():
+    """Test the paths a merge publishes a release from.
+
+    Given:
+        The publish-release workflow.
+    When:
+        Its pull_request_target paths filter is read.
+    Then:
+        It should name only the package's source and its project file.
+    """
+    # Arrange
+    definition = yaml.safe_load((WORKFLOWS / "publish-release.yaml").read_text())
+
+    # Act
+    # ``on`` is parsed as the boolean True by the YAML 1.1 loader.
+    paths = definition[True]["pull_request_target"]["paths"]
+
+    # Assert
+    assert paths == ["wool/src/**", "wool/pyproject.toml"]
+
+
+@pytest.mark.parametrize(
+    "definition",
+    [
+        *WORKFLOWS.glob("*.yaml"),
+        *ACTIONS.glob("*/action.yaml"),
+    ],
+    ids=lambda path: path.parent.name + "/" + path.name,
+)
+def test_every_referenced_script_should_be_executable(definition):
+    """Test the release scripts the workflows invoke directly.
+
+    Given:
+        A workflow or action naming scripts under .github/scripts.
+    When:
+        Each referenced script is resolved.
+    Then:
+        It should exist and be executable.
+    """
+    # Act
+    referenced = set(SCRIPT_REFERENCE.findall(definition.read_text()))
+
+    # Assert
+    for reference in referenced:
+        script = REPO_ROOT / reference
+        assert script.exists(), reference
+        # The workflows exec these directly rather than through bash, so a
+        # lost mode bit breaks the release at runtime and nowhere earlier.
+        assert os.access(script, os.X_OK), reference


### PR DESCRIPTION
## Summary

Three places computed "the latest tag" with three different rules, and none was scoped to the branch being released. `publish-release.yaml` and `manual-release.yaml` bumped `git describe --tags $(git rev-list --tags --max-count=1)` — the tag on the most recently committed tagged commit anywhere in the repository; `build-hooks/_git.py` labelled the package from `max(repo.tags)` by version ordering; `cut-release.sh` alone used a tag reachable from the branch. Because `master` is the production line, a fix merged into it is a patch of the last production release by construction, and the lookup ignored that: PR #395 merged into `master` while `v0.15.0-rc0` was the newest tag in the repository, was bumped to `v0.15.0-rc1` and published as a candidate, although `master`'s only reachable production tag was `v0.14.0` and the intended result was `v0.14.1`.

Scope the lookup to the lineage being released. A single helper, `.github/scripts/latest-version.sh <production|candidate|any> [REF=HEAD]`, answers the highest version of a release channel reachable from a ref, and every call site names the ref it means. The branch pair — which fixes the release channel as well as the segment — moves out of the workflow into `.github/scripts/version-segment.sh` so it can be exercised without a runner.

Three defects in the first draft of this fix came out of writing the tests and are corrected here: `git describe --abbrev=0` can return a tag *below* one already released, because its candidate ranking is not commit distance and it breaks ties toward the ancestor; an unresolvable ref reported `v0.0.0`, which bumps to `v0.0.1` and publishes; and a tag outside the versioning scheme was eligible, so a `nightly-2026-01-01` tag became `vnightly-2026-01-01.0.1` with exit 0.

Closes #400

## Proposed changes

### Scope the version lookup to the branch's own lineage

`latest-version.sh` selects the **highest** version tag of a channel reachable from a ref, via `git tag --merged` with a version sort. Each channel matches a whole version pattern, so resolution is by pattern and a commit reaching both a production tag and a candidate never tie-breaks between them.

Taking the highest rather than the nearest is load-bearing. `git describe --tags --abbrev=0` ranks candidates by a metric that a merge from an older fork point inverts: on `v0.13.1` → `v0.14.0` → eight untagged commits → a PR forked back at `v0.13.1` and merged, it returns `v0.13.1`, which patches to `v0.13.2` — below the shipped `v0.14.0`, and published silently. Selecting the highest returns `v0.14.0` on that topology.

An unresolvable ref is now a hard error rather than a silent `v0.0.0`; `v0.0.0` is reserved for a channel that genuinely has no tag reachable, which is the bootstrap case `cut-release.sh` already documented but never implemented.

### Resolve the release channel from the branch pair

| Trigger | Ref described | Channel | Segment | Result on today's tags |
|---|---|---|---|---|
| PR merged, base `master`, head not `release` | `merge_commit_sha`, falling back to `origin/$BASE_REF` | production | patch | `v0.14.0` → **`v0.14.1`** |
| PR merged, base `master`, head `release` | same | candidate | minor | `v0.15.0-rc2` → `v0.15.0` |
| PR merged, base `release`, including sync PRs | same | candidate | patch | `v0.15.0-rc2` → `v0.15.0-rc3` |
| `manual-release`, `patch` or `minor` | `HEAD`, the requested commit | production | as requested | per that commit's lineage |
| `cut-release.sh` | `HEAD` on `main` | any | unchanged | unchanged |

`publish-release.yaml` reads the version from the lineage of the very commit `tag-version` tags, so the tag a release is labelled with is the tag its version was derived from. No `ref:` is passed to `actions/checkout` — v4.4.0 refuses PR-associated refs under `pull_request_target`, as the existing comment in `tag-version` records — so the base branch is fetched explicitly and the job falls back to its tip when the API reports no merge commit.

`manual-release.yaml` reads the production channel for a minor as well as a patch. `validate-inputs` requires the commit to be a head of `master`, the production line; reading the candidate channel there moves from a candidate `master` has already consumed and produces a version that is already tagged.

### Label a build from the tag reachable at HEAD

`build-hooks/_git.py` takes the tag at HEAD when there is one, and otherwise the nearest tag reachable from it, keeping the existing `+<sha>` and `-dirty` local identifiers and the `0.0.0` fallback. A checked-out tag now builds as that tag: previously a wheel built at `v0.14.1` while a `v0.15.0-rc2` tag existed elsewhere was labelled `0.15.0-rc2+<sha>`, which is verbatim the mislabelling named in the issue.

`.github/actions/build-release` checks out with `fetch-depth: 0`, because `git describe` cannot walk a shallow history — without it a release wheel would be labelled `0.0.0+<sha>`.

A staged change now counts as dirty (`repo.is_dirty(untracked_files=True)`), which is what the hook documents but `index.diff(None)` did not do, and the `Raises:` clause names the condition the code actually guards.

### Fail loudly on input the release path cannot use

`bump-version.sh` rejects a version it cannot parse instead of emitting a shell arithmetic error to stderr, echoing the input back unchanged and exiting 0. `bump-version.sh` and `cut-release.sh` resolve their sibling scripts relative to `$0` rather than assuming the working directory is the repository root.

### Run the suite when the build hooks change

`run-tests.yaml` adds `build-hooks/` to its change-detection pathspec.

## Test cases

Neither the release scripts nor the build metadata hook had any test before this change, so a rule that only runs during a release was verified only by releasing. Every unit is exercised against throwaway git repositories with synthetic tag topologies.

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `test_latest_version` | A production tag with a nearer candidate tag | The production channel is queried | Returns the production tag | The regression in #395 |
| 2 | `test_latest_version` | A candidate tag with a nearer production tag | The candidate channel is queried | Returns the candidate tag | Candidate scoping |
| 3 | `test_latest_version` | A tag on a branch the ref does not reach | The production channel is queried for that ref | Returns the reachable tag | Lineage scoping |
| 4 | `test_latest_version` | A merge reaching a production tag and a candidate | Each channel is queried at the merge | Each returns its own channel's tag | Resolution by pattern, never by tie-breaking |
| 5 | `test_latest_version` | A merge whose other parent forks before the highest tag | The production channel is queried | Returns the highest reachable production tag | The version regression `git describe` would publish |
| 6 | `test_latest_version` | Candidates spanning one and two digit cycles | The candidate channel is queried | Returns the numerically highest candidate | Version sort across cycle numbers |
| 7 | `test_latest_version` | A release and the candidate it was promoted from | The any channel is queried | Returns the release | Pre-release ordering below its release |
| 8 | `test_latest_version` | One commit carrying a production tag and a candidate | Each channel is queried | Returns the tag matching the channel | Same-commit channel resolution |
| 9 | `test_latest_version` | Alpha and beta tags nearer than a production tag | The production channel is queried | Returns the production tag | Cycle exclusion |
| 10 | `test_latest_version` | Non-version tags nearer than the version tags | Any channel is queried | Never returns a non-version tag | Tags outside the versioning scheme |
| 11 | `test_latest_version` | A repository whose channel has no tag | The channel is queried | Returns `v0.0.0` and exits zero | Bootstrap fallback |
| 12 | `test_latest_version` | A ref that does not resolve, or no repository at all | Any channel is queried | Exits non-zero | The silent `v0.0.0` that would publish `v0.0.1` |
| 13 | `test_latest_version` | An invalid channel, or a third argument | The lookup is invoked | Exits non-zero with the usage line intact | Argument validation |
| 14 | `test_version_segment` | The base and head branches of a merged pull request | The version segment is determined | Reports the segment and the channel | The release contract, all four rows |
| 15 | `test_version_segment` | A base branch that is not a release line | The version segment is determined | Exits non-zero naming the branch | Unsupported base |
| 16 | `test_version_segment` | A master reaching `v0.14.0` with a stray candidate on its head | A fix is merged and the version derived | Yields `v0.14.1` | The issue's headline outcome, end to end |
| 17 | `test_version_segment` | A release branch carrying the pending candidate | It is merged into master and the version derived | Yields `v0.15.0` | Promotion, with the production tag not leaking in |
| 18 | `test_version_segment` | A release branch synced from master | The sync is merged and the version derived | Yields `v0.15.0-rc3` | Candidate advance |
| 19 | `test_bump_version` | A version and the segment to move | The version is bumped | Returns the next version of that segment | Every transition the workflows use |
| 20 | `test_bump_version` | A string that is not a version this tooling produces | Its patch segment is bumped | Exits non-zero | Input that previously published unchanged |
| 21 | `test_bump_version` | Any production or pre-release version, patch or minor | The version is bumped | Returns a version ranking above the original | Ordering invariant, property-based |
| 22 | `test_cut_release` | A main branch reaching a production tag | A minor release is cut | Returns the next candidate and pushes the branch | Cutting a release |
| 23 | `test_cut_release` | A main branch with no tags | A minor release is cut | Returns the first candidate of the next minor | The documented zero-version fallback |
| 24 | `test_cut_release` | A main branch reaching a candidate tag | A minor release is cut | Exits non-zero naming the pending candidate | The active-candidate guard |
| 25 | `test_cut_release` | A candidate and the release it was promoted to | A minor release is cut | Returns the next minor's first candidate | Cutting after a finalize |
| 26 | `test_git` | A head commit tagged, with a higher tag on an ancestor | The version is parsed from git | Is the tag, with no local identifier | A checked-out tag builds as that tag |
| 27 | `test_git` | A head past a tag, with a higher tag off its lineage | The version is parsed from git | Is the reachable tag plus the commit hash | The `max(repo.tags)` mislabelling |
| 28 | `test_git` | A merge reaching a production tag and a higher candidate | The version is parsed from git | Is the production tag plus the commit hash | The wheel mislabelling named in the issue |
| 29 | `test_git` | A tagged head with a staged change, or an untracked file | The version is parsed from git | Is the tag qualified as dirty | The dirty marker the docstring claims |
| 30 | `test_git` | An untagged head in a dirty worktree | The version is parsed from git | Carries the commit hash and the dirty marker | Both local identifiers, in order |
| 31 | `test_git` | A head detached at a tag | The version is parsed from git | Is the tag | The state `build-release` checks out |
| 32 | `test_git` | A working directory below the repository root | The version is parsed from git | Is the tag | Hatch invokes the hook from the package directory |
| 33 | `test_git` | A repository with a commit and no tags | The version is parsed from git | Is `0.0.0` plus the commit hash | Zero-version fallback |
| 34 | `test_workflows` | The build-release action and the publish-release workflow | Their checkout steps are read | Fetch the full history and the tags | The history `git describe` needs |
| 35 | `test_workflows` | A workflow naming scripts under `.github/scripts` | Each reference is resolved | Exists and is executable | A lost mode bit breaks the release at runtime |

Verified against the pre-fix tree: the old hook labels the merge-reaching-both topology `0.15.0-rc2+<sha>` where the new one gives `0.14.1+<sha>`, and the old `bump-version.sh` accepts `v1.0.0-rc.1` with exit 0.

Two ordering defects in `build-hooks/_version.py` surfaced while testing and are deliberately **not** fixed here, because this change removes their last production consumer — `max(repo.tags, key=SemanticVersion.parse)` was the only code that ordered versions. Pre-release identifiers compare as text, so `rc10` ranks below `rc9`; and comparing a version carrying `+build` against one without raises `TypeError`. The first is pinned as a strict `xfail` so it cannot regress unnoticed. Both are worth a follow-up issue.
