### PR TITLE
Finalize a retired entry inline on the release that drops its last reference — Closes #389

### DIFF
--- a/wool/src/wool/runtime/resourcepool.py
+++ b/wool/src/wool/runtime/resourcepool.py
@@ -112,7 +112,13 @@ class ResourcePool(Generic[T]):
     :param factory:
         Function to create new objects (sync or async).
     :param finalizer:
-        Optional cleanup function (sync or async).
+        Optional cleanup function (sync or async). It runs while the pool
+        holds its internal lock, so it must not await `acquire`,
+        `release`, `expire` or `clear` — those take the same lock and the
+        call deadlocks; the read-only members are lock-free and safe. An
+        `Exception` it raises is suppressed, a `BaseException` propagates
+        to whichever operation ran the finalizer, and the entry is
+        evicted either way.
     :param ttl:
         Time-to-live in seconds after last reference is released.
     """
@@ -338,8 +344,10 @@ class ResourcePool(Generic[T]):
         Release a reference to the cached object.
 
         Decrements reference count. If count reaches 0, schedules cleanup
-        after TTL expires (if TTL > 0). Releasing a key that is not
-        cached is a silent no-op.
+        after TTL expires (if TTL > 0); an entry retired by `expire` is
+        finalized here rather than deferred — see `expire` for the
+        retirement contract. Releasing a key that is not cached is a
+        silent no-op.
 
         :param key:
             The cache key.
@@ -357,16 +365,9 @@ class ResourcePool(Generic[T]):
             entry.reference_count -= 1
 
             if entry.reference_count <= 0:
-                if entry.doomed:
-                    # An entry expired while still referenced, whose last
-                    # reference just drained. Spawn the cleanup rather than
-                    # awaiting it here: the finalizer can be a real teardown
-                    # (closing a gRPC channel) and release sits on the
-                    # caller's unwind path, so it must not run while this
-                    # holds the pool lock. Same path a TTL expiry takes.
-                    self._expire(key)
-                elif self._ttl <= 0:
-                    # No TTL to defer to, so finalize inline.
+                if entry.doomed or self._ttl <= 0:
+                    # Inline rather than a spawned task: with nothing to
+                    # defer to, a task spawned here may never be run.
                     await self._cleanup(key)
                 else:
                     # Defer cleanup with a plain timer rather than a
@@ -386,13 +387,14 @@ class ResourcePool(Generic[T]):
         the reference count callers hold through `acquire` and `release`.
         An unreferenced entry, including one already idling out its TTL,
         is finalized immediately; a referenced entry is marked and
-        finalized when its last reference is released, so in-flight users
-        always drain first. Re-acquiring a marked entry before that
-        release clears the mark — re-access resurrects, matching the
-        pool's timer-cancellation semantics. Unlike `clear`, which tears
-        the whole pool down regardless of reference count, this never
-        finalizes a resource out from under an active reference. Expiring
-        a key that is not cached is a silent no-op.
+        finalized by the release that drops its last reference, before
+        that release returns, so in-flight users always drain first.
+        Re-acquiring a marked entry before that release clears the mark —
+        re-access resurrects, matching the pool's timer-cancellation
+        semantics. Unlike `clear`, which tears the whole pool down
+        regardless of reference count, this never finalizes a resource out
+        from under an active reference. Expiring a key that is not cached
+        is a silent no-op.
 
         :param key:
             The cache key to expire.

--- a/wool/tests/runtime/test_resourcepool.py
+++ b/wool/tests/runtime/test_resourcepool.py
@@ -4,12 +4,14 @@ import logging
 import threading
 import time
 import warnings
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
 
 import pytest
 from hypothesis import given
+from hypothesis import settings
 from hypothesis import strategies
 
 from wool.runtime.resourcepool import Resource
@@ -166,6 +168,20 @@ def resource_pool_immediate_cleanup(mock_resource_factory, mock_finalizer):
 
 
 @pytest.fixture
+def retired_entry_pool(mocker):
+    """Build a long-TTL pool holding one entry retired while referenced.
+
+    Returns the pool, its finalizer mock and its factory mock. The
+    factory yields ``"first"`` then ``"second"``, so a test can prove
+    eviction by acquiring again and getting the second object.
+    """
+    factory = mocker.Mock(side_effect=["first", "second"])
+    finalizer = mocker.AsyncMock()
+    pool = ResourcePool(factory=factory, finalizer=finalizer, ttl=60)
+    return pool, finalizer, factory
+
+
+@pytest.fixture
 def expiry_race_pool(mocker):
     """Build a short-TTL pool whose lock can be parked via a blocker key.
 
