### PR TITLE
Unify the build version lookup with the release scripts — Closes #400

### DIFF
--- a/.github/scripts/bump-version.sh
+++ b/.github/scripts/bump-version.sh
@@ -7,7 +7,7 @@ case $# in
     2)
         ;;
     *)
-        echo $USAGE
+        echo "$USAGE" >&2
         exit 1
         ;;
 esac
@@ -19,7 +19,7 @@ case $1 in
         ;;
     *)
         echo "ERROR: Invalid version segment: $1" >&2
-        echo $USAGE
+        echo "$USAGE" >&2
         exit 1
         ;;
 esac

--- a/.github/scripts/cut-release.sh
+++ b/.github/scripts/cut-release.sh
@@ -9,7 +9,7 @@ case $1 in
         ;;
     *)
         echo "ERROR: Invalid release type: $1" >&2
-        echo $USAGE
+        echo "$USAGE" >&2
         exit 1
         ;;
 esac
@@ -21,17 +21,30 @@ case $# in
         BRANCH=$2
         ;;
     *)
-        echo $USAGE
+        echo "$USAGE" >&2
         exit 1
         ;;
 esac
 
 git fetch --unshallow >/dev/null 2>&1
-git checkout main >/dev/null 2>&1
-git pull >/dev/null 2>&1
 
-# Check if the release branch already exists
-if git show-ref --verify --quiet refs/heads/$BRANCH; then
+# The release is cut from main, so failing to get there must stop the cut --
+# discarding the exit status here would cut and push a release branch from
+# whatever HEAD happened to be on.
+if ! git checkout main >/dev/null 2>&1; then
+    echo "ERROR: Cannot check out 'main'." >&2
+    exit 1
+fi
+if ! git pull >/dev/null 2>&1; then
+    echo "ERROR: Cannot update 'main' from origin." >&2
+    exit 1
+fi
+
+# Check if the release branch already exists, locally or on the remote. A
+# CI checkout has only the branch it cloned, so an existing release branch
+# is visible there as a remote ref and nowhere else.
+if git show-ref --verify --quiet "refs/heads/$BRANCH" ||
+    git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
     echo "ERROR: Branch '$BRANCH' already exists." >&2
     exit 1
 fi

--- a/.github/scripts/latest-version.sh
+++ b/.github/scripts/latest-version.sh
@@ -5,16 +5,18 @@ USAGE="Usage: $0 production|candidate|any [REF=HEAD]"
 # Evaluate release channel. Each channel matches the whole tag rather than
 # excluding cycle markers, so a tag that is not a version this tooling
 # produces -- a "nightly-2026-01-01", a "docs-rc-cleanup" -- can never be
-# bumped and published as one.
+# bumped and published as one. A pre-release always carries a zero patch
+# segment because that is the only shape bump-version.sh emits, and it is
+# the only shape split-version.sh can carry back through a bump.
 case $1 in
     production)
         PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+$'
         ;;
     candidate)
-        PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$'
+        PATTERN='^v[0-9]+\.[0-9]+\.0-rc[0-9]+$'
         ;;
     any)
-        PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+(-(a|b|rc)[0-9]+)?$'
+        PATTERN='^v[0-9]+\.[0-9]+\.([0-9]+|0-(a|b|rc)[0-9]+)$'
         ;;
     *)
         echo "ERROR: Invalid release channel: $1" >&2

--- a/build-hooks/_git.py
+++ b/build-hooks/_git.py
@@ -1,45 +1,72 @@
+import re
+
 import git
 from _version import parser
+from packaging.version import Version
+
+#: The tag shape this project's release tooling produces. Kept in step with
+#: the channel patterns in .github/scripts/latest-version.sh, which selects
+#: the version to bump from the same set.
+VERSION_TAG = re.compile(r"^v[0-9]+\.[0-9]+\.(?:[0-9]+|0-(?:a|b|rc)[0-9]+)$")
 
 
 @parser("git")
 def parse() -> str:
     """
-    Parses the current git repository to generate a version string.
+    Derive the package version from the current git repository.
 
-    A commit that carries a tag is versioned as that tag, so a release
-    artifact is labelled with the version it was cut as. Any other commit is
-    versioned as the nearest tag reachable from it -- tags on branches the
-    commit does not reach are invisible, so a pending release candidate never
-    labels a build of the production line -- qualified by a local identifier
-    naming the commit, and further qualified as ``dirty`` when the worktree
-    carries uncommitted changes. A commit with no tag in its lineage is
-    versioned as ``0.0.0``.
+    A commit that carries a version tag is versioned as the highest of them,
+    so an artifact built from a checked-out release tag is labelled with that
+    release. Any other commit is versioned as the highest version tag
+    reachable from it, qualified by a local identifier naming the commit,
+    which marks the artifact as a build between releases rather than as one.
+    Either version is further qualified as ``dirty`` when the worktree
+    carries uncommitted or untracked changes.
+
+    Only tags of the shape the release tooling produces are considered, so a
+    tag outside the scheme neither labels a build nor breaks one. A commit
+    with no version tag in its lineage is versioned as ``v0.0.0``, with the
+    same local identifier.
+
+    Tags are ordered by version and not by commit distance, which a merge
+    from an older fork point inverts — labelling a build with a version below
+    one already released.
 
     Returns:
-        A version string based on the tag reachable at HEAD, the commit hash,
-        and uncommitted changes.
+        The tag, with a local identifier appended when the commit is not the
+        release the tag names.
 
     Raises:
-        RuntimeError: If the repository is bare.
+        RuntimeError: If the repository is bare or carries no commits.
     """
     repo = git.Repo(search_parent_directories=True)
     if repo.bare:
-        raise RuntimeError(f"The repo at '{repo.working_dir}' cannot be empty!")
-    try:
-        tag_name = repo.git.describe("--tags", "--exact-match")
-    except git.GitCommandError:
-        exact = False
-        try:
-            tag_name = repo.git.describe("--tags", "--abbrev=0")
-        except git.GitCommandError:
-            tag_name = "0.0.0"
+        raise RuntimeError(f"The repo at '{repo.working_dir}' cannot be bare!")
+    if not repo.head.is_valid():
+        raise RuntimeError(f"The repo at '{repo.working_dir}' has no commits!")
+    if tags := _versions(repo, "--points-at", "HEAD"):
+        exact, tag_name = True, tags[0]
     else:
-        exact = True
-    public, *local = tag_name.split("+")
+        exact, tag_name = (
+            False,
+            next(iter(_versions(repo, "--merged", "HEAD")), "v0.0.0"),
+        )
+    local = []
     if not exact:
-        local.append(repo.git.rev_parse(repo.head.commit.hexsha, short=True))
+        local.append(repo.git.rev_parse("HEAD", short=True))
     if repo.is_dirty(untracked_files=True):
         local.append("dirty")
-    local = "-".join(local)
-    return f"{public}+{local}" if local else public
+    return f"{tag_name}+{'-'.join(local)}" if local else tag_name
+
+
+def _versions(repo: git.Repo, *selector: str) -> list[str]:
+    """
+    Return the repository's version tags for a selector, highest first.
+
+    The selector is a ``git tag`` filter, e.g. ``--points-at HEAD``.
+    """
+    return sorted(
+        (tag for tag in repo.git.tag(*selector).splitlines() if VERSION_TAG.match(tag)),
+        key=Version,
+        reverse=True,
+    )

