### PR TITLE
Close pooled gRPC channels when the event loop that opened them is done with them — Closes #388

### DIFF
--- a/wool/README.md
+++ b/wool/README.md
@@ -358,7 +358,7 @@ A `WorkerConnection` is a gRPC client managing a pooled channel to a single work
 
 Dispatch is not the whole surface: `WorkerConnection.idle` polls how long the worker has been continuously idle, in seconds, over a channel from the same pool. The count runs from the moment the worker's in-flight task set last emptied — startup counts as empty — and reads zero whenever work is in flight, which is what makes it a usable retirement signal: a supervisor polls its workers and stops the ones that have been quiet past some threshold. A worker predating the capability answers `UNIMPLEMENTED`, surfacing as `IdleUnavailable`, which descends from `WoolError` rather than `RpcError` so that an absent capability is not mistaken for an unhealthy peer. See the worker package's [_Connections → Idle reporting_](src/wool/runtime/worker/README.md#idle-reporting) for the full contract.
 
-Channels are pooled per event loop with reference counting and a 60-second TTL. A dispatch acquires a pool reference, and the result stream holds its own reference to keep the channel alive during streaming. There is no pool-level health checking — dead channels are detected reactively when a dispatch attempt fails, and the failed worker is removed from the load balancer context by the error classification logic.
+Channels are pooled per event loop with reference counting and a 60-second idle TTL, and are retired sooner when a `WorkerConnection` is closed or the last `WorkerProxy` on the loop stops — see the worker package's [_Connections → Connection pooling_](src/wool/runtime/worker/README.md#connection-pooling) for the full contract. A dispatch acquires a pool reference, and the result stream holds its own reference to keep the channel alive during streaming. There is no pool-level health checking — dead channels are detected reactively when a dispatch attempt fails, and the failed worker is removed from the load balancer context and its connection closed.
 
 ### Transport configuration
 
@@ -538,7 +538,7 @@ sequenceDiagram
     participant Routine
     participant Pool
     participant Discovery
-    participant Loadbalancer
+    participant Proxy
     participant Worker
 
     %% -- 1. Pool startup --
@@ -547,7 +547,7 @@ sequenceDiagram
 
         Client ->> Pool: create pool (spawn, discovery, loadbalancer)
         activate Client
-        Pool ->> Pool: resolve mode; classify factory by binding the call; check identity against own peers policy
+        Pool ->> Pool: resolve mode, classify the worker factory, check identity against own peers policy
 
         opt If spawn specified, spawn ephemeral workers
             loop Per worker
@@ -558,28 +558,33 @@ sequenceDiagram
             end
         end
 
-        Pool ->> Pool: create proxy (discovery subscriber, loadbalancer)
+        Pool ->> Proxy: create proxy (discovery subscriber, loadbalancer, lazy)
+        opt Eager proxy now, lazy proxy on its first dispatch
+            Proxy ->> Proxy: start — take a hold on the loop's channel pool, enter the load balancer, subscribe to discovery, launch the worker sentinel
+        end
         Pool -->> Client: pool ready
         deactivate Client
     end
 
     %% -- 2. Discovery --
     rect rgba(0, 0, 0, 0)
-        Note over Discovery, Loadbalancer: Worker discovery (the admission gate is WorkerProxy's)
+        Note over Discovery, Proxy: Worker discovery (the proxy's sentinel applies the admission gate)
 
         par Worker discovery
             loop Per worker lifecycle event
-                Discovery -->> Loadbalancer: worker event
+                Discovery -->> Proxy: worker event
                 activate Discovery
                 alt Worker-added or worker-updated
-                    Loadbalancer ->> Loadbalancer: admission gate — secure flag, protocol version, advertised identity vs peers policy
-                    alt Admitted
-                        Loadbalancer ->> Loadbalancer: add or refresh worker, pinning the advertised name when a policy is configured
+                    Proxy ->> Proxy: admission gate — secure flag, protocol version, advertised identity vs peers policy
+                    alt Admitted, not yet held
+                        Proxy ->> Proxy: add worker with a connection pinned to the advertised name when a policy is configured
+                    else Admitted, already held
+                        Proxy ->> Proxy: refresh in place — keep the connection when the channel key is unchanged, otherwise build a fresh one and leave the displaced channel to the idle TTL
                     else Rejected
-                        Loadbalancer ->> Loadbalancer: ignore if not held, evict if held
+                        Proxy ->> Proxy: ignore if not held, otherwise evict and close its connection
                     end
                 else Worker-dropped
-                    Loadbalancer ->> Loadbalancer: remove worker
+                    Proxy ->> Proxy: remove worker and close its connection (retiring its channel now rather than at the idle TTL)
                 end
                 deactivate Discovery
             end
@@ -593,30 +598,30 @@ sequenceDiagram
         Client ->> Routine: invoke wool routine
         activate Client
         Routine ->> Routine: create task, serialize via cloudpickle
-        Routine ->> Loadbalancer: route task
+        Routine ->> Proxy: route task
 
         loop Until handshake resolves or all workers exhausted
-            Loadbalancer ->> Loadbalancer: select next worker
-            Loadbalancer ->> Worker: open stream pinned to the advertised identity (when peers configured), write task frame
+            Proxy ->> Proxy: load balancer selects next worker
+            Proxy ->> Worker: acquire the worker's pooled channel, open a stream pinned to the advertised identity (when peers configured), write task frame
             Worker ->> Worker: VersionInterceptor, then DispatchSession.__aenter__ (parse)
             alt Ack
-                Worker -->> Loadbalancer: Ack
-                Loadbalancer ->> Loadbalancer: break
+                Worker -->> Proxy: Ack
+                Proxy ->> Proxy: break (the result stream holds its own channel reference until drained)
             else Nack with cloudpickled parse-failure exception
-                Worker -->> Loadbalancer: Nack
-                Loadbalancer ->> Loadbalancer: deserialize, re-raise (no eviction)
-                Loadbalancer -->> Routine: typed exception
+                Worker -->> Proxy: Nack
+                Proxy ->> Proxy: deserialize, re-raise (no eviction)
+                Proxy -->> Routine: typed exception
                 Routine -->> Client: re-raise
             else Handshake failure (UNAUTHENTICATED, or UNAVAILABLE carrying TLS evidence — untrusted CA, name mismatch, expired)
-                Loadbalancer ->> Loadbalancer: skip without eviction, rate-limited warning
+                Proxy ->> Proxy: skip without eviction, rate-limited warning
             else Transient gRPC error (UNAVAILABLE, DEADLINE_EXCEEDED, RESOURCE_EXHAUSTED)
-                Loadbalancer ->> Loadbalancer: skip, continue
+                Proxy ->> Proxy: skip, continue
             else Non-transient gRPC error (incl. FAILED_PRECONDITION on version mismatch)
-                Loadbalancer ->> Loadbalancer: evict worker, continue
+                Proxy ->> Proxy: evict worker, close its connection, continue
             end
         end
         opt All workers exhausted
-            Loadbalancer -->> Client: raise NoWorkersAvailable
+            Proxy -->> Client: raise NoWorkersAvailable
         end
 
         Worker ->> Worker: DispatchSession.__aiter__ schedules worker driver lazily
@@ -652,18 +657,21 @@ sequenceDiagram
         Client ->> Pool: exit pool
         activate Client
 
-        Pool ->> Pool: stop proxy
+        Pool ->> Proxy: stop proxy
+        Proxy ->> Proxy: cancel the sentinel, exit discovery and the load balancer, release the hold
+        opt Last hold on the loop
+            Proxy ->> Proxy: retire every channel cached on the loop, drain-first (a channel a stream still uses closes when that stream drains)
+        end
 
         opt Stop ephemeral workers
             loop Per worker
-                Pool ->> Discovery: publish "worker dropped"
-                Discovery -->> Loadbalancer: worker event
-                Loadbalancer ->> Loadbalancer: remove worker
-                Pool ->> Worker: stop worker
+                Pool ->> Discovery: publish "worker dropped" (this proxy has already stopped, other subscribers evict)
+                Pool ->> Worker: stop RPC over a WorkerConnection entered as a context manager, so its channel closes on exit
                 Worker ->> Worker: stop service, exit process
             end
         end
 
+        Pool ->> Discovery: exit the publisher, bounded by what remains of shutdown_timeout
         Pool ->> Discovery: close discovery
         Pool -->> Client: pool exited
         deactivate Client

--- a/wool/src/wool/runtime/discovery/README.md
+++ b/wool/src/wool/runtime/discovery/README.md
@@ -34,7 +34,7 @@ Both protocols optionally accept a filter predicate for targeted subscriptions.
 
 Wool supports custom discovery protocols via structural subtyping.
 
-`WorkerPool` accepts `DiscoveryLike` or `Factory[DiscoveryLike]` for its `discovery` parameter. The `Factory` type alias covers bare instances, context managers, async context managers, callables, and awaitables. This means you can pass a discovery instance directly, wrap it in a context manager for lifecycle management, or provide a factory callable — `WorkerPool` will manage it appropriately.
+`WorkerPool` accepts a `DiscoveryLike` instance or any `Factory` form for its `discovery` parameter — see `Factory` for the forms and `resolved` for how one is entered. This means you can pass a discovery instance directly, wrap it in a context manager for lifecycle management, or provide a factory callable — `WorkerPool` will manage it appropriately.
 
 ### `DiscoveryLike` protocol
 

--- a/wool/src/wool/runtime/loadbalancer/README.md
+++ b/wool/src/wool/runtime/loadbalancer/README.md
@@ -18,7 +18,7 @@ Wool ships with `RoundRobinLoadBalancer`, the default when no load balancer is e
 
 Wool supports custom load balancers via structural subtyping.
 
-`WorkerPool` and `WorkerProxy` accept any `LoadBalancerLike` (or `Factory[LoadBalancerLike]`). The `Factory` type alias covers bare instances, context managers, async context managers, callables, and awaitables. You can pass a load balancer instance directly, wrap it in a context manager for lifecycle management, or provide a factory callable — `WorkerPool` manages it appropriately.
+`WorkerPool` and `WorkerProxy` accept a `LoadBalancerLike` instance or any `Factory` form — see `Factory` for the forms and `resolved` for how one is entered. You can pass a load balancer instance directly, wrap it in a context manager for lifecycle management, or provide a factory callable — `WorkerPool` manages it appropriately.
 
 ### `LoadBalancerLike` protocol
 

--- a/wool/src/wool/runtime/loadbalancer/base.py
+++ b/wool/src/wool/runtime/loadbalancer/base.py
@@ -92,10 +92,10 @@ class LoadBalancerContextLike(LoadBalancerContextView, Protocol):
     from. Writes are last-writer-wins: the stored entry is replaced
     with the given record wholesale, so a caller writing a record it
     captured earlier regresses a fresher one for the same uid.
-    A displaced `WorkerConnection` is *not* closed — see
-    `wool.runtime.worker.connection.WorkerConnection` for why channel
-    lifetime belongs to the pooling layer rather than to the holder of
-    a connection handle.
+    The context does not close connections: closing belongs to whoever
+    created the connection, and channel lifetime otherwise belongs to
+    the pooling layer — see
+    `wool.runtime.worker.connection.WorkerConnection`.
     """
 
     def add_worker(
@@ -125,7 +125,8 @@ class LoadBalancerContextLike(LoadBalancerContextView, Protocol):
         :param metadata:
             Information about the worker to refresh.
         :param connection:
-            New `WorkerConnection` for this worker.
+            The `WorkerConnection` to store for this worker; it may be the
+            one already held.
         """
         ...
 

--- a/wool/src/wool/runtime/resourcepool.py
+++ b/wool/src/wool/runtime/resourcepool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import inspect
 import logging
 from dataclasses import dataclass
@@ -21,12 +22,13 @@ _log = logging.getLogger(__name__)
 
 
 class Resource(Generic[T]):
-    """
-    A single-use async context manager for resource acquisition.
+    """Acquire one cached object for the duration of an ``async with`` block.
 
     This class can only be used once as an async context manager. After
     acquisition, it cannot be reacquired, and after release, it cannot be
-    released again.
+    released again. The cached object may be any value, ``None`` and other
+    falsy values included: the release is tied to the acquisition, not to
+    the value acquired.
 
     :param pool:
         The `ResourcePool` this resource belongs to.
@@ -59,7 +61,7 @@ class Resource(Generic[T]):
         try:
             self._resource = await self._pool.acquire(self._key)
             return cast(T, self._resource)
-        except Exception:
+        except BaseException:
             self._acquired = False
             raise
 
@@ -92,8 +94,7 @@ class Resource(Generic[T]):
             )
 
         self._released = True
-        if self._resource:
-            await self._pool.release(self._key)
+        await self._pool.release(self._key)
 
 
 class ResourcePool(Generic[T]):
@@ -144,8 +145,7 @@ class ResourcePool(Generic[T]):
 
     @dataclass
     class CacheEntry:
-        """
-        Internal cache entry tracking an object and its metadata.
+        """Track a cached object and the lifecycle state the pool keeps for it.
 
         :param obj:
             The cached object.
@@ -284,10 +284,22 @@ class ResourcePool(Generic[T]):
         async with self._lock:
             if key in self._cache:
                 entry = self._cache[key]
+                try:
+                    await self._cancel_cleanup(entry)
+                except BaseException:
+                    # Interrupted after the cleanup task was cancelled:
+                    # the entry is unreferenced with neither timer nor
+                    # cleanup, so re-arm its TTL rather than orphan it.
+                    if (
+                        entry.reference_count == 0
+                        and entry.timer is None
+                        and self._ttl > 0
+                    ):
+                        self._arm_timer(key, entry)
+                    raise
+                self._cancel_timer(entry)
                 entry.reference_count += 1
                 entry.doomed = False
-                self._cancel_timer(entry)
-                await self._cancel_cleanup(entry)
                 return entry.obj
             else:
                 # Cache miss - create new object
@@ -297,14 +309,17 @@ class ResourcePool(Generic[T]):
                 return obj
 
     async def release(self, key: Any) -> None:
-        """
-        Release a reference to the cached object.
+        """Release a reference to the cached object.
 
         Decrements reference count. If count reaches 0, schedules cleanup
         after TTL expires (if TTL > 0); an entry retired by `expire` or
         `expire_all` is finalized here rather than deferred — see `expire`
         for the retirement contract. Releasing a key that is not cached is
         a silent no-op.
+
+        A cancellation delivered while the release waits for the pool's
+        lock does not abandon the decrement; the release completes and
+        the caller still observes the cancellation.
 
         :param key:
             The cache key.
@@ -318,30 +333,18 @@ class ResourcePool(Generic[T]):
         the resource: with nothing left to defer to, a task spawned there
         may never run — the closing loop would orphan it, and the
         resource with it.
+
+        A cancellation delivered while this waits on a contended lock
+        would abandon the decrement, i.e., the reference would be held
+        forever and the entry never finalized, so the contended path
+        runs shielded: the release completes on its own task after the
+        caller has been cancelled. The uncontended path never suspends
+        before the decrement, so it needs no shield and no task.
         """
-        async with self._lock:
-            if key not in self._cache:
-                return
-            entry = self._cache[key]
-
-            if entry.reference_count <= 0:
-                raise ValueError(f"Reference count for key '{key}' is already 0")
-
-            entry.reference_count -= 1
-
-            if entry.reference_count <= 0:
-                if entry.doomed or self._ttl <= 0:
-                    # Inline — see the implementation notes on this method.
-                    await self._cleanup(key)
-                else:
-                    # Defer cleanup with a plain timer rather than a
-                    # task parked on a TTL sleep: an unfired
-                    # TimerHandle is discarded silently at loop close,
-                    # whereas a parked task is destroyed pending —
-                    # and, if never started, its coroutine emits a
-                    # "never awaited" RuntimeWarning.
-                    loop = asyncio.get_running_loop()
-                    entry.timer = loop.call_later(self._ttl, self._expire, key)
+        if self._lock.locked():
+            await asyncio.shield(self._release(key))
+        else:
+            await self._release(key)
 
     async def expire(self, key: Any) -> None:
         """Treat *key* as TTL-expired now, finalizing it once unreferenced.
@@ -498,6 +501,50 @@ class ResourcePool(Generic[T]):
         self._mutex = asyncio.Lock()
         self._loop = loop
 
+    async def _release(self, key: Any) -> None:
+        """Drop one reference under the lock — see `release`.
+
+        :param key:
+            The cache key.
+        :raises ValueError:
+            If the key's reference count is already 0.
+        """
+        async with self._lock:
+            if key not in self._cache:
+                return
+            entry = self._cache[key]
+
+            if entry.reference_count <= 0:
+                raise ValueError(f"Reference count for key '{key}' is already 0")
+
+            entry.reference_count -= 1
+
+            if entry.reference_count <= 0:
+                if entry.doomed or self._ttl <= 0:
+                    # Inline — see the implementation notes on release.
+                    await self._cleanup(key)
+                else:
+                    self._arm_timer(key, entry)
+
+    def _arm_timer(self, key: Any, entry: ResourcePool.CacheEntry) -> None:
+        """Schedule an unreferenced entry's TTL expiry on the bound loop.
+
+        :param key:
+            The cache key whose TTL to start.
+        :param entry:
+            The entry cached under ``key``.
+
+        .. rubric:: Implementation notes
+
+        Defers cleanup with a plain timer rather than a task parked on a
+        TTL sleep: an unfired `asyncio.TimerHandle` is discarded silently
+        at loop close, whereas a parked task is destroyed pending — and,
+        if never started, its coroutine emits a "never awaited"
+        `RuntimeWarning`.
+        """
+        loop = asyncio.get_running_loop()
+        entry.timer = loop.call_later(self._ttl, self._expire, key)
+
     def _cancel_timer(self, entry: ResourcePool.CacheEntry) -> None:
         """
         Cancel an entry's pending TTL timer, if any.
@@ -517,9 +564,11 @@ class ResourcePool(Generic[T]):
         """
         Cancel an entry's in-flight cleanup task, if any.
 
-        The task is cancelled and awaited. The current task is left
-        alone: on the expiry path this runs *inside* the entry's own
-        cleanup task (`_finalize`), which must not cancel itself.
+        The task is cancelled and waited for; its own cancellation is
+        not re-raised here, while a cancellation of the current task is
+        honored. The current task is left alone: on the expiry path this
+        runs *inside* the entry's own cleanup task (`_finalize`), which
+        must not cancel itself.
 
         :param entry:
             The cache entry whose cleanup task to cancel.
@@ -529,10 +578,7 @@ class ResourcePool(Generic[T]):
         if cleanup is None or cleanup.done() or cleanup is asyncio.current_task():
             return
         cleanup.cancel()
-        try:
-            await cleanup
-        except asyncio.CancelledError:
-            pass
+        await asyncio.wait({cleanup})
 
     def _expire(self, key: Any) -> None:
         """
@@ -553,6 +599,30 @@ class ResourcePool(Generic[T]):
             return
         entry.timer = None
         entry.cleanup = asyncio.get_running_loop().create_task(self._finalize(key))
+        entry.cleanup.add_done_callback(functools.partial(self._report_cleanup, key))
+
+    def _report_cleanup(self, key: Any, cleanup: asyncio.Task[None]) -> None:
+        """Log a cleanup task that ended in a failure.
+
+        A `BaseException` a finalizer raises inside a spawned cleanup has
+        no caller to propagate to, so it is retrieved and reported here
+        rather than left for the loop's unretrieved-exception hook.
+
+        :param key:
+            The cache key the cleanup was for.
+        :param cleanup:
+            The finished cleanup task.
+        """
+        if cleanup.cancelled():
+            return
+        error = cleanup.exception()
+        if error is not None:
+            _log.warning(
+                "ResourcePool(%s) cleanup of key %r failed",
+                self._name,
+                key,
+                exc_info=error,
+            )
 
     async def _finalize(self, key: Any) -> None:
         """

--- a/wool/src/wool/runtime/resourcepool.py
+++ b/wool/src/wool/runtime/resourcepool.py
@@ -103,11 +103,16 @@ class ResourcePool(Generic[T]):
     binds to the first loop that uses it and rebinds when used from
     another loop once the bound loop is no longer running, dropping every
     cached entry without running its finalizer: a resource cannot be torn
-    down from a loop other than the one that made it. Entries still
-    referenced when their loop stopped are reported at warning level,
-    idle ones at debug. Using a bound pool from a second *running* loop
-    raises `RuntimeError`, so tearing a pool down belongs to the loop that
-    owns it.
+    down from a loop other than the one that made it. Every dropped
+    entry is reported at warning level, referenced and idle alike: a
+    drop is not an expiry, so an idle entry the TTL would have closed
+    is abandoned rather than finalized, and both counts name a resource
+    that outlived every chance to finalize it. The record names the pool
+    by its factory, and it is expected only of a loop that stopped with
+    entries it did not clear: a loop that clears its pools before
+    stopping leaves nothing to report. Using a bound pool from a second
+    *running* loop raises `RuntimeError`, so tearing a pool down belongs
+    to the loop that owns it.
 
     :param factory:
         Function to create new objects (sync or async).
@@ -182,66 +187,6 @@ class ResourcePool(Generic[T]):
         self._cache: dict[Any, ResourcePool.CacheEntry] = {}
         self._mutex: asyncio.Lock | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
-
-    @property
-    def _lock(self) -> asyncio.Lock:
-        """Return the mutex serializing this pool on its bound loop.
-
-        Binds the pool on first use and rebinds it when the running loop
-        differs from the bound one and the bound one is no longer running
-        — see the class docstring for what a rebind drops. Every method
-        that touches ``_cache`` takes this lock first, so the loop check
-        happens once per operation.
-
-        :raises RuntimeError:
-            If the pool is bound to another loop that is still running.
-
-        .. rubric:: Implementation notes
-
-        `asyncio.Lock` binds to a loop the first time it is *contended*
-        — the uncontended acquire path never consults one — and never
-        unbinds, so a single mutex built at construction would serve
-        every uncontended caller and then raise for the first contender
-        on any later loop. Liveness is `is_running`, not `is_closed`: a
-        loop that has stopped but not yet closed cannot contend the
-        mutex, and both the worker's loop rotation and the test fixtures
-        stop a loop before closing it. `is_running` reads one attribute,
-        so it is safe to call from another thread.
-        """
-        loop = asyncio.get_running_loop()
-        if self._loop is not loop:
-            if self._loop is not None and self._loop.is_running():
-                raise RuntimeError(
-                    "ResourcePool is bound to another running event loop; "
-                    "use one pool per loop"
-                )
-            self._rebind(loop)
-        assert self._mutex is not None
-        return self._mutex
-
-    def _rebind(self, loop: asyncio.AbstractEventLoop) -> None:
-        """Bind this pool to ``loop``, dropping what the previous loop left.
-
-        The dropped entries are never finalized: their finalizer would
-        run against a loop that is no longer running. Entries still
-        referenced when that loop stopped are a leak and are logged at
-        warning level; idle entries are what the TTL would have
-        discarded and are logged at debug level.
-        """
-        if self._cache:
-            referenced = sum(1 for e in self._cache.values() if e.reference_count > 0)
-            idle = len(self._cache) - referenced
-            log = _log.warning if referenced else _log.debug
-            log(
-                "ResourcePool rebinding to a new event loop; dropping %d "
-                "referenced and %d idle entries left by a loop that is no "
-                "longer running (finalizers not run)",
-                referenced,
-                idle,
-            )
-            self._cache.clear()
-        self._mutex = asyncio.Lock()
-        self._loop = loop
 
     async def __aenter__(self):
         """Async context manager entry.
@@ -420,6 +365,64 @@ class ResourcePool(Generic[T]):
         async with self._lock:
             for key in list(self._cache.keys()):
                 await self._cleanup(key)
+
+    @property
+    def _lock(self) -> asyncio.Lock:
+        """Return the mutex serializing this pool on its bound loop.
+
+        Binds the pool on first use and rebinds it when the running loop
+        differs from the bound one and the bound one is no longer running
+        — see the class docstring for what a rebind drops. Every method
+        that touches ``_cache`` takes this lock first, so the loop check
+        happens once per operation.
+
+        :raises RuntimeError:
+            If the pool is bound to another loop that is still running.
+
+        .. rubric:: Implementation notes
+
+        `asyncio.Lock` binds to a loop the first time it is *contended*
+        — the uncontended acquire path never consults one — and never
+        unbinds, so a single mutex built at construction would serve
+        every uncontended caller and then raise for the first contender
+        on any later loop. Liveness is `is_running`, not `is_closed`: a
+        loop that has stopped but not yet closed cannot contend the
+        mutex, and both the worker's loop rotation and the test fixtures
+        stop a loop before closing it. `is_running` reads one attribute,
+        so it is safe to call from another thread.
+        """
+        loop = asyncio.get_running_loop()
+        if self._loop is not loop:
+            if self._loop is not None and self._loop.is_running():
+                raise RuntimeError(
+                    "ResourcePool is bound to another running event loop; "
+                    "use one pool per loop"
+                )
+            self._rebind(loop)
+        assert self._mutex is not None
+        return self._mutex
+
+    def _rebind(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Bind this pool to ``loop``, dropping what the previous loop left.
+
+        Both counts are logged — see the class docstring for why an idle
+        drop is a leak and not a deferred expiry.
+        """
+        if self._cache:
+            referenced = sum(1 for e in self._cache.values() if e.reference_count > 0)
+            idle = len(self._cache) - referenced
+            _log.warning(
+                "ResourcePool(%s) rebinding to a new event loop; dropping %d "
+                "referenced and %d idle entries left by a loop that is no "
+                "longer running (finalizers not run)",
+                getattr(self._factory, "__qualname__", None)
+                or type(self._factory).__name__,
+                referenced,
+                idle,
+            )
+            self._cache.clear()
+        self._mutex = asyncio.Lock()
+        self._loop = loop
 
     def _cancel_timer(self, entry: ResourcePool.CacheEntry) -> None:
         """

--- a/wool/src/wool/runtime/resourcepool.py
+++ b/wool/src/wool/runtime/resourcepool.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from dataclasses import dataclass
 from typing import Any
 from typing import Awaitable
 from typing import Callable
+from typing import Final
 from typing import Generic
 from typing import TypeVar
 from typing import cast
+
+#: Process-level interrupts — see `ResourcePool.expire_all` for their rank in a sweep.
+_INTERRUPTS: Final = (KeyboardInterrupt, SystemExit)
 
 T = TypeVar("T")
 
@@ -92,8 +97,7 @@ class Resource(Generic[T]):
 
 
 class ResourcePool(Generic[T]):
-    """
-    An asynchronous reference-counted cache with TTL-based cleanup.
+    """Cache objects by key with reference counting and TTL-based cleanup.
 
     Objects are created on-demand via a factory function (sync or async) and
     automatically cleaned up after all references are released and the TTL
@@ -115,15 +119,25 @@ class ResourcePool(Generic[T]):
     to the loop that owns it.
 
     :param factory:
-        Function to create new objects (sync or async).
+        Function to create new objects (sync or async). A coroutine a
+        sync factory returns is awaited; any other awaitable is cached
+        as the object itself.
     :param finalizer:
         Optional cleanup function (sync or async). It runs while the pool
-        holds its internal lock, so it must not await `acquire`,
-        `release`, `expire` or `clear` — those take the same lock and the
-        call deadlocks; the read-only members are lock-free and safe. An
-        `Exception` it raises is suppressed, a `BaseException` propagates
-        to whichever operation ran the finalizer, and the entry is
-        evicted either way.
+        holds its internal lock, so it must not await any operation of
+        *this* pool that mutates the cache — they all take the same lock
+        and the call deadlocks, and reaching a resource through `get`
+        counts; the read-only members are lock-free and safe, and so are
+        the mutating members of a different pool, provided the
+        finalizer-to-pool relation stays acyclic: two pools whose
+        finalizers each mutate the other deadlock. An `Exception` it
+        raises is contained — reported at warning level against the
+        pool's factory name and the key, then suppressed — a
+        `BaseException` propagates to whichever operation ran the
+        finalizer (`expire_all` defers it to the end of its sweep), and
+        the entry is evicted either way; a failure inside a cleanup the
+        TTL spawned has no caller to propagate to and is reported the
+        same way.
     :param ttl:
         Time-to-live in seconds after last reference is released.
     """
@@ -144,11 +158,11 @@ class ResourcePool(Generic[T]):
         :param cleanup:
             Optional cleanup task created when the TTL timer fires.
         :param doomed:
-            Whether `ResourcePool.expire` marked this entry for
-            finalization as soon as its reference count reaches zero.
-            Cleared when the entry is re-acquired first — re-access
-            resurrects, matching the pool's timer-cancellation
-            semantics.
+            Whether the entry has been retired (see `ResourcePool.expire`
+            for the retirement contract) and is finalized as soon as its
+            reference count reaches zero. Cleared when the entry is
+            re-acquired first — re-access resurrects, matching the pool's
+            timer-cancellation semantics.
         """
 
         obj: Any
@@ -247,20 +261,17 @@ class ResourcePool(Generic[T]):
         }
 
     def get(self, key: Any) -> Resource[T]:
-        """
-        Get a resource acquisition that can be awaited or used as context
-        manager.
+        """Return a single-use `Resource` for ``key``, entered with ``async with``.
 
         :param key:
             The cache key.
         :returns:
-            `Resource` that can be awaited or used with 'async with'.
+            The `Resource` for ``key``.
         """
         return Resource(self, key)
 
     async def acquire(self, key: Any) -> T:
-        """
-        Internal acquire method - acquires a reference to the cached object.
+        """Acquire a reference to the cached object, creating it on a miss.
 
         Creates a new object via the factory if not cached. Increments
         reference count and cancels any pending cleanup.
@@ -280,7 +291,8 @@ class ResourcePool(Generic[T]):
                 return entry.obj
             else:
                 # Cache miss - create new object
-                obj = await self._await(self._factory, key)
+                created = self._factory(key)
+                obj = cast(T, await created if asyncio.iscoroutine(created) else created)
                 self._cache[key] = self.CacheEntry(obj=obj, reference_count=1)
                 return obj
 
@@ -289,15 +301,23 @@ class ResourcePool(Generic[T]):
         Release a reference to the cached object.
 
         Decrements reference count. If count reaches 0, schedules cleanup
-        after TTL expires (if TTL > 0); an entry retired by `expire` is
-        finalized here rather than deferred — see `expire` for the
-        retirement contract. Releasing a key that is not cached is a
-        silent no-op.
+        after TTL expires (if TTL > 0); an entry retired by `expire` or
+        `expire_all` is finalized here rather than deferred — see `expire`
+        for the retirement contract. Releasing a key that is not cached is
+        a silent no-op.
 
         :param key:
             The cache key.
         :raises ValueError:
             If the key's reference count is already 0.
+
+        .. rubric:: Implementation notes
+
+        Finalizing inline rather than in a spawned task is what lets a
+        release that lands while its loop is shutting down still close
+        the resource: with nothing left to defer to, a task spawned there
+        may never run — the closing loop would orphan it, and the
+        resource with it.
         """
         async with self._lock:
             if key not in self._cache:
@@ -311,8 +331,7 @@ class ResourcePool(Generic[T]):
 
             if entry.reference_count <= 0:
                 if entry.doomed or self._ttl <= 0:
-                    # Inline rather than a spawned task: with nothing to
-                    # defer to, a task spawned here may never be run.
+                    # Inline — see the implementation notes on this method.
                     await self._cleanup(key)
                 else:
                     # Defer cleanup with a plain timer rather than a
@@ -348,23 +367,79 @@ class ResourcePool(Generic[T]):
             entry = self._cache.get(key)
             if entry is None:
                 return
-            if entry.reference_count <= 0:
-                # Also cancels any pending TTL timer or cleanup task.
-                await self._cleanup(key)
-            else:
-                entry.doomed = True
+            await self._retire(key, entry)
+
+    async def expire_all(self) -> None:
+        """Treat every cached key as TTL-expired now.
+
+        `expire` applied to every cached key at once (see `expire` for
+        the per-key drain-first and resurrection semantics), with one
+        difference: the sweep never stops early. It is the
+        retirement primitive for a pool whose loop stays running.
+
+        Retirement is all-or-nothing in reach, not in outcome: every
+        cached key is retired even if finalizing one of them fails. A
+        finalizer's `Exception` is contained as it is for every
+        operation (see ``finalizer``), here per entry, so a failure does
+        not end the sweep; any other `BaseException`, e.g., a cancelled
+        teardown's `asyncio.CancelledError`, propagates once the sweep
+        is over, not in place of it.
+
+        A failure the ranking below does not re-raise or chain is logged
+        at warning level and discarded, and a cancellation absorbed that
+        way is uncancelled, so the caller's cancellation count is left
+        as it found it.
+
+        :raises asyncio.CancelledError:
+            A cancellation delivered to a finalizer, re-raised once every
+            remaining key has been retired.
+        :raises KeyboardInterrupt:
+            A process-level interrupt raised in a finalizer, re-raised
+            likewise; it supersedes an earlier cancellation, which is
+            chained as its ``__cause__``.
+        :raises SystemExit:
+            As `KeyboardInterrupt`.
+
+        .. rubric:: Implementation notes
+
+        The sweep deliberately outlives its own failures. This is the
+        primitive a loop retires its resources through, and it is
+        reached on teardown paths that are themselves cancellable, so
+        abandoning the loop at the first `BaseException` would strand
+        every key it had not reached yet, i.e., the leak the primitive
+        exists to close, reappearing under cancellation. A delivered
+        cancellation is consumed by the finalizer it lands in and the
+        finalizers after it run uncancelled, so the sweep defers a single
+        delivered ``cancel()`` by at most one finalizer, and uncancels
+        what it absorbed so `asyncio.timeout` and `TaskGroup` see the
+        count they expect.
+        """
+        async with self._lock:
+            await self._sweep(self._retire)
 
     async def clear(self) -> None:
         """Finalize every cached entry and cancel pending cleanups.
 
         The teardown primitive: it force-finalizes regardless of reference
         count, which is correct when the pool itself is going away and
-        there is nothing left to drain for. To retire a single key while
-        the pool stays in use, use `expire`, which drains first.
+        there is nothing left to drain for. To retire keys while the pool
+        stays in use, use `expire` or `expire_all`, which drain first. A
+        finalizer that raises does not end the sweep: every key is
+        reached, and an uncontained failure is re-raised afterwards under
+        `expire_all`'s contract.
+
+        :raises BaseException:
+            As `expire_all`.
         """
         async with self._lock:
-            for key in list(self._cache.keys()):
-                await self._cleanup(key)
+            await self._sweep(lambda key, _: self._cleanup(key))
+
+    @property
+    def _name(self) -> str:
+        """Return the name the pool's log records carry: its factory's."""
+        return (
+            getattr(self._factory, "__qualname__", None) or type(self._factory).__name__
+        )
 
     @property
     def _lock(self) -> asyncio.Lock:
@@ -395,8 +470,8 @@ class ResourcePool(Generic[T]):
         if self._loop is not loop:
             if self._loop is not None and self._loop.is_running():
                 raise RuntimeError(
-                    "ResourcePool is bound to another running event loop; "
-                    "use one pool per loop"
+                    f"ResourcePool({self._name}) is bound to another running "
+                    "event loop; use one pool per loop"
                 )
             self._rebind(loop)
         assert self._mutex is not None
@@ -415,8 +490,7 @@ class ResourcePool(Generic[T]):
                 "ResourcePool(%s) rebinding to a new event loop; dropping %d "
                 "referenced and %d idle entries left by a loop that is no "
                 "longer running (finalizers not run)",
-                getattr(self._factory, "__qualname__", None)
-                or type(self._factory).__name__,
+                self._name,
                 referenced,
                 idle,
             )
@@ -502,6 +576,70 @@ class ResourcePool(Generic[T]):
         except asyncio.CancelledError:
             pass
 
+    async def _sweep(
+        self, retire: Callable[[Any, ResourcePool.CacheEntry], Awaitable[None]]
+    ) -> None:
+        """Apply ``retire`` to every cached entry, deferring failures to the end.
+
+        See `expire_all` for the contract this implements.
+
+        .. warning::
+            Must be called while holding the lock.
+
+        :param retire:
+            The per-entry retirement, given the key and its entry.
+        """
+        failure: BaseException | None = None
+        superseded: BaseException | None = None
+        absorbed = 0
+        for key, entry in list(self._cache.items()):
+            try:
+                await retire(key, entry)
+            except BaseException as error:
+                if isinstance(error, asyncio.CancelledError):
+                    absorbed += 1
+                # Ranking — see expire_all's :raises: contract.
+                if failure is None:
+                    failure = error
+                elif isinstance(error, _INTERRUPTS) and not isinstance(
+                    failure, _INTERRUPTS
+                ):
+                    failure, superseded = error, failure
+                else:
+                    _log.warning(
+                        "ResourcePool(%s) sweep discarding a later failure for key %r",
+                        self._name,
+                        key,
+                        exc_info=error,
+                    )
+        if isinstance(failure, asyncio.CancelledError):
+            absorbed -= 1
+        # Uncancel what the sweep absorbed — see expire_all.
+        task = asyncio.current_task()
+        if task is not None:
+            for _ in range(absorbed):
+                task.uncancel()
+        if failure is not None:
+            if superseded is not None:
+                raise failure from superseded
+            raise failure
+
+    async def _retire(self, key: Any, entry: ResourcePool.CacheEntry) -> None:
+        """Retire one entry under `expire`'s drain-first contract.
+
+        .. warning::
+            Must be called while holding the lock.
+
+        :param key:
+            The cache key to retire.
+        :param entry:
+            The entry cached under ``key``.
+        """
+        if entry.reference_count <= 0:
+            await self._cleanup(key)
+        else:
+            entry.doomed = True
+
     async def _cleanup(self, key: Any) -> None:
         """
         Remove entry from cache and call finalizer.
@@ -531,31 +669,15 @@ class ResourcePool(Generic[T]):
             try:
                 if self._finalizer:
                     try:
-                        await self._await(self._finalizer, entry.obj)
+                        result = self._finalizer(entry.obj)
+                        if inspect.isawaitable(result):
+                            await result
                     except Exception:
-                        pass
+                        _log.warning(
+                            "ResourcePool(%s) finalizer failed for key %r",
+                            self._name,
+                            key,
+                            exc_info=True,
+                        )
             finally:
                 del self._cache[key]
-
-    async def _await(self, func: Callable, *args) -> Any:
-        """
-        Call a function that might be sync or async.
-
-        If the function is a coroutine function, await it. Otherwise, call it
-        synchronously. If the result is a coroutine, await that as well.
-
-        :param func:
-            The function to call.
-        :param args:
-            Arguments to pass to the function.
-        :returns:
-            The result of the function call.
-        """
-        if asyncio.iscoroutinefunction(func):
-            return await func(*args)
-        else:
-            result = func(*args)
-            # Check if the result is a coroutine and await it if so
-            if asyncio.iscoroutine(result):
-                return await result
-            return result

--- a/wool/src/wool/runtime/typing.py
+++ b/wool/src/wool/runtime/typing.py
@@ -1,13 +1,19 @@
+"""Type aliases and the dependency resolver shared by the runtime."""
+
 from __future__ import annotations
 
+from contextlib import AsyncExitStack
+from contextlib import asynccontextmanager
 from enum import Enum
 from typing import AsyncContextManager
+from typing import AsyncIterator
 from typing import Awaitable
 from typing import Callable
 from typing import ContextManager
 from typing import Final
 from typing import TypeAlias
 from typing import TypeVar
+from typing import cast
 from typing import final
 
 F = TypeVar("F", bound=Callable)
@@ -19,6 +25,8 @@ PassthroughWrapper = Callable[[F], F]
 # public
 @final
 class UndefinedType(Enum):
+    """The single-member enum whose member is the `Undefined` sentinel."""
+
     Undefined = "Undefined"
 
 
@@ -26,6 +34,7 @@ Undefined: Final = UndefinedType.Undefined
 
 
 T_CO: Final = TypeVar("T_CO", covariant=True)
+T = TypeVar("T")
 
 # public
 Factory: TypeAlias = (
@@ -36,3 +45,71 @@ Factory: TypeAlias = (
         [], T_CO | Awaitable[T_CO] | AsyncContextManager[T_CO] | ContextManager[T_CO]
     ]
 )
+"""The forms a configured dependency may take: an awaitable, a sync or
+async context manager, or a zero-argument callable producing an instance
+or any of those — see `resolved` for how one is entered.
+"""
+
+
+@asynccontextmanager
+async def resolved(
+    dependency: T | Factory[T], *, expect: type | tuple[type, ...] | None = None
+) -> AsyncIterator[T]:
+    """Enter a configured dependency and yield the live object.
+
+    Accepts a bare instance or any `Factory` form. Forms are tried in a
+    fixed order, i.e., sync context manager, async context manager,
+    callable, awaitable, bare instance, and the first that matches wins,
+    so an
+    instance that is also a context manager is entered here and exited
+    when the block ends. A context manager's exit receives the block's
+    exception info, and its return value is ignored, so a manager that
+    suppresses cannot swallow the block's failure.
+
+    :param dependency:
+        The instance, or the `Factory` producing it.
+    :param expect:
+        A type, or tuple of types, the resolved object must be an
+        instance of. Checked once the object is in hand, so a factory
+        that produces the wrong thing is exited with the failure.
+    :yields:
+        The resolved object, for the duration of the block.
+    :raises TypeError:
+        If ``expect`` is given and the resolved object is not an
+        instance of it.
+    """
+    async with _resolved(dependency) as obj:
+        if expect is not None and not isinstance(obj, expect):
+            names = (
+                " | ".join(t.__name__ for t in expect)
+                if isinstance(expect, tuple)
+                else expect.__name__
+            )
+            raise TypeError(f"Expected {names}, got: {type(obj)}")
+        yield obj
+
+
+@asynccontextmanager
+async def _resolved(dependency: T | Factory[T]) -> AsyncIterator[T]:
+    """Enter ``dependency`` by its first matching form — see `resolved`."""
+    if isinstance(dependency, (ContextManager, AsyncContextManager)):
+        stack = AsyncExitStack()
+        if isinstance(dependency, ContextManager):
+            obj = stack.enter_context(dependency)
+        else:
+            obj = await stack.enter_async_context(dependency)
+        try:
+            yield cast(T, obj)
+        except BaseException as exc:
+            # Verdict discarded — see resolved's docstring.
+            await stack.__aexit__(type(exc), exc, exc.__traceback__)
+            raise
+        else:
+            await stack.__aexit__(None, None, None)
+    elif callable(dependency):
+        async with _resolved(dependency()) as obj:
+            yield cast(T, obj)
+    elif isinstance(dependency, Awaitable):
+        yield cast(T, await dependency)
+    else:
+        yield cast(T, dependency)

--- a/wool/src/wool/runtime/worker/README.md
+++ b/wool/src/wool/runtime/worker/README.md
@@ -206,7 +206,7 @@ async with wool.WorkerPool(
 Each worker subprocess has a two-loop architecture:
 
 - The **gRPC event loop** runs the gRPC server (`WorkerService`). It receives dispatch RPCs, sends acknowledgments, and streams results back.
-- A dedicated **worker event loop** runs on a daemon thread. Routines are scheduled here so that long-running work never blocks gRPC operations. The pools a routine draws on — the proxy pool and the discovery-subscriber pool — are bound to this loop and are finalized on it when the loop retires; a `ResourcePool` serves one running loop at a time.
+- A dedicated **worker event loop** runs on a daemon thread. Routines are scheduled here so that long-running work never blocks gRPC operations. The pools a routine draws on — its proxies, its discovery subscribers, and the gRPC channels a nested dispatch opens — are finalized on this loop when it retires, because a `ResourcePool` serves one running loop at a time; see `WorkerService` for the teardown order.
 
 Per-dispatch, the gRPC handler instantiates a `DispatchSession` — an async context manager and async iterator that owns the dispatch's full worker-side lifecycle as a uniform driver for both coroutine and async-generator Wool routines. The session has four phases:
 
@@ -266,7 +266,7 @@ Signal handlers map `SIGTERM` to timeout 0 (cancel immediately) and `SIGINT` to 
 
 ### Nested routines
 
-Worker subprocesses can dispatch tasks to other workers. Each subprocess is configured with a `ResourcePool` of `WorkerProxy` instances (via `wool.__proxy_pool__`), so `@wool.routine` calls within a task transparently route to the target pool. Spinning up a `WorkerProxy` is not free — it involves establishing a discovery subscription, starting a worker-sentinel task (a background coroutine that keeps the proxy's connection context alive), and opening gRPC connections — so the resource pool caches proxies with a configurable TTL (default 60 seconds, set via `proxy_pool_ttl` on `LocalWorker`). If the interval between dispatches for a given pool on a given worker is shorter than the TTL, the cached proxy is reused. If it exceeds the TTL, the proxy is finalized and must be recreated on the next dispatch. The proxy pool is bound to the worker event loop that dispatches through it, so proxies are also finalized when that loop retires after its own idle TTL; a proxy is reused only while the interval between dispatches is shorter than both. Tuning `proxy_pool_ttl` above the expected dispatch interval keeps proxies warm and avoids this cold-start overhead.
+Worker subprocesses can dispatch tasks to other workers. Each subprocess is configured with a `ResourcePool` of `WorkerProxy` instances (via `wool.__proxy_pool__`), so `@wool.routine` calls within a task transparently route to the target pool. Spinning up a `WorkerProxy` is not free — it involves establishing a discovery subscription, starting a worker-sentinel task (a background coroutine that keeps the proxy's connection context alive), and opening gRPC connections — so the resource pool caches proxies with a configurable TTL (default 60 seconds, set via `proxy_pool_ttl` on `LocalWorker`). If the interval between dispatches for a given pool on a given worker is shorter than the TTL, the cached proxy is reused. If it exceeds the TTL, the proxy is finalized and must be recreated on the next dispatch. The proxy pool is bound to the worker event loop that dispatches through it, so proxies are also finalized when that loop retires after its own idle TTL; a proxy is reused only while the interval between dispatches is shorter than both. Tuning `proxy_pool_ttl` above the expected dispatch interval keeps proxies warm and avoids this cold-start overhead. Retiring the last cached proxy also releases the worker loop's hold on the channel pool, so the loop's gRPC channels are retired with it — see [Connection pooling](#connection-pooling).
 
 Proxies on worker subprocesses are lazy by default — the `WorkerPool` propagates its `lazy` flag to every `WorkerProxy` it constructs, and each task serializes the proxy (including the flag) so that workers receiving the task inherit the same laziness setting. A lazy proxy defers discovery subscription and worker-sentinel task setup until its first `dispatch()` call, so workers that never invoke nested routines pay no startup cost.
 
@@ -303,18 +303,18 @@ Because the fast path is out of reach on macOS, treat the forking path as the on
 
 ### Lazy startup
 
-`WorkerProxy` accepts a `lazy` parameter (default `True`) that controls when the proxy actually starts — i.e., when it subscribes to discovery, launches the worker sentinel task, and initializes the load balancer context.
+`WorkerProxy` accepts a `lazy` parameter (default `True`) that controls when the proxy actually starts, i.e., when it acquires the resources it dispatches through — the channel-pool hold, the load-balancer context, the discovery subscription, and the worker sentinel — see `WorkerProxy.start`.
 
 | `lazy` | `enter()` / `__aenter__` | `dispatch()` | `exit()` on un-started proxy |
 | ------ | ------------------------ | ------------- | ----------------------------- |
-| `True` | Sets context var only | Calls `start()` on first call (retrying on a later call if it failed), then dispatches | No-op (safe to call) |
+| `True` | Sets context var only | Calls `start()` on first call (retrying on a later call if it failed), then dispatches; raises `RuntimeError` once the proxy has been stopped | No-op (safe to call) |
 | `False` | Sets context var, calls `start()` | Raises `RuntimeError` if not started | Raises `RuntimeError` |
 
 When `lazy=True`, concurrent `dispatch()` calls use a double-checked lock to ensure the proxy starts exactly once. The `lazy` flag is preserved through `cloudpickle` serialization, so proxies sent to worker subprocesses as part of a task retain their laziness setting.
 
 ### Context lifecycle
 
-Both `WorkerPool` and `WorkerProxy` are **single-use** async context managers. Once entered and exited, the same instance cannot be entered again — create a new instance instead. Attempting to call `enter()` or `__aenter__()` a second time raises `RuntimeError`. This prevents silent state corruption from reentrant or repeated context usage (e.g., accidentally nesting `async with proxy:` blocks or calling `enter()` in a retry loop).
+Both `WorkerPool` and `WorkerProxy` are **single-use** async context managers. Once entered and exited, the same instance cannot be entered again — create a new instance instead. Attempting to call `enter()` or `__aenter__()` a second time raises `RuntimeError`. This prevents silent state corruption from reentrant or repeated context usage (e.g., accidentally nesting `async with proxy:` blocks or calling `enter()` in a retry loop). `start()` and `stop()` are likewise single-use: a proxy is started once and stopped once, and a stopped proxy cannot be restarted or dispatched through — see `WorkerProxy` for the states and the error each rejected call carries.
 
 ```python
 # Correct — one instance per context
@@ -332,7 +332,7 @@ Workers are self-describing: each worker advertises its gRPC transport configura
 
 ### Connection pooling
 
-`WorkerConnection` is a lightweight facade that dispatches tasks over pooled gRPC channels. Channels are cached at the module level in a `ResourcePool` keyed by `(target, credentials, options, peer)`, with a 60-second TTL — idle channels are finalized after the TTL expires. The pool serves one running event loop at a time: a process that runs successive loops gets a fresh channel set per loop, channels left by a loop that is no longer running are dropped without being closed, and using the pool from two running loops at once raises. Keying on the `WorkerCredentials` value (a frozen dataclass, so hashable and value-equal) is what makes rotation observable at the channel layer — see [Credential providers: admission and rotation](#credential-providers-admission-and-rotation). Each channel's concurrency semaphore is sized by the worker's advertised `max_concurrent_streams` — the client-side dispatch gate. The worker's own HTTP/2 `MAX_CONCURRENT_STREAMS` ceiling is set to twice that value to absorb transient permit-turnover overshoot without faulting the connection. See issue #290.
+`WorkerConnection` is a lightweight facade that dispatches tasks over pooled gRPC channels. Channels are cached at the module level in a `ResourcePool` keyed by `(target, credentials, options, peer)`, with a 60-second idle TTL, i.e., a channel no dispatch still references is finalized 60 seconds after its last reference drops. The pool serves one running event loop at a time: a process that runs successive loops gets a fresh channel set per loop, and using the pool from two running loops at once raises. A `WorkerConnection` used as an async context manager closes on exit, retiring its own keys drain-first; each `WorkerProxy` holds the pool for its started lifetime and closes the connections of workers that depart it — see `WorkerProxy` for the contract, `channel_pool_hold` for the hold, and `ResourcePool` for what a stopped loop's leftovers become. Keying on the `WorkerCredentials` value (a frozen dataclass, so hashable and value-equal) is what makes rotation observable at the channel layer — see [Credential providers: admission and rotation](#credential-providers-admission-and-rotation). Each channel's concurrency semaphore — the client-side dispatch gate — is sized by the worker's advertised `max_concurrent_streams`. The worker's own HTTP/2 `MAX_CONCURRENT_STREAMS` ceiling is set to twice that value to absorb transient permit-turnover overshoot without faulting the connection. See issue #290.
 
 ### Idle reporting
 
@@ -340,7 +340,7 @@ Workers are self-describing: each worker advertises its gRPC transport configura
 
 Idle is measured as the time since the worker's in-flight task set last emptied, with worker startup counting as the initial empty state. It reads `0.0` while any task is in flight and restarts from zero each time the set drains again, so the value answers "how long has this worker had nothing to do", not "how long since it was started". The measurement is taken on a monotonic clock, so a wall-clock adjustment cannot distort it. Polling creates no `DispatchSession` and never enters the in-flight set, so reading the measurement cannot disturb it.
 
-This is worker idleness, not channel idleness: the 60-second `ResourcePool` TTL above and `WorkerOptions.max_connection_idle_ms` govern how long an unused *channel* survives within the loop that opened it, and neither is affected by whether the worker at the other end is executing tasks.
+This is worker idleness, not channel idleness: the channel-lifetime rules in [Connection pooling](#connection-pooling) and the `max_connection_idle_ms` limit below govern how long an unused *channel* survives within the loop that opened it, and none of them is affected by whether the worker at the other end is executing tasks.
 
 A worker that predates the idle capability answers the RPC with gRPC `UNIMPLEMENTED`, which surfaces as `IdleUnavailable`. It descends from `WoolError` rather than `RpcError`, so `except RpcError` does not catch it — an absent capability is not an RPC-health fault, and a polling client should treat it as "idle reporting is unavailable on this worker" rather than as a transient hiccup or an unhealthy peer. Every other gRPC failure classifies as it does for dispatch: transient codes raise `TransientRpcError`, everything else raises `RpcError`.
 
@@ -370,7 +370,9 @@ options = WorkerOptions(
 async with wool.WorkerPool(
     spawn=4,
     worker=lambda *tags, credentials=None: LocalWorker(
-        *tags, credentials=credentials, options=options,
+        *tags,
+        credentials=credentials,
+        options=options,
     ),
 ):
     result = await my_routine()

--- a/wool/src/wool/runtime/worker/connection.py
+++ b/wool/src/wool/runtime/worker/connection.py
@@ -10,11 +10,14 @@ import asyncio
 import logging
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
+from types import TracebackType
 from typing import Any
+from typing import AsyncContextManager
 from typing import AsyncGenerator
 from typing import Coroutine
 from typing import Final
 from typing import Generic
+from typing import Self
 from typing import TypeAlias
 from typing import TypeVar
 from typing import cast
@@ -260,8 +263,8 @@ class WorkerConnection:
 
     Exposes `dispatch` (task execution), `idle` (poll the worker's
     continuous idle duration), and `stop` (shut the remote worker
-    down). ``close`` is distinct: it releases this connection's local
-    pooled channel, whereas `stop` terminates the remote worker.
+    down). `close` is distinct: it retires this connection's pooled
+    channel keys, whereas `stop` terminates the remote worker.
 
     Acquires pooled gRPC channels keyed by ``(target, credentials,
     options, peer)``.  Each `dispatch` call obtains a reference-counted
@@ -272,9 +275,13 @@ class WorkerConnection:
 
     A connection is a lazy handle, not a channel owner: channel lifetime
     belongs to the pool, which reaps a channel by refcount and TTL once
-    no handle is using it. Discarding a connection therefore does not
-    close its channel, and closing one retires its keys without
-    disturbing a channel another handle is still using.
+    no handle is using it, or sooner when the loop's last
+    `channel_pool_hold` is released. Discarding a connection therefore
+    does not close its channel, and a loop that stops before the pool
+    reaps it strands the channel, which `ResourcePool` reports; entering
+    the connection as an async context manager, or calling `close`,
+    retires this connection's keys first — see `close` — and leaves the
+    handle usable afterwards.
 
     **Cleanup semantics on cancellation.** Every code path that owns
     an in-flight gRPC call wraps its body in
@@ -333,10 +340,9 @@ class WorkerConnection:
 
     .. code-block:: python
 
-        conn = WorkerConnection("localhost:50051")
-        async for result in conn.dispatch(task):
-            process(result)
-        await conn.close()
+        async with WorkerConnection("localhost:50051") as conn:
+            async for result in conn.dispatch(task):
+                process(result)
     """
 
     # The codes dispatch maps to a *bare* TransientRpcError. Not the
@@ -397,6 +403,19 @@ class WorkerConnection:
         # self-dispatches over the loopback UDS never set it.
         self._key: _ChannelKey | None = None
         self._uds_key: _ChannelKey | None = None
+
+    async def __aenter__(self) -> Self:
+        """Enter the connection, returning it for use in the block."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Close the connection on exit — see `close`."""
+        await self.close()
 
     async def _resolve_key(self) -> _ChannelKey:
         """Resolve the pool key routing the next RPC.
@@ -553,7 +572,7 @@ class WorkerConnection:
         return cast(AsyncGenerator[protocol.Message, None], stream)
 
     async def close(self):
-        """Close the connection and release all pooled resources.
+        """Retire this connection's pooled channel keys.
 
         Retires the pooled channel entries for the most recent TCP key
         and, if this connection ever routed over the loopback, the UDS
@@ -860,6 +879,9 @@ async def _channel_finalizer(channel: _Channel):
     await channel.close()
 
 
+# One pool for the whole process, so every handle to the same worker
+# shares a channel. Retirement: see `channel_pool_hold` and
+# `WorkerConnection.close`. What a stopped loop strands: see `ResourcePool`.
 _channel_pool: ResourcePool[_Channel] = ResourcePool(
     factory=_channel_factory, finalizer=_channel_finalizer, ttl=60
 )
@@ -879,13 +901,76 @@ def channel_pool_stats() -> ResourcePool.Stats:
     return _channel_pool.stats
 
 
+# A def rather than a lambda so a stranded hold's rebind record names this
+# pool by qualname — see ResourcePool.
+def _channel_pool_hold_factory(key: Any) -> None:
+    """Return the inert entry behind a hold."""
+    return None
+
+
+# A one-key pool whose reference count is the hold count — see
+# channel_pool_hold.
+_channel_pool_holds: ResourcePool[None] = ResourcePool(
+    factory=_channel_pool_hold_factory,
+    finalizer=lambda _: _channel_pool.expire_all(),
+    ttl=0,
+)
+
+
 async def clear_channel_pool() -> None:
     """Close and clear every gRPC channel in the process-wide pool.
 
-    Invalidates cached channels across every pool key, including
-    UDS targets.
+    The teardown primitive: runs `ResourcePool.clear` over the channel
+    pool, across every pool key, including UDS targets. Holds are not
+    dropped: each is released by its holder, and a hold a loop strands
+    is reported by `ResourcePool` at the next rebind. To retire while
+    the loop keeps dispatching, exit or close a `WorkerConnection` for
+    its own keys, or let the last `channel_pool_hold` release retire the
+    loop's channels drain-first.
     """
     await _channel_pool.clear()
+
+
+def channel_pool_hold() -> AsyncContextManager[None]:
+    """Return a hold on the channel pool for the calling event loop.
+
+    A hold declares a period during which repeated dispatches are
+    expected on the loop, and exists to keep the loop's channels cached
+    for that period: while any hold is open an idle channel is left to
+    the pool's TTL, and a hold nested inside another retires nothing on
+    its own. The last release ends the period and retires every cached
+    channel on the loop, whether or not a holder opened it, through
+    `ResourcePool.expire_all` without waiting for the idle TTL — with no
+    period declared there is nothing to keep a channel warm for.
+    A hold belongs to a component with a start-to-stop lifetime on the
+    loop; a handle with no lifecycle of its own takes none.
+
+    :returns:
+        A single-use async context manager whose entered value is
+        ``None``: the hold is the count, not a handle on the pool.
+
+    .. rubric:: Implementation notes
+
+    The holds are references on a one-key `ResourcePool` whose finalizer
+    retires the channel pool: a reference count that finalizes on the
+    last release is exactly what `ResourcePool` already is, so composing
+    it avoids a second counter that would have to reproduce the same
+    rules — and, because both pools bind by loop the same way, a hold
+    can never outlive the channels it governs. ``ttl=0`` makes the final
+    release retire the channels inline rather than after a grace period.
+    Retirement is `ResourcePool.expire_all` rather than
+    `ResourcePool.clear` because the loop keeps running: a dispatch whose
+    teardown lands after the last hold is released still holds its
+    channel reference, and force-closing under it would let that late
+    release corrupt an entry rebuilt for the same key. The sweep is
+    loop-scoped rather than holder-scoped by design: the leak the hold
+    exists to close is a channel nobody holds (e.g., a bare
+    `WorkerConnection`'s or a departed worker's), and a sweep limited to
+    the keys the holders opened would strand exactly those. The price is
+    a fresh handshake for a bare connection kept warm on the loop when
+    its last proxy stops.
+    """
+    return _channel_pool_holds.get(None)
 
 
 _TEARDOWN_TIMEOUT: Final = 60.0

--- a/wool/src/wool/runtime/worker/local.py
+++ b/wool/src/wool/runtime/worker/local.py
@@ -204,10 +204,11 @@ class LocalWorker(Worker):
             if self._worker_process.is_alive():
                 assert self.address
 
-                # Route the stop RPC through WorkerConnection; ``close``
-                # releases the pooled channel this stop acquired. The
-                # provider rides along so the connection resolves
-                # current credential material per call.
+                # Route the stop RPC through `WorkerConnection` so the
+                # stop's channel is retired on exit — see
+                # `WorkerConnection.close`. The provider rides along so
+                # the connection resolves current credential material
+                # per call.
                 # Pin the worker's own identity — nothing else here
                 # supplies a name — see `WorkerProxy` for why. A worker
                 # declaring none keeps the dialed-address fallback,
@@ -221,7 +222,7 @@ class LocalWorker(Worker):
                         peer=self._identity,
                     )
                 )
-                try:
+                async with connection:
                     # Only a bounded drain (positive grace) admits a
                     # finite deadline; a negative grace drains
                     # indefinitely, and ``None`` keeps the pre-existing
@@ -232,8 +233,6 @@ class LocalWorker(Worker):
                     else:
                         deadline = grace + _STOP_RPC_MARGIN
                     await connection.stop(grace=grace, timeout=deadline)
-                finally:
-                    await connection.close()
         finally:
             # `reap` blocks on `join`, so it must run off-loop — see
             # the docstring for the cancellation contract. A negative

--- a/wool/src/wool/runtime/worker/pool.py
+++ b/wool/src/wool/runtime/worker/pool.py
@@ -14,9 +14,6 @@ import uuid
 import warnings
 from contextlib import asynccontextmanager
 from typing import Any
-from typing import AsyncContextManager
-from typing import Awaitable
-from typing import ContextManager
 from typing import Coroutine
 from typing import Final
 from typing import cast
@@ -33,6 +30,7 @@ from wool.runtime.discovery.local import LocalDiscovery
 from wool.runtime.typing import Factory
 from wool.runtime.typing import Undefined
 from wool.runtime.typing import UndefinedType
+from wool.runtime.typing import resolved
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.auth import WorkerCredentialsProvider
 from wool.runtime.worker.auth import normalize_peer
@@ -683,13 +681,9 @@ class WorkerPool:
 
                 @asynccontextmanager
                 async def create_proxy():
-                    discovery_svc, discovery_ctx = await self._enter_context(discovery)
-                    if not isinstance(discovery_svc, DiscoveryLike):
-                        raise TypeError(
-                            f"Expected DiscoveryLike, got: {type(discovery_svc)}"
-                        )
-
-                    try:
+                    async with resolved(
+                        discovery, expect=DiscoveryLike
+                    ) as discovery_svc:
                         async with self._worker_context(
                             *tags,
                             spawn=spawn,
@@ -705,8 +699,6 @@ class WorkerPool:
                                 lazy=self._lazy,
                             ):
                                 yield
-                    finally:
-                        await self._exit_context(discovery_ctx)
 
             case (spawn, None) if spawn is not None:
                 if lease is not None:
@@ -747,12 +739,9 @@ class WorkerPool:
 
                 @asynccontextmanager
                 async def create_proxy():
-                    discovery_svc, discovery_ctx = await self._enter_context(discovery)
-                    if not isinstance(discovery_svc, DiscoveryLike):
-                        raise TypeError(
-                            f"Expected DiscoveryLike, got: {type(discovery_svc)}"
-                        )
-                    try:
+                    async with resolved(
+                        discovery, expect=DiscoveryLike
+                    ) as discovery_svc:
                         async with self._make_proxy(
                             discovery=discovery_svc.subscriber,
                             loadbalancer=loadbalancer,
@@ -762,8 +751,6 @@ class WorkerPool:
                             lazy=self._lazy,
                         ):
                             yield
-                    finally:
-                        await self._exit_context(discovery_ctx)
 
             case (None, None):
                 if lease is not None:
@@ -859,12 +846,10 @@ class WorkerPool:
         `~wool.DiscoveryPublisherLike.bind_host`). Teardown applies the pool's
         ``shutdown_timeout`` as a single deadline across worker stops
         and publisher cleanup — see that parameter for the contract
-        this implements — and runs even when publisher validation or
-        worker construction fails, so an entered publisher context is
-        always exited rather than dropped on the floor. Cleanup is
-        itself bounded by what remains of the deadline, so a teardown
-        that exhausts the deadline can time cleanup out before the
-        publisher's ``__aexit__`` runs.
+        this implements. The publisher's exit always starts, and an
+        exhausted deadline cancels it in flight rather than skipping
+        it; a publisher that fails validation is exited by `resolved`
+        before this context is entered at all.
 
         :yields:
             Metadata for the spawned workers.
@@ -888,12 +873,9 @@ class WorkerPool:
         below exists to enforce — trading a leaked worker for an
         unbounded teardown.
         """
-        publisher_svc, publisher_ctx = await self._enter_context(publisher)
+        publisher_ctx = resolved(publisher, expect=DiscoveryPublisherLike)
+        publisher_svc = await publisher_ctx.__aenter__()
         try:
-            if not isinstance(publisher_svc, DiscoveryPublisherLike):
-                raise TypeError(
-                    f"Expected DiscoveryPublisherLike, got: {type(publisher_svc)}"
-                )
             if factory is None:
                 factory = LocalWorker
 
@@ -1018,13 +1000,18 @@ class WorkerPool:
                         extra={"reaped_worker_uids": reaped_uids},
                     )
 
+            exit_task = asyncio.ensure_future(publisher_ctx.__aexit__(*sys.exc_info()))
+            # One tick so the exit takes its first step before the deadline
+            # is enforced: wait_for with an exhausted budget cancels a
+            # coroutine before it starts, which would skip the exit and
+            # strand resolved's generators instead of bounding them.
+            await asyncio.sleep(0)
             try:
-                await asyncio.wait_for(
-                    self._exit_context(publisher_ctx), timeout=remaining()
-                )
+                await asyncio.wait_for(exit_task, timeout=remaining())
             except TimeoutError:
                 logger.warning(
-                    "WorkerPool publisher cleanup did not complete within %ss",
+                    "WorkerPool publisher cleanup did not complete within %ss "
+                    "and was cancelled",
                     self._shutdown_timeout,
                 )
 
@@ -1064,40 +1051,6 @@ class WorkerPool:
             quorum=None,
             lazy=lazy,
         )
-
-    async def _enter_context(self, factory):
-        """Normalize a configured dependency into a live object.
-
-        Accepts a bare instance, a callable factory, an awaitable, or
-        a sync/async context manager (entering the latter) and
-        returns ``(object, owning_context)``, where the context is
-        ``None`` unless this call entered one and owes it an exit via
-        `_exit_context`.
-        """
-        ctx = None
-        if isinstance(factory, ContextManager):
-            ctx = factory
-            obj = ctx.__enter__()
-        elif isinstance(factory, AsyncContextManager):
-            ctx = factory
-            obj = await ctx.__aenter__()
-        elif callable(factory):
-            return await self._enter_context(factory())
-        elif isinstance(factory, Awaitable):
-            obj = await factory
-        else:
-            obj = factory
-        return obj, ctx
-
-    async def _exit_context(self, ctx: AsyncContextManager | ContextManager | None):
-        """Exit a sync or async context manager, if any.
-
-        Forwards the active exception info; ``None`` is a no-op.
-        """
-        if isinstance(ctx, AsyncContextManager):
-            await ctx.__aexit__(*sys.exc_info())
-        elif isinstance(ctx, ContextManager):
-            ctx.__exit__(*sys.exc_info())
 
 
 def _resolve_spawn(spawn: int) -> int:

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -12,6 +12,8 @@ import logging
 import uuid
 import warnings
 from contextlib import AsyncExitStack
+from contextlib import asynccontextmanager
+from enum import Enum
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import AsyncContextManager
@@ -263,6 +265,22 @@ class _HandshakeWarningThrottle:
         self._throttle.discard(uid)
 
 
+class _Lifecycle(Enum):
+    """The single-use lifecycle of a `WorkerProxy`.
+
+    A proxy moves ``NEW`` → ``STARTING`` → ``STARTED`` → ``STOPPING`` →
+    ``STOPPED`` and never back; a start that fails returns it to ``NEW``.
+    Each member's value is the `RuntimeError` text a call the state
+    rejects carries.
+    """
+
+    NEW = "Proxy not started - call start() first"
+    STARTING = "Proxy is starting"
+    STARTED = "Proxy already started"
+    STOPPING = "Proxy is stopping"
+    STOPPED = "Proxy is stopped and cannot be restarted"
+
+
 # public
 class WorkerProxy:
     """Client-side proxy for dispatching tasks to distributed workers.
@@ -273,7 +291,8 @@ class WorkerProxy:
 
     Connects to workers through discovery services, pool URIs, or static
     worker lists. Handles connection lifecycle and fault tolerance
-    automatically.
+    automatically. A proxy is single-use: it is started once and stopped
+    once, and a start that fails leaves it un-started and free to retry.
 
     Every worker on every construction path — discovery stream, pool
     URI, or static list — passes an admission gate before joining the
@@ -576,7 +595,7 @@ class WorkerProxy:
             raise ValueError("Quorum timeout must be positive")
 
         self._id: uuid.UUID = uuid.uuid4()
-        self._started = False
+        self._state = _Lifecycle.NEW
         self._dispatching_deprecation_warned = False
         self._delegating = False
         self._lazy = lazy
@@ -586,7 +605,10 @@ class WorkerProxy:
         self._quorum = quorum
         self._quorum_timeout = quorum_timeout
         self._proxy_token: Token[WorkerProxy | None] | None = None
-        self._exit_stack: AsyncExitStack | None = None
+        # Cannot ride the start stack: a lazy proxy's enter outlives its
+        # start.
+        self._enter_stack: AsyncExitStack | None = None
+        self._start_stack: AsyncExitStack | None = None
 
         if isinstance(loadbalancer, (ContextManager, AsyncContextManager)):
             warnings.warn(
@@ -692,7 +714,7 @@ class WorkerProxy:
             token = self._armed.set(True)
             stack.callback(self._armed.reset, token)
             await self.enter()
-            self._exit_stack = stack.pop_all()
+            self._enter_stack = stack.pop_all()
         return self
 
     async def __aexit__(self, *args):
@@ -700,9 +722,9 @@ class WorkerProxy:
         try:
             await self.exit(*args)
         finally:
-            if self._exit_stack is not None:
-                await self._exit_stack.aclose()
-                self._exit_stack = None
+            if self._enter_stack is not None:
+                await self._enter_stack.aclose()
+                self._enter_stack = None
 
     def __hash__(self) -> int:
         return hash(str(self.id))
@@ -786,7 +808,12 @@ class WorkerProxy:
 
     @property
     def started(self) -> bool:
-        return self._started
+        """Return whether the proxy is currently started.
+
+        ``False`` both before a start and after a stop; see `WorkerProxy`
+        for the lifecycle.
+        """
+        return self._state is _Lifecycle.STARTED
 
     @property
     def lazy(self) -> bool:
@@ -848,106 +875,89 @@ class WorkerProxy:
         """Start the proxy by initiating discovery and load balancing.
 
         Subscribes to worker discovery, initializes the load-balancer
-        context, and launches the worker sentinel task.  Acquired
-        resources are unwound in reverse order if any setup step
-        (including the quorum wait) raises.
+        context, and launches the worker sentinel task.  A start that
+        fails at any step, the quorum wait included, releases what it had
+        acquired in reverse order and leaves the proxy un-started and
+        free to retry; a load balancer or discovery source configured as
+        a context manager is exited with the failure, as a ``with`` block
+        would exit it.
 
         :raises RuntimeError:
-            If the proxy has already been started.
+            If the proxy is starting, started, stopping, or stopped.
         :raises asyncio.TimeoutError:
             If the quorum wait does not complete within
             ``quorum_timeout``.
-        """
-        if self._started:
-            raise RuntimeError("Proxy already started")
 
-        async with AsyncExitStack() as stack:
-            (
-                self._loadbalancer_service,
-                self._loadbalancer_context_manager,
-            ) = await self._enter_context(self._loadbalancer)
-            if not isinstance(
-                self._loadbalancer_service,
-                (LoadBalancerLike, DispatchingLoadBalancerLike),
-            ):
-                raise ValueError
-            # Classify the balancer once, here, so dispatch() need not
-            # re-run a @runtime_checkable isinstance on the hot path.
-            self._delegating = isinstance(self._loadbalancer_service, LoadBalancerLike)
-            if (
-                not self._delegating
-                and isinstance(self._loadbalancer_service, DispatchingLoadBalancerLike)
-                and not self._dispatching_deprecation_warned
-            ):
-                warnings.warn(
-                    DISPATCHING_LOADBALANCER_DEPRECATION_MESSAGE,
-                    DeprecationWarning,
-                    stacklevel=2,
+        .. rubric:: Implementation notes
+
+        Every context is entered on one `~contextlib.AsyncExitStack`,
+        retained by `start` and unwound by `stop`, so the teardown order
+        is written once. A failed start unwinds that same stack with the
+        exception in hand rather than through a rollback path of its
+        own, which is what forwards the failure to each entered context.
+        """
+        if self._state is not _Lifecycle.NEW:
+            raise RuntimeError(self._state.value)
+
+        self._state = _Lifecycle.STARTING
+        try:
+            async with AsyncExitStack() as stack:
+                # Pushed first so it runs last, after every context has
+                # exited, on both the rollback and the stop path.
+                stack.callback(self._reset_state)
+                self._loadbalancer_service = await stack.enter_async_context(
+                    _resolved(self._loadbalancer)
                 )
-                self._dispatching_deprecation_warned = True
-            stack.push_async_callback(
-                self._exit_context,
-                self._loadbalancer_context_manager,
-                None,
-                None,
-                None,
-            )
+                if not isinstance(
+                    self._loadbalancer_service,
+                    (LoadBalancerLike, DispatchingLoadBalancerLike),
+                ):
+                    raise ValueError
+                # Classify the balancer once, here, so dispatch() need not
+                # re-run a @runtime_checkable isinstance on the hot path.
+                self._delegating = isinstance(
+                    self._loadbalancer_service, LoadBalancerLike
+                )
+                if (
+                    not self._delegating
+                    and isinstance(
+                        self._loadbalancer_service, DispatchingLoadBalancerLike
+                    )
+                    and not self._dispatching_deprecation_warned
+                ):
+                    warnings.warn(
+                        DISPATCHING_LOADBALANCER_DEPRECATION_MESSAGE,
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    self._dispatching_deprecation_warned = True
 
-            (
-                self._discovery_stream,
-                self._discovery_context_manager,
-            ) = await self._enter_context(self._discovery)
-            if not isinstance(self._discovery_stream, DiscoverySubscriberLike):
-                raise ValueError
-            stack.push_async_callback(
-                self._exit_context,
-                self._discovery_context_manager,
-                None,
-                None,
-                None,
-            )
+                self._discovery_stream = await stack.enter_async_context(
+                    _resolved(self._discovery)
+                )
+                if not isinstance(self._discovery_stream, DiscoverySubscriberLike):
+                    raise ValueError
 
-            self._loadbalancer_context = LoadBalancerContext()
-            # Built here, not in __init__, so its keys cannot outlive the
-            # pool membership they mirror: a uid stranded by teardown could
-            # never be discarded again, since a respawned worker gets a
-            # fresh one.
-            self._handshake_throttle = _HandshakeWarningThrottle()
-            self._workers_changed = asyncio.Event()
-            self._sentinel_task = asyncio.create_task(self._worker_sentinel())
-            stack.push_async_callback(self._teardown_sentinel)
+                self._loadbalancer_context = LoadBalancerContext()
+                # Built here, not in __init__, so its keys cannot outlive the
+                # pool membership they mirror: a uid stranded by teardown could
+                # never be discarded again, since a respawned worker gets a
+                # fresh one.
+                self._handshake_throttle = _HandshakeWarningThrottle()
+                self._workers_changed = asyncio.Event()
+                self._sentinel_task = asyncio.create_task(self._worker_sentinel())
+                stack.push_async_callback(self._cancel_sentinel)
 
-            if self._quorum:
-                await asyncio.wait_for(self._await_workers(), self._quorum_timeout)
+                if self._quorum:
+                    await asyncio.wait_for(self._await_workers(), self._quorum_timeout)
 
-            stack.pop_all()
+                self._start_stack = stack.pop_all()
 
-        self._started = True
+        except BaseException:
+            self._state = _Lifecycle.NEW
+            raise
 
-    async def _teardown_sentinel(self) -> None:
-        """Cancel the sentinel task and null all partial-init attributes.
-
-        Idempotent rollback callback used by `start`'s
-        `~contextlib.AsyncExitStack` and reused by `stop`.  Cancels
-        ``_sentinel_task`` (if any), awaits its termination swallowing
-        ``CancelledError``, and resets every attribute populated by
-        `start` to ``None`` so a failed start leaves no stale
-        references.
-        """
-        if self._sentinel_task:
-            self._sentinel_task.cancel()
-            try:
-                await self._sentinel_task
-            except asyncio.CancelledError:
-                pass
-            self._sentinel_task = None
-        self._loadbalancer_context = None
-        self._handshake_throttle = None
-        self._loadbalancer_service = None
-        self._loadbalancer_context_manager = None
-        self._discovery_stream = None
-        self._discovery_context_manager = None
-        self._workers_changed = None
+        self._state = _Lifecycle.STARTED
 
     async def exit(self, *args) -> None:
         """Exit the proxy context.
@@ -958,8 +968,8 @@ class WorkerProxy:
         ``exit()`` on an un-started lazy proxy is a safe no-op.
 
         :raises RuntimeError:
-            If the proxy was not started first and ``lazy`` is
-            ``False``.
+            If the proxy is not started, or was stopped, and ``lazy``
+            is ``False``.
         """
         if self._proxy_token is not None:
             try:
@@ -971,40 +981,37 @@ class WorkerProxy:
                 # nothing to restore.
                 pass
             self._proxy_token = None
-        if not self._started:
+        if not self.started:
             if not self._lazy:
-                raise RuntimeError("Proxy not started - call start() first")
+                raise RuntimeError(self._state.value)
             return
         await self.stop(*args)
 
     async def stop(self, *args) -> None:
         """Stop the proxy, terminating discovery and clearing connections.
 
-        Teardown runs in reverse-acquisition order: sentinel first
+        Unwinds what `start` acquired in reverse order: sentinel first
         (so it stops reading from the discovery stream), then
-        discovery, then load balancer.  All three are guaranteed to
-        run via `~contextlib.AsyncExitStack` even if an earlier teardown
-        raises.
+        discovery, then load balancer.  Every step runs even if an
+        earlier one raises, each context manager among them receives the
+        exception info passed to ``stop``, and the proxy is stopping from
+        the moment the unwind begins and stopped once it returns, so a
+        second ``stop``, or a ``start``, raises rather than racing the
+        unwind.
 
         :raises RuntimeError:
-            If the proxy was not started first.
+            If the proxy is not started, or is already stopping or
+            stopped.
         """
-        if not self._started:
-            raise RuntimeError("Proxy not started - call start() first")
-
-        async with AsyncExitStack() as stack:
-            stack.push_async_callback(
-                self._exit_context,
-                self._loadbalancer_context_manager,
-                *args,
-            )
-            stack.push_async_callback(
-                self._exit_context,
-                self._discovery_context_manager,
-                *args,
-            )
-            stack.push_async_callback(self._teardown_sentinel)
-        self._started = False
+        if self._state is not _Lifecycle.STARTED:
+            raise RuntimeError(self._state.value)
+        self._state = _Lifecycle.STOPPING
+        teardown, self._start_stack = self._start_stack, None
+        assert teardown is not None, "a started proxy holds its start stack"
+        try:
+            await teardown.__aexit__(*(args or (None, None, None)))
+        finally:
+            self._state = _Lifecycle.STOPPED
 
     async def dispatch(
         self, task: Task, *, timeout: float | None = None
@@ -1037,7 +1044,10 @@ class WorkerProxy:
         :returns:
             An async generator streaming task results from the worker.
         :raises RuntimeError:
-            If the proxy is not started and ``lazy`` is ``False``.
+            If the proxy is stopping or stopped, or if it is not started
+            and ``lazy`` is ``False``; a lazy dispatch concurrent with an
+            explicit `start` raises, while one concurrent with another
+            lazy dispatch's start waits for it.
         :raises NoWorkersAvailable:
             If every candidate the balancer yields fails to dispatch.
         :raises asyncio.TimeoutError:
@@ -1046,13 +1056,18 @@ class WorkerProxy:
             worker connection reports it as an `RpcError` that the
             dispatch loop handles.
         """
-        if not self._started:
-            if not self._lazy:
-                raise RuntimeError("Proxy not started - call start() first")
+        if self._state is not _Lifecycle.STARTED:
+            if not self._lazy or self._state in (
+                _Lifecycle.STOPPING,
+                _Lifecycle.STOPPED,
+            ):
+                raise RuntimeError(self._state.value)
             assert self._start_lock is not None
             async with self._start_lock:
-                if not self._started:
+                if self._state is _Lifecycle.NEW:
                     await self.start()
+                elif self._state is not _Lifecycle.STARTED:
+                    raise RuntimeError(self._state.value)
 
         assert self._loadbalancer_context is not None
         # Balancer kind was resolved in start(); branch on the cached flag
@@ -1188,29 +1203,27 @@ class WorkerProxy:
             # cancellation, and contract violations.
             await generator.aclose()
 
-    async def _enter_context(self, factory):
-        ctx = None
-        if isinstance(factory, ContextManager):
-            ctx = factory
-            obj = ctx.__enter__()
-        elif isinstance(factory, AsyncContextManager):
-            ctx = factory
-            obj = await ctx.__aenter__()
-        elif callable(factory):
-            return await self._enter_context(factory())
-        elif isinstance(factory, Awaitable):
-            obj = await factory
-        else:
-            obj = factory
-        return obj, ctx
+    async def _cancel_sentinel(self) -> None:
+        """Cancel the worker sentinel task, if any, and await its exit."""
+        if self._sentinel_task:
+            self._sentinel_task.cancel()
+            try:
+                await self._sentinel_task
+            except asyncio.CancelledError:
+                pass
+            self._sentinel_task = None
 
-    async def _exit_context(
-        self, ctx: AsyncContextManager | ContextManager | None, *args
-    ):
-        if isinstance(ctx, AsyncContextManager):
-            await ctx.__aexit__(*args)
-        elif isinstance(ctx, ContextManager):
-            ctx.__exit__(*args)
+    def _reset_state(self) -> None:
+        """Null every attribute `start` populates.
+
+        Runs last on both the rollback and the stop path, so neither a
+        failed start nor a stopped proxy keeps stale references.
+        """
+        self._loadbalancer_context = None
+        self._handshake_throttle = None
+        self._loadbalancer_service = None
+        self._discovery_stream = None
+        self._workers_changed = None
 
     def _create_security_filter(
         self, provider: WorkerCredentialsProvider | None
@@ -1451,3 +1464,28 @@ class WorkerProxy:
                     # Departed the pool — see _HandshakeWarningThrottle.
                     self._handshake_throttle.discard(event.metadata.uid)
                     self._workers_changed.set()
+
+
+@asynccontextmanager
+async def _resolved(dependency: Any) -> AsyncIterator[Any]:
+    """Enter a configured dependency and yield the live object.
+
+    Accepts a bare instance, a callable factory producing any of these
+    forms, an awaitable, or a sync or async context manager.  A context
+    manager is entered for the duration of the block and exited with
+    the block's exception info, so a dependency configured as a manager
+    sees the same exit semantics as a plain ``with`` over it would.
+    """
+    if isinstance(dependency, ContextManager):
+        with dependency as obj:
+            yield obj
+    elif isinstance(dependency, AsyncContextManager):
+        async with dependency as obj:
+            yield obj
+    elif callable(dependency):
+        async with _resolved(dependency()) as obj:
+            yield obj
+    elif isinstance(dependency, Awaitable):
+        yield await dependency
+    else:
+        yield dependency

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -12,7 +12,6 @@ import logging
 import uuid
 import warnings
 from contextlib import AsyncExitStack
-from contextlib import asynccontextmanager
 from enum import Enum
 from types import TracebackType
 from typing import TYPE_CHECKING
@@ -20,7 +19,6 @@ from typing import Any
 from typing import AsyncContextManager
 from typing import AsyncGenerator
 from typing import AsyncIterator
-from typing import Awaitable
 from typing import Callable
 from typing import ClassVar
 from typing import ContextManager
@@ -52,6 +50,7 @@ from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
 from wool.runtime.typing import Factory
 from wool.runtime.typing import Undefined
 from wool.runtime.typing import UndefinedType
+from wool.runtime.typing import resolved
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.auth import WorkerCredentialsProvider
 from wool.runtime.worker.auth import current_credentials
@@ -484,15 +483,9 @@ class WorkerProxy:
     """
 
     _discovery: DiscoverySubscriberLike | Factory[DiscoverySubscriberLike]
-    _discovery_manager: (
-        AsyncContextManager[DiscoverySubscriberLike]
-        | ContextManager[DiscoverySubscriberLike]
-    )
-
-    _loadbalancer = LoadBalancerLike | Factory[LoadBalancerLike]
-    _loadbalancer_manager: (
-        AsyncContextManager[LoadBalancerLike] | ContextManager[LoadBalancerLike]
-    )
+    _discovery_stream: DiscoverySubscriberLike | None
+    _loadbalancer: LoadBalancerLike | Factory[LoadBalancerLike]
+    _loadbalancer_service: LoadBalancerLike | DispatchingLoadBalancerLike | None
     _provider: WorkerCredentialsProvider | None
     _security_filter: Callable[[WorkerMetadata], bool]
     _version_filter: Callable[[WorkerMetadata], bool]
@@ -661,13 +654,13 @@ class WorkerProxy:
             self._dispatching_deprecation_warned = True
 
         if credentials is Undefined:
-            resolved = current_credentials()
+            material = current_credentials()
         else:
-            resolved = credentials
+            material = credentials
         # Normalize an explicitly passed value into a provider the sentinel
         # resolves per connection; an ambient read already yields a coerced
         # provider (see credentials_scope), for which this is a no-op.
-        self._provider = WorkerCredentialsProvider.coerce(resolved)
+        self._provider = WorkerCredentialsProvider.coerce(material)
 
         # Deliberately not serialized: __wool_reduce__ restores the proxy
         # through __init__, so a restored proxy rebuilds the gate from its
@@ -713,6 +706,7 @@ class WorkerProxy:
         self._sentinel_task: asyncio.Task[None] | None = None
         self._loadbalancer_context: LoadBalancerContext | None = None
         self._handshake_throttle: _HandshakeWarningThrottle | None = None
+        self._workers_changed: asyncio.Event | None = None
 
     async def __aenter__(self):
         """Enter the proxy context and set it as the active proxy.
@@ -897,17 +891,24 @@ class WorkerProxy:
         Takes a hold on the loop's channel pool (see `channel_pool_hold`),
         enters the load balancer, then the discovery stream, and launches
         the worker sentinel, handing all of it to `stop` to unwind in
-        reverse.  A start that fails at any step, the
-        quorum wait included, releases what it had acquired in reverse
-        order and leaves the proxy un-started and free to retry; a load
-        balancer or discovery source configured as a context manager is
-        exited with the failure (see `_resolved` for the exit contract),
-        and a failed start stays failed.
+        reverse. A start that fails at any step, the quorum wait
+        included, releases what it had acquired in reverse order and
+        leaves the proxy un-started, so a later `start` may retry. A
+        load balancer or discovery source configured as a context
+        manager is exited with the failure and its suppression verdict
+        ignored — see `wool.runtime.typing.resolved` — so a failed start
+        is never reported as a started proxy. The proxy is starting for
+        the whole of a failed start's unwind and new only once it
+        returns, so a concurrent start, or a lazy dispatch, raises
+        rather than racing it.
 
         :raises RuntimeError:
             If the proxy is starting, started, stopping, or stopped, or
             the channel pool is bound to another running event loop (see
             `wool.runtime.resourcepool.ResourcePool`).
+        :raises TypeError:
+            If the resolved load balancer or discovery source does not
+            implement its protocol.
         :raises asyncio.TimeoutError:
             If the quorum wait does not complete within
             ``quorum_timeout``.
@@ -931,13 +932,11 @@ class WorkerProxy:
             stack.callback(self._reset_state)
             await stack.enter_async_context(channel_pool_hold())
             self._loadbalancer_service = await stack.enter_async_context(
-                _resolved(self._loadbalancer)
+                resolved(
+                    self._loadbalancer,
+                    expect=(LoadBalancerLike, DispatchingLoadBalancerLike),
+                )
             )
-            if not isinstance(
-                self._loadbalancer_service,
-                (LoadBalancerLike, DispatchingLoadBalancerLike),
-            ):
-                raise ValueError
             # Classify the balancer once, here, so dispatch() need not
             # re-run a @runtime_checkable isinstance on the hot path.
             self._delegating = isinstance(self._loadbalancer_service, LoadBalancerLike)
@@ -954,10 +953,8 @@ class WorkerProxy:
                 self._dispatching_deprecation_warned = True
 
             self._discovery_stream = await stack.enter_async_context(
-                _resolved(self._discovery)
+                resolved(self._discovery, expect=DiscoverySubscriberLike)
             )
-            if not isinstance(self._discovery_stream, DiscoverySubscriberLike):
-                raise ValueError
 
             self._loadbalancer_context = LoadBalancerContext()
             # Built here, not in __init__, so its keys cannot outlive the
@@ -1569,28 +1566,3 @@ class WorkerProxy:
                         changed.set()
                 case "worker-dropped":
                     await self._evict(context, throttle, changed, event.metadata)
-
-
-@asynccontextmanager
-async def _resolved(dependency: Any) -> AsyncIterator[Any]:
-    """Enter a configured dependency and yield the live object.
-
-    Accepts a bare instance, a callable factory producing any of these
-    forms, an awaitable, or a sync or async context manager.  A context
-    manager is entered for the duration of the block and exited with
-    the block's exception info, so a dependency configured as a manager
-    sees the same exit semantics as a plain ``with`` over it would.
-    """
-    if isinstance(dependency, ContextManager):
-        with dependency as obj:
-            yield obj
-    elif isinstance(dependency, AsyncContextManager):
-        async with dependency as obj:
-            yield obj
-    elif callable(dependency):
-        async with _resolved(dependency()) as obj:
-            yield obj
-    elif isinstance(dependency, Awaitable):
-        yield await dependency
-    else:
-        yield dependency

--- a/wool/src/wool/runtime/worker/proxy.py
+++ b/wool/src/wool/runtime/worker/proxy.py
@@ -14,6 +14,7 @@ import warnings
 from contextlib import AsyncExitStack
 from contextlib import asynccontextmanager
 from enum import Enum
+from types import TracebackType
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import AsyncContextManager
@@ -58,6 +59,7 @@ from wool.runtime.worker.connection import HandshakeError
 from wool.runtime.worker.connection import RpcError
 from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.connection import channel_pool_hold
 from wool.runtime.worker.exceptions import UnparsableVersionWarning
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.utilities.noreentry import noreentry
@@ -322,12 +324,25 @@ class WorkerProxy:
     then fails the handshake. See `WorkerCredentialsProvider`'s
     ``peers`` parameter for the accepted shapes.
 
-    The gate is re-derived from the
-    credentials and protocol version of whichever process holds the proxy,
-    so a static-worker proxy re-gated after serialization may admit
-    fewer workers than at construction, and its construction-time
-    quorum check (see ``:raises ValueError:``) does not carry across a
-    pickle.
+    The gate is re-derived from the credentials and protocol version of
+    whichever process holds the proxy, so a static-worker proxy re-gated
+    after serialization may admit fewer workers than at construction,
+    and its construction-time quorum check (see ``:raises ValueError:``)
+    does not carry across a pickle.
+
+    **Channel lifetime.** A started proxy holds the loop's channel pool
+    for its lifetime (see `channel_pool_hold`), so channels stay cached
+    between dispatches and the last proxy to stop on a loop retires that
+    loop's channels without waiting for the idle TTL. A worker that
+    departs the pool, by a discovery drop, an admission-gate eviction,
+    or a non-transient dispatch failure, has its connection closed
+    rather than left to the TTL; a close that fails is logged and does
+    not disturb the proxy. A refresh of a worker still in the pool
+    closes nothing: the handle is kept when the advertised inputs to the
+    channel key are unchanged, and a changed input gets a fresh handle
+    while any channel the displaced handle was the last user of is left
+    to the pool's idle TTL. The pool serves one running loop at a time,
+    so a proxy is started on the loop it will dispatch from.
 
     :param pool_uri:
         Pool identifier for discovery-based connection.
@@ -717,10 +732,15 @@ class WorkerProxy:
             self._enter_stack = stack.pop_all()
         return self
 
-    async def __aexit__(self, *args):
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ):
         """Exit the proxy context and reset the active proxy."""
         try:
-            await self.exit(*args)
+            await self.exit(exc_type, exc_val, exc_tb)
         finally:
             if self._enter_stack is not None:
                 await self._enter_stack.aclose()
@@ -874,16 +894,20 @@ class WorkerProxy:
     async def start(self) -> None:
         """Start the proxy by initiating discovery and load balancing.
 
-        Subscribes to worker discovery, initializes the load-balancer
-        context, and launches the worker sentinel task.  A start that
-        fails at any step, the quorum wait included, releases what it had
-        acquired in reverse order and leaves the proxy un-started and
-        free to retry; a load balancer or discovery source configured as
-        a context manager is exited with the failure, as a ``with`` block
-        would exit it.
+        Takes a hold on the loop's channel pool (see `channel_pool_hold`),
+        enters the load balancer, then the discovery stream, and launches
+        the worker sentinel, handing all of it to `stop` to unwind in
+        reverse.  A start that fails at any step, the
+        quorum wait included, releases what it had acquired in reverse
+        order and leaves the proxy un-started and free to retry; a load
+        balancer or discovery source configured as a context manager is
+        exited with the failure (see `_resolved` for the exit contract),
+        and a failed start stays failed.
 
         :raises RuntimeError:
-            If the proxy is starting, started, stopping, or stopped.
+            If the proxy is starting, started, stopping, or stopped, or
+            the channel pool is bound to another running event loop (see
+            `wool.runtime.resourcepool.ResourcePool`).
         :raises asyncio.TimeoutError:
             If the quorum wait does not complete within
             ``quorum_timeout``.
@@ -900,73 +924,86 @@ class WorkerProxy:
             raise RuntimeError(self._state.value)
 
         self._state = _Lifecycle.STARTING
+        stack = AsyncExitStack()
         try:
-            async with AsyncExitStack() as stack:
-                # Pushed first so it runs last, after every context has
-                # exited, on both the rollback and the stop path.
-                stack.callback(self._reset_state)
-                self._loadbalancer_service = await stack.enter_async_context(
-                    _resolved(self._loadbalancer)
+            # Pushed first so it unwinds last, after every context has
+            # exited.
+            stack.callback(self._reset_state)
+            await stack.enter_async_context(channel_pool_hold())
+            self._loadbalancer_service = await stack.enter_async_context(
+                _resolved(self._loadbalancer)
+            )
+            if not isinstance(
+                self._loadbalancer_service,
+                (LoadBalancerLike, DispatchingLoadBalancerLike),
+            ):
+                raise ValueError
+            # Classify the balancer once, here, so dispatch() need not
+            # re-run a @runtime_checkable isinstance on the hot path.
+            self._delegating = isinstance(self._loadbalancer_service, LoadBalancerLike)
+            if (
+                not self._delegating
+                and isinstance(self._loadbalancer_service, DispatchingLoadBalancerLike)
+                and not self._dispatching_deprecation_warned
+            ):
+                warnings.warn(
+                    DISPATCHING_LOADBALANCER_DEPRECATION_MESSAGE,
+                    DeprecationWarning,
+                    stacklevel=2,
                 )
-                if not isinstance(
-                    self._loadbalancer_service,
-                    (LoadBalancerLike, DispatchingLoadBalancerLike),
-                ):
-                    raise ValueError
-                # Classify the balancer once, here, so dispatch() need not
-                # re-run a @runtime_checkable isinstance on the hot path.
-                self._delegating = isinstance(
-                    self._loadbalancer_service, LoadBalancerLike
-                )
-                if (
-                    not self._delegating
-                    and isinstance(
-                        self._loadbalancer_service, DispatchingLoadBalancerLike
-                    )
-                    and not self._dispatching_deprecation_warned
-                ):
-                    warnings.warn(
-                        DISPATCHING_LOADBALANCER_DEPRECATION_MESSAGE,
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
-                    self._dispatching_deprecation_warned = True
+                self._dispatching_deprecation_warned = True
 
-                self._discovery_stream = await stack.enter_async_context(
-                    _resolved(self._discovery)
-                )
-                if not isinstance(self._discovery_stream, DiscoverySubscriberLike):
-                    raise ValueError
+            self._discovery_stream = await stack.enter_async_context(
+                _resolved(self._discovery)
+            )
+            if not isinstance(self._discovery_stream, DiscoverySubscriberLike):
+                raise ValueError
 
-                self._loadbalancer_context = LoadBalancerContext()
-                # Built here, not in __init__, so its keys cannot outlive the
-                # pool membership they mirror: a uid stranded by teardown could
-                # never be discarded again, since a respawned worker gets a
-                # fresh one.
-                self._handshake_throttle = _HandshakeWarningThrottle()
-                self._workers_changed = asyncio.Event()
-                self._sentinel_task = asyncio.create_task(self._worker_sentinel())
-                stack.push_async_callback(self._cancel_sentinel)
+            self._loadbalancer_context = LoadBalancerContext()
+            # Built here, not in __init__, so its keys cannot outlive the
+            # pool membership they mirror: a uid stranded by teardown could
+            # never be discarded again, since a respawned worker gets a
+            # fresh one.
+            self._handshake_throttle = _HandshakeWarningThrottle()
+            self._workers_changed = asyncio.Event()
+            self._sentinel_task = asyncio.create_task(self._worker_sentinel())
+            stack.push_async_callback(self._cancel_sentinel)
 
-                if self._quorum:
-                    await asyncio.wait_for(self._await_workers(), self._quorum_timeout)
-
-                self._start_stack = stack.pop_all()
-
-        except BaseException:
-            self._state = _Lifecycle.NEW
+            if self._quorum:
+                await asyncio.wait_for(self._await_workers(), self._quorum_timeout)
+        except BaseException as exc:
+            try:
+                # Verdict discarded — see this method's docstring.
+                await stack.__aexit__(type(exc), exc, exc.__traceback__)
+            finally:
+                # Starting until the unwind returns — see the docstring.
+                self._state = _Lifecycle.NEW
             raise
 
+        self._start_stack = stack
         self._state = _Lifecycle.STARTED
 
-    async def exit(self, *args) -> None:
+    async def exit(
+        self,
+        exc_type: type[BaseException] | None = None,
+        exc_val: BaseException | None = None,
+        exc_tb: TracebackType | None = None,
+    ) -> None:
         """Exit the proxy context.
 
         Resets the context variable when this context minted its token;
         a token from another context is discarded.  If the proxy was
-        started, delegates to `stop` to release resources.  Calling
+        started, delegates to `stop`'s unwind with the exception info,
+        which every context `start` entered receives.  Calling
         ``exit()`` on an un-started lazy proxy is a safe no-op.
 
+        :param exc_type:
+            Exception type if the context is exiting on an error, else
+            ``None``.
+        :param exc_val:
+            The exception, else ``None``.
+        :param exc_tb:
+            Its traceback, else ``None``.
         :raises RuntimeError:
             If the proxy is not started, or was stopped, and ``lazy``
             is ``False``.
@@ -985,33 +1022,28 @@ class WorkerProxy:
             if not self._lazy:
                 raise RuntimeError(self._state.value)
             return
-        await self.stop(*args)
+        await self._unwind(exc_type, exc_val, exc_tb)
 
-    async def stop(self, *args) -> None:
+    async def stop(self) -> None:
         """Stop the proxy, terminating discovery and clearing connections.
 
         Unwinds what `start` acquired in reverse order: sentinel first
-        (so it stops reading from the discovery stream), then
-        discovery, then load balancer.  Every step runs even if an
-        earlier one raises, each context manager among them receives the
-        exception info passed to ``stop``, and the proxy is stopping from
-        the moment the unwind begins and stopped once it returns, so a
-        second ``stop``, or a ``start``, raises rather than racing the
-        unwind.
+        (so it stops reading from the discovery stream), then discovery,
+        then load balancer, and last the proxy's hold on the channel pool
+        (see `channel_pool_hold`).  Every step runs even if an earlier one
+        raises, and the proxy is stopping from the moment the unwind
+        begins and stopped once it returns, so a second ``stop``, or a
+        ``start``, raises rather than racing the unwind.
 
         :raises RuntimeError:
             If the proxy is not started, or is already stopping or
             stopped.
+        :raises BaseException:
+            An uncontained failure from retiring the loop's channels when
+            this was the last hold — see
+            `wool.runtime.resourcepool.ResourcePool.expire_all`.
         """
-        if self._state is not _Lifecycle.STARTED:
-            raise RuntimeError(self._state.value)
-        self._state = _Lifecycle.STOPPING
-        teardown, self._start_stack = self._start_stack, None
-        assert teardown is not None, "a started proxy holds its start stack"
-        try:
-            await teardown.__aexit__(*(args or (None, None, None)))
-        finally:
-            self._state = _Lifecycle.STOPPED
+        await self._unwind(None, None, None)
 
     async def dispatch(
         self, task: Task, *, timeout: float | None = None
@@ -1125,7 +1157,11 @@ class WorkerProxy:
         """
         assert self._loadbalancer_context is not None
         assert self._handshake_throttle is not None
+        assert self._workers_changed is not None
+        # Snapshot before the awaits — see _evict.
         ctx = self._loadbalancer_context
+        throttle = self._handshake_throttle
+        changed = self._workers_changed
         generator = loadbalancer.delegate(task, context=ctx)
         try:
             try:
@@ -1152,14 +1188,13 @@ class WorkerProxy:
                     # outer finally, which aclose()s the generator without
                     # eviction.
                     if not isinstance(exc, TransientRpcError):
-                        ctx.remove_worker(metadata)
-                        self._handshake_throttle.discard(metadata.uid)
+                        await self._evict(ctx, throttle, changed, metadata, connection)
                     elif isinstance(exc, HandshakeError):
                         # Transient by the worker-health contract, so the
                         # split above already skips without eviction; this
                         # branch only selects the diagnostic warning — see
                         # HandshakeError and _HandshakeWarningThrottle.
-                        self._handshake_throttle.warn(metadata, exc)
+                        throttle.warn(metadata, exc)
                     try:
                         uid = await generator.athrow(exc)
                     except StopAsyncIteration:
@@ -1168,7 +1203,7 @@ class WorkerProxy:
 
                 # Successful dispatch: a later failure from this worker
                 # is a new incident — see _HandshakeWarningThrottle.
-                self._handshake_throttle.discard(uid)
+                throttle.discard(uid)
 
                 # Success path: connection.dispatch() returned a live
                 # stream. The proxy owns it until handed off via
@@ -1202,28 +1237,6 @@ class WorkerProxy:
             # Runs on every exit path: success, NoWorkersAvailable,
             # cancellation, and contract violations.
             await generator.aclose()
-
-    async def _cancel_sentinel(self) -> None:
-        """Cancel the worker sentinel task, if any, and await its exit."""
-        if self._sentinel_task:
-            self._sentinel_task.cancel()
-            try:
-                await self._sentinel_task
-            except asyncio.CancelledError:
-                pass
-            self._sentinel_task = None
-
-    def _reset_state(self) -> None:
-        """Null every attribute `start` populates.
-
-        Runs last on both the rollback and the stop path, so neither a
-        failed start nor a stopped proxy keeps stale references.
-        """
-        self._loadbalancer_context = None
-        self._handshake_throttle = None
-        self._loadbalancer_service = None
-        self._discovery_stream = None
-        self._workers_changed = None
 
     def _create_security_filter(
         self, provider: WorkerCredentialsProvider | None
@@ -1360,6 +1373,95 @@ class WorkerProxy:
             await self._workers_changed.wait()
             self._workers_changed.clear()
 
+    async def _cancel_sentinel(self) -> None:
+        """Cancel the worker sentinel task, if any, and await its exit."""
+        if self._sentinel_task:
+            self._sentinel_task.cancel()
+            try:
+                await self._sentinel_task
+            except asyncio.CancelledError:
+                pass
+            self._sentinel_task = None
+
+    async def _unwind(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Unwind what `start` acquired with the given exception info.
+
+        Each context `start` entered receives it — see `stop` for the
+        order and the state contract.
+        """
+        if self._state is not _Lifecycle.STARTED:
+            raise RuntimeError(self._state.value)
+        self._state = _Lifecycle.STOPPING
+        stack, self._start_stack = self._start_stack, None
+        assert stack is not None, "a started proxy holds its start stack"
+        try:
+            await stack.__aexit__(exc_type, exc_val, exc_tb)
+        finally:
+            self._state = _Lifecycle.STOPPED
+
+    def _reset_state(self) -> None:
+        """Null the per-start collaborator references."""
+        self._loadbalancer_context = None
+        self._handshake_throttle = None
+        self._loadbalancer_service = None
+        self._discovery_stream = None
+        self._workers_changed = None
+
+    async def _evict(
+        self,
+        context: LoadBalancerContext,
+        throttle: _HandshakeWarningThrottle,
+        changed: asyncio.Event,
+        metadata: WorkerMetadata,
+        connection: WorkerConnection | None = None,
+    ) -> None:
+        """Remove a worker from the pool and retire its channel.
+
+        Closes the worker's connection now rather than leaving its
+        channel to the pool's idle TTL — see `WorkerConnection.close`. A
+        close that fails is logged and contained, so a departure cannot
+        propagate into the path that observed it.
+
+        The context, throttle, and event are supplied by the caller
+        rather than read from the proxy, so a caller holding a snapshot
+        across an await is not exposed to a concurrent stop's reset.
+
+        :param context:
+            The load-balancer context to remove the worker from.
+        :param throttle:
+            The handshake-warning throttle to forget the worker in.
+        :param changed:
+            The event that wakes a quorum wait on a membership change.
+        :param metadata:
+            The departing worker's record.
+        :param connection:
+            The handle to close; defaults to the one the context
+            currently holds for the worker, which a refresh may have
+            replaced.
+        """
+        if connection is None:
+            held = context.workers.get(metadata.uid)
+            connection = held[1] if held is not None else None
+        context.remove_worker(metadata)
+        # Departed the pool — see _HandshakeWarningThrottle.
+        throttle.discard(metadata.uid)
+        changed.set()
+        if connection is None:
+            return
+        try:
+            await connection.close()
+        except Exception:
+            _logger.warning(
+                "Closing the connection of departed worker %s failed",
+                metadata.uid,
+                exc_info=True,
+            )
+
     async def _worker_sentinel(self):
         """Reconcile discovery events against the load-balancer context.
 
@@ -1383,6 +1485,9 @@ class WorkerProxy:
         assert self._handshake_throttle is not None
         assert self._discovery_stream is not None
         assert self._workers_changed is not None
+        context = self._loadbalancer_context
+        throttle = self._handshake_throttle
+        changed = self._workers_changed
 
         # Pinning is gated on the policy being configured — see
         # `WorkerProxy` for the two states. The local reason: a policy is
@@ -1404,6 +1509,15 @@ class WorkerProxy:
                 peer=metadata.identity if gated else None,
             )
 
+        def same_channel_key(a: WorkerMetadata, b: WorkerMetadata) -> bool:
+            # The advertised inputs to the channel key — the identity only
+            # when the peers policy gates it. See WorkerConnection.
+            return (a.address, a.options, a.identity) == (
+                b.address,
+                b.options,
+                b.identity,
+            )
+
         async for event in self._discovery_stream:
             match event.type:
                 case "worker-added" | "worker-updated":
@@ -1411,7 +1525,7 @@ class WorkerProxy:
                     # Bind once: the ``workers`` property builds a fresh
                     # MappingProxyType per access, and this branch runs per
                     # still-registered worker every rescan.
-                    workers = self._loadbalancer_context.workers
+                    workers = context.workers
                     present = uid in workers
                     reason = self._incompatibility_reason(event.metadata)
                     if reason is not None:
@@ -1425,11 +1539,7 @@ class WorkerProxy:
                                 uid,
                                 reason,
                             )
-                            self._loadbalancer_context.remove_worker(event.metadata)
-                            # Departed the pool — see
-                            # _HandshakeWarningThrottle.
-                            self._handshake_throttle.discard(uid)
-                            self._workers_changed.set()
+                            await self._evict(context, throttle, changed, event.metadata)
                         else:
                             # Fires per rescan for standing chaff, so
                             # debug keeps it out of the default log.
@@ -1440,12 +1550,14 @@ class WorkerProxy:
                             )
                         continue
                     if present:
-                        # Refresh in place; membership is unchanged, so
-                        # the quorum wait need not re-evaluate. Displaced
-                        # connections are not closed — see
-                        # LoadBalancerContextLike.
-                        self._loadbalancer_context.update_worker(
-                            event.metadata, connect(event.metadata)
+                        # Refresh in place; membership is unchanged — see
+                        # the class docstring for the handle.
+                        held_metadata, held_connection = workers[uid]
+                        context.update_worker(
+                            event.metadata,
+                            held_connection
+                            if same_channel_key(held_metadata, event.metadata)
+                            else connect(event.metadata),
                         )
                     elif self._lease is not None and len(workers) >= self._lease:
                         # Admission is per uid — see the ``lease``
@@ -1453,17 +1565,10 @@ class WorkerProxy:
                         continue
                     else:
                         _logger.debug("Admission gate admitted worker %s", uid)
-                        # Displaced connections are not closed — see
-                        # LoadBalancerContextLike.
-                        self._loadbalancer_context.add_worker(
-                            event.metadata, connect(event.metadata)
-                        )
-                        self._workers_changed.set()
+                        context.add_worker(event.metadata, connect(event.metadata))
+                        changed.set()
                 case "worker-dropped":
-                    self._loadbalancer_context.remove_worker(event.metadata)
-                    # Departed the pool — see _HandshakeWarningThrottle.
-                    self._handshake_throttle.discard(event.metadata.uid)
-                    self._workers_changed.set()
+                    await self._evict(context, throttle, changed, event.metadata)
 
 
 @asynccontextmanager

--- a/wool/src/wool/runtime/worker/service.py
+++ b/wool/src/wool/runtime/worker/service.py
@@ -751,9 +751,6 @@ class WorkerService(protocol.WorkerServicer):
         if timeout is None or timeout > 0:
             # Offload the synchronous ``thread.join`` to a worker
             # thread so the main loop keeps pumping while we wait.
-            # ``ResourcePool._await`` already dispatches coroutine
-            # finalizers, so changing this function to ``async def``
-            # is transparent at the call site.
             await asyncio.get_running_loop().run_in_executor(None, thread.join, timeout)
 
     @asynccontextmanager

--- a/wool/src/wool/runtime/worker/service.py
+++ b/wool/src/wool/runtime/worker/service.py
@@ -25,6 +25,7 @@ from wool.runtime.context.factory import install_task_factory
 from wool.runtime.discovery import __subscriber_pool__
 from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.routine.task import Task
+from wool.runtime.worker.connection import clear_channel_pool
 from wool.runtime.worker.frame import AckResponseFrame
 from wool.runtime.worker.frame import NackResponseFrame
 from wool.runtime.worker.session import DispatchSession
@@ -650,14 +651,23 @@ class WorkerService(protocol.WorkerServicer):
     ) -> None:
         """Schedule worker-loop shutdown and optionally join the thread.
 
-        Finalizes the proxy and discovery-subscriber pools on the worker
-        loop first: they are bound to it, and a `ResourcePool` refuses
-        use from any other running loop, so this finalizer is the one
-        place they can still be cleared. A clear that raises or exceeds
-        the shared `_DRAIN_TIMEOUT` budget is logged and does not
-        prevent the stop; whatever it left cached is dropped when the
-        pool next rebinds. With ``timeout=0`` the clears run best-effort
-        on the daemon thread after this returns.
+        Finalizes the proxy and discovery-subscriber pools, then the
+        channel pool, on the worker loop first: they are bound to it, and
+        a `ResourcePool` refuses use from any other running loop, so this
+        finalizer is the one place they can still be cleared. A clear
+        that raises or exceeds the shared `_DRAIN_TIMEOUT` budget is
+        logged and does not prevent the stop; the budget bounds when a
+        clear is cancelled, not when it returns, since a clear finishes
+        its sweep before re-raising (see `ResourcePool.clear`), a clear
+        reached with the budget already exhausted is cancelled before it
+        starts and logged the same way, and whatever a clear left cached
+        is dropped when the pool next rebinds.
+        With ``timeout=0`` the clears run best-effort on the daemon
+        thread after this returns; on that path the channel clear can
+        race a successor loop's first use of the process-wide pool, and
+        a pool partitioned per loop (#381) removes the race. An
+        interrupt raised by a clear still drains the loop before
+        propagating.
 
         Drains successive generations of pending tasks on the
         worker loop, then signals the loop to stop. A cancelled
@@ -687,54 +697,65 @@ class WorkerService(protocol.WorkerServicer):
             A tuple of the event loop and the thread running it.
         """
         loop, thread = loop_thread
-        pools = [
-            ("proxy", wool.__proxy_pool__.get()),
-            ("subscriber", __subscriber_pool__.get()),
+        proxy_pool = wool.__proxy_pool__.get()
+        subscriber_pool = __subscriber_pool__.get()
+        # Proxies first: exiting them releases the loop's channel-pool
+        # hold, so the channel clear that follows finds nothing to
+        # force-close on a rotation that drained cleanly.
+        clears = [
+            (name, pool.clear)
+            for name, pool in (("proxy", proxy_pool), ("subscriber", subscriber_pool))
+            if pool is not None
         ]
+        clears.append(("channel", clear_channel_pool))
 
         async def _shutdown():
             current = asyncio.current_task()
             deadline = loop.time() + _DRAIN_TIMEOUT
             leaked: list[asyncio.Task] = []
             try:
-                for name, pool in pools:
-                    if pool is None:
-                        continue
-                    try:
-                        await asyncio.wait_for(
-                            pool.clear(), timeout=max(0.0, deadline - loop.time())
-                        )
-                    except Exception:
+                try:
+                    for name, clear in clears:
+                        try:
+                            await asyncio.wait_for(
+                                clear(), timeout=max(0.0, deadline - loop.time())
+                            )
+                        except Exception:
+                            _log.warning(
+                                f"Failed to clear the {name} pool during "
+                                "worker-loop teardown; continuing to drain and "
+                                "stop the loop.",
+                                exc_info=True,
+                            )
+                finally:
+                    # The drain runs whatever a clear raised — see the
+                    # docstring.
+                    while True:
+                        pending = [
+                            task for task in asyncio.all_tasks() if task is not current
+                        ]
+                        if not pending:
+                            break
+                        for task in pending:
+                            task.cancel()
+                        remaining = deadline - loop.time()
+                        if remaining <= 0:
+                            leaked = pending
+                            break
+                        try:
+                            await asyncio.wait_for(
+                                asyncio.gather(*pending, return_exceptions=True),
+                                timeout=remaining,
+                            )
+                        except TimeoutError:
+                            leaked = pending
+                            break
+                    if leaked:
                         _log.warning(
-                            f"Failed to clear the {name} pool during worker-loop "
-                            "teardown; continuing to drain and stop the loop.",
-                            exc_info=True,
+                            f"Worker-loop teardown drain timed out after "
+                            f"{_DRAIN_TIMEOUT}s; {len(leaked)} task(s) still "
+                            "pending."
                         )
-                while True:
-                    pending = [
-                        task for task in asyncio.all_tasks() if task is not current
-                    ]
-                    if not pending:
-                        break
-                    for task in pending:
-                        task.cancel()
-                    remaining = deadline - loop.time()
-                    if remaining <= 0:
-                        leaked = pending
-                        break
-                    try:
-                        await asyncio.wait_for(
-                            asyncio.gather(*pending, return_exceptions=True),
-                            timeout=remaining,
-                        )
-                    except TimeoutError:
-                        leaked = pending
-                        break
-                if leaked:
-                    _log.warning(
-                        f"Worker-loop teardown drain timed out after "
-                        f"{_DRAIN_TIMEOUT}s; {len(leaked)} task(s) still pending."
-                    )
             finally:
                 loop.stop()
 

--- a/wool/tests/conftest.py
+++ b/wool/tests/conftest.py
@@ -4,9 +4,11 @@ from typing import Final
 
 import debugpy
 import pytest
+import pytest_asyncio
 
 import wool
 from wool.runtime.resourcepool import ResourcePool
+from wool.runtime.worker.connection import clear_channel_pool
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +69,20 @@ def pytest_addoption(parser):
         default=False,
         help="Wait for a debugpy client to attach before running tests",
     )
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clear_channel_pool():
+    """Finalize the module-level gRPC channel pool on the loop that used it.
+
+    This loop is the only place a channel a test left cached can still
+    be closed, and a hold a test left open would strand its entry for
+    the next loop to report (see
+    `wool.runtime.resourcepool.ResourcePool`), where a record is meant
+    to mean a real leak.
+    """
+    yield
+    await clear_channel_pool()
 
 
 @pytest.fixture

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -414,7 +414,7 @@ class _DirectDiscovery:
     """Wraps an already-entered discovery service as a plain object.
 
     Does NOT implement ``__enter__``/``__exit__``/``__aenter__``/
-    ``__aexit__``, forcing ``WorkerPool._enter_context`` to take the
+    ``__aexit__``, so the pool's dependency resolution takes the
     passthrough path. Used for the ``*_DIRECT`` factory form arrangements.
 
     ``publisher`` overrides the wrapped service's publisher, for tests

--- a/wool/tests/integration/conftest.py
+++ b/wool/tests/integration/conftest.py
@@ -7,6 +7,7 @@ fixtures, and builder functions for composable integration tests.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
 import signal
 import subprocess
@@ -37,6 +38,7 @@ from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
 from wool.runtime.worker.auth import WorkerCredentials
 from wool.runtime.worker.base import ChannelOptions
 from wool.runtime.worker.base import WorkerOptions
+from wool.runtime.worker.connection import channel_pool_stats
 from wool.runtime.worker.local import LocalWorker
 from wool.runtime.worker.pool import WorkerPool
 
@@ -47,24 +49,80 @@ from .routines import ContextVarPattern
 _TIMEOUT = 30
 
 
-async def poll_until_count(get_uids, expected_count, *, timeout=5.0, interval=0.02):
-    """Poll get_uids() until it reports expected_count uids, or fail.
+async def poll_until(
+    get, predicate, *, description, timeout=5.0, interval=0.02, tolerate=()
+):
+    """Poll ``get()`` until ``predicate`` accepts its value, or fail.
 
-    Returns the uid set once its size equals expected_count. Replaces a
-    fixed settle sleep: it waits no longer than necessary and fails
-    loudly — rather than silently passing on a change that arrived late
-    — if the count never reaches the expected value within the deadline.
+    Returns the accepted value. ``get`` may be sync or async: an
+    awaitable value is awaited before the predicate sees it. An
+    exception in ``tolerate`` counts as "not yet" rather than a failure,
+    for a probe whose subject may not exist yet. Replaces a fixed settle
+    sleep: it waits no longer than necessary and fails loudly — rather
+    than silently passing on a change that arrived late — if no value
+    satisfies ``predicate`` within the deadline, naming ``description``
+    and the last value, or tolerated exception, seen.
     """
     loop = asyncio.get_event_loop()
     deadline = loop.time() + timeout
     while True:
-        uids = get_uids()
-        if len(uids) == expected_count:
-            return uids
-        assert loop.time() < deadline, (
-            f"admitted count never reached {expected_count}; last saw {len(uids)}"
-        )
+        try:
+            value = get()
+            if inspect.isawaitable(value):
+                value = await value
+        except tolerate as exc:
+            value = exc
+        else:
+            if predicate(value):
+                return value
+        assert loop.time() < deadline, f"{description}; last saw {value!r}"
         await asyncio.sleep(interval)
+
+
+async def poll_until_count(get_uids, expected_count, *, timeout=5.0, interval=0.02):
+    """Poll ``get_uids()`` until it reports ``expected_count`` uids, or fail."""
+    return await poll_until(
+        get_uids,
+        lambda uids: len(uids) == expected_count,
+        description=f"admitted count never reached {expected_count}",
+        timeout=timeout,
+        interval=interval,
+    )
+
+
+async def poll_until_channel_pool_settles(
+    *, get=channel_pool_stats, timeout=5.0, interval=0.02
+):
+    """Poll a channel pool until it caches nothing, or fail.
+
+    Returns the settled `wool.runtime.resourcepool.ResourcePool.Stats`
+    once ``total_entries`` reaches zero. ``get`` reads the stats, this
+    process's own by default, or a worker's through a probe routine. The
+    channel a pool exit retires closes a beat after ``__aexit__``
+    returns, so a bare assertion on the counters races that lag; the
+    failure message carries the last snapshot so a real leak names what
+    it stranded.
+    """
+    return await poll_until(
+        get,
+        lambda stats: stats.total_entries == 0,
+        description="channel pool never settled to zero entries",
+        timeout=timeout,
+        interval=interval,
+    )
+
+
+async def run_on_foreign_loop(factory):
+    """Run ``factory()`` to completion on a fresh loop on another thread.
+
+    Returns whatever the coroutine returns. ``asyncio.run`` closes its
+    loop the moment the coroutine finishes, so whatever the coroutine
+    left in the channel pool is stranded exactly as it would be in a
+    program whose loop stops — which is the condition a stranded-channel
+    test needs. The factory is called on the worker thread so the
+    coroutine is never created on the calling loop's thread.
+    """
+    return await asyncio.to_thread(lambda: asyncio.run(factory()))
 
 
 async def poll_dispatch_until_pid(target_pid, message, *, timeout=15.0, interval=0.1):
@@ -74,16 +132,14 @@ async def poll_dispatch_until_pid(target_pid, message, *, timeout=15.0, interval
     event being published and the sentinel admitting the worker, so an
     empty pool mid-propagation is retried rather than raised.
     """
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + timeout
-    while True:
-        try:
-            if await routines.get_pid() == target_pid:
-                return
-        except NoWorkersAvailable:
-            pass
-        assert loop.time() < deadline, message
-        await asyncio.sleep(interval)
+    await poll_until(
+        routines.get_pid,
+        lambda pid: pid == target_pid,
+        description=message,
+        tolerate=(NoWorkersAvailable,),
+        timeout=timeout,
+        interval=interval,
+    )
 
 
 async def poll_dispatch_until_unavailable(message, *, timeout=15.0, interval=0.1):
@@ -93,15 +149,20 @@ async def poll_dispatch_until_unavailable(message, *, timeout=15.0, interval=0.1
     evicted worker is observable only as a dispatch that can no longer
     be routed.
     """
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + timeout
-    while True:
+
+    async def routed():
         try:
-            await routines.get_pid()
+            return await routines.get_pid()
         except NoWorkersAvailable:
-            return
-        assert loop.time() < deadline, message
-        await asyncio.sleep(interval)
+            return None
+
+    await poll_until(
+        routed,
+        lambda pid: pid is None,
+        description=message,
+        timeout=timeout,
+        interval=interval,
+    )
 
 
 class RoutineShape(Enum):
@@ -125,6 +186,18 @@ class PoolMode(Enum):
     HYBRID = auto()
     NESTED_DEFAULT_IN_EPHEMERAL = auto()
     NESTED_EPHEMERAL_IN_EPHEMERAL = auto()
+
+
+#: The pool modes that spawn LAN `LocalWorker` processes themselves.
+_SPAWNING_MODES = frozenset(
+    {
+        PoolMode.DEFAULT,
+        PoolMode.EPHEMERAL,
+        PoolMode.HYBRID,
+        PoolMode.NESTED_DEFAULT_IN_EPHEMERAL,
+        PoolMode.NESTED_EPHEMERAL_IN_EPHEMERAL,
+    }
+)
 
 
 class DiscoveryFactory(Enum):
@@ -372,7 +445,7 @@ class _DirectDiscovery:
 # as a plain coroutine, breaking ``async with`` analysis at every call site.
 @asynccontextmanager
 async def build_pool_from_scenario(
-    scenario, credentials_map, *, backpressure=None
+    scenario, credentials_map, *, backpressure=None, proxy_pool_ttl=None
 ) -> AsyncIterator[WorkerPool]:
     """Build and enter a WorkerPool from a complete Scenario.
 
@@ -382,8 +455,18 @@ async def build_pool_from_scenario(
     :param backpressure:
         Optional admission-control hook that overrides the hook the
         ``BackpressureMode`` dimension would otherwise resolve. Tests
-        that need a bespoke (e.g. context-var-aware) hook pass it here
-        rather than building a :class:`WorkerPool` by hand.
+        that need a bespoke (e.g., context-var-aware) hook pass it here
+        rather than building a `WorkerPool` by hand.
+    :param proxy_pool_ttl:
+        Optional idle TTL, in seconds, for the proxy pool each
+        spawned `wool.LocalWorker` caches its nested-dispatch
+        proxies in. ``None`` leaves the worker's own default in
+        place. Applies only to the LAN `LocalWorker` processes the
+        builder spawns itself, so a durable mode, which spawns none,
+        rejects it.
+    :raises ValueError:
+        If the scenario is incomplete, or ``proxy_pool_ttl`` is given
+        for a pool mode that spawns no workers.
     """
     missing = [
         f.name
@@ -392,6 +475,8 @@ async def build_pool_from_scenario(
     ]
     if missing:
         raise ValueError(f"Scenario incomplete; missing required dimensions: {missing}")
+    if proxy_pool_ttl is not None and scenario.pool_mode not in _SPAWNING_MODES:
+        raise ValueError("proxy_pool_ttl applies only to pools that spawn LAN workers")
 
     creds = credentials_map[scenario.credential]
 
@@ -538,6 +623,11 @@ async def build_pool_from_scenario(
                 ) as pool:
                     yield pool
             else:
+                worker = partial(
+                    LocalWorker, host="127.0.0.1", options=options, backpressure=bp_hook
+                )
+                if proxy_pool_ttl is not None:
+                    worker = partial(worker, proxy_pool_ttl=proxy_pool_ttl)
                 pool_kwargs = {
                     "loadbalancer": lb,
                     "credentials": creds,
@@ -550,12 +640,7 @@ async def build_pool_from_scenario(
                     # keyword outright rather than pre-supply it.
                     # The publisher-prescribed bind host is covered by
                     # test_lan_publish.py.
-                    "worker": partial(
-                        LocalWorker,
-                        host="127.0.0.1",
-                        options=options,
-                        backpressure=bp_hook,
-                    ),
+                    "worker": worker,
                     "lazy": lazy,
                     "quorum": quorum,
                 }
@@ -1578,19 +1663,6 @@ def credentials_map(test_certificates):
             mutual=False,
         ),
     }
-
-
-@pytest_asyncio.fixture(autouse=True)
-async def _clear_channel_pool():
-    """Finalize the module-level gRPC channel pool on the loop that used it.
-
-    Prompt finalization only; the pool rebinds and drops orphans on its
-    own, so this is not required for correctness.
-    """
-    yield
-    import wool.runtime.worker.connection as _conn
-
-    await _conn.clear_channel_pool()
 
 
 # Integration tests rely on pytest-asyncio's Task-per-test scoping

--- a/wool/tests/integration/routines.py
+++ b/wool/tests/integration/routines.py
@@ -19,7 +19,9 @@ from enum import Enum
 from enum import auto
 
 import wool
+from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.worker.auth import current_credentials
+from wool.runtime.worker.connection import channel_pool_stats
 
 
 class ContextVarPattern(Enum):
@@ -559,6 +561,19 @@ async def get_pid() -> int:
     Used to observe which worker process executed a dispatch.
     """
     return os.getpid()
+
+
+@wool.routine
+async def worker_channel_pool_stats() -> ResourcePool.Stats:
+    """Report the worker task loop's gRPC channel pool counters.
+
+    Reads the pool's `ResourcePool.Stats` on the loop that runs the
+    worker's tasks, which is the loop a nested dispatch caches its
+    channel on. Lets a caller observe what a worker's own outbound
+    channels leave behind — the counters are otherwise invisible from
+    outside the worker process.
+    """
+    return channel_pool_stats()
 
 
 @wool.routine

--- a/wool/tests/integration/test_channel_lifecycle.py
+++ b/wool/tests/integration/test_channel_lifecycle.py
@@ -1,0 +1,478 @@
+"""Channel-pool lifecycle integration tests.
+
+These pin the symptom the channel-pool hold exists to remove: a channel
+left unclosed when the loop that opened it stops. They stand apart from
+the pairwise array because the oracle here is what the pool holds after
+a successful dispatch, which the array's dispatch-success oracle cannot
+express.
+"""
+
+import asyncio
+import logging
+import uuid
+
+import pytest
+
+from wool.runtime.discovery.local import LocalDiscovery
+from wool.runtime.loadbalancer.roundrobin import RoundRobinLoadBalancer
+from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.connection import channel_pool_stats
+from wool.runtime.worker.connection import clear_channel_pool
+from wool.runtime.worker.local import LocalWorker
+from wool.runtime.worker.pool import WorkerPool
+from wool.runtime.worker.proxy import WorkerProxy
+
+from . import routines
+from .conftest import PoolMode
+from .conftest import RoutineShape
+from .conftest import _DirectDiscovery
+from .conftest import build_pool_from_scenario
+from .conftest import default_scenario
+from .conftest import invoke_routine
+from .conftest import poll_until
+from .conftest import poll_until_channel_pool_settles
+from .conftest import run_on_foreign_loop
+
+#: The logger a `~wool.runtime.resourcepool.ResourcePool` reports a
+#: dropped entry on. A stranded-entry claim is only meaningful against
+#: records from this logger, so every assertion here filters by it.
+_RESOURCEPOOL_LOGGER = "wool.runtime.resourcepool"
+
+#: Seconds a spawned worker keeps a nested-dispatch proxy cached, for
+#: tests that observe the proxy's retirement. Short enough that the
+#: retirement is observable inside one test, long enough that the warm
+#: probe still finds the proxy alive.
+_PROXY_POOL_TTL = 1.0
+
+
+#: The name a `~wool.runtime.resourcepool.ResourcePool` reports the
+#: channel pool under: its factory's. The hold pool shares the logger, so
+#: a stranded-channel claim filters on this name as well.
+_CHANNEL_POOL = "_channel_factory"
+
+
+def _resourcepool_records(caplog, *, pool=_CHANNEL_POOL):
+    """Return the records the resource pool's logger holds for ``pool``."""
+    return [
+        record
+        for record in caplog.records
+        if record.name == _RESOURCEPOOL_LOGGER
+        and record.getMessage().startswith(f"ResourcePool({pool})")
+    ]
+
+
+async def _records_after_stranding(caplog, factory):
+    """Run ``factory()`` on a foreign loop and report what its rebind drops.
+
+    Returns the coroutine's result and the resource pool's records from
+    this loop's first channel-pool operation afterwards, which is what
+    rebinds the pool and drops whatever the stopped loop left (see
+    `wool.runtime.resourcepool.ResourcePool`).
+    """
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger=_RESOURCEPOOL_LOGGER):
+        result = await run_on_foreign_loop(factory)
+        # Deliberately this loop's first channel-pool operation — that
+        # is when the rebind runs.
+        await clear_channel_pool()
+    return result, _resourcepool_records(caplog)
+
+
+@pytest.mark.integration
+class TestChannelPoolLifecycle:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "pool_mode",
+        [PoolMode.DEFAULT, PoolMode.EPHEMERAL],
+        ids=lambda mode: mode.name,
+    )
+    async def test___aexit___should_close_pooled_channels_when_last_pool_exits(
+        self, pool_mode, credentials_map, retry_grpc_internal
+    ):
+        """Test a pool's exit closes the channels its dispatches opened.
+
+        Given:
+            A one-worker or two-worker pool that has dispatched a
+            coroutine routine, leaving a channel cached on the caller's
+            loop.
+        When:
+            The pool's context is exited.
+        Then:
+            It should leave the channel pool caching nothing. A pool
+            that spawns its own workers closes their channels through
+            the stop RPC either way, so this pins the symptom end to end
+            rather than the hold alone.
+        """
+
+        async def body():
+            # Arrange
+            scenario = default_scenario(
+                shape=RoutineShape.COROUTINE, pool_mode=pool_mode
+            )
+
+            # Act
+            async with build_pool_from_scenario(scenario, credentials_map):
+                await invoke_routine(scenario)
+                # Guards the assertion below against passing vacuously
+                # on a pool that never opened a channel at all.
+                assert channel_pool_stats().total_entries >= 1
+
+            # Assert
+            await poll_until_channel_pool_settles()
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_close_pooled_channels_when_worker_outlives_pool(
+        self, started_worker, retry_grpc_internal
+    ):
+        """Test a pool closes its channels even when it stops no worker.
+
+        Given:
+            A worker started outside the pool and published to a private
+            discovery namespace, and a pool that discovers it, dispatches
+            a coroutine, and leaves it running on exit.
+        When:
+            The pool's context is exited.
+        Then:
+            It should leave the channel pool caching nothing, closing the
+            dispatch channel through the proxy's own hold rather than
+            through the stop RPC a pool-owned worker's shutdown would
+            have sent over the same pool key.
+        """
+        # Arrange
+        worker = await started_worker(LocalWorker())
+        namespace = f"channel-lifecycle-{uuid.uuid4().hex[:12]}"
+
+        async def body():
+            # Arrange
+            with LocalDiscovery(namespace) as discovery:
+                async with discovery.publisher as publisher:
+                    await publisher.publish("worker-added", worker.metadata)
+
+                    # Act
+                    async with WorkerPool(
+                        discovery=_DirectDiscovery(discovery),
+                        loadbalancer=RoundRobinLoadBalancer,
+                    ):
+                        assert await routines.add(1, 2) == 3
+                        # Guards the assertion below against passing
+                        # vacuously on a pool that never opened a channel.
+                        assert channel_pool_stats().total_entries >= 1
+
+                    # Assert
+                    await poll_until_channel_pool_settles()
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_strand_no_channel_when_loop_stops_after_exit(
+        self, credentials_map, caplog
+    ):
+        """Test a pool that closed its channels strands nothing at loop stop.
+
+        Given:
+            A full pool lifecycle — build, dispatch, exit — run to
+            completion under ``asyncio.run`` on another thread, whose
+            loop then stops.
+        When:
+            This test's loop makes its first channel-pool operation,
+            which is what rebinds the pool and drops what the stopped
+            loop left.
+        Then:
+            It should drop nothing, reporting no record at all on the
+            resource pool's logger.
+        """
+
+        # Arrange
+        scenario = default_scenario(pool_mode=PoolMode.DEFAULT)
+
+        async def lifecycle():
+            async with build_pool_from_scenario(scenario, credentials_map):
+                await invoke_routine(scenario)
+                # Guards the assertions below against passing vacuously
+                # on a pool that never opened a channel at all.
+                assert channel_pool_stats().total_entries >= 1
+            settled = await poll_until_channel_pool_settles()
+            return settled.total_entries
+
+        # Act
+        stranded, records = await _records_after_stranding(caplog, lifecycle)
+
+        # Assert
+        assert stranded == 0
+        assert channel_pool_stats().total_entries == 0
+        assert records == []
+
+    @pytest.mark.asyncio
+    async def test_clear_channel_pool_should_warn_when_loop_stops_without_a_proxy(
+        self, started_worker, caplog
+    ):
+        """Test a channel nobody closed is reported when its loop stops.
+
+        Given:
+            A running worker polled for its idle duration by a
+            `wool.runtime.worker.connection.WorkerConnection` on another
+            thread's loop that is never entered and never closed before
+            that loop stops.
+        When:
+            This test's loop makes its first channel-pool operation,
+            rebinding the pool off the stopped loop.
+        Then:
+            It should report exactly one warning naming the one idle
+            entry it dropped without finalizing.
+        """
+        # Arrange
+        worker = await started_worker(LocalWorker())
+
+        async def strand():
+            connection = WorkerConnection(worker.address)
+            # Deliberately never closed: this is the control case the
+            # proxy-scoped tests are measured against.
+            await connection.idle()
+
+        # Act
+        _, records = await _records_after_stranding(caplog, strand)
+
+        # Assert
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+        assert "0 referenced and 1 idle" in records[0].getMessage()
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_strand_no_channel_when_connection_used_as_context(
+        self, started_worker, caplog
+    ):
+        """Test a connection used as a context manager cleans up after itself.
+
+        Given:
+            A running worker polled for its idle duration by a
+            `wool.runtime.worker.connection.WorkerConnection` entered as
+            an async context manager on another thread's loop, which
+            stops once the block exits.
+        When:
+            This test's loop makes its first channel-pool operation,
+            rebinding the pool off the stopped loop.
+        Then:
+            It should report nothing on the resource pool's logger,
+            since exiting the connection retired the channel it opened.
+        """
+        # Arrange
+        worker = await started_worker(LocalWorker())
+
+        async def use_and_exit():
+            async with WorkerConnection(worker.address) as connection:
+                await connection.idle()
+
+        # Act
+        _, records = await _records_after_stranding(caplog, use_and_exit)
+
+        # Assert
+        assert records == []
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_close_channels_when_proxy_loop_stops_at_once(
+        self, started_worker, caplog
+    ):
+        """Test a proxy over an external worker strands no channel.
+
+        Given:
+            A running worker dispatched one coroutine through a static
+            `wool.WorkerProxy` entered on another thread's loop, which
+            stops the instant the proxy's context exits.
+        When:
+            This test's loop makes its first channel-pool operation,
+            rebinding the pool off the stopped loop.
+        Then:
+            It should drop nothing, and the stats read inside the proxy
+            should show the completed dispatch's channel idle rather
+            than still referenced.
+        """
+        # Arrange
+        worker = await started_worker(LocalWorker())
+
+        async def dispatch_under_proxy():
+            async with WorkerProxy(workers=[worker.metadata]):
+                assert await routines.add(1, 2) == 3
+                stats = channel_pool_stats()
+            return stats.total_entries, stats.referenced_entries
+
+        # Act
+        (total, referenced), records = await _records_after_stranding(
+            caplog, dispatch_under_proxy
+        )
+
+        # Assert
+        assert total == 1
+        assert referenced == 0
+        assert records == []
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_keep_outer_pool_channels_when_inner_pool_exits(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test an inner pool's exit retires only its own channels.
+
+        Given:
+            An outer pool that has dispatched once, leaving one idle
+            channel, with a second pool entered and dispatched through
+            inside it on the same loop.
+        When:
+            The inner pool's context exits while the outer pool's stays
+            open.
+        Then:
+            It should drop only the inner pool's entry, leave the outer
+            pool's cached with its idle timer, keep the outer pool
+            dispatchable, and settle to nothing once the outer pool
+            exits too.
+        """
+
+        async def body():
+            # Arrange
+            scenario = default_scenario(pool_mode=PoolMode.EPHEMERAL)
+            async with build_pool_from_scenario(scenario, credentials_map):
+                assert await routines.add(1, 2) == 3
+                outer_only = channel_pool_stats()
+
+                # Act
+                async with WorkerPool(spawn=1):
+                    assert await routines.add(3, 4) == 7
+                    nested = channel_pool_stats()
+                after_inner = channel_pool_stats()
+                # The dispatchability probe has to run while the outer
+                # pool is still open, so it stays inside the block.
+                assert await routines.add(5, 6) == 11
+
+            # Assert
+            assert outer_only.total_entries == 1
+            assert nested.total_entries == outer_only.total_entries + 1
+            assert after_inner.total_entries == outer_only.total_entries
+            assert after_inner.referenced_entries == 0
+            assert after_inner.pending_cleanup == 1
+            await poll_until_channel_pool_settles()
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test_stop_should_close_worker_channels_when_pooled_proxy_retires(
+        self, credentials_map, retry_grpc_internal
+    ):
+        """Test a worker closes its nested-dispatch channel with its proxy.
+
+        Given:
+            A single-worker pool whose worker caches nested-dispatch
+            proxies for one second, warmed by a nested coroutine
+            dispatch that opens a channel on the worker's task loop.
+        When:
+            The worker's channel pool counters are read straight after
+            the nested dispatch and again once the proxy's idle TTL has
+            elapsed several times over.
+        Then:
+            It should report one idle channel awaiting cleanup while the
+            proxy is warm and nothing at all once the proxy has retired.
+        """
+
+        async def body():
+            # Arrange
+            scenario = default_scenario(
+                shape=RoutineShape.NESTED_COROUTINE, pool_mode=PoolMode.DEFAULT
+            )
+
+            # Act
+            async with build_pool_from_scenario(
+                scenario, credentials_map, proxy_pool_ttl=_PROXY_POOL_TTL
+            ):
+                assert await routines.nested_add(1, 2) == 3
+                warm = await routines.worker_channel_pool_stats()
+                # Every probe is itself a task on the worker, which
+                # re-acquires the cached proxy and restarts its idle
+                # TTL, so the interval must outlast the TTL or the
+                # proxy never idles long enough to retire.
+                retired = await poll_until_channel_pool_settles(
+                    get=routines.worker_channel_pool_stats,
+                    timeout=_PROXY_POOL_TTL * 8,
+                    interval=_PROXY_POOL_TTL * 2,
+                )
+
+            # Assert
+            assert warm.total_entries == 1
+            assert warm.referenced_entries == 0
+            assert warm.pending_cleanup == 1
+            assert retired.total_entries == 0
+            assert retired.referenced_entries == 0
+            assert retired.pending_cleanup == 0
+
+        await retry_grpc_internal(body)
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_settle_channel_pool_when_release_lands_late(
+        self, credentials_map, retry_grpc_internal, caplog, tmp_path
+    ):
+        """Test a release landing during pool exit finalizes cleanly.
+
+        Given:
+            An async-generator dispatch whose consumer task is cancelled
+            and left unawaited, so its teardown release of the pooled
+            channel lands while the pool's exit is rebuilding a channel
+            for the same key to send each worker its stop RPC.
+        When:
+            The pool exits and the cancelled task is awaited afterwards.
+        Then:
+            It should raise `asyncio.CancelledError`, run the
+            worker-side ``finally``, and settle the channel pool to
+            nothing without a dropped-entry record.
+        """
+
+        async def body():
+            # Arrange
+            caplog.clear()
+            scenario = default_scenario(
+                shape=RoutineShape.ASYNC_GEN_ACLOSE,
+                pool_mode=PoolMode.EPHEMERAL,
+            )
+            sentinel = tmp_path / "cleanup_reason.txt"
+            collected = []
+            started = asyncio.Event()
+
+            async def consume():
+                gen = routines.cancellable_gen(str(sentinel))
+                collected.append(await gen.__anext__())
+                started.set()
+                # Park awaiting the next value; the cancellation lands
+                # here, and its teardown release chases the pool's exit.
+                collected.append(await gen.__anext__())
+
+            # Act
+            with caplog.at_level(logging.WARNING, logger=_RESOURCEPOOL_LOGGER):
+                async with build_pool_from_scenario(scenario, credentials_map):
+                    task = asyncio.create_task(consume())
+                    await asyncio.wait_for(started.wait(), timeout=15)
+                    task.cancel()
+                    # Deliberately not awaited before the exit: that is
+                    # what makes the release land mid-teardown.
+
+                # Act & assert: a ValueError here would be the entry the
+                # stop RPC rebuilt being corrupted by the late release.
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+                # Poll for the worker's ``finally`` to write the
+                # sentinel — it runs after the gRPC stream tears down
+                # and tolerates CI load.
+                await poll_until(
+                    lambda: sentinel.exists() and sentinel.read_text() == "cleaned_up",
+                    bool,
+                    description="sentinel never written",
+                    timeout=15.0,
+                    interval=0.1,
+                )
+
+                settled = await poll_until_channel_pool_settles()
+
+            # Assert
+            assert collected == ["alive"]
+            assert sentinel.read_text() == "cleaned_up"
+            assert settled.total_entries == 0
+            assert _resourcepool_records(caplog) == []
+
+        await retry_grpc_internal(body)

--- a/wool/tests/integration/test_worker_shutdown.py
+++ b/wool/tests/integration/test_worker_shutdown.py
@@ -563,8 +563,8 @@ class _BrokenDropPublisher:
 
     Every other event, and the publisher's context-manager protocol,
     delegate to the wrapped publisher: `LocalDiscovery.Publisher` is an
-    async context manager, and hiding that would send
-    ``WorkerPool._enter_context`` down the passthrough path, leaving the
+    async context manager, and hiding that would send the pool's
+    dependency resolution down the passthrough path, leaving the
     real publisher neither entered nor exited and teardown's publisher
     cleanup a no-op. Passing `_HANG` hangs the announcement instead of
     raising it, modelling an unresponsive discovery service.

--- a/wool/tests/runtime/test_resourcepool.py
+++ b/wool/tests/runtime/test_resourcepool.py
@@ -462,6 +462,103 @@ class TestResourcePool:
             await ttl_pool.release(unique_key)
 
     @pytest.mark.asyncio
+    async def test_expire_should_await_finalizer_when_it_returns_an_awaitable(self):
+        """Test a finalizer's non-coroutine awaitable is awaited.
+
+        Given:
+            A pool whose synchronous finalizer returns an object that is
+            awaitable but not a coroutine.
+        When:
+            An idle entry is expired.
+        Then:
+            It should await that object as part of the finalization.
+        """
+        # Arrange
+        awaited = []
+
+        class Completion:
+            def __await__(self):
+                awaited.append(True)
+                yield from ()
+
+        pool = ResourcePool(
+            factory=lambda key: f"obj-{key}",
+            finalizer=lambda obj: Completion(),
+            ttl=60,
+        )
+        async with pool.get("key"):
+            pass
+
+        # Act
+        await pool.expire("key")
+
+        # Assert
+        assert awaited == [True]
+        assert pool.stats.total_entries == 0
+
+    @pytest.mark.asyncio
+    async def test_acquire_should_cache_an_awaitable_object_as_is(self):
+        """Test a factory's non-coroutine awaitable is the cached object.
+
+        Given:
+            A pool whose synchronous factory returns an object that is
+            awaitable but not a coroutine.
+        When:
+            A key is acquired.
+        Then:
+            It should hand back that object itself rather than await it.
+        """
+
+        # Arrange
+        class Handle:
+            def __await__(self):
+                raise AssertionError("the handle must not be awaited")
+                yield
+
+        handle = Handle()
+        pool = ResourcePool(factory=lambda key: handle, ttl=60)
+
+        # Act
+        async with pool.get("key") as resource:
+            # Assert
+            assert resource is handle
+
+    @pytest.mark.asyncio
+    async def test_expire_should_log_warning_when_finalizer_raises(self, caplog):
+        """Test a finalizer's contained failure is still reported.
+
+        Given:
+            A pool whose finalizer raises an Exception.
+        When:
+            An idle entry is expired.
+        Then:
+            It should evict the entry and log one warning naming the
+            pool's factory and the key.
+        """
+
+        # Arrange
+        def factory(key):
+            return f"obj-{key}"
+
+        async def finalizer(obj):
+            raise RuntimeError("close failed")
+
+        pool = ResourcePool(factory=factory, finalizer=finalizer, ttl=60)
+        async with pool.get("key"):
+            pass
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="wool.runtime.resourcepool"):
+            await pool.expire("key")
+
+        # Assert
+        records = [r for r in caplog.records if r.name == "wool.runtime.resourcepool"]
+        assert len(records) == 1
+        assert "factory" in records[0].getMessage()
+        assert "'key'" in records[0].getMessage()
+        assert pool.stats.total_entries == 0
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "ttl, retire_first",
         [(0, False), (60, True)],
@@ -602,7 +699,7 @@ class TestResourcePool:
         When:
             The pool is used from a second event loop.
         Then:
-            It should raise RuntimeError naming the other running loop
+            It should raise RuntimeError naming the pool by its factory
             rather than rebinding, so one pool never serves two live
             loops.
         """
@@ -617,7 +714,10 @@ class TestResourcePool:
             )
 
             # Act & assert
-            with pytest.raises(RuntimeError, match="another running event loop"):
+            with pytest.raises(
+                RuntimeError,
+                match=r"ResourcePool\(.*\) is bound to another running event loop",
+            ):
                 asyncio.run(pool.acquire("other"))
         finally:
             live_loop.call_soon_threadsafe(live_loop.stop)

--- a/wool/tests/runtime/test_resourcepool.py
+++ b/wool/tests/runtime/test_resourcepool.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import gc
 import logging
 import threading
@@ -10,6 +11,7 @@ from unittest.mock import AsyncMock
 from unittest.mock import Mock
 
 import pytest
+from hypothesis import HealthCheck
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies
@@ -787,8 +789,8 @@ class TestResourcePool:
         assert records[0].levelno == logging.WARNING
         assert "1 referenced" in records[0].getMessage()
 
-    def test_acquire_should_not_warn_when_dropping_idle_orphan(self, mocker, caplog):
-        """Test idle orphans are dropped silently.
+    def test_acquire_should_warn_when_dropping_idle_orphan(self, mocker, caplog):
+        """Test an idle orphan is reported as a leak too.
 
         Given:
             A pool whose bound loop closed with only idle entries cached
@@ -796,9 +798,10 @@ class TestResourcePool:
         When:
             The pool is used from a fresh event loop.
         Then:
-            It should drop the idle entries with a DEBUG record and no
-            WARNING from wool.runtime.resourcepool, since nothing was in
-            use when the loop stopped.
+            It should log one WARNING from wool.runtime.resourcepool
+            reporting the idle entry it dropped without finalizing,
+            since a drop abandons the resource where the TTL it was
+            waiting on would have closed it.
         """
         # Arrange
         pool = ResourcePool(factory=mocker.Mock(return_value="obj"), ttl=60)
@@ -812,12 +815,14 @@ class TestResourcePool:
         closed_loop.close()
 
         # Act
-        with caplog.at_level(logging.DEBUG, logger="wool.runtime.resourcepool"):
+        with caplog.at_level(logging.WARNING, logger="wool.runtime.resourcepool"):
             asyncio.run(pool.acquire("other"))
 
         # Assert
         records = [r for r in caplog.records if r.name == "wool.runtime.resourcepool"]
-        assert [r.levelno for r in records] == [logging.DEBUG]
+        assert len(records) == 1
+        assert records[0].levelno == logging.WARNING
+        assert "1 idle" in records[0].getMessage()
 
     def test_acquire_should_rebind_when_bound_loop_stopped_but_not_closed(self, mocker):
         """Test liveness is whether the bound loop runs, not whether it closed.
@@ -963,31 +968,38 @@ class TestResourcePool:
         assert pool.stats.total_entries == 2
 
     @pytest.mark.asyncio
-    async def test_expire_should_cancel_in_flight_cleanup_when_expired_after_ttl(
-        self, expiry_race_pool
+    @pytest.mark.parametrize(
+        "retire",
+        [
+            pytest.param(lambda pool: pool.expire("expired"), id="expire"),
+            pytest.param(lambda pool: pool.expire_all(), id="expire_all"),
+        ],
+    )
+    async def test_retirement_should_cancel_in_flight_cleanup_when_expired_after_ttl(
+        self, expiry_race_pool, retire
     ):
-        """Test expire cancels a fired cleanup racing on the pool lock.
+        """Test retirement cancels a fired cleanup racing on the pool lock.
 
         Given:
             A pool whose expired key's TTL timer has fired while the
-            pool lock is held by another key's acquire, so the
-            spawned cleanup task and a queued expiry of the expired
-            key both wait on the lock with the expiry first
+            pool lock is held by another key's acquire, so the spawned
+            cleanup task and a queued retirement of that key both wait
+            on the lock with the retirement first.
         When:
-            The lock holder completes and the queued expiry runs
+            The lock holder completes and the queued retirement runs.
         Then:
             It should cancel the in-flight cleanup, still run the
-            finalizer exactly once, and evict the entry
+            finalizer exactly once, and evict the entry.
         """
         # Arrange
         pool, finalizer, factory_calls, release_blocker = expiry_race_pool
-        blocker_task, clear_task = await _queue_behind_fired_cleanup(
-            pool, factory_calls, pool.expire("expired")
+        blocker_task, retire_task = await _queue_behind_fired_cleanup(
+            pool, factory_calls, retire(pool)
         )
 
         # Act
         release_blocker.set()
-        await clear_task
+        await retire_task
         await blocker_task
 
         # Assert
@@ -1140,32 +1152,41 @@ class TestResourcePool:
             assert "key2" in pool.pending_cleanup
 
     @pytest.mark.asyncio
-    async def test_expire_should_finalize_immediately_when_unreferenced(self):
-        """Test expiring an unreferenced entry skips its remaining TTL.
+    @pytest.mark.parametrize(
+        "retire",
+        [
+            pytest.param(lambda pool: pool.expire("idle"), id="expire"),
+            pytest.param(lambda pool: pool.expire_all(), id="expire_all"),
+        ],
+    )
+    async def test_retirement_should_finalize_only_the_idle_entry_when_one_is_held(
+        self, mocker, retire
+    ):
+        """Test an idle entry is finalized at once and a referenced one left alone.
 
         Given:
-            A long-TTL pool holding an unreferenced entry whose TTL timer is
-            pending.
+            A long-TTL pool holding one idle entry awaiting its TTL and
+            one still referenced.
         When:
-            expire() is called with that entry's key.
+            The idle key is expired, or expire_all() is awaited.
         Then:
-            It should run the finalizer immediately, remove the entry, and
-            leave no pending cleanup — no TTL wait.
+            It should finalize the idle entry immediately, skipping its
+            TTL, and leave the referenced one cached with no pending
+            cleanup.
         """
         # Arrange
-        mock_factory = Mock(return_value="resource")
-        mock_finalizer = AsyncMock()
-        pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
-        async with pool.get("key"):
-            pass  # Released: the TTL timer is now armed.
-        assert "key" in pool.pending_cleanup
+        mock_finalizer = mocker.AsyncMock()
+        pool = ResourcePool(factory=lambda key: key, finalizer=mock_finalizer, ttl=60)
+        async with pool.get("idle"):
+            pass
+        await pool.acquire("held")
 
         # Act
-        await pool.expire("key")
+        await retire(pool)
 
         # Assert
-        mock_finalizer.assert_awaited_once_with("resource")
-        assert pool.stats.total_entries == 0
+        mock_finalizer.assert_awaited_once_with("idle")
+        assert pool.stats.total_entries == 1
         assert not pool.pending_cleanup
 
     @pytest.mark.asyncio
@@ -1194,25 +1215,31 @@ class TestResourcePool:
         assert pool.stats.total_entries == 1
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "retire",
+        [
+            pytest.param(lambda pool: pool.expire("key"), id="expire"),
+            pytest.param(lambda pool: pool.expire_all(), id="expire_all"),
+        ],
+    )
     async def test_release_should_finalize_retired_entry_when_last_reference_released(
-        self, retired_entry_pool
+        self, retired_entry_pool, retire
     ):
-        """Test a retired entry is finalized as soon as its users drain.
+        """Test a retired entry is finalized by the release that drains it.
 
         Given:
-            A long-TTL pool holding an entry that has been retired by
-            ``expire`` while still referenced.
+            A long-TTL pool whose only entry is referenced and has been
+            retired.
         When:
             The last reference is released.
         Then:
-            It should have awaited the finalizer before the release
-            returns, without waiting out the TTL and without leaving
-            pending cleanup behind for the loop to drain.
+            It should finalize the entry then, ending with an empty pool
+            and no pending cleanup.
         """
         # Arrange
         pool, finalizer, _ = retired_entry_pool
         await pool.acquire("key")
-        await pool.expire("key")
+        await retire(pool)
 
         # Act
         await pool.release("key")
@@ -1350,59 +1377,603 @@ class TestResourcePool:
         ]
 
     @pytest.mark.asyncio
-    async def test_expire_should_resurrect_entry_when_reacquired(self):
-        """Test re-acquiring an expired entry cancels its doom.
+    @pytest.mark.parametrize(
+        "retire",
+        [
+            pytest.param(lambda pool: pool.expire("key"), id="expire"),
+            pytest.param(lambda pool: pool.expire_all(), id="expire_all"),
+        ],
+    )
+    async def test_acquire_should_clear_retirement_when_entry_reacquired(
+        self, mocker, retire
+    ):
+        """Test re-acquiring a retired entry clears its retirement.
 
         Given:
-            A long-TTL pool holding a referenced entry that has been
-            expired.
+            A long-TTL pool whose only entry is referenced and has been
+            retired.
         When:
-            The key is acquired again before the references drain and both
-            references are then released.
+            The same key is acquired again and both references are
+            released.
         Then:
-            It should keep the entry cached on the normal TTL schedule — the
-            re-acquire resurrects it — with the finalizer never called.
+            It should hand back the cached object without rebuilding it
+            and keep it cached under its normal TTL schedule, the
+            retirement cleared.
         """
         # Arrange
-        mock_factory = Mock(return_value="resource")
-        mock_finalizer = AsyncMock()
+        mock_factory = mocker.Mock(return_value="resource")
+        mock_finalizer = mocker.AsyncMock()
         pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
-        async with pool:
-            await pool.acquire("key")
-            await pool.expire("key")
-
-            # Act
-            await pool.acquire("key")  # Resurrection: clears the mark.
-            await pool.release("key")
-            await pool.release("key")
-
-            # Assert
-            mock_finalizer.assert_not_awaited()
-            assert pool.stats.total_entries == 1
-            assert "key" in pool.pending_cleanup  # Normal TTL schedule.
-
-    @pytest.mark.asyncio
-    async def test_expire_should_not_raise_when_key_unknown(self):
-        """Test expiring an uncached key is a silent no-op.
-
-        Given:
-            A pool that has never cached the given key.
-        When:
-            expire() is called with that key.
-        Then:
-            It should neither raise nor invoke the finalizer.
-        """
-        # Arrange
-        mock_factory = Mock(return_value="resource")
-        mock_finalizer = AsyncMock()
-        pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
+        await pool.acquire("key")
+        await retire(pool)
 
         # Act
-        await pool.expire("missing")
+        acquired = await pool.acquire("key")
+        await pool.release("key")
+        await pool.release("key")
+
+        # Assert
+        assert acquired == "resource"
+        assert mock_factory.call_count == 1
+        mock_finalizer.assert_not_awaited()
+        assert pool.stats.total_entries == 1
+        assert "key" in pool.pending_cleanup
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "retire",
+        [
+            pytest.param(lambda pool: pool.expire("missing"), id="expire"),
+            pytest.param(lambda pool: pool.expire_all(), id="expire_all"),
+        ],
+    )
+    async def test_retirement_should_not_raise_when_nothing_cached(self, mocker, retire):
+        """Test retiring what is not cached is a no-op.
+
+        Given:
+            A pool that has never cached anything.
+        When:
+            expire() is awaited for an unknown key, or expire_all() on
+            the empty pool.
+        Then:
+            It should return without raising, invoke no finalizer, and
+            leave the pool empty with no pending cleanup.
+        """
+        # Arrange
+        mock_finalizer = mocker.AsyncMock()
+        pool = ResourcePool(
+            factory=mocker.Mock(return_value="resource"),
+            finalizer=mock_finalizer,
+            ttl=60,
+        )
+
+        # Act
+        await retire(pool)
 
         # Assert
         mock_finalizer.assert_not_awaited()
         assert pool.stats.total_entries == 0
+        assert not pool.pending_cleanup
+
+    @pytest.mark.asyncio
+    async def test_expire_all_should_finalize_retired_entry_when_release_is_late(
+        self, mocker
+    ):
+        """Test a late release finalizes the entry it was taken against.
+
+        Given:
+            A pool whose only entry is referenced and has been retired
+            by expire_all().
+        When:
+            The outstanding reference is released and the same key is
+            acquired again afterwards.
+        Then:
+            It should finalize the retired object exactly once on that
+            release and build a fresh object for the new acquire, so a
+            release landing after retirement can never finalize a
+            resource handed out since.
+        """
+        # Arrange
+        mock_factory = mocker.Mock(side_effect=["first", "second"])
+        mock_finalizer = mocker.AsyncMock()
+        pool = ResourcePool(factory=mock_factory, finalizer=mock_finalizer, ttl=60)
+        await pool.acquire("key")
+        await pool.expire_all()
+
+        # Act
+        await pool.release("key")
+        reacquired = await pool.acquire("key")
+
+        # Assert
+        mock_finalizer.assert_awaited_once_with("first")
+        assert mock_factory.call_count == 2
+        assert reacquired == "second"
+        assert pool.stats.referenced_entries == 1
+
+    @pytest.mark.asyncio
+    @given(reference_counts=strategies.lists(strategies.integers(0, 3), max_size=5))
+    @settings(max_examples=25, deadline=None)
+    async def test_expire_all_should_finalize_every_entry_exactly_once(
+        self, reference_counts
+    ):
+        """Test retirement drains a whole pool without double finalizing.
+
+        Given:
+            Any pool of up to five distinct keys whose entries carry
+            reference counts between zero and three.
+        When:
+            expire_all() is awaited and every outstanding reference is
+            then released.
+        Then:
+            It should finalize each cached object exactly once and end
+            with an empty pool holding no pending cleanup.
+        """
+        # Arrange
+        finalized = []
+
+        async def finalizer(obj):
+            finalized.append(obj)
+
+        pool = ResourcePool(
+            factory=lambda key: f"obj-{key}", finalizer=finalizer, ttl=60
+        )
+        keys = [f"key-{index}" for index in range(len(reference_counts))]
+        for key, count in zip(keys, reference_counts):
+            # One seeding reference caches the entry; the extra
+            # acquires and the single release leave `count` behind.
+            await pool.acquire(key)
+            for _ in range(count):
+                await pool.acquire(key)
+            await pool.release(key)
+
+        # Act
+        await pool.expire_all()
+        for key, count in zip(keys, reference_counts):
+            for _ in range(count):
+                await pool.release(key)
+
+        # Assert
+        assert sorted(finalized) == sorted(f"obj-{key}" for key in keys)
+        assert pool.stats.total_entries == 0
+        assert not pool.pending_cleanup
+
+    @pytest.mark.asyncio
+    async def test_expire_all_should_finalize_idle_entry_when_ttl_zero(self, mocker):
+        """Test retirement holds for a pool with no idle grace at all.
+
+        Given:
+            A pool with no TTL holding one idle entry and one still
+            referenced.
+        When:
+            expire_all() is awaited and the outstanding reference is
+            then released.
+        Then:
+            It should finalize both without ever scheduling pending
+            cleanup, since a zero TTL leaves nothing to defer to.
+        """
+        # Arrange
+        mock_finalizer = mocker.AsyncMock()
+        pool = ResourcePool(factory=lambda key: key, finalizer=mock_finalizer, ttl=0)
+        async with pool.get("idle"):
+            pass
+        await pool.acquire("held")
+
+        # Act
+        await pool.expire_all()
+        await pool.release("held")
+
+        # Assert
+        assert sorted(c.args[0] for c in mock_finalizer.await_args_list) == [
+            "held",
+            "idle",
+        ]
+        assert pool.stats.total_entries == 0
+        assert not pool.pending_cleanup
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("failures", "expected", "cause", "discarded"),
+        [
+            pytest.param(
+                {"obj-b": RuntimeError("teardown failed")},
+                None,
+                None,
+                0,
+                id="exception-contained",
+            ),
+            pytest.param(
+                {"obj-a": asyncio.CancelledError()},
+                "obj-a",
+                None,
+                0,
+                id="expire_all-cancelled",
+            ),
+            pytest.param(
+                {"obj-a": asyncio.CancelledError(), "obj-b": asyncio.CancelledError()},
+                "obj-a",
+                None,
+                1,
+                id="first-cancellation-wins",
+            ),
+            pytest.param(
+                {"obj-a": asyncio.CancelledError(), "obj-b": KeyboardInterrupt()},
+                "obj-b",
+                "obj-a",
+                0,
+                id="signal-outranks-cancellation",
+            ),
+            pytest.param(
+                {"obj-a": SystemExit(), "obj-b": KeyboardInterrupt()},
+                "obj-a",
+                None,
+                1,
+                id="two-signals",
+            ),
+        ],
+    )
+    async def test_expire_all_should_finish_sweep_when_finalizer_fails(
+        self, failures, expected, cause, discarded, caplog
+    ):
+        """Test a failing finalizer does not spare the entries after it.
+
+        Given:
+            A long-TTL pool of three idle entries whose finalizer raises
+            the given failures: a contained Exception, a cancellation,
+            two distinct cancellations, a cancellation followed by a
+            process-level signal, or two signals.
+        When:
+            expire_all() is awaited.
+        Then:
+            It should attempt every finalizer, leave the pool empty with
+            no pending cleanup, and propagate the expected failure
+            afterwards: nothing for a contained Exception, the first
+            cancellation otherwise, unless a signal arrived later, which
+            chains the cancellation it superseded as its cause; a failure
+            it neither re-raises nor chains is logged at warning level.
+        """
+        # Arrange
+        attempted = []
+
+        async def finalizer(obj):
+            attempted.append(obj)
+            if obj in failures:
+                raise failures[obj]
+
+        pool = ResourcePool(
+            factory=lambda key: f"obj-{key}", finalizer=finalizer, ttl=60
+        )
+        for key in ("a", "b", "c"):
+            async with pool.get(key):
+                pass
+        expectation = (
+            pytest.raises(type(failures[expected]))
+            if expected is not None
+            else contextlib.nullcontext()
+        )
+
+        # Act
+        with (
+            caplog.at_level(logging.WARNING, logger="wool.runtime.resourcepool"),
+            expectation as raised,
+        ):
+            await pool.expire_all()
+
+        # Assert
+        if expected is not None:
+            assert raised is not None and raised.value is failures[expected]
+            assert raised.value.__cause__ is (failures[cause] if cause else None)
+        assert attempted == ["obj-a", "obj-b", "obj-c"]
+        assert pool.stats.total_entries == 0
+        assert not pool.pending_cleanup
+        assert (
+            sum("discarding" in record.getMessage() for record in caplog.records)
+            == discarded
+        )
+
+    @pytest.mark.asyncio
+    async def test_clear_should_finish_sweep_when_finalizer_cancelled(self, caplog):
+        """Test a cancelled finalizer does not spare the entries after it under clear.
+
+        Given:
+            A long-TTL pool of three idle entries whose first finalizer
+            raises a cancellation.
+        When:
+            clear() is awaited.
+        Then:
+            It should attempt every finalizer, leave the pool empty with
+            no pending cleanup, and re-raise the cancellation afterwards
+            without discarding anything.
+        """
+        # Arrange
+        attempted = []
+
+        async def finalizer(obj):
+            attempted.append(obj)
+            if obj == "obj-a":
+                raise asyncio.CancelledError()
+
+        pool = ResourcePool(
+            factory=lambda key: f"obj-{key}", finalizer=finalizer, ttl=60
+        )
+        for key in ("a", "b", "c"):
+            async with pool.get(key):
+                pass
+
+        # Act
+        with (
+            caplog.at_level(logging.WARNING, logger="wool.runtime.resourcepool"),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await pool.clear()
+
+        # Assert
+        assert attempted == ["obj-a", "obj-b", "obj-c"]
+        assert pool.stats.total_entries == 0
+        assert not pool.pending_cleanup
+        assert not [r for r in caplog.records if "discarding" in r.getMessage()]
+
+    @pytest.mark.asyncio
+    @given(
+        outcomes=strategies.lists(
+            strategies.sampled_from(["clean", "error", "cancel", "interrupt", "exit"]),
+            min_size=1,
+            max_size=5,
+        )
+    )
+    @settings(
+        max_examples=50,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    async def test_expire_all_should_rank_failures_for_any_sequence_of_outcomes(
+        self, outcomes, caplog
+    ):
+        """Test the sweep's failure ranking holds for any run of finalizer outcomes.
+
+        Given:
+            A long-TTL pool of one to five idle entries whose finalizers
+            each finish cleanly, raise a contained Exception, raise a
+            cancellation, raise KeyboardInterrupt, or raise SystemExit,
+            in any order.
+        When:
+            expire_all() is awaited.
+        Then:
+            It should attempt every finalizer in cache order, leave the
+            pool empty with no pending cleanup, raise the first
+            uncontained failure unless a later process-level signal
+            superseded it, chaining the superseded failure as its cause,
+            log every other uncontained failure as discarded, and leave
+            the task's cancellation count at zero.
+        """
+        # Arrange
+        raised = {
+            "error": RuntimeError,
+            "cancel": asyncio.CancelledError,
+            "interrupt": KeyboardInterrupt,
+            "exit": SystemExit,
+        }
+        keys = [f"k{index}" for index in range(len(outcomes))]
+        failures = {
+            key: raised[outcome]()
+            for key, outcome in zip(keys, outcomes)
+            if outcome != "clean"
+        }
+        attempted = []
+
+        async def finalizer(obj):
+            attempted.append(obj)
+            if obj in failures:
+                raise failures[obj]
+
+        pool = ResourcePool(factory=lambda key: key, finalizer=finalizer, ttl=60)
+        for key in keys:
+            async with pool.get(key):
+                pass
+        # The expectation, walked the way the ranking is documented: a
+        # contained Exception never reaches the sweep, the first failure
+        # latches, a later signal supersedes a latched cancellation, and
+        # anything else is discarded.
+        expected = cause = None
+        discarded = 0
+        for key, outcome in zip(keys, outcomes):
+            if outcome in ("clean", "error"):
+                continue
+            if expected is None:
+                expected = (key, outcome)
+            elif outcome in ("interrupt", "exit") and expected[1] == "cancel":
+                expected, cause = (key, outcome), expected
+            else:
+                discarded += 1
+        expectation = (
+            pytest.raises(type(failures[expected[0]]))
+            if expected is not None
+            else contextlib.nullcontext()
+        )
+        caplog.clear()
+
+        # Act
+        with (
+            caplog.at_level(logging.WARNING, logger="wool.runtime.resourcepool"),
+            expectation as raised_failure,
+        ):
+            await pool.expire_all()
+
+        # Assert
+        assert attempted == keys
+        assert pool.stats.total_entries == 0
+        assert not pool.pending_cleanup
+        if expected is not None:
+            assert raised_failure is not None
+            assert raised_failure.value is failures[expected[0]]
+            assert raised_failure.value.__cause__ is (
+                failures[cause[0]] if cause is not None else None
+            )
+        assert (
+            sum(
+                "discarding" in record.getMessage()
+                for record in caplog.records
+                if record.name == "wool.runtime.resourcepool"
+            )
+            == discarded
+        )
+        task = asyncio.current_task()
+        assert task is not None
+        assert task.cancelling() == 0
+
+    @pytest.mark.asyncio
+    async def test_expire_all_should_uncancel_when_a_signal_supersedes_a_cancellation(
+        self,
+    ):
+        """Test an absorbed cancellation is uncancelled when a signal wins.
+
+        Given:
+            A long-TTL pool of two idle entries whose first finalizer
+            parks until the sweeping task is cancelled and whose second
+            raises KeyboardInterrupt.
+        When:
+            expire_all() runs in a task that is cancelled while parked.
+        Then:
+            It should raise the KeyboardInterrupt with the cancellation
+            chained as its cause and leave the task's cancellation count
+            at zero, since the cancellation it absorbed is not the
+            failure it re-raised.
+        """
+        # Arrange
+        parked = asyncio.Event()
+
+        async def finalizer(obj):
+            if obj == "obj-a":
+                parked.set()
+                await asyncio.Event().wait()
+            raise KeyboardInterrupt()
+
+        pool = ResourcePool(
+            factory=lambda key: f"obj-{key}", finalizer=finalizer, ttl=60
+        )
+        for key in ("a", "b"):
+            async with pool.get(key):
+                pass
+
+        async def sweep():
+            # Caught here: a KeyboardInterrupt escaping a task ends the loop.
+            try:
+                await pool.expire_all()
+            except KeyboardInterrupt as error:
+                task = asyncio.current_task()
+                assert task is not None
+                return error, task.cancelling()
+
+        sweeping = asyncio.ensure_future(sweep())
+        await asyncio.wait_for(parked.wait(), timeout=2.0)
+
+        # Act
+        sweeping.cancel()
+        outcome = await sweeping
+
+        # Assert
+        assert outcome is not None
+        error, cancelling = outcome
+        assert isinstance(error.__cause__, asyncio.CancelledError)
+        assert cancelling == 0
+        assert pool.stats.total_entries == 0
+
+    @pytest.mark.asyncio
+    async def test_expire_all_should_preserve_cancellation_count_when_it_reraises(
+        self,
+    ):
+        """Test a re-raised cancellation leaves the task's cancellation count alone.
+
+        Given:
+            A long-TTL pool of two idle entries whose first finalizer
+            parks until the sweeping task is cancelled and whose second
+            finalizes cleanly.
+        When:
+            expire_all() runs in a task that is cancelled while parked.
+        Then:
+            It should finish the sweep, re-raise the cancellation, and
+            leave the task's cancellation count at one, since the
+            cancellation it re-raises is the one it absorbed.
+        """
+        # Arrange
+        parked = asyncio.Event()
+        counts = []
+
+        async def finalizer(obj):
+            if obj == "obj-a":
+                parked.set()
+                await asyncio.Event().wait()
+
+        pool = ResourcePool(
+            factory=lambda key: f"obj-{key}", finalizer=finalizer, ttl=60
+        )
+        for key in ("a", "b"):
+            async with pool.get(key):
+                pass
+
+        async def sweep():
+            try:
+                await pool.expire_all()
+            except asyncio.CancelledError:
+                task = asyncio.current_task()
+                assert task is not None
+                counts.append(task.cancelling())
+                raise
+
+        sweeping = asyncio.ensure_future(sweep())
+        await asyncio.wait_for(parked.wait(), timeout=2.0)
+
+        # Act
+        sweeping.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await sweeping
+
+        # Assert
+        assert counts == [1]
+        assert pool.stats.total_entries == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "retire",
+        [
+            pytest.param(lambda pool: pool.expire("key"), id="expire"),
+            pytest.param(lambda pool: pool.expire_all(), id="expire_all"),
+        ],
+    )
+    async def test_release_should_finalize_before_returning_when_entry_retired(
+        self, mocker, retire
+    ):
+        """Test the release of a retired entry finalizes it inline.
+
+        Given:
+            A long-TTL pool holding a referenced entry retired by either
+            expire() for its key or expire_all() for the whole pool.
+        When:
+            The last reference is released.
+        Then:
+            It should have awaited the finalizer and emptied the pool by
+            the time release returns, spawning no task to do it later — a
+            task would be orphaned by a loop that stops straight after
+            the release.
+        """
+        # Arrange
+        mock_finalizer = mocker.AsyncMock()
+        pool = ResourcePool(
+            factory=mocker.Mock(return_value="resource"),
+            finalizer=mock_finalizer,
+            ttl=60,
+        )
+        await pool.acquire("key")
+        await retire(pool)
+        tasks_before = asyncio.all_tasks()
+
+        # Act
+        await pool.release("key")
+
+        # Assert
+        mock_finalizer.assert_awaited_once_with("resource")
+        assert pool.stats.total_entries == 0
+        assert not pool.pending_cleanup
+        assert asyncio.all_tasks() == tasks_before
 
     @pytest.mark.asyncio
     async def test_ttl_cleanup_should_schedule_resource_removal(self):

--- a/wool/tests/runtime/test_resourcepool.py
+++ b/wool/tests/runtime/test_resourcepool.py
@@ -561,6 +561,56 @@ class TestResourcePool:
         assert pool.stats.total_entries == 0
 
     @pytest.mark.asyncio
+    async def test_ttl_cleanup_should_log_warning_when_spawned_cleanup_fails(
+        self, caplog
+    ):
+        """Test a failure inside a spawned cleanup task is reported.
+
+        Given:
+            A short-TTL pool whose finalizer raises a BaseException that
+            is neither a cancellation nor a process-level interrupt, so
+            the spawned cleanup ends with it and no caller receives it.
+        When:
+            An entry's TTL elapses and its cleanup task runs.
+        Then:
+            It should evict the entry and log one warning naming the
+            pool's factory and the key, rather than leave the failure
+            unretrieved.
+        """
+
+        # Arrange
+        class Interrupt(BaseException):
+            pass
+
+        def factory(key):
+            return f"obj-{key}"
+
+        async def finalizer(obj):
+            raise Interrupt()
+
+        pool = ResourcePool(factory=factory, finalizer=finalizer, ttl=0.01)
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="wool.runtime.resourcepool"):
+            async with pool.get("key"):
+                pass
+            # The report lands one tick after the eviction, so poll for
+            # the record rather than the empty pool.
+            deadline = time.monotonic() + 2.0
+            while (
+                not any(r.name == "wool.runtime.resourcepool" for r in caplog.records)
+                and time.monotonic() < deadline
+            ):
+                await asyncio.sleep(0.01)
+
+        # Assert
+        records = [r for r in caplog.records if r.name == "wool.runtime.resourcepool"]
+        assert len(records) == 1
+        assert "factory" in records[0].getMessage()
+        assert "'key'" in records[0].getMessage()
+        assert pool.stats.total_entries == 0
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "ttl, retire_first",
         [(0, False), (60, True)],
@@ -968,6 +1018,53 @@ class TestResourcePool:
         assert pool.stats.total_entries == 2
 
     @pytest.mark.asyncio
+    async def test_get_should_not_mark_acquired_when_the_acquire_is_cancelled(self):
+        """Test a cancelled entry leaves the resource enterable again.
+
+        Given:
+            A pool whose factory parks until released, and a Resource
+            for a key it has never cached.
+        When:
+            A task entering the Resource is cancelled while the factory
+            is parked, and the Resource is entered again once the
+            factory is released.
+        Then:
+            It should leave the pool with nothing cached or referenced
+            after the cancellation, and hand back the object on the
+            second entry rather than refuse a re-acquire.
+        """
+        # Arrange
+        parked = asyncio.Event()
+        gate = asyncio.Event()
+
+        async def factory(key):
+            parked.set()
+            await gate.wait()
+            return f"obj-{key}"
+
+        pool = ResourcePool(factory=factory, ttl=60)
+        resource = pool.get("key")
+
+        async def enter():
+            async with resource:
+                pass
+
+        entering = asyncio.ensure_future(enter())
+        await asyncio.wait_for(parked.wait(), timeout=2.0)
+
+        # Act
+        entering.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await entering
+        gate.set()
+
+        # Assert
+        assert pool.stats.total_entries == 0
+        assert pool.stats.referenced_entries == 0
+        async with resource as obj:
+            assert obj == "obj-key"
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "retire",
         [
@@ -1319,6 +1416,65 @@ class TestResourcePool:
 
         assert pool.stats.total_entries == 0
         assert await pool.acquire("key") == "second"
+
+    @pytest.mark.asyncio
+    async def test_release_should_drop_reference_when_cancelled_waiting_on_the_lock(
+        self,
+    ):
+        """Test a release cancelled while contending the lock still releases.
+
+        Given:
+            A pool of two entries whose sweep is parked inside the idle
+            first entry's finalizer, holding the lock, while the second
+            is still referenced.
+        When:
+            A release of the second entry, parked behind that lock, is
+            cancelled, and the sweep then completes.
+        Then:
+            It should raise CancelledError to the releasing task yet still
+            drop the reference, so the retired second entry is finalized
+            rather than held forever.
+        """
+        # Arrange
+        parked = asyncio.Event()
+        gate = asyncio.Event()
+        done = asyncio.Event()
+        finalized = []
+
+        async def finalizer(obj):
+            finalized.append(obj)
+            if obj == "obj-a":
+                parked.set()
+                await gate.wait()
+            else:
+                done.set()
+
+        pool = ResourcePool(
+            factory=lambda key: f"obj-{key}", finalizer=finalizer, ttl=60
+        )
+        await pool.acquire("a")
+        await pool.acquire("b")
+        await pool.release("a")
+        sweep = asyncio.ensure_future(pool.expire_all())
+        await asyncio.wait_for(parked.wait(), timeout=2.0)
+        release = asyncio.ensure_future(pool.release("b"))
+        # The lock is held by the parked finalizer for the whole window,
+        # so any number of ticks past the shield's entry leaves the
+        # release waiting on it.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        # Act
+        release.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await release
+        gate.set()
+        await sweep
+
+        # Assert
+        await asyncio.wait_for(done.wait(), timeout=2.0)
+        assert finalized == ["obj-a", "obj-b"]
+        assert pool.stats.total_entries == 0
 
     def test_release_should_finalize_retired_entry_when_loop_ends_immediately(
         self, mocker, caplog
@@ -1929,6 +2085,51 @@ class TestResourcePool:
 
         # Assert
         assert counts == [1]
+        assert pool.stats.total_entries == 0
+
+    @pytest.mark.asyncio
+    async def test_acquire_should_leave_entry_unreferenced_when_cancelled_mid_cleanup(
+        self, expiry_race_pool
+    ):
+        """Test a cancelled acquire neither leaks a reference nor orphans the entry.
+
+        Given:
+            A pool whose expired key's TTL timer has fired while the
+            pool lock is held by another key's acquire, so the spawned
+            cleanup task and a queued acquire of that key both wait on
+            the lock with the acquire first.
+        When:
+            The lock holder completes and the acquire is cancelled while
+            it waits for the cleanup task it has just cancelled.
+        Then:
+            It should raise CancelledError, leave the entry cached and
+            unreferenced with its TTL re-armed, and finalize it once
+            that TTL elapses.
+        """
+        # Arrange
+        pool, finalizer, factory_calls, release_blocker = expiry_race_pool
+        blocker_task, acquire_task = await _queue_behind_fired_cleanup(
+            pool, factory_calls, pool.acquire("expired")
+        )
+
+        # Act
+        release_blocker.set()
+        while "expired" in pool.pending_cleanup:
+            await asyncio.sleep(0)
+        acquire_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await acquire_task
+        await blocker_task
+        rearmed = isinstance(pool.pending_cleanup.get("expired"), asyncio.TimerHandle)
+        await pool.release("blocker")
+        referenced = pool.stats.referenced_entries
+        await asyncio.sleep(0.1)
+
+        # Assert
+        assert rearmed
+        assert referenced == 0
+        assert finalizer.await_count == 2
+        finalizer.assert_any_await("obj-expired")
         assert pool.stats.total_entries == 0
 
     @pytest.mark.asyncio
@@ -2549,3 +2750,42 @@ class TestResource:
             match="Cannot release a resource that has already been released",
         ):
             await resource.__aexit__(None, None, None)
+
+    @pytest.mark.asyncio
+    @given(
+        resource=strategies.sampled_from(
+            [None, 0, 0.0, False, "", b"", (), [], {}, set()]
+        )
+    )
+    @settings(max_examples=10, deadline=None)
+    async def test___aexit___should_release_when_resource_is_falsy(self, resource):
+        """Test a falsy resource is still released on context exit.
+
+        Given:
+            A zero-TTL pool whose factory yields a falsy object (e.g.,
+            None, zero, False, or an empty string, bytes, tuple, list,
+            dict, or set).
+        When:
+            The Resource is used as an async context manager and exits.
+        Then:
+            It should drop the reference and finalize the entry, so the
+            release follows the acquisition rather than the value.
+        """
+        # Arrange
+        finalized = []
+        pool = ResourcePool(
+            factory=lambda key: resource,
+            finalizer=lambda obj: finalized.append(obj),
+            ttl=0,
+        )
+
+        # Act
+        async with pool.get("key") as acquired:
+            referenced = pool.stats.referenced_entries
+
+        # Assert
+        assert acquired is resource
+        assert referenced == 1
+        assert pool.stats.total_entries == 0
+        assert len(finalized) == 1
+        assert finalized[0] is resource

--- a/wool/tests/runtime/test_typing.py
+++ b/wool/tests/runtime/test_typing.py
@@ -1,0 +1,372 @@
+import pytest
+
+from wool.runtime.typing import resolved
+
+
+class _Recording:
+    """Record how a context manager is entered and exited."""
+
+    def __init__(self, obj="obj", *, suppress=False, error=None):
+        self.obj = obj
+        self.suppress = suppress
+        self.error = error
+        self.events = []
+        self.exits = []
+
+    def _enter(self):
+        self.events.append("enter")
+        return self.obj
+
+    def _exit(self, args):
+        self.events.append("exit")
+        self.exits.append(args)
+        if self.error is not None:
+            raise self.error
+        return self.suppress
+
+
+class _RecordingManager(_Recording):
+    """A sync context manager that records its exits."""
+
+    def __enter__(self):
+        return self._enter()
+
+    def __exit__(self, *args):
+        return self._exit(args)
+
+
+class _AsyncRecordingManager(_Recording):
+    """An async context manager that records its exits."""
+
+    async def __aenter__(self):
+        return self._enter()
+
+    async def __aexit__(self, *args):
+        return self._exit(args)
+
+
+_MANAGERS = [
+    pytest.param(_RecordingManager, id="sync"),
+    pytest.param(_AsyncRecordingManager, id="async"),
+]
+
+
+@pytest.mark.asyncio
+async def test_resolved_should_yield_object_when_dependency_is_plain():
+    """Test a bare instance is yielded as is.
+
+    Given:
+        A plain object that is neither awaitable, callable, nor a
+        context manager.
+    When:
+        It is resolved.
+    Then:
+        It should yield that same object.
+    """
+    # Arrange
+    dependency = object()
+
+    # Act
+    async with resolved(dependency) as obj:
+        # Assert
+        assert obj is dependency
+
+
+@pytest.mark.asyncio
+async def test_resolved_should_await_dependency_when_awaitable():
+    """Test an awaitable is awaited and its result yielded.
+
+    Given:
+        A coroutine that resolves to a sentinel object.
+    When:
+        It is resolved.
+    Then:
+        It should yield the coroutine's result.
+    """
+    # Arrange
+    sentinel = object()
+
+    async def dependency():
+        return sentinel
+
+    # Act
+    async with resolved(dependency()) as obj:
+        # Assert
+        assert obj is sentinel
+
+
+@pytest.mark.asyncio
+async def test_resolved_should_recurse_when_dependency_is_callable():
+    """Test a callable factory is called and its product resolved.
+
+    Given:
+        A zero-argument callable returning an async context manager.
+    When:
+        It is resolved.
+    Then:
+        It should yield what the manager yields and exit it afterwards.
+    """
+    # Arrange
+    manager = _AsyncRecordingManager()
+
+    # Act
+    async with resolved(lambda: manager) as obj:
+        assert obj == "obj"
+
+    # Assert
+    assert manager.events == ["enter", "exit"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_type", _MANAGERS)
+async def test_resolved_should_exit_manager_with_exception_when_block_raises(
+    manager_type,
+):
+    """Test a context manager receives the block's exception on exit.
+
+    Given:
+        A sync or async context manager recording the exception info
+        its exit receives.
+    When:
+        The resolved block raises.
+    Then:
+        It should exit the manager with that exception and re-raise it.
+    """
+    # Arrange
+    manager = manager_type()
+    error = ValueError("boom")
+
+    # Act
+    with pytest.raises(ValueError):
+        async with resolved(manager):
+            raise error
+
+    # Assert
+    assert len(manager.exits) == 1
+    assert manager.exits[0][0] is ValueError
+    assert manager.exits[0][1] is error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("manager_type", _MANAGERS)
+async def test_resolved_should_exit_manager_with_none_when_block_completes(
+    manager_type,
+):
+    """Test a context manager exits cleanly after a normal block.
+
+    Given:
+        A sync or async context manager recording its exit arguments.
+    When:
+        The resolved block completes without raising.
+    Then:
+        It should exit the manager with no exception info.
+    """
+    # Arrange
+    manager = manager_type()
+
+    # Act
+    async with resolved(manager):
+        pass
+
+    # Assert
+    assert manager.exits == [(None, None, None)]
+
+
+@pytest.mark.asyncio
+async def test_resolved_should_reraise_when_manager_suppresses_exception():
+    """Test a suppressing manager cannot swallow the block's failure.
+
+    Given:
+        An async context manager whose exit returns True.
+    When:
+        The resolved block raises.
+    Then:
+        It should still propagate the exception, ignoring the
+        manager's verdict.
+    """
+    # Arrange
+    manager = _AsyncRecordingManager(suppress=True)
+
+    # Act & assert
+    with pytest.raises(ValueError, match="boom"):
+        async with resolved(manager):
+            raise ValueError("boom")
+
+
+@pytest.mark.asyncio
+async def test_resolved_should_propagate_error_when_manager_exit_raises():
+    """Test an error raised by the manager's own exit propagates.
+
+    Given:
+        A sync context manager whose exit raises.
+    When:
+        The resolved block completes normally.
+    Then:
+        It should propagate the exit's error.
+    """
+    # Arrange
+    manager = _RecordingManager(error=RuntimeError("exit failed"))
+
+    # Act & assert
+    with pytest.raises(RuntimeError, match="exit failed"):
+        async with resolved(manager):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_resolved_should_enter_manager_when_dependency_is_also_callable():
+    """Test the context-manager form wins over the callable form.
+
+    Given:
+        An object that is both a sync context manager and callable.
+    When:
+        It is resolved.
+    Then:
+        It should enter the manager for the block and never call the
+        object.
+    """
+
+    # Arrange
+    class Both(_RecordingManager):
+        def __call__(self):
+            self.events.append("call")
+            return "called"
+
+    manager = Both()
+
+    # Act
+    async with resolved(manager) as obj:
+        assert obj == "obj"
+
+    # Assert
+    assert manager.events == ["enter", "exit"]
+
+
+@pytest.mark.asyncio
+async def test_resolved_should_prefer_sync_protocol_when_manager_is_both():
+    """Test a manager implementing both protocols is entered synchronously.
+
+    Given:
+        An object that is both a sync and an async context manager.
+    When:
+        It is resolved.
+    Then:
+        It should enter and exit the sync protocol and never touch the
+        async one.
+    """
+
+    # Arrange
+    class Both(_RecordingManager):
+        async def __aenter__(self):
+            self.events.append("aenter")
+            return self.obj
+
+        async def __aexit__(self, *args):
+            self.events.append("aexit")
+
+    manager = Both()
+
+    # Act
+    async with resolved(manager) as obj:
+        assert obj == "obj"
+
+    # Assert
+    assert manager.events == ["enter", "exit"]
+
+
+@pytest.mark.asyncio
+async def test_resolved_should_yield_object_when_expect_satisfied():
+    """Test a resolved object of the expected type is yielded.
+
+    Given:
+        An async context manager yielding a string, resolved with
+        ``expect=str``.
+    When:
+        It is resolved.
+    Then:
+        It should yield the string and exit the manager cleanly.
+    """
+    # Arrange
+    manager = _AsyncRecordingManager()
+
+    # Act
+    async with resolved(manager, expect=str) as obj:
+        assert obj == "obj"
+
+    # Assert
+    assert manager.exits == [(None, None, None)]
+
+
+@pytest.mark.asyncio
+async def test_resolved_should_raise_type_error_when_expect_not_satisfied():
+    """Test a resolved object of the wrong type fails after entry.
+
+    Given:
+        An async context manager yielding a string, resolved with
+        ``expect=int``.
+    When:
+        It is resolved.
+    Then:
+        It should raise TypeError naming the expected type and exit the
+        manager with that failure.
+    """
+    # Arrange
+    manager = _AsyncRecordingManager()
+
+    # Act
+    with pytest.raises(TypeError, match="Expected int"):
+        async with resolved(manager, expect=int):
+            pass
+
+    # Assert
+    assert manager.events == ["enter", "exit"]
+    assert manager.exits[0][0] is TypeError
+
+
+@pytest.mark.asyncio
+async def test_resolved_should_name_every_type_when_expect_is_a_tuple():
+    """Test a wrong-typed object fails against every type of a tuple ``expect``.
+
+    Given:
+        An async context manager yielding a string, resolved with
+        ``expect=(int, float)``.
+    When:
+        It is resolved.
+    Then:
+        It should raise TypeError naming both expected types and exit
+        the manager with that failure.
+    """
+    # Arrange
+    manager = _AsyncRecordingManager()
+
+    # Act
+    with pytest.raises(TypeError, match=r"Expected int \| float"):
+        async with resolved(manager, expect=(int, float)):
+            pass
+
+    # Assert
+    assert manager.events == ["enter", "exit"]
+    assert manager.exits[0][0] is TypeError
+
+
+@pytest.mark.asyncio
+async def test_resolved_should_yield_object_when_expect_tuple_satisfied():
+    """Test a resolved object matching one type of a tuple ``expect`` is yielded.
+
+    Given:
+        An async context manager yielding a string, resolved with
+        ``expect=(str, bytes)``.
+    When:
+        It is resolved.
+    Then:
+        It should yield the string and exit the manager cleanly.
+    """
+    # Arrange
+    manager = _AsyncRecordingManager()
+
+    # Act
+    async with resolved(manager, expect=(str, bytes)) as obj:
+        assert obj == "obj"
+
+    # Assert
+    assert manager.exits == [(None, None, None)]

--- a/wool/tests/runtime/worker/conftest.py
+++ b/wool/tests/runtime/worker/conftest.py
@@ -6,8 +6,12 @@ import time
 import uuid
 from types import MappingProxyType
 from typing import Any
+from typing import Callable
+from typing import Coroutine
 from unittest.mock import MagicMock
 
+import cloudpickle
+import grpc.aio
 import pytest
 import pytest_asyncio
 from cryptography import x509
@@ -19,13 +23,18 @@ from cryptography.x509.oid import NameOID
 from pytest_mock import MockerFixture
 
 import wool.runtime.worker.pool as wp
+import wool.runtime.worker.proxy as proxy_module
 from tests.helpers import scoped_context
 from wool import protocol
 from wool.runtime.context.factory import _loops_with_factory
 from wool.runtime.context.factory import install_task_factory
 from wool.runtime.discovery.base import DiscoveryEvent
+from wool.runtime.routine.task import Task
+from wool.runtime.routine.task import WorkerProxyLike
 from wool.runtime.worker.auth import WorkerCredentials
+from wool.runtime.worker.connection import WorkerConnection
 from wool.runtime.worker.metadata import WorkerMetadata
+from wool.runtime.worker.proxy import WorkerProxy
 
 
 class PicklableMock(MagicMock):
@@ -51,22 +60,6 @@ def _isolate_wool_context():
     """
     with scoped_context():
         yield
-
-
-@pytest_asyncio.fixture(autouse=True)
-async def _clear_channel_pool():
-    """Finalize the module-level gRPC channel pool on the loop that used it.
-
-    Not required for correctness: a `ResourcePool` rebinds to the next
-    test's loop and drops whatever a loop that is no longer running left
-    behind. Closing each test's channels here, on their own loop, is the
-    only place a ``grpc.aio`` channel can still be closed -- a dropped
-    orphan never is.
-    """
-    yield
-    import wool.runtime.worker.connection as _conn
-
-    await _conn.clear_channel_pool()
 
 
 @pytest.fixture(autouse=True)
@@ -590,6 +583,182 @@ def mock_grpc_stub_factory():
         return MockGrpcStub(metadata, **kwargs)
 
     return factory
+
+
+@pytest.fixture
+def sample_task():
+    """Build a `Task` whose callable returns ``"test_result"``.
+
+    The task carries a picklable mock proxy, so it survives the
+    serialization a dispatch performs.
+    """
+
+    async def sample_task():
+        return "test_result"
+
+    mock_proxy = PicklableMock(spec=WorkerProxyLike, id="test-proxy-id")
+
+    return Task(
+        id=uuid.uuid4(),
+        callable=sample_task,
+        args=(),
+        kwargs={},
+        proxy=mock_proxy,
+    )
+
+
+@pytest.fixture
+def async_stream():
+    """Return a factory that turns an iterable into an async generator.
+
+    The generator yields each item as a mock gRPC response, calling any
+    callable item and awaiting any coroutine item in place of yielding
+    it, so a stream can interleave side effects with responses.
+    """
+
+    async def create_async_stream(iterable):
+        """Convert an iterable into an async generator.
+
+        :param iterable:
+            Any iterable (list, tuple, generator, etc.).
+        """
+        for item in iterable:
+            if isinstance(item, Callable):
+                item()
+            elif isinstance(item, Coroutine):
+                await item
+            else:
+                yield item
+
+    return create_async_stream
+
+
+@pytest.fixture
+def mock_grpc_call(mocker: MockerFixture):
+    """Return a factory for mock bidi-streaming gRPC calls.
+
+    Each call wraps a caller-supplied stream iterator and exposes async
+    ``write`` and ``done_writing`` plus a configurable ``cancel``.
+    """
+
+    def create_call(stream_iterator, cancel_raises=False):
+        """Create a mock gRPC call object for bidi-streaming.
+
+        :param stream_iterator:
+            The async iterator the call iterates over.
+        :param cancel_raises:
+            If ``True``, ``cancel()`` raises `RuntimeError`.
+        """
+        mock_call = mocker.MagicMock()
+        mock_call.__aiter__ = lambda _: stream_iterator
+        mock_call.write = mocker.AsyncMock()
+        mock_call.done_writing = mocker.AsyncMock()
+
+        if cancel_raises:
+            mock_call.cancel = mocker.MagicMock(
+                side_effect=RuntimeError("cancel failed")
+            )
+        else:
+            mock_call.cancel = mocker.MagicMock()
+
+        return mock_call
+
+    return create_call
+
+
+@pytest.fixture
+def dispatching_stub(mocker: MockerFixture, async_stream, mock_grpc_call):
+    """Patch `protocol.WorkerStub` with a stub whose dispatch always succeeds.
+
+    Every call builds a fresh ack-then-result stream, so a test may
+    dispatch any number of times without exhausting a shared generator.
+    Returns the stub, for tests that assert on the dispatch calls.
+    """
+
+    def fresh_call(*args, **kwargs):
+        responses = (
+            protocol.Response(ack=protocol.Ack()),
+            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("ok"))),
+        )
+        return mock_grpc_call(async_stream(responses))
+
+    stub = mocker.MagicMock()
+    stub.dispatch = mocker.MagicMock(side_effect=fresh_call)
+    mocker.patch.object(protocol, "WorkerStub", return_value=stub)
+    return stub
+
+
+@pytest.fixture
+def insecure_channel(mocker: MockerFixture):
+    """Patch `grpc.aio.insecure_channel`, returning the patch.
+
+    The patch records how each insecure channel was requested, and its
+    ``return_value`` is the `AsyncMock` channel every insecure dispatch
+    receives — see `pooled_channel` for the channel alone.
+
+    :returns:
+        The patch mock standing in for `grpc.aio.insecure_channel`.
+    """
+    return mocker.patch.object(
+        grpc.aio, "insecure_channel", return_value=mocker.AsyncMock()
+    )
+
+
+@pytest.fixture
+def pooled_channel(insecure_channel):
+    """Patch `grpc.aio.insecure_channel` with a mock channel.
+
+    Every insecure dispatch made while this fixture is active caches the
+    returned channel in the module-level channel pool, so a test asserts
+    on the pool's lifecycle through the channel's ``close``.
+
+    :returns:
+        The `AsyncMock` channel the patched factory hands out.
+    """
+    return insecure_channel.return_value
+
+
+@pytest.fixture
+def closable_connection(mocker: MockerFixture):
+    """Patch `WorkerConnection` in the proxy module with a closable mock.
+
+    :returns:
+        A factory ``make(*, close_error=None)`` returning the mock the
+        patched constructor hands out, whose ``close`` is an `AsyncMock`
+        raising ``close_error`` when one is given.
+    """
+
+    def make(*, close_error: BaseException | None = None) -> MagicMock:
+        connection = mocker.MagicMock(spec=WorkerConnection)
+        connection.close = mocker.AsyncMock(side_effect=close_error)
+        mocker.patch.object(proxy_module, "WorkerConnection", return_value=connection)
+        return connection
+
+    return make
+
+
+@pytest_asyncio.fixture
+async def proxy_factory():
+    """Build `WorkerProxy` instances and stop any still started at teardown.
+
+    For tests that start a proxy incidentally, so a leftover hold is
+    released on the loop that took it rather than reported (see the
+    root ``tests/conftest.py`` fixture ``_clear_channel_pool``); a test
+    whose stop, exit, or failed start is the behavior under test
+    constructs directly.
+    """
+    proxies: list[WorkerProxy] = []
+
+    def factory(**kwargs) -> WorkerProxy:
+        proxy = WorkerProxy(**kwargs)
+        proxies.append(proxy)
+        return proxy
+
+    yield factory
+
+    for proxy in proxies:
+        if proxy.started:
+            await proxy.stop()
 
 
 @pytest.fixture

--- a/wool/tests/runtime/worker/test_connection.py
+++ b/wool/tests/runtime/worker/test_connection.py
@@ -2,10 +2,9 @@ import asyncio
 import logging
 import pickle
 import threading
+from contextlib import AsyncExitStack
 from datetime import timedelta
 from pathlib import Path
-from typing import Callable
-from typing import Coroutine
 from uuid import uuid4
 
 import cloudpickle
@@ -34,6 +33,7 @@ from wool.runtime.worker.connection import RpcError
 from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.connection import UnexpectedResponse
 from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.connection import channel_pool_hold
 from wool.runtime.worker.connection import channel_pool_stats
 from wool.runtime.worker.connection import clear_channel_pool
 
@@ -134,107 +134,6 @@ class MyAppError(Exception):
     class on deserialization in tests that round-trip user-defined
     exception types through Nack.exception payloads.
     """
-
-
-@pytest.fixture
-def sample_task(mocker: MockerFixture):
-    """Provides a mock `Task` for testing.
-
-    Creates a Task with a simple async function that returns a
-    test value.
-    """
-
-    async def sample_task():
-        return "test_result"
-
-    mock_proxy = PicklableMock(spec=WorkerProxyLike, id="test-proxy-id")
-
-    return Task(
-        id=uuid4(),
-        callable=sample_task,
-        args=(),
-        kwargs={},
-        proxy=mock_proxy,
-    )
-
-
-@pytest.fixture
-def async_stream():
-    """Provides a factory for converting iterables into async generators.
-
-    Returns a function that takes any iterable and converts it into an
-    async generator, making it easy to create mock gRPC response streams.
-    """
-
-    async def create_async_stream(iterable):
-        """Convert an iterable into an async generator.
-
-        Args:
-            iterable: Any iterable (list, tuple, generator, etc.)
-        """
-        for item in iterable:
-            if isinstance(item, Callable):
-                item()
-            elif isinstance(item, Coroutine):
-                await item
-            else:
-                yield item
-
-    return create_async_stream
-
-
-@pytest.fixture
-def mock_grpc_call(mocker: MockerFixture):
-    """Provides a factory for creating mock gRPC call objects.
-
-    Returns a function that creates a mock gRPC call with configurable
-    stream iterator and cancel behavior.
-    """
-
-    def create_call(stream_iterator, cancel_raises=False):
-        """Create a mock gRPC call object for bidi-streaming.
-
-        Args:
-            stream_iterator: The async iterator to wrap
-            cancel_raises: If True, cancel() raises RuntimeError
-        """
-        mock_call = mocker.MagicMock()
-        mock_call.__aiter__ = lambda _: stream_iterator
-        mock_call.write = mocker.AsyncMock()
-        mock_call.done_writing = mocker.AsyncMock()
-
-        if cancel_raises:
-            mock_call.cancel = mocker.MagicMock(
-                side_effect=RuntimeError("cancel failed")
-            )
-        else:
-            mock_call.cancel = mocker.MagicMock()
-
-        return mock_call
-
-    return create_call
-
-
-@pytest.fixture
-def dispatching_stub(mocker: MockerFixture, async_stream, mock_grpc_call):
-    """Patch `protocol.WorkerStub` with a stub whose dispatch always succeeds.
-
-    Every call builds a fresh ack-then-result stream, so a test may
-    dispatch any number of times without exhausting a shared generator.
-    Returns the stub, for tests that assert on the dispatch calls.
-    """
-
-    def fresh_call(*args, **kwargs):
-        responses = (
-            protocol.Response(ack=protocol.Ack()),
-            protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("ok"))),
-        )
-        return mock_grpc_call(async_stream(responses))
-
-    stub = mocker.MagicMock()
-    stub.dispatch = mocker.MagicMock(side_effect=fresh_call)
-    mocker.patch.object(protocol, "WorkerStub", return_value=stub)
-    return stub
 
 
 @pytest.fixture
@@ -1402,7 +1301,12 @@ class TestWorkerConnection:
 
     @pytest.mark.asyncio
     async def test_dispatch_should_use_insecure_uds_when_self_dispatch_secure(
-        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+        insecure_channel,
     ):
         """Test a secure worker self-dispatches over the insecure loopback.
 
@@ -1435,12 +1339,8 @@ class TestWorkerConnection:
             return_value=mock_grpc_call(async_stream(responses))
         )
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
-        mock_channel = mocker.AsyncMock()
-        insecure_spy = mocker.patch.object(
-            grpc.aio, "insecure_channel", return_value=mock_channel
-        )
         secure_spy = mocker.patch.object(
-            grpc.aio, "secure_channel", return_value=mock_channel
+            grpc.aio, "secure_channel", return_value=insecure_channel.return_value
         )
         connection = WorkerConnection(
             target, credentials=_secure_provider(), peer="wool-worker"
@@ -1451,13 +1351,20 @@ class TestWorkerConnection:
 
         # Assert
         assert results == ["ok"]
-        uds_calls = [c for c in insecure_spy.call_args_list if c.args[0] == uds_target]
+        uds_calls = [
+            c for c in insecure_channel.call_args_list if c.args[0] == uds_target
+        ]
         assert len(uds_calls) >= 1
         secure_spy.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_dispatch_should_not_invoke_factory_when_self_dispatch_uds(
-        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+        pooled_channel,
     ):
         """Test the self-dispatch route skips credential resolution entirely.
 
@@ -1502,8 +1409,6 @@ class TestWorkerConnection:
             return_value=mock_grpc_call(async_stream(responses))
         )
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
-        mock_channel = mocker.AsyncMock()
-        mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
         connection = WorkerConnection(target, credentials=provider)
 
         # Act
@@ -2803,6 +2708,7 @@ class TestWorkerConnection:
         sample_task,
         async_stream,
         mock_grpc_call,
+        pooled_channel,
     ):
         """Test a second close after a UDS dispatch is a no-op.
 
@@ -2838,9 +2744,6 @@ class TestWorkerConnection:
         mock_stub = mocker.MagicMock()
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
-
-        mock_channel = mocker.AsyncMock()
-        mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
 
         connection = WorkerConnection(
             target, options=ChannelOptions(max_concurrent_streams=10)
@@ -3508,7 +3411,12 @@ class TestWorkerConnection:
 
     @pytest.mark.asyncio
     async def test_stream_should_release_pool_ref_when_fully_consumed(
-        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+        pooled_channel,
     ):
         """Test consuming the full stream releases the channel.
 
@@ -3522,9 +3430,6 @@ class TestWorkerConnection:
             dangling pool references prevented finalization.
         """
         # Arrange
-        mock_channel = mocker.AsyncMock()
-        mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
-
         responses = (
             protocol.Response(ack=protocol.Ack()),
             protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("done"))),
@@ -3545,11 +3450,16 @@ class TestWorkerConnection:
         await connection.close()
 
         # Assert
-        mock_channel.close.assert_called_once()
+        pooled_channel.close.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_error_should_release_pool_ref_when_raised_mid_stream(
-        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+        pooled_channel,
     ):
         """Test an error mid-stream releases the channel.
 
@@ -3565,9 +3475,6 @@ class TestWorkerConnection:
             pool reference was released despite the error.
         """
         # Arrange
-        mock_channel = mocker.AsyncMock()
-        mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
-
         responses = (
             protocol.Response(ack=protocol.Ack()),
             protocol.Response(
@@ -3591,11 +3498,16 @@ class TestWorkerConnection:
         await connection.close()
 
         # Assert
-        mock_channel.close.assert_called_once()
+        pooled_channel.close.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_close_should_invoke_channel_finalizer(
-        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+        pooled_channel,
     ):
         """Test that close() tears down the pooled gRPC channel.
 
@@ -3609,9 +3521,6 @@ class TestWorkerConnection:
             finalizer.
         """
         # Arrange
-        mock_channel = mocker.AsyncMock()
-        mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
-
         responses = (
             protocol.Response(ack=protocol.Ack()),
             protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("done"))),
@@ -3633,7 +3542,7 @@ class TestWorkerConnection:
         await connection.close()
 
         # Assert
-        mock_channel.close.assert_called_once()
+        pooled_channel.close.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_two_dispatches_should_share_one_channel_when_target_matches(
@@ -3681,7 +3590,12 @@ class TestWorkerConnection:
 
     @pytest.mark.asyncio
     async def test_dispatch_should_use_default_message_sizes_when_no_options(
-        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+        insecure_channel,
     ):
         """Test dispatch creates gRPC channel with default ChannelOptions.
 
@@ -3695,10 +3609,6 @@ class TestWorkerConnection:
         """
         # Arrange
         defaults = ChannelOptions()
-        mock_channel = mocker.AsyncMock()
-        mock_insecure = mocker.patch.object(
-            grpc.aio, "insecure_channel", return_value=mock_channel
-        )
 
         responses = (
             protocol.Response(ack=protocol.Ack()),
@@ -3717,8 +3627,8 @@ class TestWorkerConnection:
             pass
 
         # Assert
-        mock_insecure.assert_called_once()
-        call_options = mock_insecure.call_args[1]["options"]
+        insecure_channel.assert_called_once()
+        call_options = insecure_channel.call_args[1]["options"]
         assert (
             "grpc.max_receive_message_length",
             defaults.max_receive_message_length,
@@ -3730,7 +3640,12 @@ class TestWorkerConnection:
 
     @pytest.mark.asyncio
     async def test_dispatch_should_use_custom_message_sizes_when_options_provided(
-        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+        insecure_channel,
     ):
         """Test dispatch creates gRPC channel with custom ChannelOptions.
 
@@ -3745,10 +3660,6 @@ class TestWorkerConnection:
         custom_options = ChannelOptions(
             max_receive_message_length=200 * 1024 * 1024,
             max_send_message_length=50 * 1024 * 1024,
-        )
-        mock_channel = mocker.AsyncMock()
-        mock_insecure = mocker.patch.object(
-            grpc.aio, "insecure_channel", return_value=mock_channel
         )
 
         responses = (
@@ -3768,8 +3679,8 @@ class TestWorkerConnection:
             pass
 
         # Assert
-        mock_insecure.assert_called_once()
-        call_options = mock_insecure.call_args[1]["options"]
+        insecure_channel.assert_called_once()
+        call_options = insecure_channel.call_args[1]["options"]
         assert (
             "grpc.max_receive_message_length",
             200 * 1024 * 1024,
@@ -3781,7 +3692,12 @@ class TestWorkerConnection:
 
     @pytest.mark.asyncio
     async def test_dispatch_should_use_custom_keepalive_options_when_provided(
-        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+        insecure_channel,
     ):
         """Test dispatch creates gRPC channel with custom keepalive options.
 
@@ -3799,10 +3715,6 @@ class TestWorkerConnection:
             keepalive_timeout_ms=10000,
             keepalive_permit_without_calls=False,
         )
-        mock_channel = mocker.AsyncMock()
-        mock_insecure = mocker.patch.object(
-            grpc.aio, "insecure_channel", return_value=mock_channel
-        )
 
         responses = (
             protocol.Response(ack=protocol.Ack()),
@@ -3821,15 +3733,20 @@ class TestWorkerConnection:
             pass
 
         # Assert
-        mock_insecure.assert_called_once()
-        call_options = mock_insecure.call_args[1]["options"]
+        insecure_channel.assert_called_once()
+        call_options = insecure_channel.call_args[1]["options"]
         assert ("grpc.keepalive_time_ms", 60000) in call_options
         assert ("grpc.keepalive_timeout_ms", 10000) in call_options
         assert ("grpc.keepalive_permit_without_calls", 0) in call_options
 
     @pytest.mark.asyncio
     async def test_dispatch_should_use_default_keepalive_options_when_no_options(
-        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+        insecure_channel,
     ):
         """Test dispatch includes default keepalive options in channel.
 
@@ -3842,10 +3759,6 @@ class TestWorkerConnection:
         """
         # Arrange
         opts = ChannelOptions()
-        mock_channel = mocker.AsyncMock()
-        mock_insecure = mocker.patch.object(
-            grpc.aio, "insecure_channel", return_value=mock_channel
-        )
 
         responses = (
             protocol.Response(ack=protocol.Ack()),
@@ -3864,15 +3777,20 @@ class TestWorkerConnection:
             pass
 
         # Assert
-        mock_insecure.assert_called_once()
-        call_options = mock_insecure.call_args[1]["options"]
+        insecure_channel.assert_called_once()
+        call_options = insecure_channel.call_args[1]["options"]
         assert ("grpc.keepalive_time_ms", 30000) in call_options
         assert ("grpc.keepalive_timeout_ms", 30000) in call_options
         assert ("grpc.keepalive_permit_without_calls", 1) in call_options
 
     @pytest.mark.asyncio
     async def test_dispatch_should_use_custom_transport_options_when_provided(
-        self, mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+        self,
+        mocker: MockerFixture,
+        sample_task,
+        async_stream,
+        mock_grpc_call,
+        insecure_channel,
     ):
         """Test dispatch creates gRPC channel with custom transport options.
 
@@ -3891,10 +3809,6 @@ class TestWorkerConnection:
             max_concurrent_streams=50,
             compression=grpc.Compression.Gzip,
         )
-        mock_channel = mocker.AsyncMock()
-        mock_insecure = mocker.patch.object(
-            grpc.aio, "insecure_channel", return_value=mock_channel
-        )
 
         responses = (
             protocol.Response(ack=protocol.Ack()),
@@ -3913,8 +3827,8 @@ class TestWorkerConnection:
             pass
 
         # Assert
-        mock_insecure.assert_called_once()
-        call_options = mock_insecure.call_args[1]["options"]
+        insecure_channel.assert_called_once()
+        call_options = insecure_channel.call_args[1]["options"]
         assert ("grpc.http2.max_pings_without_data", 5) in call_options
         assert ("grpc.max_concurrent_streams", 50) in call_options
         assert ("grpc.default_compression_algorithm", 2) in call_options
@@ -3978,6 +3892,7 @@ class TestWorkerConnection:
         sample_task,
         async_stream,
         mock_grpc_call,
+        insecure_channel,
     ):
         """Test self-dispatch uses UDS channel when UDS address is set.
 
@@ -4011,12 +3926,8 @@ class TestWorkerConnection:
         mock_stub.dispatch = mocker.MagicMock(return_value=mock_call)
         mocker.patch.object(protocol, "WorkerStub", return_value=mock_stub)
 
-        mock_channel = mocker.AsyncMock()
-        channel_spy = mocker.patch.object(
-            grpc.aio, "insecure_channel", return_value=mock_channel
-        )
         secure_spy = mocker.patch.object(
-            grpc.aio, "secure_channel", return_value=mock_channel
+            grpc.aio, "secure_channel", return_value=insecure_channel.return_value
         )
 
         connection = WorkerConnection(target)
@@ -4028,8 +3939,10 @@ class TestWorkerConnection:
 
         # Assert
         assert results == ["result"]
-        channel_spy.assert_called()
-        uds_calls = [c for c in channel_spy.call_args_list if c.args[0] == uds_target]
+        insecure_channel.assert_called()
+        uds_calls = [
+            c for c in insecure_channel.call_args_list if c.args[0] == uds_target
+        ]
         assert len(uds_calls) >= 1
         secure_spy.assert_not_called()
 
@@ -5205,10 +5118,132 @@ class TestWorkerConnection:
         assert not isinstance(exc_info.value, UnexpectedResponse)
         assert not isinstance(exc_info.value, RpcError)
 
+    @pytest.mark.asyncio
+    async def test___aenter___should_return_connection(self):
+        """Test entering a connection hands back the connection itself.
+
+        Given:
+            A bare WorkerConnection.
+        When:
+            It is entered as an async context manager.
+        Then:
+            It should bind the same connection object in the block.
+        """
+        # Arrange
+        connection = WorkerConnection("localhost:50051")
+
+        # Act
+        async with connection as entered:
+            # Assert
+            assert entered is connection
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_close_connection_when_block_exits(
+        self, sample_task, dispatching_stub, pooled_channel
+    ):
+        """Test leaving the block retires the channel the connection opened.
+
+        Given:
+            A connection entered as an async context manager that has
+            dispatched once, caching a channel under its key.
+        When:
+            The block exits normally.
+        Then:
+            It should close the cached channel exactly once and leave
+            the pool empty, as an explicit close would.
+        """
+        # Arrange
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
+
+        # Act
+        async with connection:
+            async for _ in await connection.dispatch(sample_task):
+                pass
+            closed_inside = pooled_channel.close.await_count
+
+        # Assert
+        assert closed_inside == 0
+        pooled_channel.close.assert_awaited_once()
+        assert channel_pool_stats().total_entries == 0
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_close_connection_when_body_raises(
+        self, sample_task, dispatching_stub, pooled_channel
+    ):
+        """Test a raising block still retires the channel on the way out.
+
+        Given:
+            A connection entered as an async context manager that has
+            dispatched once, caching a channel under its key.
+        When:
+            The block raises.
+        Then:
+            It should propagate the error and still close the cached
+            channel exactly once.
+        """
+        # Arrange
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
+
+        # Act
+        with pytest.raises(RuntimeError, match="body failed"):
+            async with connection:
+                async for _ in await connection.dispatch(sample_task):
+                    pass
+                raise RuntimeError("body failed")
+
+        # Assert
+        pooled_channel.close.assert_awaited_once()
+        assert channel_pool_stats().total_entries == 0
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_defer_close_when_another_handle_dispatches(
+        self, sample_task, dispatching_stub, pooled_channel
+    ):
+        """Test exiting drains before closing a channel another handle uses.
+
+        Given:
+            Two connections to the same worker, so they share one pooled
+            channel, one of them entered as an async context manager and
+            the other holding a primed but undrained result stream.
+        When:
+            The entered connection's block exits, then the other
+            handle's stream is drained.
+        Then:
+            It should leave the channel open at the exit, since the
+            stream still references it, and close it exactly once when
+            that stream drains.
+        """
+        # Arrange
+        options = ChannelOptions(max_concurrent_streams=10)
+        entered = WorkerConnection("localhost:50051", options=options)
+        other = WorkerConnection("localhost:50051", options=options)
+        stream = await other.dispatch(sample_task)
+
+        # Act
+        async with entered:
+            async for _ in await entered.dispatch(sample_task):
+                pass
+        closed_after_exit = pooled_channel.close.await_count
+        async for _ in stream:
+            pass
+
+        # Assert
+        assert closed_after_exit == 0
+        pooled_channel.close.assert_awaited_once()
+        assert channel_pool_stats().total_entries == 0
+
 
 @pytest.mark.asyncio
 async def test_clear_channel_pool_should_close_cached_channels(
-    mocker: MockerFixture, sample_task, async_stream, mock_grpc_call
+    mocker: MockerFixture,
+    sample_task,
+    async_stream,
+    mock_grpc_call,
+    pooled_channel,
 ):
     """Test `clear_channel_pool` closes every cached gRPC channel.
 
@@ -5224,9 +5259,6 @@ async def test_clear_channel_pool_should_close_cached_channels(
         would build a fresh channel.
     """
     # Arrange
-    mock_channel = mocker.AsyncMock()
-    mocker.patch.object(grpc.aio, "insecure_channel", return_value=mock_channel)
-
     responses = (
         protocol.Response(ack=protocol.Ack()),
         protocol.Response(result=protocol.Message(dump=cloudpickle.dumps("ok"))),
@@ -5248,7 +5280,7 @@ async def test_clear_channel_pool_should_close_cached_channels(
     await clear_channel_pool()
 
     # Assert
-    mock_channel.close.assert_called_once()
+    pooled_channel.close.assert_called_once()
 
 
 def test_dispatch_should_open_fresh_channel_when_run_on_a_later_loop(
@@ -5319,3 +5351,227 @@ async def test_clear_channel_pool_should_not_raise_when_pool_empty():
     """
     # Act & assert — must not raise
     await clear_channel_pool()
+
+
+@pytest.mark.asyncio
+async def test_clear_channel_pool_should_not_disturb_a_live_hold(
+    sample_task,
+    dispatching_stub,
+    pooled_channel,
+):
+    """Test a teardown under a live hold leaves that hold's count intact.
+
+    Given:
+        A hold taken before `clear_channel_pool` ran and a second hold
+        taken after it, with a channel cached under the second.
+    When:
+        The first hold is released while the second is open, then the
+        second.
+    Then:
+        It should leave the channel open after the first release and
+        close it exactly once after the second: a teardown does not
+        detach a holder from its count.
+    """
+    # Arrange
+    connection = WorkerConnection(
+        "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+    )
+
+    # Act
+    async with AsyncExitStack() as first:
+        await first.enter_async_context(channel_pool_hold())
+        await clear_channel_pool()
+        async with channel_pool_hold():
+            async for _ in await connection.dispatch(sample_task):
+                pass
+            await first.aclose()
+            closed_after_first = pooled_channel.close.await_count
+            entries_after_first = channel_pool_stats().total_entries
+
+    # Assert
+    assert closed_after_first == 0
+    assert entries_after_first == 1
+    pooled_channel.close.assert_awaited_once()
+    assert channel_pool_stats().total_entries == 0
+
+
+@pytest.mark.asyncio
+async def test_channel_pool_hold_should_close_channels_when_last_hold_released(
+    sample_task,
+    dispatching_stub,
+    pooled_channel,
+):
+    """Test the loop's idle channels close once its last hold is released.
+
+    Given:
+        Two nested holds on the channel pool and an idle channel the
+        pool cached for a dispatch made while both were open.
+    When:
+        The inner hold is released, then the outer one.
+    Then:
+        It should leave the channel open after the inner release and
+        close it exactly once after the outer, emptying the pool: a
+        hold nested inside another retires nothing on its own.
+    """
+    # Arrange
+    connection = WorkerConnection(
+        "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+    )
+
+    # Act
+    async with channel_pool_hold():
+        async with channel_pool_hold():
+            async for _ in await connection.dispatch(sample_task):
+                pass
+        closed_after_inner = pooled_channel.close.await_count
+        entries_after_inner = channel_pool_stats().total_entries
+
+    # Assert
+    assert closed_after_inner == 0
+    assert entries_after_inner == 1
+    pooled_channel.close.assert_awaited_once()
+    assert channel_pool_stats().total_entries == 0
+
+
+@pytest.mark.asyncio
+async def test_channel_pool_hold_should_close_channels_it_did_not_open(
+    sample_task,
+    dispatching_stub,
+    pooled_channel,
+):
+    """Test the last release retires a channel cached with no hold open.
+
+    Given:
+        An idle channel the pool cached for a bare connection's dispatch
+        made while no hold was open on the loop.
+    When:
+        A hold is taken and released with nothing dispatched under it.
+    Then:
+        It should close that channel exactly once and empty the pool:
+        the sweep is loop-scoped, retiring every cached channel whether
+        or not a holder opened it.
+    """
+    # Arrange
+    connection = WorkerConnection(
+        "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+    )
+    async for _ in await connection.dispatch(sample_task):
+        pass
+    assert channel_pool_stats().total_entries == 1
+    assert pooled_channel.close.await_count == 0
+
+    # Act
+    async with channel_pool_hold():
+        pass
+
+    # Assert
+    pooled_channel.close.assert_awaited_once()
+    assert channel_pool_stats().total_entries == 0
+
+
+@pytest.mark.asyncio
+async def test_channel_pool_hold_should_defer_close_when_dispatch_holds_channel(
+    sample_task,
+    dispatching_stub,
+    pooled_channel,
+):
+    """Test a hold released mid-dispatch leaves the in-flight channel open.
+
+    Given:
+        A single hold on the channel pool and a dispatch started under
+        it whose result stream is primed but not yet drained, so the
+        dispatch still references the pooled channel.
+    When:
+        The hold is released and the dispatch is then drained to
+        completion.
+    Then:
+        It should leave the channel open at the release — the
+        dispatch's own reference outlives the hold — and close it
+        exactly once when that last reference is dropped, leaving the
+        pool empty.
+    """
+    # Arrange
+    connection = WorkerConnection(
+        "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+    )
+
+    # Act
+    async with channel_pool_hold():
+        stream = await connection.dispatch(sample_task)
+    closed_after_release = pooled_channel.close.await_count
+    async for _ in stream:
+        pass
+
+    # Assert
+    assert closed_after_release == 0
+    pooled_channel.close.assert_awaited_once()
+    assert channel_pool_stats().total_entries == 0
+
+
+@pytest.mark.asyncio
+async def test_channel_pool_hold_should_empty_the_pool_when_a_channel_close_raises(
+    sample_task,
+    dispatching_stub,
+    pooled_channel,
+):
+    """Test a channel that fails to close is still retired.
+
+    Given:
+        One hold on the channel pool and a cached channel whose
+        ``close`` raises.
+    When:
+        The hold is released.
+    Then:
+        It should return without raising and leave the pool empty, so a
+        gRPC channel that refuses to close cannot wedge the teardown
+        that releases the last hold or leave a torn-down channel cached.
+    """
+    # Arrange
+    pooled_channel.close.side_effect = RuntimeError("close failed")
+    connection = WorkerConnection(
+        "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+    )
+
+    # Act
+    async with channel_pool_hold():
+        async for _ in await connection.dispatch(sample_task):
+            pass
+
+    # Assert
+    pooled_channel.close.assert_awaited_once()
+    assert channel_pool_stats().total_entries == 0
+
+
+@pytest.mark.asyncio
+async def test_channel_pool_hold_should_propagate_cancellation_when_close_cancelled(
+    sample_task,
+    dispatching_stub,
+    pooled_channel,
+):
+    """Test a cancelled channel close surfaces from the last release.
+
+    Given:
+        One hold on the channel pool and a cached channel whose
+        ``close`` raises `asyncio.CancelledError`.
+    When:
+        The hold is released.
+    Then:
+        It should propagate the CancelledError out of the release and
+        still leave the pool empty, so a teardown cancelled mid-close
+        neither hides the cancellation nor leaves the channel cached.
+    """
+    # Arrange
+    pooled_channel.close.side_effect = asyncio.CancelledError()
+    connection = WorkerConnection(
+        "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+    )
+
+    # Act
+    with pytest.raises(asyncio.CancelledError):
+        async with channel_pool_hold():
+            async for _ in await connection.dispatch(sample_task):
+                pass
+
+    # Assert
+    pooled_channel.close.assert_awaited_once()
+    assert channel_pool_stats().total_entries == 0

--- a/wool/tests/runtime/worker/test_pool.py
+++ b/wool/tests/runtime/worker/test_pool.py
@@ -2622,7 +2622,7 @@ class TestWorkerPool:
         assert isinstance(pool, WorkerPool)
 
     @pytest.mark.asyncio
-    async def test___aexit___handles_shared_memory_cleanup_exceptions(
+    async def test___aexit___should_not_reshape_error_when_proxy_exit_raises(
         self, mocker: MockerFixture, mock_local_worker, mock_worker_proxy
     ):
         """Test handle exceptions gracefully without propagating them.
@@ -2652,7 +2652,8 @@ class TestWorkerPool:
         assert raised is None or isinstance(raised, OSError)
 
     @pytest.mark.asyncio
-    async def test___aexit___bounds_teardown_when_worker_stop_hangs(
+    @pytest.mark.filterwarnings("error::RuntimeWarning")
+    async def test___aexit___should_bound_teardown_when_worker_stop_hangs(
         self, mocker: MockerFixture
     ):
         """Test pool teardown returns within the configured shutdown bound.
@@ -2693,6 +2694,145 @@ class TestWorkerPool:
         assert elapsed < shutdown_timeout * 5
 
     @pytest.mark.asyncio
+    @pytest.mark.filterwarnings("error::RuntimeWarning")
+    async def test___aexit___should_exit_publisher_when_shutdown_deadline_exhausted(
+        self, mocker: MockerFixture
+    ):
+        """Test the publisher's exit still runs once the deadline is spent.
+
+        Given:
+            A WorkerPool whose worker has a stop() that never returns and
+            whose discovery publisher is a context manager recording its
+            exit
+        When:
+            The async-with block exits and the worker stop exhausts
+            shutdown_timeout
+        Then:
+            It should still enter the publisher's exit exactly once
+            rather than skip it, leaving no coroutine un-awaited
+        """
+        # Arrange
+        exits: list[tuple] = []
+
+        class ExitRecordingDiscovery(_FakeDiscovery):
+            @property
+            def publisher(self):
+                publisher = self._publisher
+
+                class Manager:
+                    async def __aenter__(self):
+                        return publisher
+
+                    async def __aexit__(self, *args):
+                        exits.append(args)
+                        return False
+
+                return Manager()
+
+        def hanging_factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+
+            async def hang(*, grace=None):
+                await asyncio.sleep(60)
+
+            worker.stop = hang
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        # Act
+        async with WorkerPool(
+            worker=hanging_factory,
+            spawn=1,
+            shutdown_timeout=0.05,
+            discovery=ExitRecordingDiscovery(mocker),
+        ):
+            pass
+
+        # Assert
+        assert exits == [(None, None, None)]
+
+    @pytest.mark.asyncio
+    @pytest.mark.filterwarnings("error::RuntimeWarning")
+    async def test___aexit___should_cancel_publisher_exit_when_cleanup_exceeds_budget(
+        self, mocker: MockerFixture, caplog
+    ):
+        """Test a publisher exit that outlives the deadline is cancelled and reported.
+
+        Given:
+            A WorkerPool whose worker has a stop() that never returns and
+            whose discovery publisher is a context manager whose exit
+            parks until cancelled
+        When:
+            The async-with block exits and the worker stop exhausts
+            shutdown_timeout
+        Then:
+            It should still enter the publisher's exit, cancel it once
+            the budget is spent, log one warning saying so, and return
+            within a small multiple of shutdown_timeout
+        """
+        # Arrange
+        entered = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        class ParkingDiscovery(_FakeDiscovery):
+            @property
+            def publisher(self):
+                publisher = self._publisher
+
+                class Manager:
+                    async def __aenter__(self):
+                        return publisher
+
+                    async def __aexit__(self, *args):
+                        entered.set()
+                        try:
+                            await asyncio.Event().wait()
+                        except asyncio.CancelledError:
+                            cancelled.set()
+                            raise
+                        return False
+
+                return Manager()
+
+        def hanging_factory(*tags, credentials=None):
+            worker = mocker.MagicMock(spec=LocalWorker)
+            worker.start = mocker.AsyncMock()
+
+            async def hang(*, grace=None):
+                await asyncio.sleep(60)
+
+            worker.stop = hang
+            worker.metadata = _make_worker_metadata()
+            return worker
+
+        shutdown_timeout = 0.05
+
+        # Act
+        start = time.monotonic()
+        with caplog.at_level(logging.WARNING, "wool.runtime.worker.pool"):
+            async with WorkerPool(
+                worker=hanging_factory,
+                spawn=1,
+                shutdown_timeout=shutdown_timeout,
+                discovery=ParkingDiscovery(mocker),
+            ):
+                pass
+        elapsed = time.monotonic() - start
+
+        # Assert
+        assert entered.is_set()
+        assert cancelled.is_set()
+        messages = [
+            r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert [
+            "publisher cleanup did not complete" in message for message in messages
+        ].count(True) == 1
+        assert elapsed < shutdown_timeout * 5
+
+    @pytest.mark.asyncio
+    @pytest.mark.filterwarnings("error::RuntimeWarning")
     async def test___aexit___should_log_warning_when_workers_reaped(
         self, mocker: MockerFixture, caplog
     ):
@@ -2740,7 +2880,8 @@ class TestWorkerPool:
         )
 
     @pytest.mark.asyncio
-    async def test___aexit___cancels_pending_stops_after_timeout(
+    @pytest.mark.filterwarnings("error::RuntimeWarning")
+    async def test___aexit___should_cancel_pending_stops_when_shutdown_bound_elapses(
         self, mocker: MockerFixture
     ):
         """Test pending stop coroutines receive CancelledError on timeout.
@@ -2821,7 +2962,8 @@ class TestWorkerPool:
         )
 
     @pytest.mark.asyncio
-    async def test___aexit___does_not_block_other_cleanup_when_one_worker_hangs(
+    @pytest.mark.filterwarnings("error::RuntimeWarning")
+    async def test___aexit___should_stop_other_workers_when_one_worker_hangs(
         self, mocker: MockerFixture
     ):
         """Test fast worker still stops when a sibling worker's stop hangs.
@@ -3077,6 +3219,7 @@ class TestWorkerPool:
         stop.assert_awaited_once_with(grace=pytest.approx(5.0, abs=0.1))
 
     @pytest.mark.asyncio
+    @pytest.mark.filterwarnings("error::RuntimeWarning")
     async def test___aexit___should_stop_worker_when_drop_announcement_hangs(
         self, mocker: MockerFixture
     ):
@@ -3206,6 +3349,7 @@ class TestWorkerPool:
         stop.assert_awaited_once_with(grace=-1.0)
 
     @pytest.mark.asyncio
+    @pytest.mark.filterwarnings("error::RuntimeWarning")
     async def test___aexit___should_log_error_when_drop_announcement_hangs(
         self, mocker: MockerFixture, caplog
     ):
@@ -4465,17 +4609,18 @@ class TestWorkerPool:
         assert str(caught_exception) == exception_message
 
     @pytest.mark.asyncio
-    async def test_enter_context_with_awaitable(
+    async def test___aenter___should_resolve_discovery_when_awaitable(
         self, mocker: MockerFixture, mock_shared_memory, mock_local_worker
     ):
-        """Test await the Awaitable and return the result.
+        """Test entering the pool awaits an awaitable discovery factory.
 
         Given:
             WorkerPool with a discovery factory that returns an Awaitable
         When:
-            _enter_context is called
+            The pool is entered
         Then:
-            It should await the Awaitable and return the result
+            It should await the Awaitable and hand its subscriber to the
+            proxy
         """
 
         # Arrange
@@ -4496,8 +4641,10 @@ class TestWorkerPool:
             def subscribe(self, filter=None):
                 return self._subscriber
 
+        discovery = ConcreteDiscovery()
+
         async def discovery_awaitable():
-            return ConcreteDiscovery()
+            return discovery
 
         # Patch WorkerProxy to avoid actual proxy initialization
         mock_proxy = mocker.MagicMock()
@@ -4507,23 +4654,28 @@ class TestWorkerPool:
 
         pool = WorkerPool(discovery=discovery_awaitable)
 
-        # Act & assert - should not raise
+        # Act
         async with pool:
             pass
 
+        # Assert
+        assert (
+            pool_module.WorkerProxy.call_args.kwargs["discovery"] is discovery.subscriber
+        )
+
     @pytest.mark.asyncio
-    async def test_enter_context_with_plain_object(
+    async def test___aenter___should_resolve_discovery_when_plain_object(
         self, mocker: MockerFixture, mock_shared_memory, mock_local_worker
     ):
-        """Test return the object directly.
+        """Test entering the pool passes a plain discovery object through.
 
         Given:
             WorkerPool with a discovery that is a plain object (not
             callable/context manager)
         When:
-            _enter_context is called
+            The pool is entered
         Then:
-            It should return the object directly
+            It should hand the object's subscriber to the proxy
         """
 
         # Arrange
@@ -4554,20 +4706,26 @@ class TestWorkerPool:
 
         pool = WorkerPool(discovery=mock_discovery)
 
-        # Act & assert - should not raise
+        # Act
         async with pool:
             pass
 
+        # Assert
+        assert (
+            pool_module.WorkerProxy.call_args.kwargs["discovery"]
+            is mock_discovery.subscriber
+        )
+
     @pytest.mark.asyncio
-    async def test_exit_context_with_sync_context_manager(
+    async def test___aexit___should_exit_sync_context_manager_when_discovery_is_one(
         self, mocker: MockerFixture, mock_shared_memory, mock_local_worker
     ):
-        """Test call __exit__ on the context manager.
+        """Test exiting the pool exits a synchronous discovery context manager.
 
         Given:
             WorkerPool with a discovery that is a synchronous ContextManager
         When:
-            _exit_context is called
+            The pool is exited
         Then:
             It should call __exit__ on the context manager
         """

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -43,12 +43,16 @@ from wool.runtime.worker.connection import HandshakeError
 from wool.runtime.worker.connection import RpcError
 from wool.runtime.worker.connection import TransientRpcError
 from wool.runtime.worker.connection import WorkerConnection
+from wool.runtime.worker.connection import channel_pool_hold
+from wool.runtime.worker.connection import channel_pool_stats
 from wool.runtime.worker.exceptions import UnparsableVersionWarning
 from wool.runtime.worker.metadata import WorkerMetadata
 from wool.runtime.worker.proxy import WorkerProxy
 from wool.runtime.worker.proxy import is_version_compatible
 from wool.runtime.worker.proxy import parse_version
 from wool.utilities.afilter import afilter
+
+from .conftest import MockDiscoveryService
 
 
 async def _drain_until(predicate, *, timeout=2.0):
@@ -1142,7 +1146,10 @@ class TestWorkerProxy:
 
     @pytest.mark.asyncio
     async def test_start_sets_started_flag(
-        self, mock_discovery_service, mock_proxy_session
+        self,
+        mock_discovery_service,
+        mock_proxy_session,
+        proxy_factory,
     ):
         """Test set the started flag to True.
 
@@ -1154,7 +1161,7 @@ class TestWorkerProxy:
             It should set the started flag to True
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
+        proxy = proxy_factory(discovery=mock_discovery_service, lazy=False, quorum=0)
 
         # Act
         await proxy.start()
@@ -1184,7 +1191,10 @@ class TestWorkerProxy:
 
     @pytest.mark.asyncio
     async def test_enter_with_non_lazy_proxy(
-        self, mock_discovery_service, mock_proxy_session
+        self,
+        mock_discovery_service,
+        mock_proxy_session,
+        proxy_factory,
     ):
         """Test enter eagerly starts a non-lazy proxy.
 
@@ -1196,7 +1206,7 @@ class TestWorkerProxy:
             It should set started to True.
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
+        proxy = proxy_factory(discovery=mock_discovery_service, lazy=False, quorum=0)
 
         # Act
         await proxy.enter()
@@ -1266,8 +1276,836 @@ class TestWorkerProxy:
         assert len(proxy.workers) == 0
 
     @pytest.mark.asyncio
+    async def test_stop_should_close_pooled_channels_when_last_proxy_on_loop(
+        self,
+        mock_discovery_service,
+        mock_proxy_session,
+        sample_task,
+        dispatching_stub,
+        pooled_channel,
+    ):
+        """Test the last proxy to stop on a loop closes the loop's channels.
+
+        Given:
+            Two started proxies on the same event loop and an idle
+            channel the module-level pool cached for a dispatch made
+            while both were started.
+        When:
+            The proxies are stopped one after the other.
+        Then:
+            It should leave the channel open after the first stop and
+            close it exactly once after the second, emptying the pool,
+            so a proxy nested inside another never closes channels the
+            outer one still uses.
+        """
+        # Arrange
+        outer = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
+        inner = WorkerProxy(discovery=MockDiscoveryService(), lazy=False, quorum=0)
+        await outer.start()
+        await inner.start()
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
+        async for _ in await connection.dispatch(sample_task):
+            pass
+
+        # Act
+        await inner.stop()
+        closed_after_inner = pooled_channel.close.await_count
+        entries_after_inner = channel_pool_stats().total_entries
+        await outer.stop()
+
+        # Assert
+        assert closed_after_inner == 0
+        assert entries_after_inner == 1
+        pooled_channel.close.assert_awaited_once()
+        assert channel_pool_stats().total_entries == 0
+
+    @pytest.mark.asyncio
+    async def test_start_should_release_channel_pool_hold_when_loadbalancer_invalid(
+        self,
+        mock_discovery_service,
+        mock_proxy_session,
+        sample_task,
+        dispatching_stub,
+        pooled_channel,
+    ):
+        """Test a failed start hands back the channel-pool hold it took.
+
+        Given:
+            A non-lazy proxy whose load balancer is not a
+            `LoadBalancerLike`, so ``start`` raises after taking its
+            channel-pool hold.
+        When:
+            A fresh hold is taken after the failed start, a dispatch
+            caches a channel under it, and that hold is released.
+        Then:
+            It should close the cached channel and empty the pool —
+            which only happens when the failed start's rollback gave its
+            own hold back, leaving the fresh one as the last.
+        """
+        # Arrange
+        proxy = WorkerProxy(
+            discovery=mock_discovery_service,
+            loadbalancer=object(),  # type: ignore[arg-type]
+            lazy=False,
+            quorum=0,
+        )
+
+        # Act
+        with pytest.raises(ValueError):
+            await proxy.start()
+        # The probe hold.
+        async with channel_pool_hold():
+            connection = WorkerConnection(
+                "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+            )
+            async for _ in await connection.dispatch(sample_task):
+                pass
+
+        # Assert
+        assert not proxy.started
+        pooled_channel.close.assert_awaited_once()
+        assert channel_pool_stats().total_entries == 0
+
+    @pytest.mark.asyncio
+    async def test_stop_should_release_channel_pool_hold_when_teardown_raises(
+        self,
+        mock_proxy_session,
+        sample_task,
+        dispatching_stub,
+        pooled_channel,
+    ):
+        """Test a raising teardown still hands the channel-pool hold back.
+
+        Given:
+            A started proxy holding the loop's only channel-pool hold,
+            with one idle cached channel and a discovery context manager
+            whose exit raises.
+        When:
+            The proxy is stopped and the error observed.
+        Then:
+            It should still close the cached channel, since the hold's
+            release is guaranteed by the exit stack rather than by the
+            teardowns before it completing.
+        """
+
+        # Arrange
+        async def fail():
+            raise RuntimeError("teardown failed")
+
+        proxy = WorkerProxy(
+            discovery=_discovery_context(on_exit=fail), lazy=False, quorum=0
+        )
+        await proxy.start()
+        connection = WorkerConnection(
+            "localhost:50051", options=ChannelOptions(max_concurrent_streams=10)
+        )
+        async for _ in await connection.dispatch(sample_task):
+            pass
+
+        # Act
+        with pytest.raises(RuntimeError, match="teardown failed"):
+            await proxy.stop()
+
+        # Assert
+        pooled_channel.close.assert_awaited_once()
+        assert channel_pool_stats().total_entries == 0
+
+    @pytest.mark.asyncio
+    async def test_start_should_close_connection_when_worker_dropped(
+        self, mock_proxy_session, proxy_factory, closable_connection
+    ):
+        """Test a departed worker's connection is closed by the proxy.
+
+        Given:
+            A started proxy that admitted one worker over a connection
+            whose close is observable.
+        When:
+            Discovery reports the worker dropped.
+        Then:
+            It should remove the worker and close its connection exactly
+            once, retiring the worker's channel now rather than after the
+            pool's idle TTL.
+        """
+        # Arrange
+        metadata = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version=protocol.__version__,
+        )
+        connection = closable_connection()
+        discovery = wp.ReducibleAsyncIterator(
+            [
+                DiscoveryEvent("worker-added", metadata=metadata),
+                DiscoveryEvent("worker-dropped", metadata=metadata),
+            ]
+        )
+        proxy = proxy_factory(discovery=discovery, lazy=False, quorum=0)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: connection.close.await_count == 1)
+
+        # Assert
+        assert metadata not in proxy.workers
+        connection.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_should_close_connection_when_worker_dropped_after_a_refresh(
+        self, mock_proxy_session, proxy_factory, mocker: MockerFixture
+    ):
+        """Test a refresh that leaves the channel key alone keeps the handle.
+
+        Given:
+            A started proxy that admitted one worker and then received a
+            refresh carrying the same address, options, and identity.
+        When:
+            Discovery reports the worker dropped.
+        Then:
+            It should have built one connection, kept it across the
+            refresh, and closed it on the drop.
+        """
+        # Arrange
+        metadata = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version=protocol.__version__,
+        )
+        connections: list = []
+
+        def connect(*args, **kwargs):
+            connection = mocker.MagicMock(spec=WorkerConnection)
+            connection.close = mocker.AsyncMock()
+            connections.append(connection)
+            return connection
+
+        mocker.patch.object(wp, "WorkerConnection", side_effect=connect)
+        discovery = wp.ReducibleAsyncIterator(
+            [
+                DiscoveryEvent("worker-added", metadata=metadata),
+                DiscoveryEvent("worker-updated", metadata=replace(metadata, pid=9001)),
+                DiscoveryEvent("worker-dropped", metadata=metadata),
+            ]
+        )
+        proxy = proxy_factory(discovery=discovery, lazy=False, quorum=0)
+
+        # Act
+        await proxy.start()
+        await _drain_until(
+            lambda: bool(connections) and connections[0].close.await_count == 1
+        )
+
+        # Assert
+        assert len(connections) == 1
+        assert metadata not in proxy.workers
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("change", "peers"),
+        [
+            pytest.param(
+                lambda metadata: replace(metadata, address="127.0.0.1:50101"),
+                None,
+                id="address",
+            ),
+            pytest.param(
+                lambda metadata: replace(
+                    metadata, options=ChannelOptions(keepalive_time_ms=90000)
+                ),
+                None,
+                id="options",
+            ),
+            pytest.param(
+                lambda metadata: replace(metadata, identity="beta.svc"),
+                ["alpha.svc", "beta.svc"],
+                id="identity",
+            ),
+        ],
+    )
+    async def test_start_should_rebuild_connection_when_refresh_changes_the_channel_key(
+        self,
+        mock_proxy_session,
+        proxy_factory,
+        worker_credentials,
+        mocker: MockerFixture,
+        change,
+        peers,
+    ):
+        """Test a refresh that changes the channel key replaces the handle.
+
+        Given:
+            A started proxy that admitted one worker, gated on a peers
+            policy accepting two names when the field that changes is
+            the worker's identity.
+        When:
+            Discovery refreshes the worker with a different address,
+            different channel options, or a different accepted identity.
+        Then:
+            It should build a second connection from the refreshed
+            metadata, hold that one for the worker, and leave the
+            displaced one unclosed, for the pool's idle TTL.
+        """
+        # Arrange
+        before = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version=protocol.__version__,
+            secure=peers is not None,
+            identity="alpha.svc",
+            options=ChannelOptions(keepalive_time_ms=60000),
+        )
+        after = change(before)
+        connections: list = []
+        built: list[tuple] = []
+
+        def connect(*args, **kwargs):
+            connection = mocker.MagicMock(spec=WorkerConnection)
+            connection.close = mocker.AsyncMock()
+            connections.append(connection)
+            built.append((args[0], kwargs.get("options"), kwargs.get("peer")))
+            return connection
+
+        mocker.patch.object(wp, "WorkerConnection", side_effect=connect)
+        discovery = wp.ReducibleAsyncIterator(
+            [
+                DiscoveryEvent("worker-added", metadata=before),
+                DiscoveryEvent("worker-updated", metadata=after),
+            ]
+        )
+        credentials = (
+            WorkerCredentialsProvider(lambda: worker_credentials, peers=peers)
+            if peers is not None
+            else None
+        )
+        proxy = proxy_factory(
+            discovery=discovery, credentials=credentials, lazy=False, quorum=0
+        )
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: len(connections) == 2)
+
+        # Assert
+        assert proxy.workers == [after]
+        assert built == [
+            (before.address, before.options, before.identity if peers else None),
+            (after.address, after.options, after.identity if peers else None),
+        ]
+        connections[0].close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_should_close_connection_when_admission_gate_evicts_worker(
+        self, mock_proxy_session, proxy_factory, closable_connection
+    ):
+        """Test a worker evicted by the admission gate has its connection closed.
+
+        Given:
+            A started proxy that admitted a worker whose later update
+            advertises an incompatible protocol version.
+        When:
+            The sentinel processes that update.
+        Then:
+            It should evict the worker and close its connection exactly
+            once.
+        """
+        # Arrange
+        uid = uuid.uuid4()
+        admitted = WorkerMetadata(
+            uid=uid, address="127.0.0.1:50100", pid=9000, version=protocol.__version__
+        )
+        incompatible = WorkerMetadata(
+            uid=uid, address="127.0.0.1:50100", pid=9000, version="999.0.0"
+        )
+        connection = closable_connection()
+        discovery = wp.ReducibleAsyncIterator(
+            [
+                DiscoveryEvent("worker-added", metadata=admitted),
+                DiscoveryEvent("worker-updated", metadata=incompatible),
+            ]
+        )
+        proxy = proxy_factory(discovery=discovery, lazy=False, quorum=0)
+
+        # Act
+        await proxy.start()
+        await _drain_until(lambda: connection.close.await_count == 1)
+
+        # Assert
+        assert proxy.workers == []
+        connection.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_close_connection_when_worker_evicted_on_error(
+        self, mock_proxy_session, mock_wool_task, proxy_factory, mocker: MockerFixture
+    ):
+        """Test a non-transient failure closes the evicted worker's connection.
+
+        Given:
+            A delegating balancer with two workers, the first of whose
+            connections raises a non-transient RpcError on dispatch.
+        When:
+            dispatch() fails over to the second worker.
+        Then:
+            It should evict the first worker and close its connection
+            exactly once, leaving the survivor's open.
+        """
+        # Arrange
+        failing = mocker.MagicMock(spec=WorkerConnection)
+        failing.dispatch = mocker.AsyncMock(side_effect=RpcError())
+        failing.close = mocker.AsyncMock()
+        streams: list = []
+        survivor = _make_success_connection(mocker, streams)
+        survivor.close = mocker.AsyncMock()
+        proxy, metadata_list = await _make_proxy_with_workers(
+            connections=[failing, survivor],
+            loadbalancer=make_delegating_balancer(),
+            mocker=mocker,
+            factory=proxy_factory,
+        )
+
+        # Act
+        results = [r async for r in await proxy.dispatch(mock_wool_task)]
+
+        # Assert
+        assert results == ["ok"]
+        assert metadata_list[0] not in proxy.workers
+        failing.close.assert_awaited_once()
+        survivor.close.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_evict_from_its_snapshot_when_worker_fails_after_stop(
+        self, mock_proxy_session, mock_wool_task, mocker: MockerFixture
+    ):
+        """Test a failure observed after a stop evicts without the reset state.
+
+        Given:
+            A started proxy with one worker whose dispatch parks until
+            released and then raises a non-transient RpcError.
+        When:
+            The proxy is stopped while that dispatch is parked, and the
+            dispatch is then released.
+        Then:
+            It should raise NoWorkersAvailable rather than fail on the
+            collaborators the stop nulled, and close the connection it
+            dispatched over.
+        """
+        # Arrange
+        gate = asyncio.Event()
+        parked = asyncio.Event()
+
+        async def dispatch(task, *, timeout=None):
+            parked.set()
+            await gate.wait()
+            raise RpcError()
+
+        failing = mocker.MagicMock(spec=WorkerConnection)
+        failing.dispatch = mocker.AsyncMock(side_effect=dispatch)
+        failing.close = mocker.AsyncMock()
+        proxy, _ = await _make_proxy_with_workers(
+            connections=[failing],
+            loadbalancer=make_delegating_balancer(),
+            mocker=mocker,
+        )
+        dispatching = asyncio.create_task(proxy.dispatch(mock_wool_task))
+        await asyncio.wait_for(parked.wait(), timeout=2.0)
+
+        # Act
+        await proxy.stop()
+        gate.set()
+
+        # Assert
+        with pytest.raises(NoWorkersAvailable):
+            await dispatching
+        failing.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_should_continue_when_closing_a_departed_connection_raises(
+        self, mock_proxy_session, proxy_factory, closable_connection, caplog
+    ):
+        """Test a close that fails on departure does not kill the sentinel.
+
+        Given:
+            A started proxy whose admitted worker's connection raises
+            from close.
+        When:
+            Discovery reports that worker dropped, then admits another.
+        Then:
+            It should still admit the later worker, so the failed close
+            neither ended the sentinel nor left the proxy unusable, and
+            report the failed close at warning level naming the departed
+            worker.
+        """
+        # Arrange
+        first = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version=protocol.__version__,
+        )
+        second = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50101",
+            pid=9001,
+            version=protocol.__version__,
+        )
+        connection = closable_connection(close_error=RuntimeError("close failed"))
+        discovery = wp.ReducibleAsyncIterator(
+            [
+                DiscoveryEvent("worker-added", metadata=first),
+                DiscoveryEvent("worker-dropped", metadata=first),
+                DiscoveryEvent("worker-added", metadata=second),
+            ]
+        )
+        proxy = proxy_factory(discovery=discovery, lazy=False)
+
+        # Act
+        with caplog.at_level(logging.WARNING, logger="wool.runtime.worker.proxy"):
+            await proxy.start()
+            await _drain_until(lambda: second in proxy.workers)
+
+        # Assert
+        assert proxy.workers == [second]
+        connection.close.assert_awaited_once()
+        assert proxy.started
+        records = [
+            record
+            for record in caplog.records
+            if record.name == "wool.runtime.worker.proxy"
+            and record.levelno == logging.WARNING
+        ]
+        assert [str(first.uid) in record.getMessage() for record in records] == [True]
+
+    @pytest.mark.asyncio
+    async def test_start_should_forward_failure_when_dependency_context_suppresses(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test a suppressing dependency cannot turn a failed start into a started proxy.
+
+        Given:
+            A proxy whose load balancer is an async context manager that
+            returns True from its exit, and whose discovery object is not
+            a subscriber, so start raises after entering the balancer.
+        When:
+            The proxy is started.
+        Then:
+            It should raise the start failure regardless of the
+            suppression and leave the proxy un-started.
+        """
+        # Arrange
+        manager, exits = _recording_loadbalancer(mocker, suppress=True)
+        proxy = WorkerProxy(
+            discovery=object(),  # type: ignore[arg-type]
+            loadbalancer=manager,
+            lazy=False,
+            quorum=0,
+        )
+
+        # Act
+        with pytest.raises(ValueError) as excinfo:
+            await proxy.start()
+
+        # Assert
+        assert not proxy.started
+        assert len(exits) == 1
+        assert exits[0][1] is excinfo.value
+
+    @pytest.mark.asyncio
+    async def test_stop_should_raise_runtime_error_when_called_concurrently(
+        self, mock_proxy_session
+    ):
+        """Test a second stop during an unwind raises the documented error.
+
+        Given:
+            A started proxy whose discovery context blocks on exit, so
+            a stop stays suspended inside its unwind.
+        When:
+            A second stop is called while the first is suspended.
+        Then:
+            It should raise RuntimeError rather than unwinding twice,
+            and the first stop should complete once the exit unblocks.
+        """
+        # Arrange
+        gate = asyncio.Event()
+        parked = asyncio.Event()
+
+        async def on_exit():
+            parked.set()
+            await gate.wait()
+
+        proxy = WorkerProxy(
+            discovery=_discovery_context(on_exit=on_exit), lazy=False, quorum=0
+        )
+        await proxy.start()
+        first = asyncio.create_task(proxy.stop())
+        await asyncio.wait_for(parked.wait(), timeout=2.0)
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="stopping"):
+            await proxy.stop()
+        gate.set()
+        await first
+        assert not proxy.started
+
+    @pytest.mark.asyncio
+    async def test_start_should_raise_when_called_during_stop_unwind(
+        self, mock_proxy_session
+    ):
+        """Test a start during an unwind raises rather than racing it.
+
+        Given:
+            A started proxy whose discovery context blocks on exit, so
+            a stop stays suspended inside its unwind.
+        When:
+            Start is called while the stop is suspended.
+        Then:
+            It should raise RuntimeError naming the stopping state, and
+            the first stop should complete once the exit unblocks,
+            leaving the proxy stopped.
+        """
+        # Arrange
+        gate = asyncio.Event()
+        parked = asyncio.Event()
+
+        async def on_exit():
+            parked.set()
+            await gate.wait()
+
+        proxy = WorkerProxy(
+            discovery=_discovery_context(on_exit=on_exit), lazy=False, quorum=0
+        )
+        await proxy.start()
+        first = asyncio.create_task(proxy.stop())
+        await asyncio.wait_for(parked.wait(), timeout=2.0)
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="stopping"):
+            await proxy.start()
+        gate.set()
+        await first
+        assert not proxy.started
+
+    @pytest.mark.asyncio
+    async def test_start_should_raise_when_called_during_failed_start_unwind(
+        self, mock_proxy_session, closable_connection
+    ):
+        """Test a start during a failed start's unwind raises rather than racing it.
+
+        Given:
+            A proxy whose discovery context reports no worker on its
+            first entry and blocks on its first exit, so a failed start
+            stays suspended inside its rollback, and reports one worker
+            on its second entry.
+        When:
+            Start is called while the rollback is suspended, and again
+            once the failed start has returned.
+        Then:
+            It should raise RuntimeError naming the starting state, the
+            first start should fail once the exit unblocks, leaving the
+            proxy un-started with no workers, and the later start should
+            succeed.
+        """
+        # Arrange
+        gate = asyncio.Event()
+        parked = asyncio.Event()
+        metadata = WorkerMetadata(
+            uid=uuid.uuid4(),
+            address="127.0.0.1:50100",
+            pid=9000,
+            version=protocol.__version__,
+        )
+        closable_connection()
+        entries = 0
+
+        class Discovery:
+            async def __aenter__(self):
+                nonlocal entries
+                entries += 1
+                events = (
+                    []
+                    if entries == 1
+                    else [DiscoveryEvent("worker-added", metadata=metadata)]
+                )
+                return wp.ReducibleAsyncIterator(events)
+
+            async def __aexit__(self, *args):
+                if entries == 1:
+                    parked.set()
+                    await gate.wait()
+
+        proxy = WorkerProxy(
+            discovery=Discovery(), lazy=False, quorum=1, quorum_timeout=0.2
+        )
+        first = asyncio.create_task(proxy.start())
+        await asyncio.wait_for(parked.wait(), timeout=2.0)
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="starting"):
+            await proxy.start()
+        gate.set()
+        with pytest.raises(TimeoutError):
+            await first
+        assert not proxy.started
+        assert proxy.workers == []
+        await proxy.start()
+        assert proxy.started
+        assert proxy.workers == [metadata]
+        await proxy.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_should_raise_when_proxy_stopped(
+        self, mock_discovery_service, mock_proxy_session, proxy_factory
+    ):
+        """Test a stopped proxy cannot be started again.
+
+        Given:
+            A proxy that was started and then stopped.
+        When:
+            Start is called again.
+        Then:
+            It should raise RuntimeError naming the stopped state and
+            leave the proxy un-started.
+        """
+        # Arrange
+        proxy = proxy_factory(discovery=mock_discovery_service, lazy=False, quorum=0)
+        await proxy.start()
+        await proxy.stop()
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="stopped"):
+            await proxy.start()
+        assert not proxy.started
+
+    @pytest.mark.asyncio
+    async def test_stop_should_raise_when_proxy_already_stopped(
+        self, mock_discovery_service, mock_proxy_session, proxy_factory
+    ):
+        """Test a stopped proxy cannot be stopped again.
+
+        Given:
+            A proxy that was started and then stopped.
+        When:
+            Stop is called again.
+        Then:
+            It should raise RuntimeError naming the stopped state and
+            leave the proxy stopped.
+        """
+        # Arrange
+        proxy = proxy_factory(discovery=mock_discovery_service, lazy=False, quorum=0)
+        await proxy.start()
+        await proxy.stop()
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="stopped"):
+            await proxy.stop()
+        assert not proxy.started
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_raise_when_lazy_proxy_stopped(
+        self, mock_discovery_service, mock_proxy_session, mock_wool_task, proxy_factory
+    ):
+        """Test a lazy dispatch after stop does not restart the proxy.
+
+        Given:
+            A lazy proxy that was started and then stopped.
+        When:
+            A task is dispatched through it.
+        Then:
+            It should raise RuntimeError naming the stopped state rather
+            than starting the proxy again.
+        """
+        # Arrange
+        proxy = proxy_factory(discovery=mock_discovery_service, lazy=True, quorum=0)
+        await proxy.start()
+        await proxy.stop()
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="stopped"):
+            await proxy.dispatch(mock_wool_task)
+        assert not proxy.started
+
+    @pytest.mark.asyncio
+    async def test_dispatch_should_raise_when_lazy_proxy_is_starting(
+        self, mock_proxy_session, mock_wool_task, proxy_factory
+    ):
+        """Test a lazy dispatch during an explicit start raises rather than racing it.
+
+        Given:
+            A lazy proxy whose discovery context blocks on entry, so an
+            explicit start stays suspended inside it.
+        When:
+            A task is dispatched through the proxy while the start is
+            suspended.
+        Then:
+            It should raise RuntimeError naming the starting state rather
+            than start the proxy a second time, and the first start
+            should complete once the entry unblocks.
+        """
+        # Arrange
+        gate = asyncio.Event()
+        parked = asyncio.Event()
+
+        async def on_enter():
+            parked.set()
+            await gate.wait()
+
+        proxy = proxy_factory(
+            discovery=_discovery_context(on_enter=on_enter), lazy=True, quorum=0
+        )
+        first = asyncio.create_task(proxy.start())
+        await asyncio.wait_for(parked.wait(), timeout=2.0)
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="starting"):
+            await proxy.dispatch(mock_wool_task)
+        gate.set()
+        await first
+        assert proxy.started
+
+    @pytest.mark.asyncio
+    async def test_start_should_raise_when_called_concurrently(
+        self, mock_proxy_session, proxy_factory
+    ):
+        """Test a second start during a start in progress raises.
+
+        Given:
+            A proxy whose discovery context blocks on entry, so a start
+            stays suspended inside it.
+        When:
+            Start is called again while the first is suspended.
+        Then:
+            It should raise RuntimeError naming the starting state, and
+            the first start should complete once the entry unblocks.
+        """
+        # Arrange
+        gate = asyncio.Event()
+        parked = asyncio.Event()
+
+        async def on_enter():
+            parked.set()
+            await gate.wait()
+
+        proxy = proxy_factory(
+            discovery=_discovery_context(on_enter=on_enter), lazy=False, quorum=0
+        )
+        first = asyncio.create_task(proxy.start())
+        await asyncio.wait_for(parked.wait(), timeout=2.0)
+
+        # Act & assert
+        with pytest.raises(RuntimeError, match="starting"):
+            await proxy.start()
+        gate.set()
+        await first
+        assert proxy.started
+
+    @pytest.mark.asyncio
     async def test_start_already_started_raises_error(
-        self, mock_discovery_service, mock_proxy_session
+        self,
+        mock_discovery_service,
+        mock_proxy_session,
+        proxy_factory,
     ):
         """Test raise RuntimeError.
 
@@ -1279,7 +2117,7 @@ class TestWorkerProxy:
             It should raise RuntimeError
         """
         # Arrange
-        proxy = WorkerProxy(discovery=mock_discovery_service, lazy=False, quorum=0)
+        proxy = proxy_factory(discovery=mock_discovery_service, lazy=False, quorum=0)
         await proxy.start()
 
         # Act & assert
@@ -1588,7 +2426,11 @@ class TestWorkerProxy:
 
     @pytest.mark.asyncio
     async def test_start_with_awaitable_loadbalancer(
-        self, mock_discovery_service, mock_proxy_session, mocker: MockerFixture
+        self,
+        mock_discovery_service,
+        mock_proxy_session,
+        proxy_factory,
+        mocker: MockerFixture,
     ):
         """Test start with an awaitable load balancer.
 
@@ -1608,7 +2450,7 @@ class TestWorkerProxy:
         async def make_lb():
             return mock_lb
 
-        proxy = WorkerProxy(
+        proxy = proxy_factory(
             discovery=mock_discovery_service,
             loadbalancer=make_lb(),
             lazy=False,
@@ -1620,9 +2462,6 @@ class TestWorkerProxy:
 
         # Assert
         assert proxy.started
-
-        # Cleanup
-        await proxy.stop()
 
     @pytest.mark.asyncio
     async def test_discovers_workers_from_service(self, mock_discovery_service):
@@ -5073,6 +5912,7 @@ class TestWorkerProxy:
         mock_wool_task,
         mock_proxy_session,
         mocker,
+        proxy_factory,
     ):
         """Test delegate the task to the load balancer and yield results.
 
@@ -5087,7 +5927,7 @@ class TestWorkerProxy:
         discovery, _ = spy_discovery_with_events
         mocker.patch.object(wp, "WorkerConnection", return_value=mock_worker_connection)
 
-        proxy = WorkerProxy(
+        proxy = proxy_factory(
             discovery=discovery,
             loadbalancer=spy_loadbalancer_with_workers,
         )
@@ -5390,6 +6230,7 @@ class TestWorkerProxy:
         mock_wool_task,
         mock_proxy_session,
         mocker,
+        proxy_factory,
     ):
         """Test dispatch auto-starts a lazy proxy on first call.
 
@@ -5404,7 +6245,7 @@ class TestWorkerProxy:
         discovery, _ = spy_discovery_with_events
         mocker.patch.object(wp, "WorkerConnection", return_value=mock_worker_connection)
 
-        proxy = WorkerProxy(
+        proxy = proxy_factory(
             discovery=discovery,
             loadbalancer=spy_loadbalancer_with_workers,
         )
@@ -5418,7 +6259,6 @@ class TestWorkerProxy:
         # Assert
         assert proxy.started
         assert results == ["test_result"]
-        await proxy.stop()
 
     @pytest.mark.asyncio
     async def test_dispatch_with_lazy_concurrent_start(
@@ -5467,6 +6307,7 @@ class TestWorkerProxy:
         mock_worker_connection,
         mock_wool_task,
         mock_proxy_session,
+        proxy_factory,
     ):
         """Test propagate the error from the load balancer.
 
@@ -5490,7 +6331,7 @@ class TestWorkerProxy:
 
         failing_loadbalancer = FailingLoadBalancer()
 
-        proxy = WorkerProxy(discovery=discovery, loadbalancer=failing_loadbalancer)
+        proxy = proxy_factory(discovery=discovery, loadbalancer=failing_loadbalancer)
 
         await proxy.start()
         await _drain_until(lambda: len(proxy.workers) == 1)
@@ -5507,6 +6348,7 @@ class TestWorkerProxy:
         mock_worker_connection,
         mock_wool_task,
         mock_proxy_session,
+        proxy_factory,
     ):
         """Test wait via _await_workers, then dispatch when workers appear.
 
@@ -5533,7 +6375,7 @@ class TestWorkerProxy:
         # Delegating loadbalancer that yields straight from the context
         waiting_loadbalancer = make_delegating_balancer()
 
-        proxy = WorkerProxy(
+        proxy = proxy_factory(
             discovery=discovery,
             loadbalancer=waiting_loadbalancer,
         )
@@ -7008,13 +7850,15 @@ async def _make_proxy_with_workers(
     mocker: MockerFixture,
     discovery=None,
     metadata_list=None,
+    factory=WorkerProxy,
 ) -> tuple[WorkerProxy, list[WorkerMetadata]]:
     """Build and start a WorkerProxy seeded via the public discovery flow.
 
     Patches `WorkerConnection` so the sentinel creates the given mock
     connections, constructs a proxy with a `ReducibleAsyncIterator`
-    discovery stream, starts it, and waits until all workers are visible
-    on ``proxy.workers``.
+    discovery stream through ``factory`` (pass the ``proxy_factory``
+    fixture to leave the stop to teardown), starts it, and waits until
+    all workers are visible on ``proxy.workers``.
 
     A custom ``discovery`` stream (e.g. `_GatedDiscovery`) and matching
     ``metadata_list`` may be supplied; the drain then waits only for the
@@ -7040,7 +7884,7 @@ async def _make_proxy_with_workers(
         discovery = wp.ReducibleAsyncIterator(
             [DiscoveryEvent("worker-added", metadata=m) for m in metadata_list]
         )
-    proxy = WorkerProxy(
+    proxy = factory(
         discovery=discovery,
         loadbalancer=loadbalancer,
         lazy=False,

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -1353,7 +1353,7 @@ class TestWorkerProxy:
         )
 
         # Act
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             await proxy.start()
         # The probe hold.
         async with channel_pool_hold():
@@ -1804,7 +1804,7 @@ class TestWorkerProxy:
         )
 
         # Act
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(TypeError) as excinfo:
             await proxy.start()
 
         # Assert
@@ -2416,13 +2416,13 @@ class TestWorkerProxy:
         )
 
         # Act
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(TypeError) as excinfo:
             await proxy.start()
 
         # Assert
         assert not proxy.started
         assert len(exits) == 1
-        assert exits[0][:2] == (ValueError, excinfo.value)
+        assert exits[0][:2] == (TypeError, excinfo.value)
 
     @pytest.mark.asyncio
     async def test_start_with_awaitable_loadbalancer(
@@ -7508,7 +7508,7 @@ class TestWorkerProxy:
     async def test_start_invalid_loadbalancer_type_raises_error(
         self, mocker: MockerFixture
     ):
-        """Test raise ValueError.
+        """Test raise TypeError.
 
         Given:
             A non-lazy WorkerProxy with a loadbalancer that doesn't
@@ -7516,7 +7516,7 @@ class TestWorkerProxy:
         When:
             Start() is called
         Then:
-            It should raise ValueError
+            It should raise TypeError
         """
 
         # Arrange
@@ -7532,14 +7532,14 @@ class TestWorkerProxy:
         )
 
         # Act & assert
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             await proxy.start()
 
     @pytest.mark.asyncio
     async def test_start_invalid_discovery_type_raises_error(
         self, mocker: MockerFixture
     ):
-        """Test raise ValueError.
+        """Test raise TypeError.
 
         Given:
             A non-lazy WorkerProxy with a discovery that doesn't
@@ -7547,7 +7547,7 @@ class TestWorkerProxy:
         When:
             Start() is called
         Then:
-            It should raise ValueError
+            It should raise TypeError
         """
         # Arrange - use a simple string which is definitely not an AsyncIterator
         invalid_discovery = "not_an_async_iterator"
@@ -7555,7 +7555,7 @@ class TestWorkerProxy:
         proxy = WorkerProxy(discovery=lambda: invalid_discovery, lazy=False)
 
         # Act & assert
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             await proxy.start()
 
     @pytest.mark.asyncio

--- a/wool/tests/runtime/worker/test_proxy.py
+++ b/wool/tests/runtime/worker/test_proxy.py
@@ -724,6 +724,44 @@ def _gate_predicate(local_version):
 # ============================================================================
 
 
+def _recording_loadbalancer(mocker, *, suppress=False):
+    """Build a load-balancer context manager that records how it is exited.
+
+    Returns the manager class and the list its exit arguments are appended
+    to; the manager yields a `LoadBalancerLike` mock and its exit returns
+    ``suppress``.
+    """
+    balancer = mocker.MagicMock(spec=wp.LoadBalancerLike)
+    balancer.dispatch = mocker.AsyncMock()
+    exits: list[tuple] = []
+
+    class Recording:
+        async def __aenter__(self):
+            return balancer
+
+        async def __aexit__(self, *args):
+            exits.append(args)
+            return suppress
+
+    return Recording, exits
+
+
+def _discovery_context(*, on_enter=None, on_exit=None):
+    """Build a discovery context manager whose enter and exit await the hooks."""
+
+    class Discovery:
+        async def __aenter__(self):
+            if on_enter is not None:
+                await on_enter()
+            return MockDiscoveryService()
+
+        async def __aexit__(self, *args):
+            if on_exit is not None:
+                await on_exit()
+
+    return Discovery
+
+
 class TestWorkerProxy:
     """Comprehensive test suite for WorkerProxy."""
 
@@ -1475,6 +1513,78 @@ class TestWorkerProxy:
         # Assert
         assert cm.exited
         assert not proxy.started
+
+    @pytest.mark.asyncio
+    async def test___aexit___should_forward_exception_to_loadbalancer_context(
+        self, mock_discovery_service, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test the body's exception reaches the load balancer's exit.
+
+        Given:
+            A started proxy whose load balancer is an async context
+            manager recording the exception info its ``__aexit__``
+            receives.
+        When:
+            The proxy's ``async with`` block raises.
+        Then:
+            It should exit the load balancer with that exception, as a
+            plain ``async with`` over the manager would.
+        """
+        # Arrange
+        manager, exits = _recording_loadbalancer(mocker)
+        error = ValueError("body failed")
+        proxy = WorkerProxy(
+            discovery=mock_discovery_service,
+            loadbalancer=manager,
+            lazy=False,
+            quorum=0,
+        )
+
+        # Act
+        with pytest.raises(ValueError):
+            async with proxy:
+                raise error
+
+        # Assert
+        assert not proxy.started
+        assert len(exits) == 1
+        assert exits[0][:2] == (ValueError, error)
+        assert exits[0][2] is not None
+
+    @pytest.mark.asyncio
+    async def test_start_should_exit_loadbalancer_context_with_failure_when_rolled_back(
+        self, mock_proxy_session, mocker: MockerFixture
+    ):
+        """Test a failed start hands its exception to the entered contexts.
+
+        Given:
+            A proxy whose load balancer is an async context manager
+            recording the exception info its ``__aexit__`` receives, and
+            a discovery object that is not a subscriber, so ``start``
+            raises after the load balancer has been entered.
+        When:
+            The proxy is started.
+        Then:
+            It should raise, leave the proxy un-started, and exit the
+            load balancer with that same exception.
+        """
+        # Arrange
+        manager, exits = _recording_loadbalancer(mocker)
+        proxy = WorkerProxy(
+            discovery=object(),  # type: ignore[arg-type]
+            loadbalancer=manager,
+            lazy=False,
+            quorum=0,
+        )
+
+        # Act
+        with pytest.raises(ValueError) as excinfo:
+            await proxy.start()
+
+        # Assert
+        assert not proxy.started
+        assert len(exits) == 1
+        assert exits[0][:2] == (ValueError, excinfo.value)
 
     @pytest.mark.asyncio
     async def test_start_with_awaitable_loadbalancer(

--- a/wool/tests/runtime/worker/test_service.py
+++ b/wool/tests/runtime/worker/test_service.py
@@ -23,6 +23,7 @@ from wool.runtime.discovery import __subscriber_pool__
 from wool.runtime.resourcepool import ResourcePool
 from wool.runtime.routine.task import Task
 from wool.runtime.routine.task import WorkerProxyLike
+from wool.runtime.worker import service as service_module
 from wool.runtime.worker.interceptor import VersionInterceptor
 from wool.runtime.worker.service import WorkerService
 from wool.runtime.worker.session import DispatchSession
@@ -324,6 +325,30 @@ async def _stop_streaming_routine():
         if _stop_cancellation_observed is not None:
             _stop_cancellation_observed.set()
         raise
+
+
+#: Set by `_park_on_worker_loop`'s background task when the worker-loop
+#: teardown drain cancels it.
+_drained = threading.Event()
+
+
+async def _park_on_worker_loop():
+    """Leave a task parked on the worker loop and report that it was drained.
+
+    The parked task records its cancellation on `_drained`, so a stop
+    that skips the teardown drain leaves the event clear. Defined at
+    module level so cloudpickle can serialize the callable for dispatch.
+    """
+
+    async def park():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            _drained.set()
+            raise
+
+    asyncio.get_running_loop().create_task(park())
+    return "parked"
 
 
 async def _worker_loop_identity_probe():
@@ -2388,6 +2413,67 @@ class TestWorkerService:
         assert isinstance(stop_result, protocol.Void)
         assert grpc_servicer.stopped.is_set()
         assert cleared_on == [worker_thread_name]
+
+    @pytest.mark.asyncio
+    async def test_stop_should_clear_channel_pool_after_the_proxy_pool_when_warm(
+        self,
+        grpc_aio_stub,
+        grpc_servicer,
+        mocker: MockerFixture,
+        mock_worker_proxy_cache,
+    ):
+        """Test `WorkerService.stop` sweeps the channel pool after the proxy pool.
+
+        Given:
+            A `WorkerService` that has serviced a dispatch, leaving one
+            worker event-loop warm on a daemon thread, a proxy pool whose
+            ``clear`` records its turn, and a channel-pool clear that
+            records its turn and the thread it runs on
+        When:
+            The stop RPC is invoked with a positive timeout
+        Then:
+            It should clear the channel pool exactly once, on the worker
+            loop's daemon thread, after the proxy pool -- so exiting the
+            proxies releases their hold before the channels are swept
+        """
+        # Arrange
+        order: list[str] = []
+        cleared_on: list[str] = []
+
+        async def record_proxy():
+            order.append("proxy")
+
+        async def record_channel():
+            order.append("channel")
+            cleared_on.append(threading.current_thread().name)
+
+        mock_worker_proxy_cache.clear = mocker.AsyncMock(side_effect=record_proxy)
+        clear_channel_pool = mocker.patch.object(
+            service_module,
+            "clear_channel_pool",
+            mocker.AsyncMock(side_effect=record_channel),
+        )
+        wool_task = make_task(_worker_loop_identity_probe)
+
+        # Act
+        async with grpc_aio_stub() as stub:
+            stream = stub.dispatch()
+            await stream.write(protocol.Request(task=wool_task.to_protobuf()))
+            await stream.done_writing()
+            ack, result = [r async for r in stream]
+            assert ack.HasField("ack")
+            assert result.HasField("result")
+            _, _, worker_thread_name = cloudpickle.loads(result.result.dump)
+            stop_result = await asyncio.wait_for(
+                stub.stop(protocol.StopRequest(timeout=5)), 10
+            )
+
+        # Assert
+        assert isinstance(stop_result, protocol.Void)
+        assert grpc_servicer.stopped.is_set()
+        clear_channel_pool.assert_awaited_once()
+        assert cleared_on == [worker_thread_name]
+        assert order == ["proxy", "channel"]
 
     @pytest.mark.asyncio
     async def test_dispatch_should_clear_proxy_pool_when_idle_worker_loop_expires(
@@ -5085,6 +5171,54 @@ class TestWorkerService:
             and "proxy pool" in record.getMessage()
             for record in caplog.records
         )
+
+    @pytest.mark.asyncio
+    async def test_stop_should_still_drain_when_proxy_pool_clear_raises_base_exception(
+        self,
+        grpc_aio_stub,
+        grpc_servicer,
+        mocker: MockerFixture,
+        mock_worker_proxy_cache,
+    ):
+        """Test `WorkerService.stop` drains the worker loop past a failing clear.
+
+        Given:
+            A `WorkerService` that has serviced one dispatch, leaving a
+            warm worker loop with a task parked on it, while the
+            proxy-pool ``clear`` coroutine raises a ``BaseException``
+            the teardown's ``except Exception`` cannot contain
+        When:
+            The stop RPC is invoked with a positive timeout
+        Then:
+            It should still cancel the parked task before stopping the
+            loop, and set ``stopped``, so an escaping clear does not
+            skip the drain
+        """
+
+        # Arrange
+        class Interrupt(BaseException):
+            pass
+
+        mock_worker_proxy_cache.clear = mocker.AsyncMock(side_effect=Interrupt())
+        _drained.clear()
+        wool_task = make_task(_park_on_worker_loop)
+        async with grpc_aio_stub() as stub:
+            stream = stub.dispatch()
+            await stream.write(protocol.Request(task=wool_task.to_protobuf()))
+            await stream.done_writing()
+            ack, result = [r async for r in stream]
+            assert ack.HasField("ack")
+            assert result.HasField("result")
+
+            # Act
+            stop_result = await asyncio.wait_for(
+                stub.stop(protocol.StopRequest(timeout=5)), timeout=10
+            )
+
+        # Assert
+        assert isinstance(stop_result, protocol.Void)
+        assert grpc_servicer.stopped.is_set()
+        assert _drained.wait(timeout=5)
 
     @pytest.mark.asyncio
     async def test_dispatch_should_ship_synthesized_runtime_error_when_routine_exception_unpicklable(  # noqa: E501


### PR DESCRIPTION
## Summary

A pooled gRPC channel closes by two paths, the 60 s idle TTL and an explicit `WorkerConnection.close()`, and both run on the event loop that opened the channel. Before this change nothing else did: a dispatch's release only armed the TTL timer, and `WorkerProxy` never closed the connections it created. A loop that stopped inside the TTL, which is what `asyncio.run` around a short script or a test does, left every channel it had cached open. The socket and the gRPC threads serving it were abandoned, and the pool's next rebind dropped the entry without running its finalizer, logged at debug as though the drop were an expiry. An expiry closes a channel; a drop leaks it.

The pool cannot know when a loop is done with its channels. The proxy can: every dispatch on a loop passes through a started `WorkerProxy`, so the last proxy to stop on a loop marks the end of wool's use of that loop's channels. This change adds `ResourcePool.expire_all`, which retires every cached entry, where to retire an entry is to finalize it now if nothing references it and otherwise by the release that drops its last reference. It binds `expire_all` to a reference-counted hold on the channel pool that each proxy takes in `start` and releases in `stop`, so the last release on a loop retires the loop's channels without closing one under a dispatch still using it. The proxy closes the connection of a worker that leaves its pool, `WorkerConnection` gains `async with` as the documented form for direct use, and a channel a loop strands anyway is reported at warning level naming the pool it belonged to.

The pool's one-running-loop contract is unchanged; partitioning the pool per loop is #381, which stacks on this branch. Two defects the work exposed are fixed here as well: `Resource` released its entry only when the object it held was truthy, and `WorkerProxy` and `WorkerPool` carried divergent copies of one dependency resolver.

Closes #388

## Proposed changes

### `ResourcePool.expire_all` (`wool/src/wool/runtime/resourcepool.py`)

`ResourcePool` had two ways to drop an entry. `clear` force-finalizes every entry regardless of reference count and is correct only when the pool itself is going away; `expire` retires one key while the pool stays in use. Add `expire_all`, `expire` applied to every cached key at once, and share the per-entry step between them through `_retire`.

Retirement is all-or-nothing in reach, not in outcome. A finalizer raising `Exception` is contained per entry, as it already was, and reported at warning level; any other `BaseException` is re-raised only after every remaining key has been retired, because abandoning the sweep at the first failure would strand every key behind it, which is the leak this primitive exists to close reappearing under cancellation. A delivered cancellation is consumed by the finalizer it lands in and the finalizers after it run uncancelled, so the sweep defers a `cancel()` by at most one finalizer. A `KeyboardInterrupt` or `SystemExit` raised later in the sweep supersedes a recorded `CancelledError` and chains it as its cause, so a process-level signal is never held behind a cancellation. Every cancellation the sweep absorbed and did not re-raise is uncancelled, so a caller under `asyncio.timeout` or a `TaskGroup` sees the cancellation count it expects.

### The channel-pool hold (`wool/src/wool/runtime/worker/connection.py`, `proxy.py`)

A hold declares a period during which repeated dispatches are expected on a loop. While any hold is open an idle channel is left to the TTL; the last release ends the period and retires every channel cached on the loop through `expire_all`, whether or not a holder opened it. The sweep is loop-scoped rather than holder-scoped because the leak the hold exists to close is a channel nobody holds, a bare connection's or a departed worker's, and a sweep limited to the holders' own keys would strand exactly those.

The hold is `ResourcePool` composed with itself. `_channel_pool_holds` is a one-key pool whose entry is an inert `None`, whose finalizer is `expire_all` over the channel pool, and whose `ttl=0` makes the last release retire inline. A reference count that finalizes on its last release is what `ResourcePool` already is, and because both pools bind by loop the same way, a hold cannot outlive the channels it governs. `channel_pool_hold()` is package-internal and returns a single-use `Resource[None]`; the hold is the count, not a handle on the pool. Retirement goes through `expire_all` rather than `clear` because the loop keeps running after the last proxy leaves: a dispatch whose teardown lands afterwards still holds its channel reference, and force-closing under it would let that late release corrupt an entry rebuilt for the same key.

`WorkerProxy.start` takes the hold before it enters the load balancer and discovery contexts, and `stop` releases it after them, so the last proxy on a loop closes that loop's channels and a proxy nested inside another cannot close the outer one's. `clear_channel_pool` remains the teardown primitive and leaves holds to their holders: force-clearing the holds pool would detach a live holder from its count.

### Connection lifecycle (`connection.py`, `proxy.py`, `loadbalancer/base.py`, `local.py`, `service.py`)

`WorkerConnection` is a lazy handle, not a channel owner: the pool key `(target, credentials, options, peer)` is shared by every handle to the same worker, so discarding a handle cannot close its channel, and the class had `close()` but no protocol that called it. Give it `__aenter__` and `__aexit__`, exit meaning `close`, and make `async with` the documented usage; a connection used bare must close itself, and one that is neither closed nor covered by a hold on a loop that stops is what the rebind reports. `LocalWorker._stop` sends its stop RPC in that form.

The proxy closes the connection of a worker that departs, on a discovery drop, an admission-gate eviction, or a non-transient dispatch failure, through one helper that contains a failing close and reports it at warning level, so a departure can neither end the sentinel nor derail a dispatch's retry. A `worker-updated` refresh closes nothing: the handle is kept when the advertised address, options, and identity are unchanged, so a later departure still closes it and a credential rotation still supersedes its key, and a changed key gets a fresh handle while the displaced one is left to the TTL. `LoadBalancerContextLike` documents that the context does not close connections and who does.

The worker loop's teardown clears the channel pool after the proxy and subscriber pools, so a rotation that drained cleanly leaves nothing for the rebind to report. Its docstring records that a clear reached with the drain budget already exhausted is cancelled before it starts; the fix for that path belongs with #381.

### Proxy lifecycle (`proxy.py`)

`start` built an `AsyncExitStack` for rollback and discarded it, so `stop` re-derived the teardown order by hand and the two disagreed on exception forwarding: a failed start exited the load balancer and discovery managers with `(None, None, None)` while `stop` forwarded the real exception, and `stop` reset a flag that let the proxy be started again. Keep the stack on the proxy and have `stop` unwind it with the exception info it was given. A failed start hands the live exception to every context it entered and discards each manager's verdict, so a manager that suppresses cannot turn a failed start into a started proxy. The hold sits first on the stack and so is released last, after every context has exited, on both paths.

A proxy is single-use, tracked by a private five-state lifecycle. `start` requires a never-started proxy, and a start that fails returns it to that state, which preserves the lazy retry after a failed quorum wait. `stop` marks the proxy stopping before its unwind and stopped after it. A second `stop`, a `start`, or a lazy dispatch during or after the unwind raises `RuntimeError` naming the state, and a lazy `dispatch` re-checks the state after taking its start lock, so a dispatch that lost the race to an explicit `start` or a `stop` raises rather than dispatching against collaborators the unwind has reset.

### Shared dependency resolver (`wool/src/wool/runtime/typing.py`, `worker/pool.py`, `worker/proxy.py`)

`WorkerPool` and `WorkerProxy` each normalized a configured dependency, a bare instance, an awaitable, a sync or async context manager, or a callable producing any of those, through byte-identical private helpers that had drifted on exception forwarding, and each raised `ValueError` when the result was the wrong type. Replace both with `resolved`, an `asynccontextmanager` beside the `Factory` alias whose forms it interprets, typed `T | Factory[T] -> AsyncIterator[T]`. Forms are tried in a fixed order, sync context manager first and bare instance last, so an instance that is also a context manager is entered. A manager's exit receives the block's exception info and its verdict is ignored. An `expect` type, or tuple of types, is checked once the object is in hand and raises `TypeError`, exiting the manager with that failure.

`WorkerPool`'s teardown starts the publisher's exit unconditionally and then bounds it by what remains of `shutdown_timeout`: an exhausted budget cancels the exit in flight and logs it. Before, `wait_for` with an exhausted budget cancelled the exit before its first step, skipping it and stranding the resolver's generators.

### Pool diagnostics and release correctness (`resourcepool.py`)

Four behaviors of `ResourcePool` were wrong or silent, and each is corrected in its own commit. The rebind logged a dropped idle entry at debug and a referenced one at warning; both name a resource that outlived every chance to finalize it, so both are reported at warning level, naming the pool by its factory, and the class docstring states that the record is expected only of a loop that stopped with entries it did not clear. The bound-loop `RuntimeError` names the pool the same way, since `WorkerProxy.start` now surfaces it. A finalizer failure under `expire`, `expire_all`, or `clear`, and a cleanup the TTL spawned that ends in a failure with no caller to receive it, are reported rather than suppressed.

`Resource._release` skipped the pool release when the object it held was falsy, so an entry whose factory returned `None`, `0`, `False`, or an empty container kept its reference count forever; the release now follows the acquisition, which is what lets the holds pool cache `None`. `acquire` incremented the reference count before awaiting the cancellation of an in-flight cleanup task, and that await could not itself be cancelled because the cleanup task swallowed the cancellation; `_cancel_cleanup` now waits through `asyncio.wait`, and `acquire` increments only afterwards, re-arming the TTL if interrupted, so a cancelled acquisition leaves its entry unreferenced and its `Resource` enterable again. A `release` cancelled while waiting on a contended lock abandoned the decrement; the contended path now runs shielded, so the release completes on its own task and the caller still observes the cancellation. An entry's TTL is armed with a loop timer rather than a task parked on a sleep, so an unfired timer is discarded silently at loop close instead of leaving a never-awaited coroutine.

### Documentation (`README.md`, `wool/src/wool/runtime/{worker,discovery,loadbalancer}/README.md`)

Each contract above has one home, on `channel_pool_hold`, `WorkerConnection`, `WorkerProxy`, `resolved`, or `ResourcePool`, and the READMEs point at it. The worker README describes the connection's `async with`, the proxy's hold, and closing on departure in its connection-pooling section, describes the pools finalized on the worker loop as a relationship that includes the channels a nested dispatch opens, and carries the single-use `start`/`stop` rule in its lazy-startup table and context-lifecycle section. The root README's channel-lifetime paragraph names the two early-retirement paths and links the worker README. The discovery and load-balancer READMEs point at `Factory` and `resolved` rather than enumerating the forms.

### Tests

Unit tests cover three altitudes. At the pool, `expire_all` is pinned in every state an entry can be retired in and on every error path, with the failure ranking as a Hypothesis property over any sequence of finalizer outcomes; the falsy release is a property over falsy objects; the shielded release, the cancelled acquisition, and each warning-level report have a test each. At the connection, the hold's nesting, its mid-dispatch release, its loop-scoped sweep, and its behavior under a failing or cancelled close are pinned alongside the context-manager protocol. At the proxy, the hold's nesting through `start` and `stop`, its release on rollback and on a raising teardown, every state transition the lifecycle rejects, the departure closes, and the kept-versus-rebuilt refresh are pinned; six tests that stopped their proxy by hand build it through a `proxy_factory` fixture that stops it at teardown. `resolved` has its own module, `WorkerPool`'s dependency-shape and teardown tests pin the resolver and the bounded publisher exit, and `WorkerService`'s stop pins the channel-pool clear running on the worker loop's thread after the proxy pool. The root conftest clears the channel pool on the loop that used it after every test, so a record on the pool's logger means a real leak.

Integration tests in `wool/tests/integration/test_channel_lifecycle.py` run over real workers and assert what the pool holds after a dispatch has already succeeded, which the pairwise array cannot express. A `WorkerConnection` never entered and never closed on a loop that stops is the control that must report a stranded channel; its siblings, a connection entered as a context manager, a static proxy, a pool, nested pools, and a worker's nested-dispatch proxy retiring, each report nothing.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestResourcePool` | A pool that has never cached anything | `expire()` or `expire_all()` is awaited | Returns without raising, invokes no finalizer, and leaves the pool empty | Retirement of nothing |
| 2 | `TestResourcePool` | A pool holding one idle entry awaiting its TTL and one still referenced | The idle key is expired, or `expire_all()` is awaited | Finalizes the idle entry immediately and leaves the referenced one cached with no pending cleanup | Retirement is drain-first |
| 3 | `TestResourcePool` | A pool whose only entry is referenced and has been retired | The last reference is released | Finalizes the entry before `release` returns, spawning no task, and leaves an empty pool | Inline finalization on the draining release |
| 4 | `TestResourcePool` | A pool whose only entry is referenced and retired | The same key is acquired again and both references are released | Hands back the cached object without rebuilding it and keeps it under its TTL, the retirement cleared | Re-acquire clears a retirement |
| 5 | `TestResourcePool` | A pool whose only entry is referenced and retired | The reference is released and the key is acquired again afterwards | Finalizes the retired object exactly once and builds a fresh object for the new acquire | A late release never finalizes a rebuilt entry |
| 6 | `TestResourcePool` | Any pool of up to five keys with reference counts between zero and three (Hypothesis) | `expire_all()` is awaited and every reference is released | Finalizes each object exactly once and ends with an empty pool | Exactly-once finalization invariant |
| 7 | `TestResourcePool` | A `ttl=0` pool holding one idle entry and one still referenced | `expire_all()` is awaited and the reference is released | Finalizes both without scheduling a pending cleanup | Retirement at the holds pool's configuration |
| 8 | `TestResourcePool` | Three idle entries whose finalizers raise a contained `Exception`, one cancellation, two cancellations, a cancellation then a signal, or two signals (parametrized) | `expire_all()` is awaited | Attempts every finalizer, empties the pool, and re-raises the first uncontained failure unless a later signal supersedes it, chaining the superseded one and logging the rest as discarded | Failure ranking, by example |
| 9 | `TestResourcePool` | One to five idle entries whose finalizers finish cleanly or raise `Exception`, `CancelledError`, `KeyboardInterrupt`, or `SystemExit` in any order (Hypothesis) | `expire_all()` is awaited | Matches the ranking computed from the outcomes, attempts every finalizer in order, and leaves the task's cancellation count at zero | Failure ranking, as a property |
| 10 | `TestResourcePool` | Two idle entries whose first finalizer parks until the sweeping task is cancelled, the second raising `KeyboardInterrupt` or finishing cleanly | The sweeping task is cancelled while parked | Re-raises the signal with the cancellation chained and a count of zero, or re-raises the cancellation itself with a count of one | Cancellation count after a sweep |
| 11 | `TestResourcePool` | Three idle entries whose first finalizer raises `CancelledError` | `clear()` is awaited | Attempts every finalizer, empties the pool, and re-raises the cancellation afterwards | `clear` finishes its sweep |
| 12 | `TestResourcePool` | An expired key's TTL timer has fired while the pool lock is held, with the cleanup task and a queued retirement both waiting on the lock | The lock holder completes and the retirement runs | Cancels the in-flight cleanup, runs the finalizer exactly once, and evicts the entry | Retirement racing a fired TTL timer |
| 13 | `TestResourcePool` | A pool holding an unreferenced entry whose TTL timer is pending | `expire()` is awaited for that key | Runs the finalizer immediately and leaves no pending cleanup | `expire` skips the TTL |
| 14 | `TestResourcePool` | A pool whose bound loop closed with only idle entries cached | The pool is used from a fresh event loop | Logs one WARNING naming the pool and the idle entry dropped without finalizing | Idle drop reported at warning level |
| 15 | `TestResourcePool` | A pool bound to an event loop still running on another thread | The pool is used from a second event loop | Raises `RuntimeError` naming the pool by its factory rather than rebinding | One pool never serves two live loops |
| 16 | `TestResourcePool` | A pool whose finalizer raises `Exception`, or whose spawned cleanup ends in an uncontained `BaseException` | The idle key is expired, or its TTL elapses | Evicts the entry and logs one WARNING naming the pool's factory and the key | Finalizer and cleanup failures are reported |
| 17 | `TestResourcePool` | A synchronous finalizer, or factory, that returns an awaitable that is not a coroutine | The entry is expired, or acquired | Awaits the finalizer's result; caches the factory's object itself rather than awaiting it | Awaitable results |
| 18 | `TestResourcePool` | An expired key's cleanup task and a queued acquire of that key both wait on the lock | The acquire is cancelled while it waits for the cleanup it cancelled | Raises `CancelledError`, leaves the entry unreferenced with its TTL re-armed, and finalizes it once the TTL elapses | A cancelled acquisition neither leaks nor orphans |
| 19 | `TestResourcePool` | A pool whose factory parks, and a `Resource` for an uncached key | The task entering the `Resource` is cancelled mid-factory, then the `Resource` is entered again | Leaves nothing cached or referenced after the cancellation and hands back the object on the second entry | A cancelled acquisition leaves the resource enterable |
| 20 | `TestResourcePool` | A sweep parked in the first entry's finalizer, holding the lock, while a release of the second entry waits behind it | The waiting release is cancelled and the sweep completes | Raises `CancelledError` to the releasing task yet still drops the reference, so the retired entry is finalized | Shielded release under contention |
| 21 | `TestResource` | A zero-TTL pool whose factory returns a falsy object, `None` included (Hypothesis) | The resource context exits | Releases the reference and finalizes the entry | Release follows the acquisition, not the value |
| 22 | `test_typing` | A plain object, an awaitable, a sync context manager, an async context manager, and callables producing each | Each is resolved | Yields the object, the awaited result, or the entered value, and exits any manager afterwards | `resolved` over every `Factory` form |
| 23 | `test_typing` | Context managers recording their exits | The resolved block raises, a manager's exit returns `True`, or a manager's exit raises | Forwards the block's exception to the exit, ignores the suppressing verdict, and propagates the exit's own error | Exit contract of `resolved` |
| 24 | `test_typing` | An object that is both a context manager and callable, or both a sync and an async context manager | It is resolved | Enters the sync manager protocol and never calls the object or the async protocol | Resolution precedence |
| 25 | `test_typing` | An async context manager yielding a string, resolved with `expect=str`, `expect=(str, bytes)`, `expect=int`, or `expect=(int, float)` | It is resolved | Yields the string when satisfied; otherwise raises `TypeError` naming every expected type and exits the manager with it | `expect` on a type and on a tuple |
| 26 | `TestWorkerPool` | A pool whose discovery is an awaitable, a plain object, or a sync context manager | The pool is entered and exited | Hands the resolved discovery's subscriber to the proxy and exits the manager | `WorkerPool` over the resolver |
| 27 | `TestWorkerPool` | A pool whose worker never stops and whose publisher records its exit, or parks in it until cancelled | The block exits and the worker stop exhausts `shutdown_timeout` | Enters the publisher's exit exactly once; cancels a parked exit once the budget is spent, logs one warning, and returns within a small multiple of the timeout | Publisher exit always starts, bounded |
| 28 | `test_connection` | Two nested holds and an idle channel cached under both | The inner hold is released, then the outer | Leaves the channel open after the inner release and closes it exactly once after the outer | Nested holds retire nothing on their own |
| 29 | `test_connection` | A single hold and a dispatch started under it whose stream is primed but not drained | The hold is released and the dispatch is then drained | Leaves the channel open at the release and closes it once the dispatch drops its reference | Hold released mid-dispatch |
| 30 | `test_connection` | An idle channel cached for a bare connection's dispatch made while no hold was open | A hold is taken and released with nothing dispatched under it | Closes that channel exactly once and empties the pool | The sweep is loop-scoped |
| 31 | `test_connection` | One hold and a cached channel whose `close` raises, or raises `CancelledError` | The hold is released | Leaves the pool empty, returning normally or propagating the cancellation | A channel that refuses to close is still retired |
| 32 | `test_connection` | A hold taken before `clear_channel_pool` ran and a second taken after it, with a channel cached under the second | The first hold is released, then the second | Leaves the channel open after the first release and closes it exactly once after the second | A teardown does not detach a holder from its count |
| 33 | `TestWorkerConnection` | A connection entered as a context manager that has dispatched once | The block exits normally, or raises | Closes the cached channel exactly once and leaves the pool empty, propagating the error | Exit closes the connection |
| 34 | `TestWorkerConnection` | Two connections sharing one pooled channel, one entered and the other holding an undrained stream | The entered block exits, then the stream drains | Leaves the channel open at the exit and closes it once the stream drains | Exit drains before closing a shared channel |
| 35 | `TestWorkerProxy` | Two started proxies on one loop and an idle channel cached while both were started | The proxies are stopped one after the other | Leaves the channel open after the first stop and closes it exactly once after the second | Last proxy on a loop closes its channels |
| 36 | `TestWorkerProxy` | A proxy whose `start` raises after taking its hold, or a started proxy whose discovery exit raises on `stop` | The failure is observed and the loop's channels are checked | Has released the hold, so the loop's channels close | Hold released on rollback and on a raising teardown |
| 37 | `TestWorkerProxy` | A proxy whose load balancer records the exception info its exit receives | The `async with` block raises, or `start` fails after entering it | Exits the load balancer with that exception | Exception forwarded through the retained stack |
| 38 | `TestWorkerProxy` | A proxy whose load balancer's exit returns `True` and whose discovery is not a subscriber | The proxy is started | Raises the start failure and leaves the proxy un-started | Suppression cannot half-start the proxy |
| 39 | `TestWorkerProxy` | A started proxy whose discovery exit blocks, so a stop stays suspended | A second stop, or a start, is called while the first stop is suspended | Raises `RuntimeError` naming the stopping state, and the first stop completes once the exit unblocks | Nothing races a stop's unwind |
| 40 | `TestWorkerProxy` | A proxy whose discovery entry blocks, so a start stays suspended | A second start, or a lazy dispatch, is issued while the first is suspended | Raises `RuntimeError` naming the starting state, and the first start completes once the entry unblocks | Nothing races a start |
| 41 | `TestWorkerProxy` | A proxy whose discovery reports no worker on its first entry and blocks on its first exit, then reports one worker | Start is called during the rollback, and again after the failed start returns | Raises during the rollback, leaves no workers after the failure, and succeeds on the retry | A failed start unwinds fully and may be retried |
| 42 | `TestWorkerProxy` | A proxy that was started and then stopped | Start, stop, or a lazy dispatch is called again | Raises `RuntimeError` naming the stopped state | A proxy is single-use |
| 43 | `TestWorkerProxy` | A started proxy that admitted a worker which is then dropped by discovery, evicted by the admission gate, or fails a dispatch non-transiently | The sentinel or the dispatch loop handles the departure | Removes the worker and closes its connection exactly once, leaving a survivor's open | Departure closes the connection |
| 44 | `TestWorkerProxy` | A started proxy whose admitted worker's connection raises from `close` | Discovery drops that worker and admits another | Admits the later worker and logs one WARNING naming the departed one | A failing close is contained and reported |
| 45 | `TestWorkerProxy` | A started proxy that admitted one worker | Discovery refreshes it with a different address, options, or accepted identity (parametrized) | Builds a second connection from the refreshed metadata and leaves the displaced one unclosed | A changed channel key rebuilds the handle |
| 46 | `TestWorkerProxy` | A started proxy that admitted one worker, then received a refresh with the same address, options, and identity | Discovery reports the worker dropped | Has built one connection, kept it across the refresh, and closes it on the drop | An unchanged channel key keeps the handle |
| 47 | `TestWorkerProxy` | A delegating balancer whose worker fails non-transiently while a concurrent stop resets the proxy's collaborators | The dispatch handles the failure | Evicts from the snapshot it took before awaiting | Eviction uses the dispatch's snapshot |
| 48 | `TestWorkerService` | A service with a warm worker loop, a proxy-pool clear, and a channel-pool clear that each record their turn and thread | The stop RPC is invoked with a positive timeout | Clears the channel pool exactly once, on the worker loop's thread, after the proxy pool | Channel pool cleared after the proxies |
| 49 | `TestWorkerService` | A service with a task parked on a warm worker loop whose proxy-pool `clear` raises a `BaseException` | The stop RPC is invoked | Still cancels the parked task and stops the loop | An escaping clear does not skip the drain |
| 50 | `TestChannelPoolLifecycle` | A one-worker or two-worker pool that has dispatched, leaving a channel cached | The pool's context is exited | Leaves the channel pool caching nothing | Pool exit retires channels end to end |
| 51 | `TestChannelPoolLifecycle` | A worker started outside the pool in a private discovery namespace, discovered and dispatched through, and left running | The pool's context is exited | Leaves the channel pool caching nothing, via the proxy's hold rather than a stop RPC | External worker the pool never stops |
| 52 | `TestChannelPoolLifecycle` | A full pool lifecycle run under `asyncio.run` on another thread, whose loop then stops | This test's loop rebinds the pool | Drops nothing and logs no record on the pool's logger | No stranded channel after a clean exit |
| 53 | `TestChannelPoolLifecycle` | A running worker polled by a `WorkerConnection` on another thread's loop, never entered and never closed before that loop stops | This test's loop rebinds the pool | Reports exactly one warning naming the one idle entry dropped | Control: a channel nobody closed is reported |
| 54 | `TestChannelPoolLifecycle` | The same worker polled by a connection entered as a context manager, or dispatched through a static proxy, on a loop that stops the instant the block exits | This test's loop rebinds the pool | Drops nothing | Direct use that cleans up after itself |
| 55 | `TestChannelPoolLifecycle` | An outer pool that has dispatched once, with a second pool entered and dispatched through inside it on the same loop | The inner pool exits while the outer stays open | Drops only the inner pool's entry and leaves the outer pool's dispatchable | Nested pools on one loop |
| 56 | `TestChannelPoolLifecycle` | A single-worker pool whose worker caches nested-dispatch proxies for one second, warmed by a nested dispatch | The worker's channel-pool counters are read while the proxy is warm and after it retires | Reports one idle channel while warm and nothing afterwards | Worker-side channel retires with its proxy |
| 57 | `TestChannelPoolLifecycle` | An async-generator dispatch whose consumer is cancelled and left unawaited, so its release lands during the pool's exit | The pool exits and the task is awaited afterwards | Raises `CancelledError`, runs the worker-side `finally`, and settles the pool to nothing with no dropped-entry record | Late release during exit, finalized inline |