@@ -316,6 +332,7 @@ class TestResourcePool:
         return setup
 
     @pytest.mark.asyncio
+    @settings(max_examples=50, deadline=None)
     @given(setup=setup())
     async def test_get_should_return_resource_instance(self, setup):
         """Test that get returns a Resource instance.
@@ -445,16 +462,24 @@ class TestResourcePool:
             await ttl_pool.release(unique_key)
 
     @pytest.mark.asyncio
-    async def test_finalizer_should_still_evict_entry_when_raising_base_exception(self):
+    @pytest.mark.parametrize(
+        "ttl, retire_first",
+        [(0, False), (60, True)],
+        ids=["zero-ttl", "retired-while-referenced"],
+    )
+    async def test_finalizer_should_still_evict_entry_when_raising_base_exception(
+        self, ttl, retire_first
+    ):
         """Test a cancelled finalizer still evicts the cache entry.
 
         Given:
-            A ``ttl=0`` pool whose finalizer raises
-            ``CancelledError`` — a ``BaseException``, not an
-            ``Exception`` — on its first call, modelling cleanup that
-            runs under a cancelled teardown
+            A pool that finalizes inline — either because it has no TTL
+            or because the entry was retired by ``expire`` while still
+            referenced — whose finalizer raises ``CancelledError`` — a
+            ``BaseException``, not an ``Exception`` — on its first call,
+            modelling cleanup that runs under a cancelled teardown
         When:
-            A resource is acquired and released, driving immediate
+            A resource is acquired and released, driving the inline
             cleanup whose finalizer raises
         Then:
             The ``CancelledError`` propagates, but the torn-down entry
@@ -478,14 +503,15 @@ class TestResourcePool:
                 SimpleNamespace(name="second"),
             ]
         )
-        pool = ResourcePool(factory=factory, finalizer=finalizer, ttl=0)
+        pool = ResourcePool(factory=factory, finalizer=finalizer, ttl=ttl)
 
         # Act
-        # Acquire then release: rc -> 0 drives immediate cleanup, whose
+        # Acquire then release: rc -> 0 drives inline cleanup, whose
         # finalizer raises CancelledError out of the release.
         with pytest.raises(asyncio.CancelledError):
             async with pool.get("key"):
-                pass
+                if retire_first:
+                    await pool.expire("key")
 
         # Assert
         # The finalized resource must not survive in the cache.
@@ -870,42 +896,63 @@ class TestResourcePool:
         assert pool.stats.total_entries == 1
 
     @pytest.mark.asyncio
+    @settings(max_examples=50, deadline=None)
     @given(
         operations=strategies.lists(
             strategies.tuples(
-                strategies.sampled_from(["acquire", "release"]),
+                strategies.sampled_from(["acquire", "release", "expire"]),
                 strategies.sampled_from(["a", "b", "c"]),
             ),
             max_size=30,
         )
     )
     async def test_release_should_maintain_bookkeeping_invariants(self, operations):
-        """Test acquire and release keep TTL bookkeeping consistent.
+        """Test acquire, release and expire keep bookkeeping consistent.
 
         Given:
-            Any interleaved sequence of acquire and release
+            Any interleaved sequence of acquire, release and expire
             operations over a small key domain, where releases are
             applied only while a reference is held
         When:
             The sequence is applied step by step to a long-TTL pool
         Then:
-            It should keep total entries equal to the keys ever
-            acquired, referenced entries equal to the keys with live
-            references, and pending cleanup on exactly the keys whose
-            references all released
+            It should evict a retired key the instant the release that
+            drops its last reference returns, keeping total entries,
+            referenced entries, pending cleanup and the finalized
+            objects equal to the model's at every step
         """
         # Arrange
-        pool = ResourcePool(factory=lambda key: f"obj-{key}", ttl=60)
+        finalized = []
+        pool = ResourcePool(
+            factory=lambda key: f"obj-{key}",
+            finalizer=finalized.append,
+            ttl=60,
+        )
         model_refcount = {}
+        model_doomed = set()
+        model_finalized = []
 
         # Act & assert
         for operation, key in operations:
             if operation == "acquire":
                 await pool.acquire(key)
                 model_refcount[key] = model_refcount.get(key, 0) + 1
+                model_doomed.discard(key)
+            elif operation == "expire":
+                if key in model_refcount:
+                    if model_refcount[key] > 0:
+                        model_doomed.add(key)
+                    else:
+                        del model_refcount[key]
+                        model_finalized.append(f"obj-{key}")
+                await pool.expire(key)
             elif model_refcount.get(key, 0) > 0:
                 await pool.release(key)
                 model_refcount[key] -= 1
+                if model_refcount[key] == 0 and key in model_doomed:
+                    model_doomed.discard(key)
+                    del model_refcount[key]
+                    model_finalized.append(f"obj-{key}")
 
             stats = pool.stats
             assert stats.total_entries == len(model_refcount)
@@ -915,6 +962,7 @@ class TestResourcePool:
             assert set(pool.pending_cleanup) == {
                 key for key, count in model_refcount.items() if count == 0
             }
+            assert finalized == model_finalized
 
     @pytest.mark.asyncio
     async def test_clear_should_finalize_all_resources(self):
@@ -1046,34 +1094,160 @@ class TestResourcePool:
         assert pool.stats.total_entries == 1
 
     @pytest.mark.asyncio
-    async def test_expire_should_finalize_at_last_release_when_expired(self):
-        """Test an expired entry is finalized as soon as its users drain.
+    async def test_release_should_finalize_retired_entry_when_last_reference_released(
+        self, retired_entry_pool
+    ):
+        """Test a retired entry is finalized as soon as its users drain.
 
         Given:
-            A long-TTL pool holding an entry that has been expired while
-            still referenced.
+            A long-TTL pool holding an entry that has been retired by
+            ``expire`` while still referenced.
         When:
             The last reference is released.
         Then:
-            It should finalize the resource promptly, without waiting out
-            the TTL. The finalizer is spawned rather than awaited by
-            release, so draining the loop is what settles it.
+            It should have awaited the finalizer before the release
+            returns, without waiting out the TTL and without leaving
+            pending cleanup behind for the loop to drain.
         """
         # Arrange
-        mock_factory = Mock(return_value="resource")
-        mock_finalizer = AsyncMock()
-        pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
+        pool, finalizer, _ = retired_entry_pool
         await pool.acquire("key")
         await pool.expire("key")
 
         # Act
         await pool.release("key")
-        await asyncio.sleep(0)
 
         # Assert
-        mock_finalizer.assert_awaited_once_with("resource")
+        finalizer.assert_awaited_once_with("first")
         assert pool.stats.total_entries == 0
         assert not pool.pending_cleanup