--- a/wool/pyproject.toml
+++ b/wool/pyproject.toml
@@ -101,6 +101,7 @@ pythonpath = ["."]
 # legitimate test (the Hypothesis dispatch exploration, ~2-3 minutes).
 faulthandler_timeout = 300
 markers = [
+    "cicd: release tooling exercised through real git and bash subprocesses",
     "integration: end-to-end integration tests against real WorkerPool",
     "stdlib_parity: stdlib contextvars propagation parity pins",
 ]

--- a/wool/tests/cicd/conftest.py
+++ b/wool/tests/cicd/conftest.py
@@ -6,10 +6,12 @@ repositories with synthetic histories rather than against this checkout.
 """
 
 import importlib.util
+import os
 import pathlib
 import subprocess
 import sys
 from collections.abc import Callable
+from collections.abc import Iterator
 from types import ModuleType
 
 import pytest
@@ -17,6 +19,10 @@ import pytest
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
 
 SCRIPTS = REPO_ROOT / ".github" / "scripts"
+
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+ACTIONS = REPO_ROOT / ".github" / "actions"
 
 BUILD_HOOKS = REPO_ROOT / "build-hooks"
 
@@ -26,6 +32,9 @@ class Repository:
 
     Wraps the handful of plumbing commands the histories in this package are
     built from, so a test reads as the topology it describes.
+
+    :param path: The directory the repository is created in. The fixture
+        creates it before ``git init`` runs.
     """
 
     def __init__(self, path: pathlib.Path) -> None:
@@ -39,16 +48,17 @@ class Repository:
             capture_output=True,
             check=True,
             cwd=self.path,
+            env=environment(self.path),
             text=True,
         ).stdout.strip()
 
     def commit(self, message: str = "") -> str:
-        """Add an empty commit and return its full hash.
+        """Commit the index, allowing an empty commit, and return its hash.
 
-        The default message is numbered because two empty commits sharing a
-        parent, a tree, a message and a one-second timestamp are the same git
-        object: sibling branches would silently collapse onto one commit and
-        a merge between them would be a no-op.
+        Each default message is distinct, so sibling branches built from one
+        parent never collapse onto a single commit: two commits sharing a
+        parent, a tree, a message, an identity and a one-second timestamp are
+        the same git object, and a merge between them would be a no-op.
         """
         self._commits += 1
         self.git("commit", "--allow-empty", "--message", message or f"c{self._commits}")
@@ -63,15 +73,14 @@ class Repository:
         self.git("checkout", "-b", name)
 
     def checkout(self, *arguments: str) -> None:
-        """Check out a branch, a tag, or a commit."""
+        """Run ``git checkout`` with the given arguments."""
         self.git("checkout", *arguments)
 
     def merge(self, name: str, message: str = "merge") -> str:
         """Merge a branch with an explicit merge commit and return its hash.
 
-        The parent count is asserted because ``git merge`` reports success
-        when it has nothing to do, which would leave a test that means to
-        exercise a merge commit asserting against a linear history.
+        Fails when the merge produced no merge commit, which ``git merge``
+        otherwise reports as success.
         """
         self.git("merge", "--no-ff", name, "--message", message)
         head = self.git("rev-parse", "HEAD")
@@ -80,22 +89,38 @@ class Repository:
         return head
 
 
+def environment(root: pathlib.Path) -> dict[str, str]:
+    """Return a git environment isolated from the one running the tests.
+
+    Ambient ``GIT_DIR`` or ``GIT_WORK_TREE`` would redirect every command at
+    the repository the tests run from -- which they push to and tag -- and
+    ambient configuration would decide results that the fixture means to set
+    itself.
+    """
+    return {
+        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+    } | {
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CEILING_DIRECTORIES": str(root.parent),
+    }
+
+
 @pytest.fixture
 def repository(tmp_path: pathlib.Path) -> Repository:
-    """An initialized git repository with no commits, on ``master``."""
+    """Return an initialized git repository with no commits, on ``master``."""
     repository = Repository(tmp_path / "repository")
     repository.path.mkdir()
     repository.git("init", "--initial-branch", "master")
     repository.git("config", "user.email", "tests@wool.io")
     repository.git("config", "user.name", "Tests")
-    repository.git("config", "commit.gpgsign", "false")
-    repository.git("config", "tag.gpgsign", "false")
     return repository
 
 
 @pytest.fixture
 def script(repository: Repository) -> Callable[..., subprocess.CompletedProcess]:
-    """Run one of the release scripts with the repository as its directory.
+    """Return a runner for the release scripts, in the repository's directory.
 
     The repository is never this checkout, so a script that resolves a
     sibling script relative to the working directory fails these tests.
@@ -108,44 +133,56 @@ def script(repository: Repository) -> Callable[..., subprocess.CompletedProcess]
             (str(SCRIPTS / name), *arguments),
             capture_output=True,
             cwd=cwd or repository.path,
+            env=environment(repository.path),
             text=True,
         )
 
     return run
 
 
-def _load(name: str) -> ModuleType:
-    """Import a build hook module by path, under a name of this suite's own.
+@pytest.fixture
+def semantic_version() -> Iterator[type]:
+    """Return the version model the release tooling's output is parsed against."""
+    yield _load("_version").SemanticVersion
+    _unload()
 
-    ``build-hooks`` holds modules named ``build`` and ``metadata``; putting
-    it on ``sys.path`` would shadow those names for every test that runs
-    afterward.
+
+@pytest.fixture
+def version(repository: Repository, monkeypatch) -> Iterator[Callable]:
+    """Return a renderer for the build hook's version of the repository.
+
+    The working directory is moved into the repository for the duration of
+    the test, which is what the hook reads.
+    """
+    monkeypatch.chdir(repository.path)
+    version = _load("_version")
+    # Importing the hook registers it with the version parser registry,
+    # which is what makes it reachable as ``parse.git``.
+    _load("_git")
+    yield lambda: version.SemanticVersion.parse.git()
+    _unload()
+
+
+def _load(name: str) -> ModuleType:
+    """Import a build hook module from its file, bypassing ``sys.path``.
+
+    ``build-hooks`` holds modules whose names would shadow common top-level
+    imports, so the directory is never put on the path; the hooks import each
+    other by bare name, so each is registered under its own.
     """
     if (module := sys.modules.get(name)) is not None:
         return module
     specification = importlib.util.spec_from_file_location(
-        name, BUILD_HOOKS / f"{name.rpartition('.')[2]}.py"
+        name, BUILD_HOOKS / f"{name}.py"
     )
     assert specification and specification.loader
     module = importlib.util.module_from_spec(specification)
-    # Registered before execution so the hook's own ``from _version import``
-    # resolves to this module rather than re-executing it under that name.
     sys.modules[name] = module
     specification.loader.exec_module(module)
     return module
 
 
-@pytest.fixture(scope="session")
-def semantic_version() -> type:
-    """The version model the release tooling's output is parsed against."""
-    return _load("_version").SemanticVersion
-
-
-@pytest.fixture
-def version(semantic_version: type, repository: Repository, monkeypatch) -> Callable:
-    """Render the build metadata hook's version for the repository."""
-    monkeypatch.chdir(repository.path)
-    # Importing the hook registers it with the version parser registry,
-    # which is what makes it reachable as ``parse.git``.
-    _load("_git")
-    return lambda: semantic_version.parse.git()
+def _unload() -> None:
+    """Drop the build hook modules a test loaded."""
+    for name in ("_git", "_version"):
+        sys.modules.pop(name, None)

--- a/wool/tests/cicd/test_bump_version.py
+++ b/wool/tests/cicd/test_bump_version.py
@@ -3,9 +3,12 @@ from hypothesis import HealthCheck
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
+from packaging.version import Version
 
-#: Release cycles in ascending order, production last.
-_CYCLES = [None, "a", "b", "rc"]
+pytestmark = pytest.mark.cicd
+
+#: The pre-release cycles bump-version.sh moves through, and no cycle.
+_CYCLES = (None, "a", "b", "rc")
 
 
 @pytest.mark.parametrize(
@@ -13,6 +16,7 @@ _CYCLES = [None, "a", "b", "rc"]
     [
         ("patch", "v0.14.0", "v0.14.1"),
         ("patch", "v0.15.0-rc2", "v0.15.0-rc3"),
+        ("patch", "v0.15.0-rc9", "v0.15.0-rc10"),
         ("patch", "v0.0.0", "v0.0.1"),
         ("minor", "v0.14.0", "v0.15.0"),
         ("minor", "v0.15.0-rc2", "v0.15.0"),
@@ -96,9 +100,10 @@ def test_bump_version_should_exit_nonzero_when_the_version_is_malformed(script, 
     minor=st.integers(min_value=0, max_value=99),
     patch=st.integers(min_value=0, max_value=99),
     cycle=st.sampled_from(_CYCLES),
+    number=st.integers(min_value=0, max_value=99),
 )
 def test_bump_version_should_return_a_greater_version(
-    script, segment, major, minor, patch, cycle
+    script, segment, major, minor, patch, cycle, number
 ):
     """Test the ordering invariant every release bump rests on.
 
@@ -110,8 +115,10 @@ def test_bump_version_should_return_a_greater_version(
         It should return a version that ranks above the original.
     """
     # Arrange
+    # A pre-release always carries a zero patch segment: that is the only
+    # shape bump-version.sh emits, and the only one it can bump.
     if cycle:
-        old_version = f"v{major}.{minor}.0-{cycle}{patch}"
+        old_version = f"v{major}.{minor}.0-{cycle}{number}"
     else:
         old_version = f"v{major}.{minor}.{patch}"
 
@@ -120,48 +127,50 @@ def test_bump_version_should_return_a_greater_version(
 
     # Assert
     assert result.returncode == 0, result.stderr
-    bumped = result.stdout.strip()
-    # Ranked on the segments themselves rather than through SemanticVersion,
-    # whose pre-release ordering compares "rc10" against "rc9" as text.
-    assert _rank(bumped) > _rank(old_version)
-
-
-def _rank(version: str) -> tuple:
-    """Order a version by its numeric segments and its release cycle."""
-    core, _, pre = version.lstrip("v").partition("-")
-    major, minor, patch = (int(segment) for segment in core.split("."))
-    if pre:
-        cycle = pre.rstrip("0123456789")
-        return (major, minor, patch, _CYCLES.index(cycle), int(pre[len(cycle) :]))
-    return (major, minor, patch, len(_CYCLES), 0)
+    # Ordered by PEP 440 rather than through SemanticVersion; see the
+    # expected failure below for why the model is not the oracle here.
+    assert Version(result.stdout.strip()) > Version(old_version)
 
 
 @pytest.mark.xfail(
     strict=True,
     reason="SemanticVersion compares pre-release identifiers as text, so "
-    "rc10 ranks below rc9. Unreachable from the release path, which no "
-    "longer orders versions, but the model still reports it.",
+    "rc10 ranks below rc9. The release path does not order versions, so "
+    "nothing depends on it, but the model still reports it.",
 )
-def test_bump_version_should_return_a_version_semantic_version_ranks_above(
-    script, semantic_version
+def test_parse_should_rank_a_two_digit_cycle_above_a_single_digit_one(
+    semantic_version,
 ):
     """Test the version model's ordering of a two-digit release candidate.
 
     Given:
-        A release candidate whose next patch carries a two-digit cycle.
+        Two release candidates of one version, with one and two digit cycles.
     When:
-        The candidate's patch segment is bumped.
+        They are compared.
     Then:
-        It should return a version the version model ranks above it.
+        It should rank the two-digit candidate above the single-digit one.
     """
-    # Arrange
-    old_version = "v0.15.0-rc9"
+    # Act & assert
+    assert semantic_version.parse("v0.15.0-rc10") > semantic_version.parse("v0.15.0-rc9")
 
+
+@pytest.mark.parametrize("arguments", [("nightly", "v0.14.0"), ("patch",), ()])
+def test_bump_version_should_exit_nonzero_when_the_arguments_are_invalid(
+    script, arguments
+):
+    """Test the argument validation.
+
+    Given:
+        An unrecognized segment, or the wrong number of arguments.
+    When:
+        The version is bumped.
+    Then:
+        It should exit non-zero and print the usage line on stderr.
+    """
     # Act
-    result = script("bump-version.sh", "patch", old_version)
+    result = script("bump-version.sh", *arguments)
 
     # Assert
-    assert result.stdout.strip() == "v0.15.0-rc10"
-    assert semantic_version.parse(result.stdout.strip()) > semantic_version.parse(
-        old_version
-    )
+    assert result.returncode != 0
+    assert "Usage:" in result.stderr
+    assert result.stdout == ""

--- a/wool/tests/cicd/test_cut_release.py
+++ b/wool/tests/cicd/test_cut_release.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytestmark = pytest.mark.cicd
+
 
 @pytest.fixture
 def published(repository, tmp_path):
@@ -125,3 +127,104 @@ def test_cut_release_should_exit_nonzero_when_the_branch_already_exists(
     # Assert
     assert result.returncode != 0
     assert "already exists" in result.stderr
+
+
+def test_cut_release_should_return_the_next_major_candidate(published, script):
+    """Test the candidate a major release is cut as.
+
+    Given:
+        A main branch reaching a production tag.
+    When:
+        A major release is cut.
+    Then:
+        It should return the next major's first candidate.
+    """
+    # Arrange
+    published.tag("v0.14.0")
+
+    # Act
+    result = script("cut-release.sh", "major")
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "v1.0.0-rc0"
+
+
+def test_cut_release_should_cut_the_named_branch_when_one_is_given(published, script):
+    """Test the branch a release is cut onto.
+
+    Given:
+        A main branch reaching a production tag.
+    When:
+        A release is cut onto a named branch.
+    Then:
+        It should create that branch rather than the default one.
+    """
+    # Arrange
+    published.tag("v0.14.0")
+
+    # Act
+    result = script("cut-release.sh", "minor", "hotfix")
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+    assert "hotfix" in published.git("branch", "--list", "hotfix")
+
+
+@pytest.mark.parametrize("arguments", [("nightly",), ("minor", "release", "extra")])
+def test_cut_release_should_exit_nonzero_when_the_arguments_are_invalid(
+    published, script, arguments
+):
+    """Test the argument validation.
+
+    Given:
+        An unrecognized release type, or too many arguments.
+    When:
+        A release is cut.
+    Then:
+        It should exit non-zero and print the usage line intact on stderr.
+    """
+    # Arrange
+    # A bracket expression in the usage line globs against the working
+    # directory unless it is quoted.
+    for name in ("B", "e", "l", "s"):
+        (published.path / name).write_text("")
+
+    # Act
+    result = script("cut-release.sh", *arguments)
+
+    # Assert
+    assert result.returncode != 0
+    assert "[BRANCH=release]" in result.stderr
+    assert result.stdout == ""
+
+
+def test_cut_release_should_exit_nonzero_when_the_branch_exists_on_the_remote(
+    published, script
+):
+    """Test the guard against cutting over a release branch on the remote.
+
+    Given:
+        A release branch that exists only on the remote.
+    When:
+        A minor release is cut.
+    Then:
+        It should exit non-zero and leave the remote branch where it was.
+    """
+    # Arrange
+    published.tag("v0.14.0")
+    published.branch("release")
+    published.git("push", "--quiet", "origin", "release")
+    published.checkout("main")
+    published.git("branch", "--delete", "--force", "release")
+    before = published.git("ls-remote", "--heads", "origin", "release")
+
+    # Act
+    result = script("cut-release.sh", "minor")
+
+    # Assert
+    # A CI checkout carries only the branch it cloned, so an existing
+    # release branch is visible there as a remote ref and nowhere else.
+    assert result.returncode != 0
+    assert "already exists" in result.stderr
+    assert published.git("ls-remote", "--heads", "origin", "release") == before

--- a/wool/tests/cicd/test_git.py
+++ b/wool/tests/cicd/test_git.py
@@ -1,8 +1,13 @@
+import pytest
+
+pytestmark = pytest.mark.cicd
+
+
 def test_parse_git_should_return_the_tag_when_head_is_tagged(repository, version):
     """Test the version of a commit that carries a tag.
 
     Given:
-        A repository whose head commit is tagged.
+        A repository whose head commit is tagged below a tag on an ancestor.
     When:
         The version is parsed from git.
     Then:
@@ -60,7 +65,7 @@ def test_parse_git_should_ignore_tags_off_the_head_lineage(repository, version):
     """Test the version of a commit a higher tag does not reach.
 
     Given:
-        A repository with a higher tag on a branch head does not reach.
+        A higher tag on a branch that head does not reach.
     When:
         The version is parsed from git.
     Then:
@@ -180,18 +185,17 @@ def test_parse_git_should_return_the_candidate_tag_when_head_is_a_candidate(
     assert result.build is None
 
 
-def test_parse_git_should_prefer_the_nearest_tag_when_a_merge_reaches_both(
+def test_parse_git_should_return_the_highest_tag_when_a_merge_reaches_both(
     repository, version
 ):
     """Test the version of a merge commit reaching both release channels.
 
     Given:
-        A commit past a merge that reaches a production tag and a higher
-        candidate tag.
+        A merge commit reaching a production tag and a lower candidate tag.
     When:
         The version is parsed from git.
     Then:
-        It should be the production tag qualified by the commit hash.
+        It should be the higher tag qualified by the commit hash.
     """
     # Arrange
     repository.commit()
@@ -200,7 +204,7 @@ def test_parse_git_should_prefer_the_nearest_tag_when_a_merge_reaches_both(
     repository.tag("v0.15.0-rc2")
     repository.checkout("master")
     repository.commit()
-    repository.tag("v0.14.1")
+    repository.tag("v0.15.0")
     repository.merge("release")
     commit = repository.git("rev-parse", "--short", "HEAD")
 
@@ -208,8 +212,9 @@ def test_parse_git_should_prefer_the_nearest_tag_when_a_merge_reaches_both(
     result = version()
 
     # Assert
-    # The wheel of a v0.14.1 build must not be labelled 0.15.0-rc2.
-    assert str(result) == f"0.14.1+{commit}"
+    # A promoted release outranks the candidate it was promoted from, so a
+    # build of it is never labelled with the candidate.
+    assert str(result) == f"0.15.0+{commit}"
 
 
 def test_parse_git_should_append_both_identifiers_when_untagged_and_dirty(
@@ -253,7 +258,7 @@ def test_parse_git_should_return_the_tag_when_head_is_detached(repository, versi
     repository.tag("v0.14.0")
     repository.commit()
     repository.tag("v0.14.1")
-    # The state `build-release` produces: `ref:` a tag, so HEAD detaches.
+    # build-release checks the release tag out by ref, detaching HEAD.
     repository.checkout("v0.14.0")
 
     # Act
@@ -287,3 +292,74 @@ def test_parse_git_should_return_the_tag_when_invoked_from_a_subdirectory(
 
     # Assert
     assert str(result) == "0.14.0"
+
+
+def test_parse_git_should_ignore_tags_that_are_not_versions(repository, version):
+    """Test the version of a commit carrying tags outside the scheme.
+
+    Given:
+        A tagged repository with non-version tags on a later commit.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the version tag rather than fail to parse one.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.commit()
+    repository.tag("nightly-2026-01-01")
+    repository.tag("docs-rc-cleanup")
+    commit = repository.git("rev-parse", "--short", "HEAD")
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == f"0.14.0+{commit}"
+
+
+def test_parse_git_should_return_the_highest_tag_when_head_carries_two(
+    repository, version
+):
+    """Test the version of a commit carrying more than one version tag.
+
+    Given:
+        A repository whose head commit carries two version tags.
+    When:
+        The version is parsed from git.
+    Then:
+        It should be the higher of them.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v1.2.3")
+    repository.tag("v1.3.0")
+
+    # Act
+    result = version()
+
+    # Assert
+    assert str(result) == "1.3.0"
+
+
+@pytest.mark.parametrize("state", ["bare", "empty"])
+def test_parse_git_should_raise_when_the_repository_cannot_be_versioned(
+    repository, version, state
+):
+    """Test the repositories the hook refuses.
+
+    Given:
+        A repository that is bare, or that carries no commits.
+    When:
+        The version is parsed from git.
+    Then:
+        It should raise.
+    """
+    # Arrange
+    if state == "bare":
+        repository.git("config", "core.bare", "true")
+
+    # Act & assert
+    with pytest.raises(RuntimeError):
+        version()

--- a/wool/tests/cicd/test_latest_version.py
+++ b/wool/tests/cicd/test_latest_version.py
@@ -1,4 +1,18 @@
+import subprocess
+import uuid
+
 import pytest
+from hypothesis import HealthCheck
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
+from packaging.version import Version
+
+from tests.cicd.conftest import SCRIPTS
+from tests.cicd.conftest import Repository
+from tests.cicd.conftest import environment
+
+pytestmark = pytest.mark.cicd
 
 
 def test_latest_version_should_return_production_tag_when_candidate_is_nearer(
@@ -135,7 +149,7 @@ def test_latest_version_should_exclude_alpha_and_beta_from_production(
     assert result.stdout.strip() == "v0.14.0"
 
 
-def test_latest_version_should_return_nearest_tag_when_channel_is_any(
+def test_latest_version_should_return_the_highest_tag_when_channel_is_any(
     repository, script
 ):
     """Test the unscoped lookup.
@@ -145,7 +159,7 @@ def test_latest_version_should_return_nearest_tag_when_channel_is_any(
     When:
         The any channel is queried.
     Then:
-        It should return the nearest tag of either channel.
+        It should return the highest tag of either channel.
     """
     # Arrange
     repository.commit()
@@ -192,7 +206,7 @@ def test_latest_version_should_return_zero_version_when_repository_has_no_tags(
     Given:
         A repository with a commit and no tags.
     When:
-        Any channel is queried.
+        Each channel is queried.
     Then:
         It should return the zero version.
     """
@@ -276,10 +290,14 @@ def test_latest_version_should_return_the_highest_reachable_tag(repository, scri
     repository.checkout("master")
     repository.merge("feature")
 
+    # Act
+    # git describe ties these two and resolves the tie itself; see
+    # latest-version.sh for why that metric is not the one used.
+    result = script("latest-version.sh", "production")
+
     # Assert
-    # Commit distance ranks v0.13.1 nearer here, and bumping it would
-    # publish a version below one already released.
-    assert script("latest-version.sh", "production").stdout.strip() == "v0.14.0"
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "v0.14.0"
 
 
 def test_latest_version_should_return_the_highest_candidate_when_cycles_are_two_digit(
@@ -299,8 +317,12 @@ def test_latest_version_should_return_the_highest_candidate_when_cycles_are_two_
         repository.commit()
         repository.tag(tag)
 
+    # Act
+    result = script("latest-version.sh", "candidate")
+
     # Assert
-    assert script("latest-version.sh", "candidate").stdout.strip() == "v0.15.0-rc10"
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "v0.15.0-rc10"
 
 
 def test_latest_version_should_rank_a_release_above_its_candidate(repository, script):
@@ -319,8 +341,12 @@ def test_latest_version_should_rank_a_release_above_its_candidate(repository, sc
     repository.commit()
     repository.tag("v0.15.0")
 
+    # Act
+    result = script("latest-version.sh", "any")
+
     # Assert
-    assert script("latest-version.sh", "any").stdout.strip() == "v0.15.0"
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "v0.15.0"
 
 
 def test_latest_version_should_resolve_both_channels_when_one_commit_carries_both(
@@ -340,21 +366,32 @@ def test_latest_version_should_resolve_both_channels_when_one_commit_carries_bot
     repository.tag("v0.16.0")
     repository.tag("v0.16.0-rc9")
 
+    # Act
+    production = script("latest-version.sh", "production")
+    candidate = script("latest-version.sh", "candidate")
+
     # Assert
-    assert script("latest-version.sh", "production").stdout.strip() == "v0.16.0"
-    assert script("latest-version.sh", "candidate").stdout.strip() == "v0.16.0-rc9"
+    assert production.stdout.strip() == "v0.16.0"
+    assert candidate.stdout.strip() == "v0.16.0-rc9"
 
 
-@pytest.mark.parametrize("channel", ["production", "candidate", "any"])
+@pytest.mark.parametrize(
+    ("channel", "expected"),
+    [
+        ("production", "v0.14.0"),
+        ("candidate", "v0.15.0-rc2"),
+        ("any", "v0.15.0-rc2"),
+    ],
+)
 def test_latest_version_should_ignore_tags_that_are_not_versions(
-    repository, script, channel
+    repository, script, channel, expected
 ):
     """Test the lookup against tags outside the versioning scheme.
 
     Given:
         Non-version tags nearer than the version tags.
     When:
-        Any channel is queried.
+        Each channel is queried.
     Then:
         It should never return a non-version tag.
     """
@@ -372,7 +409,7 @@ def test_latest_version_should_ignore_tags_that_are_not_versions(
     result = script("latest-version.sh", channel)
 
     # Assert
-    assert result.stdout.strip() in {"v0.14.0", "v0.15.0-rc2"}
+    assert result.stdout.strip() == expected
 
 
 def test_latest_version_should_exit_nonzero_when_the_ref_cannot_be_resolved(
@@ -395,7 +432,7 @@ def test_latest_version_should_exit_nonzero_when_the_ref_cannot_be_resolved(
     result = script("latest-version.sh", "production", "origin/master")
 
     # Assert
-    # Reporting v0.0.0 here would bump to v0.0.1 and publish it.
+    # See latest-version.sh for what a silent v0.0.0 would publish.
     assert result.returncode != 0
     assert "origin/master" in result.stderr
 
@@ -408,7 +445,7 @@ def test_latest_version_should_exit_nonzero_when_run_outside_a_repository(
     Given:
         A working directory that is not a git repository.
     When:
-        Any channel is queried.
+        Each channel is queried.
     Then:
         It should exit non-zero rather than report the zero version.
     """
@@ -445,3 +482,84 @@ def test_latest_version_should_exit_nonzero_when_given_extra_arguments(
     # Assert
     assert result.returncode != 0
     assert "[REF=HEAD]" in result.stderr
+
+
+#: The channel each generated tag shape belongs to.
+_CHANNELS = {
+    "production": lambda cycle: cycle is None,
+    "candidate": lambda cycle: cycle == "rc",
+    "any": lambda cycle: True,
+}
+
+
+@st.composite
+def _tags(draw):
+    """Draw a set of version tags of the shapes the release tooling emits."""
+    versions = draw(
+        st.lists(
+            st.tuples(
+                st.integers(min_value=0, max_value=9),
+                st.integers(min_value=0, max_value=9),
+                st.integers(min_value=0, max_value=9),
+                st.sampled_from([None, "a", "b", "rc"]),
+                st.integers(min_value=0, max_value=11),
+            ),
+            max_size=6,
+        )
+    )
+    tags = {}
+    for major, minor, patch, cycle, number in versions:
+        if cycle:
+            tags[f"v{major}.{minor}.0-{cycle}{number}"] = cycle
+        else:
+            tags[f"v{major}.{minor}.{patch}"] = None
+    return tags
+
+
+# Each example needs a repository of its own: a function-scoped fixture is
+# shared across a test's examples, so tags from one would survive into the
+# next. The deadline is lifted because every example forks git.
+@settings(
+    max_examples=25,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(channel=st.sampled_from(sorted(_CHANNELS)), tags=_tags())
+def test_latest_version_should_return_the_highest_tag_of_the_channel(
+    tmp_path, channel, tags
+):
+    """Test the selection invariant the release lookup rests on.
+
+    Given:
+        Any set of version tags on one lineage, and any channel.
+    When:
+        That channel is queried.
+    Then:
+        It should return the channel's highest tag, or the zero version.
+    """
+    # Arrange
+    repository = Repository(tmp_path / f"repository-{uuid.uuid4().hex}")
+    repository.path.mkdir()
+    repository.git("init", "--initial-branch", "master")
+    repository.git("config", "user.email", "tests@wool.io")
+    repository.git("config", "user.name", "Tests")
+    # An unborn HEAD is an unresolvable ref, which the lookup rejects; a
+    # repository being released always has a commit.
+    repository.commit()
+    for tag in tags:
+        repository.commit()
+        repository.tag(tag)
+    members = [tag for tag, cycle in tags.items() if _CHANNELS[channel](cycle)]
+
+    # Act
+    result = subprocess.run(
+        (str(SCRIPTS / "latest-version.sh"), channel),
+        capture_output=True,
+        cwd=repository.path,
+        env=environment(repository.path),
+        text=True,
+    )
+
+    # Assert
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == max(members, key=Version, default="v0.0.0")

--- a/wool/tests/cicd/test_release_version.py
+++ b/wool/tests/cicd/test_release_version.py
@@ -1,0 +1,117 @@
+"""The version each merge into a release line publishes.
+
+Composes the three scripts the publish workflow composes, so the release
+contract is exercised end to end rather than a script at a time.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.cicd
+
+
+def test_release_version_should_patch_the_production_tag_when_a_fix_merges(
+    repository, script
+):
+    """Test the version a fix merged into master is published as.
+
+    Given:
+        A master reaching a production tag with a stray candidate on its head.
+    When:
+        A fix branch is merged and the resulting version is derived.
+    Then:
+        It should patch the production tag rather than advance the candidate.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.0")
+    repository.branch("fix")
+    repository.commit()
+    repository.checkout("master")
+    # A candidate tag stranded on master's head by an earlier release.
+    repository.commit()
+    repository.tag("v0.15.0-rc1")
+    merge = repository.merge("fix")
+
+    # Act
+    version = _derive(script, "master", "fix", merge)
+
+    # Assert
+    assert version == "v0.14.1"
+
+
+def test_release_version_should_promote_the_candidate_when_release_merges(
+    repository, script
+):
+    """Test the version a finalized release is published as.
+
+    Given:
+        A release branch carrying the pending candidate.
+    When:
+        It is merged into master and the resulting version is derived.
+    Then:
+        It should promote the candidate to its production version.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.1")
+    repository.branch("release")
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+    repository.checkout("master")
+    merge = repository.merge("release")
+
+    # Act
+    version = _derive(script, "master", "release", merge)
+
+    # Assert
+    # The production tag the merge also reaches must not leak in.
+    assert version == "v0.15.0"
+
+
+def test_release_version_should_advance_the_candidate_when_a_sync_merges(
+    repository, script
+):
+    """Test the version a sync into the release branch is published as.
+
+    Given:
+        A release branch carrying a candidate, synced from master.
+    When:
+        The sync is merged and the resulting version is derived.
+    Then:
+        It should advance the candidate.
+    """
+    # Arrange
+    repository.commit()
+    repository.tag("v0.14.1")
+    repository.branch("release")
+    repository.commit()
+    repository.tag("v0.15.0-rc2")
+    repository.checkout("master")
+    repository.commit()
+    repository.checkout("release")
+    merge = repository.merge("master")
+
+    # Act
+    version = _derive(script, "release", "master", merge)
+
+    # Assert
+    assert version == "v0.15.0-rc3"
+
+
+def _derive(script, base_ref: str, head_ref: str, ref: str) -> str:
+    """Resolve the version a merge publishes.
+
+    Chains the three scripts as ``.github/workflows/publish-release.yaml``
+    chains them, failing on any step the workflow would have failed on.
+    """
+
+    def run(*arguments: str) -> str:
+        result = script(*arguments)
+        assert result.returncode == 0, result.stderr
+        return result.stdout.strip()
+
+    segment, channel = (
+        line.split("=", 1)[1]
+        for line in run("version-segment.sh", base_ref, head_ref).split()
+    )
+    return run("bump-version.sh", segment, run("latest-version.sh", channel, ref))

--- a/wool/tests/cicd/test_version_segment.py
+++ b/wool/tests/cicd/test_version_segment.py
@@ -1,13 +1,15 @@
 import pytest
 
+pytestmark = pytest.mark.cicd
+
 
 @pytest.mark.parametrize(
     ("base_ref", "head_ref", "segment", "channel"),
     [
-        ("master", "400-release-version-lookup", "patch", "production"),
+        ("master", "123-some-fix", "patch", "production"),
         ("master", "release", "minor", "candidate"),
         ("release", "master", "patch", "candidate"),
-        ("release", "401-fix", "patch", "candidate"),
+        ("release", "123-some-fix", "patch", "candidate"),
     ],
 )
 def test_version_segment_should_report_the_segment_and_channel_of_the_branch_pair(
@@ -43,7 +45,7 @@ def test_version_segment_should_exit_nonzero_when_the_base_branch_is_unsupported
         It should exit non-zero and name the unsupported branch.
     """
     # Act
-    result = script("version-segment.sh", "main", "401-fix")
+    result = script("version-segment.sh", "main", "123-some-fix")
 
     # Assert
     assert result.returncode != 0
@@ -66,102 +68,3 @@ def test_version_segment_should_exit_nonzero_when_a_branch_is_missing(script):
     # Assert
     assert result.returncode != 0
     assert "Usage:" in result.stderr
-
-
-def test_a_fix_merged_into_master_should_patch_the_last_production_release(
-    repository, script
-):
-    """Test the release the issue exists to make possible.
-
-    Given:
-        A master reaching a production tag with a stray candidate on its head.
-    When:
-        A fix branch is merged and the resulting version is derived.
-    Then:
-        It should patch the production tag rather than advance the candidate.
-    """
-    # Arrange
-    repository.commit()
-    repository.tag("v0.14.0")
-    repository.branch("fix")
-    repository.commit()
-    repository.checkout("master")
-    # The stray candidate PR #395's merge left on master's head.
-    repository.commit()
-    repository.tag("v0.15.0-rc1")
-    merge = repository.merge("fix")
-
-    # Act
-    version = _derive(script, "master", "fix", merge)
-
-    # Assert
-    assert version == "v0.14.1"
-
-
-def test_a_release_merged_into_master_should_promote_the_reachable_candidate(
-    repository, script
-):
-    """Test the version a finalized release is published as.
-
-    Given:
-        A release branch carrying the pending candidate.
-    When:
-        It is merged into master and the resulting version is derived.
-    Then:
-        It should promote the candidate to its production version.
-    """
-    # Arrange
-    repository.commit()
-    repository.tag("v0.14.1")
-    repository.branch("release")
-    repository.commit()
-    repository.tag("v0.15.0-rc2")
-    repository.checkout("master")
-    merge = repository.merge("release")
-
-    # Act
-    version = _derive(script, "master", "release", merge)
-
-    # Assert
-    # The production tag the merge also reaches must not leak in.
-    assert version == "v0.15.0"
-
-
-def test_a_sync_merged_into_release_should_advance_the_reachable_candidate(
-    repository, script
-):
-    """Test the version a sync into the release branch is published as.
-
-    Given:
-        A release branch carrying a candidate, synced from master.
-    When:
-        The sync is merged and the resulting version is derived.
-    Then:
-        It should advance the candidate.
-    """
-    # Arrange
-    repository.commit()
-    repository.tag("v0.14.1")
-    repository.branch("release")
-    repository.commit()
-    repository.tag("v0.15.0-rc2")
-    repository.checkout("master")
-    repository.commit()
-    repository.checkout("release")
-    merge = repository.merge("master")
-
-    # Act
-    version = _derive(script, "release", "master", merge)
-
-    # Assert
-    assert version == "v0.15.0-rc3"
-
-
-def _derive(script, base_ref: str, head_ref: str, ref: str) -> str:
-    """Resolve the version a merge publishes, as the workflow composes it."""
-    segment, channel = (
-        line.split("=", 1)[1]
-        for line in script("version-segment.sh", base_ref, head_ref).stdout.split()
-    )
-    old_version = script("latest-version.sh", channel, ref).stdout.strip()
-    return script("bump-version.sh", segment, old_version).stdout.strip()

--- a/wool/tests/cicd/test_workflows.py
+++ b/wool/tests/cicd/test_workflows.py
@@ -1,30 +1,93 @@
+"""Pins on the release workflow definitions themselves.
+
+The release scripts are exercised directly elsewhere in this package; what
+is pinned here is the wiring that decides whether they are called at all,
+and called with the history and the arguments they need.
+"""
+
 import os
-import pathlib
 import re
 
 import pytest
 import yaml
 
-REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+from tests.cicd.conftest import ACTIONS
+from tests.cicd.conftest import SCRIPTS
+from tests.cicd.conftest import WORKFLOWS
 
-WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+pytestmark = pytest.mark.cicd
 
-ACTIONS = REPO_ROOT / ".github" / "actions"
+#: The scripts that read a version out of the repository's tags. A job that
+#: calls one of these needs the history git walks to find them.
+VERSION_READERS = re.compile(r"\.github/scripts/(latest-version|cut-release)\.sh")
 
-#: Every `.github/scripts/<name>.sh` reference in a workflow or action body.
-SCRIPT_REFERENCE = re.compile(r"\.github/scripts/[\w-]+\.sh")
+#: Definitions are sorted so parametrization order does not follow the
+#: filesystem's.
+DEFINITIONS = sorted(WORKFLOWS.glob("*.yaml")) + sorted(ACTIONS.glob("*/action.yaml"))
+
+#: Every `.github/scripts/<name>.sh` the workflows or the scripts execute.
+#: Scripts nothing invokes are excluded -- their mode bit carries no risk.
+EXECUTED = sorted(
+    {
+        script
+        for source in (*DEFINITIONS, *SCRIPTS.glob("*.sh"))
+        for reference in re.findall(
+            r"(?:\.github/scripts/|BASH_SOURCE\[0\]\}\"\)/)([\w-]+\.sh)",
+            source.read_text(),
+        )
+        if (script := SCRIPTS / reference).exists()
+    }
+)
 
 
-def checkouts(definition: dict) -> list:
-    """Every ``actions/checkout`` step in a workflow or composite action."""
-    jobs = definition.get("jobs", {}).values()
-    steps = definition.get("runs", {}).get("steps", [])
-    for job in jobs:
-        steps = [*steps, *job.get("steps", [])]
-    return [step for step in steps if "actions/checkout" in step.get("uses", "")]
+def _jobs(definition: dict) -> list[dict]:
+    """Return every job of a workflow, or the single job of an action."""
+    if runs := definition.get("runs"):
+        return [runs]
+    return list(definition.get("jobs", {}).values())
 
 
-def test_build_release_should_check_out_the_full_history():
+def _checkouts(job: dict) -> list[dict]:
+    """Return every ``actions/checkout`` step of a job."""
+    return [
+        step
+        for step in job.get("steps", [])
+        if "actions/checkout" in step.get("uses", "")
+    ]
+
+
+def _run(job: dict) -> str:
+    """Return every shell body of a job, concatenated."""
+    return "\n".join(step.get("run", "") for step in job.get("steps", []))
+
+
+@pytest.mark.parametrize("path", DEFINITIONS, ids=lambda path: path.name)
+def test_every_job_that_reads_a_version_should_check_out_the_full_history(path):
+    """Test the history the release version is derived from.
+
+    Given:
+        A workflow or action whose job reads a version from the repository.
+    When:
+        That job's checkout step is read.
+    Then:
+        It should fetch the full history.
+    """
+    # Arrange
+    definition = yaml.safe_load(path.read_text())
+
+    # Act
+    readers = [job for job in _jobs(definition) if VERSION_READERS.search(_run(job))]
+
+    # Assert
+    # A shallow checkout makes the lookup report the zero version and exit
+    # zero, so the release publishes v0.0.1 rather than failing. Only the
+    # checkout the job starts from matters; a later one re-checks out a ref
+    # the version has already been read from.
+    for job in readers:
+        assert _checkouts(job)[0].get("with", {}).get("fetch-depth") == 0, path.name
+
+
+def test_build_release_should_check_out_the_tag_with_its_history():
     """Test the checkout the release build derives its version from.
 
     Given:
@@ -32,42 +95,72 @@ def test_build_release_should_check_out_the_full_history():
     When:
         Its checkout step is read.
     Then:
-        It should fetch the full history and the tags.
+        It should fetch the tags and the history they are reachable through.
     """
     # Arrange
     definition = yaml.safe_load((ACTIONS / "build-release" / "action.yaml").read_text())
 
     # Act
-    step = checkouts(definition)[0]
+    steps = _checkouts(_jobs(definition)[0])
 
     # Assert
-    # Without the full history the metadata hook cannot describe the tag it
-    # was checked out at, and the wheel is labelled 0.0.0 instead.
-    assert step["with"]["fetch-depth"] == 0
-    assert step["with"]["fetch-tags"] is True
+    # The metadata hook resolves any ref it is given, not only a tagged one;
+    # see the checkout step's own comment for what that buys.
+    assert [step["with"]["fetch-depth"] for step in steps] == [0]
+    assert [step["with"]["fetch-tags"] for step in steps] == [True]
 
 
-def test_publish_release_should_check_out_the_full_history_before_bumping():
-    """Test the checkout the published version is derived from.
+@pytest.mark.parametrize(
+    ("workflow", "channel"),
+    [
+        ("publish-release.yaml", '"$VERSION_CHANNEL"'),
+        ("manual-release.yaml", "production"),
+    ],
+)
+def test_each_release_workflow_should_read_its_channel_through_the_lookup(
+    workflow, channel
+):
+    """Test the wiring between the release workflows and the lookup.
+
+    Given:
+        A workflow that publishes a release.
+    When:
+        Its bump step is read.
+    Then:
+        It should read the old version from the channel lookup.
+    """
+    # Arrange
+    definition = yaml.safe_load((WORKFLOWS / workflow).read_text())
+
+    # Act
+    body = _run(definition["jobs"]["bump-version"])
+
+    # Assert
+    assert f".github/scripts/latest-version.sh {channel}" in body
+
+
+def test_publish_release_should_resolve_the_segment_through_the_contract():
+    """Test the wiring between the publish workflow and the branch contract.
 
     Given:
         The publish-release workflow.
     When:
-        The bump-version job's checkout step is read.
+        Its segment step is read.
     Then:
-        It should fetch the full history.
+        It should resolve the segment and channel through version-segment.
     """
     # Arrange
     definition = yaml.safe_load((WORKFLOWS / "publish-release.yaml").read_text())
 
     # Act
-    job = definition["jobs"]["bump-version"]
+    body = _run(definition["jobs"]["bump-version"])
 
     # Assert
-    assert checkouts({"jobs": {"bump-version": job}})[0]["with"]["fetch-depth"] == 0
+    assert ".github/scripts/version-segment.sh" in body
+    assert "$GITHUB_OUTPUT" in body
 
 
-def test_publish_release_should_not_be_triggered_by_this_suite():
+def test_publish_release_should_trigger_only_on_the_package_source():
     """Test the paths a merge publishes a release from.
 
     Given:
@@ -85,34 +178,24 @@ def test_publish_release_should_not_be_triggered_by_this_suite():
     paths = definition[True]["pull_request_target"]["paths"]
 
     # Assert
+    # Widening this filter to the test tree would make every change to this
+    # package publish a release.
     assert paths == ["wool/src/**", "wool/pyproject.toml"]
 
 
-@pytest.mark.parametrize(
-    "definition",
-    [
-        *WORKFLOWS.glob("*.yaml"),
-        *ACTIONS.glob("*/action.yaml"),
-    ],
-    ids=lambda path: path.parent.name + "/" + path.name,
-)
-def test_every_referenced_script_should_be_executable(definition):
-    """Test the release scripts the workflows invoke directly.
+@pytest.mark.parametrize("script", EXECUTED, ids=lambda path: path.name)
+def test_every_release_script_should_be_executable(script):
+    """Test the mode bits of the scripts the release runs.
 
     Given:
-        A workflow or action naming scripts under .github/scripts.
+        A script under .github/scripts.
     When:
-        Each referenced script is resolved.
+        Its mode is read.
     Then:
-        It should exist and be executable.
+        It should be executable.
     """
-    # Act
-    referenced = set(SCRIPT_REFERENCE.findall(definition.read_text()))
-
-    # Assert
-    for reference in referenced:
-        script = REPO_ROOT / reference
-        assert script.exists(), reference
-        # The workflows exec these directly rather than through bash, so a
-        # lost mode bit breaks the release at runtime and nowhere earlier.
-        assert os.access(script, os.X_OK), reference
+    # Act & assert
+    # The workflows and the scripts exec each other directly rather than
+    # through bash, so a lost mode bit breaks the release at runtime and
+    # nowhere earlier.
+    assert os.access(script, os.X_OK)


### PR DESCRIPTION
## Summary

Addresses issues remaining after #402, which closed #400. That change unified the *shell* version lookup behind `latest-version.sh` but left `build-hooks/_git.py` on `git describe`, so the repository still carried two answers to "which tag governs this commit" — the divergence #400 was filed about. This PR finishes the unification and closes the correctness gaps that followed from it.

It is based on the current `master`, which already carries #402 and the `v0.14.1` that #402 made possible.

Closes #400 

## Proposed changes

### Select the build version by version order, not commit distance

`build-hooks/_git.py` kept the metric `latest-version.sh` was written to replace. Three defects follow from it, each reproduced against a topology the suite already builds:

- **A build could be labelled below a released version.** `git describe` ranks by a commit-distance metric that a merge from an older fork point inverts. On `v0.13.1` → `v0.14.0` → untagged commits → a branch forked back at `v0.13.1` and merged, describe returns `v0.13.1` and the wheel is labelled `0.13.1+<sha>`.
- **A stray tag breaks the build.** `describe --tags` considers every tag, so a `nightly-2026-01-01` or `docs-rc-cleanup` tag reachable at HEAD raises `NonConformingVersionString` out of the metadata hook, failing `uv build` and every editable install.
- **A commit carrying two tags resolves arbitrarily.** By git's own ordering rather than by version: a commit tagged both `v1.2.3` and `v1.3.0` builds as `1.2.3`.

The hook now applies the same rule as the scripts — only tags of the shape the tooling emits, highest wins — with ordering delegated to `packaging`, already both a build and a runtime requirement. That also keeps it clear of the two known ordering defects in `build-hooks/_version.py` (pre-release identifiers compare as text, so `rc10` ranks below `rc9`; a `+build` comparison raises `TypeError`), which this change leaves unfixed and unreachable.

Verified on this checkout: the hook reports `0.14.1+dirty` where it previously reported `0.15.0-rc4+<sha>` — a pending candidate labelling a build of the production line, which is what the previous docstring claimed could never happen.

### Harden the release scripts against input they cannot bump

The `candidate` and `any` channels admitted a pre-release with a non-zero patch segment, which `split-version.sh` silently discards: `v0.15.2-rc1` bumps to `v0.15.0-rc2`, *below* the tag it came from. Only the shape `bump-version.sh` emits is admitted now, so the channel that selects a version and the script that moves it agree on what a version is.

Usage output moves to stderr, quoted — it was printed on stdout, the stream the workflows read the version from, and `cut-release.sh`'s unquoted `[BRANCH=release]` globbed against the working directory.

`cut-release.sh` stops when it cannot reach `main` rather than cutting from wherever HEAD happened to be, and looks for an existing release branch on the remote as well as locally. A CI checkout carries only the branch it cloned, so the branch the old guard checked for is not one it could see; pushing over it fast-forwarded the remote branch silently.

### Pin the contract the workflows actually deploy

The end-to-end tests composed the three release scripts by hand, so `publish-release.yaml` could revert to the old lookup with every test still green. The workflow definitions are now read: each release workflow's bump step must reach the version through the channel lookup, the publish workflow must resolve its segment through the branch contract, and every job that reads a version must check out the history git walks to find the tags.

The lookup's selection invariant gets a property test over generated tag sets — the examples only spot-checked it, and dropping two of the three version-sort settings left the whole suite green. Each example builds its own repository: a function-scoped fixture is shared across a test's examples, and tags from one leaked into the next.

Also fixed: the build hook's merge test rested on a commit-date tie-break rather than the rule its name claimed; an expected failure pinning the version model's ordering also swallowed the only assertion covering a two-digit release cycle; the git environment is scrubbed of ambient configuration that could redirect commands at the repository the tests run from — one they tag and push to; and the suite registers a `cicd` marker, as the test guide requires of a suite that forks real subprocesses.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `test_git` | A merge whose other parent forks before the highest tag | The version is parsed from git | Is the highest reachable tag | The version regression commit distance produced |
| 2 | `test_git` | Non-version tags reachable at head | The version is parsed from git | Is the version tag | A stray tag no longer breaks the build |
| 3 | `test_git` | A head commit carrying two version tags | The version is parsed from git | Is the higher of them | Resolution by version, not by git's ordering |
| 4 | `test_git` | A merge reaching a release and the candidate it promoted | The version is parsed from git | Is the release | Deterministic resolution, replacing a date tie-break |
| 5 | `test_git` | A bare repository, or one with no commits | The version is parsed from git | Raises | The documented error, previously raised only for one of the two |
| 6 | `test_latest_version` | Any set of version tags on one lineage, and any channel | That channel is queried | Returns the channel's highest tag, or the zero version | The selection invariant, property-based |
| 7 | `test_latest_version` | Non-version tags nearer than the version tags | Each channel is queried | Returns that channel's expected tag | Channel scoping, previously admitted either answer |
| 8 | `test_bump_version` | A release candidate with a single-digit cycle | Its patch segment is bumped | Returns the two-digit successor | A regression the expected failure had been swallowing |
| 9 | `test_bump_version` | An unrecognized segment, or the wrong argument count | The version is bumped | Exits non-zero with usage on stderr | Guards whose output previously went to stdout |
| 10 | `test_bump_version` | Any production or pre-release version the tooling emits | The version is bumped | Returns a version PEP 440 ranks above it | The ordering invariant, over the full generated domain |
| 11 | `test_cut_release` | A main branch reaching a production tag | A major release is cut | Returns the next major's first candidate | The major arm, previously untested |
| 12 | `test_cut_release` | An unrecognized release type, or too many arguments | A release is cut | Exits non-zero with the usage line intact | The bracket glob and the stdout leak |
| 13 | `test_cut_release` | A release branch that exists only on the remote | A minor release is cut | Exits non-zero and leaves the remote branch alone | The collision CI can actually produce |
| 14 | `test_workflows` | A workflow job that reads a version | Its first checkout is read | Fetches the full history | A shallow checkout silently publishing v0.0.1 |
| 15 | `test_workflows` | A workflow that publishes a release | Its bump step is read | Reads the version through the channel lookup | The wiring between the scripts and their callers |
| 16 | `test_workflows` | The publish workflow | Its segment step is read | Resolves the segment through the branch contract | The composition the end-to-end tests assume |
| 17 | `test_workflows` | A script the workflows or scripts execute | Its mode is read | Is executable | A lost mode bit, previously vacuous for 7 of 13 cases |
| 18 | `test_release_version` | Each merge into a release line | The version is derived as the workflow derives it | Is the version that line publishes | The three acceptance criteria, in a module named for them |