+
+    @pytest.mark.asyncio
+    async def test_release_should_not_finalize_retired_entry_when_references_remain(
+        self, retired_entry_pool
+    ):
+        """Test a retired entry survives a release that does not drain it.
+
+        Given:
+            A long-TTL pool holding an entry with two live references
+            that has been retired by ``expire`` while referenced.
+        When:
+            Only one of the two references is released.
+        Then:
+            It should leave the resource unfinalized and the entry
+            cached and still referenced, with no cleanup pending.
+        """
+        # Arrange
+        pool, finalizer, _ = retired_entry_pool
+        await pool.acquire("key")
+        await pool.acquire("key")
+        await pool.expire("key")
+
+        # Act
+        await pool.release("key")
+
+        # Assert
+        finalizer.assert_not_awaited()
+        assert pool.stats.total_entries == 1
+        assert pool.stats.referenced_entries == 1
+        assert not pool.pending_cleanup
+
+    @pytest.mark.asyncio
+    async def test_release_should_evict_retired_entry_when_cancelled_mid_finalizer(
+        self, mocker
+    ):
+        """Test cancelling a release mid-finalize still evicts the entry.
+
+        Given:
+            A long-TTL pool holding an entry retired by ``expire`` while
+            still referenced, whose finalizer parks on an event so the
+            release is suspended inside it.
+        When:
+            The releasing task is cancelled while the finalizer is
+            parked.
+        Then:
+            It should raise ``CancelledError`` and still evict the entry,
+            so no torn-down resource is handed back to a later acquire.
+        """
+        # Arrange
+        parked = asyncio.Event()
+        factory = mocker.Mock(side_effect=["first", "second"])
+
+        async def finalizer(_):
+            parked.set()
+            await asyncio.Event().wait()
+
+        pool = ResourcePool(factory=factory, finalizer=finalizer, ttl=60)
+        await pool.acquire("key")
+        await pool.expire("key")
+        release = asyncio.ensure_future(pool.release("key"))
+        # Bounded: a regression that never enters the finalizer must
+        # fail here rather than idle out the pool's own TTL.
+        await asyncio.wait_for(parked.wait(), timeout=2.0)
+
+        # Act & assert
+        release.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await release
+
+        assert pool.stats.total_entries == 0
+        assert await pool.acquire("key") == "second"
+
+    def test_release_should_finalize_retired_entry_when_loop_ends_immediately(
+        self, mocker, caplog
+    ):
+        """Test a release during shutdown closes the resource before returning.
+
+        Given:
+            A long-TTL pool holding an entry retired by ``expire`` while
+            still referenced, on a loop that closes as soon as the last
+            reference is released.
+        When:
+            That release is awaited and the loop is closed with no
+            further iterations.
+        Then:
+            It should have run the finalizer to completion before
+            returning, leaving no pending task on the loop and no
+            destroyed-while-pending report from asyncio.
+        """
+        # Arrange
+        closed = []
+
+        # The suspension point is load-bearing: a finalizer that never
+        # awaits would finish inside a single loop step, so this test
+        # could not tell an inline finalize from deferred work the loop
+        # happens to run before closing.
+        async def finalizer(obj):
+            await asyncio.sleep(0)
+            closed.append(obj)
+
+        pool = ResourcePool(
+            factory=mocker.Mock(return_value="obj"), finalizer=finalizer, ttl=60
+        )
+        loop = asyncio.new_event_loop()
+
+        async def acquire_and_retire():
+            await pool.acquire("key")
+            await pool.expire("key")
+
+        loop.run_until_complete(acquire_and_retire())
+
+        # Act
+        with caplog.at_level(logging.ERROR, logger="asyncio"):
+            loop.run_until_complete(pool.release("key"))
+            pending = asyncio.all_tasks(loop)
+            loop.close()
+            gc.collect()
+
+        # Assert
+        assert closed == ["obj"]
+        assert pending == set()
+        assert pool.stats.total_entries == 0
+        assert not [
+            record
+            for record in caplog.records
+            if "Task was destroyed" in record.getMessage()
+        ]
 
     @pytest.mark.asyncio
     async def test_expire_should_resurrect_entry_when_reacquired(self):
@@ -1315,11 +1489,20 @@ class TestResourcePool:
             assert pool.stats.pending_cleanup == 1
 
     @pytest.mark.asyncio
-    async def test_finalizer_should_catch_exception_and_remove_resource(self):
+    @pytest.mark.parametrize(
+        "ttl, retire_first",
+        [(0, False), (60, True)],
+        ids=["zero-ttl", "retired-while-referenced"],
+    )
+    async def test_finalizer_should_catch_exception_and_remove_resource(
+        self, ttl, retire_first
+    ):
         """Test finalizer exceptions are caught and logged.
 
         Given:
-            A finalizer that raises an exception
+            A pool that finalizes inline — either because it has no TTL
+            or because the entry was retired by ``expire`` while still
+            referenced — whose finalizer raises an exception
         When:
             Resource cleanup occurs
         Then:
@@ -1331,7 +1514,7 @@ class TestResourcePool:
         async def failing_finalizer(_):
             raise ValueError("Finalizer failed")
 
-        pool = ResourcePool(factory=mock_factory, finalizer=failing_finalizer)
+        pool = ResourcePool(factory=mock_factory, finalizer=failing_finalizer, ttl=ttl)
 
         mock_resource = Mock()
         mock_factory.return_value = mock_resource
@@ -1341,7 +1524,8 @@ class TestResourcePool:
         # Act & assert
         # This should not raise despite finalizer failing
         async with pool.get(key):
-            pass
+            if retire_first:
+                await pool.expire(key)
 
         # Resource should still be cleaned up
         assert pool.stats.total_entries == 0
@@ -1469,6 +1653,47 @@ class TestResource:
 
         # Should be automatically cleaned up after context exit
         assert pool.stats.total_entries == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "body_error",
+        [None, KeyError("boom")],
+        ids=["clean-exit", "body-raises"],
+    )
+    async def test_context_manager_should_finalize_when_retired_in_body(
+        self, retired_entry_pool, body_error
+    ):
+        """Test exiting the context finalizes a resource retired inside it.
+
+        Given:
+            A long-TTL pool whose key is retired by ``expire`` from
+            inside an ``async with pool.get(key)`` body while still
+            referenced, where the body then either returns or raises.
+        When:
+            The context manager exits, normally or on the exceptional
+            unwind.
+        Then:
+            It should have awaited the finalizer before the statement
+            following the block runs, leaving the entry evicted with no
+            cleanup pending and any original exception propagating
+            unchanged.
+        """
+        # Arrange
+        pool, finalizer, _ = retired_entry_pool
+        guard = pytest.raises(KeyError, match="boom") if body_error else nullcontext()
+
+        # Act & assert
+        with guard:
+            async with pool.get("key"):
+                await pool.expire("key")
+                # Guard: still referenced, so nothing is finalized yet.
+                finalizer.assert_not_awaited()
+                if body_error:
+                    raise body_error
+
+        finalizer.assert_awaited_once_with("first")
+        assert pool.stats.total_entries == 0
+        assert not pool.pending_cleanup
 
     @pytest.mark.asyncio
     async def test_resource_should_have_no_manual_release_method(self):

--- a/wool/tests/runtime/test_resourcepool.py
+++ b/wool/tests/runtime/test_resourcepool.py
@@ -991,6 +991,7 @@ class TestResourcePool:
             assert pool.stats.total_entries == 1
             assert "key2" in pool.pending_cleanup
 
+    @pytest.mark.asyncio
     async def test_expire_should_finalize_immediately_when_unreferenced(self):
         """Test expiring an unreferenced entry skips its remaining TTL.
 
@@ -1381,7 +1382,7 @@ class TestResourcePool:
 
     @pytest.mark.asyncio
     async def test_resource_pool_should_cleanup_immediately_when_zero_ttl(
-        self, resource_pool_immediate_cleanup
+        self, resource_pool_immediate_cleanup, mock_resource_factory, mock_finalizer
     ):
         """Test TTL=0 performs immediate cleanup as expected.
 
@@ -1395,7 +1396,7 @@ class TestResourcePool:
         # Arrange
         pool = resource_pool_immediate_cleanup
         mock_resource = Mock()
-        pool._factory.return_value = mock_resource
+        mock_resource_factory.return_value = mock_resource
 
         # Act
         async with pool.get("test-key") as resource:
@@ -1409,7 +1410,7 @@ class TestResourcePool:
         assert pool.stats.total_entries == 0
         assert pool.stats.referenced_entries == 0
         assert pool.stats.pending_cleanup == 0  # No pending cleanup tasks
-        pool._finalizer.assert_called_once_with(mock_resource)
+        mock_finalizer.assert_awaited_once_with(mock_resource)
 
     @pytest.mark.asyncio
     async def test_get_should_handle_none_key(self):


### PR DESCRIPTION
## Summary

Finalize a `ResourcePool` entry retired by `expire` inline, on the release that drops its last reference, instead of in a task spawned from that release.

The doomed branch now takes the path the zero-TTL branch already took — `if entry.doomed or self._ttl <= 0: await self._cleanup(key)`. In both cases there is nothing to defer to, so deferring only creates a task that may never run. When a release landed while its loop was shutting down, the spawned `_finalize` never got scheduled, the loop closed with the resource still open, and Python reported the orphaned coroutine. The TTL timer keeps its spawned-task path, which is what a genuinely deferred cleanup still needs.

The trade-off is that the finalizer now runs on the caller's unwind path, which the removed comment argued against. That argument did not hold: the spawned `_finalize` acquired the same pool lock before calling `_cleanup`, so the finalizer always ran under the lock, and the zero-TTL, `expire` and `clear` paths already awaited it inline. The change removes a task hop without widening any lock scope. What it does change is that a finalizer's failure and the caller's cancellation now reach each other, so this PR documents that error channel and pins those failure modes.

Closes #389

## Proposed changes

### Finalize a retired entry inline

`ResourcePool.release` fuses the doomed and zero-TTL branches into a single inline `await self._cleanup(key)`. `_expire` and `_finalize` remain, reached now only from the TTL timer callback.

### State the retirement contract once, on `expire`

`expire` owns the retirement lifecycle, so it owns the timing guarantee: a referenced entry is finalized by the release that drops its last reference, before that release returns. `release` points at that contract rather than restating it, and the branch comment carries only the rationale the code cannot show — that with nothing to defer to, a task spawned there may never be run.

Note what this deliberately does **not** claim. An earlier draft asserted that "a release awaited during loop shutdown still closes the resource"; direct measurement showed that is false in two of three shutdown shapes — a release awaited in a task that `asyncio.run` cancels, and a release suspended in the finalizer when `loop.stop()` fires, both leave the resource unclosed. The guarantee holds only when the awaiting coroutine is itself driven to completion, so the overpromise was removed rather than reworded.

### Document the finalizer's execution contract

The finalizer runs while the pool holds its internal lock, so awaiting `acquire`, `release`, `expire` or `clear` from inside it deadlocks; the read-only members are lock-free and safe. An `Exception` it raises is suppressed, a `BaseException` propagates to whichever operation ran the finalizer, and the entry is evicted either way. The lock behaviour is unchanged by this PR — it already held on the zero-TTL, `expire` and `clear` paths — but the doomed path now reaches it on ordinary teardown, and the error channel is newly reachable from `release` for any TTL. Both were measured before being written down: a *sync* finalizer that re-enters does not deadlock, so the prohibition is scoped to the awaiting case.

### Repair two pre-existing test defects

`test_expire_should_finalize_immediately_when_unreferenced` was an `async def` with no `@pytest.mark.asyncio`; under strict asyncio mode pytest never awaited it, so it reported as passed while asserting nothing — leaving `expire`'s unreferenced branch without real coverage. The zero-TTL cleanup test also reached into the pool's private `_factory` and `_finalizer` attributes; it now goes through the fixtures that own those mocks. Both repairs are committed separately from the fix, since they stand on their own.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestResourcePool` | A long-TTL pool holding an entry retired by `expire` while still referenced | The last reference is released | Awaits the finalizer before the release returns, leaving no pending cleanup | Inline finalization on the retired branch |
| 2 | `TestResourcePool` | The same pool on a loop that closes right after the release | The release is awaited and the loop is closed with no further iterations | Runs the finalizer to completion, leaves no pending task and no destroyed-while-pending report from asyncio | The reported shutdown failure |
| 3 | `TestResourcePool` | A long-TTL pool holding a retired entry with two live references | Only one of the two references is released | Leaves the resource unfinalized and the entry cached and still referenced | The branch fires only once the count drains |
| 4 | `TestResourcePool` | A long-TTL pool holding a retired entry whose finalizer parks on an event | The releasing task is cancelled while the finalizer is parked | Raises `CancelledError` and still evicts, so no torn-down resource is cached | Cancellation mid-finalize |
| 5 | `TestResourcePool` | Any interleaving of acquire, release and expire over a small key domain | The sequence is applied step by step to a long-TTL pool | Keeps entries, references, pending cleanup and finalized objects equal to the model at every step | Property coverage of the acquire, release and expire lattice |
| 6 | `TestResource` | A long-TTL pool whose key is retired from inside an `async with pool.get(key)` body that then either returns or raises | The context manager exits, normally or on the exceptional unwind | Awaits the finalizer before the following statement runs, evicts the entry, and lets any original exception propagate unchanged | The idiomatic entry point, both unwinds |
| 7 | `TestResourcePool` | A pool that finalizes inline — no TTL, or retired while referenced — whose finalizer raises | Cleanup runs | Swallows the error and still removes the entry | Finalizer failure, both entrances |
| 8 | `TestResourcePool` | The same two entrances, with a finalizer raising `CancelledError` | Cleanup runs | Lets the `BaseException` propagate and still evicts, so the next acquire rebuilds | Unconditional eviction, both entrances |
| 9 | `TestResourcePool` | A long-TTL pool holding an unreferenced entry with an armed TTL timer | `expire()` is called | Awaits the finalizer once and removes the entry with no pending cleanup | Repaired test, previously never executed |
