### PR TITLE
Derive the exception name from the exception value in Task.__exit__ — Closes #417

### DIFF
--- a/wool/pyproject.toml
+++ b/wool/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "debugpy",
     "gitpython",
     "hypothesis",
-    "pyright",
+    "pyright==1.1.413",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",

--- a/wool/src/wool/runtime/routine/task.py
+++ b/wool/src/wool/runtime/routine/task.py
@@ -218,9 +218,9 @@ class Task(Generic[W]):
             False to allow exceptions to propagate.
         """
         logging.debug(f"Exiting {self.__class__.__name__} with ID {self.id}")
-        if exception_value:
+        if exception_value is not None:
             self.exception = TaskException(
-                exception_type.__qualname__,
+                type(exception_value).__qualname__,
                 traceback=[
                     y
                     for x in traceback.format_exception(

--- a/wool/tests/runtime/routine/test_task.py
+++ b/wool/tests/runtime/routine/test_task.py
@@ -318,6 +318,13 @@ async def test_current_task_should_track_caller_when_variable_nesting_depth(
     assert current_task() is None
 
 
+class _Outer:
+    """Holds a nested exception class whose qualified name differs from its name."""
+
+    class Inner(Exception):
+        pass
+
+
 class TestTask:
     """Tests for :py:class:`Task`."""
 
@@ -570,6 +577,37 @@ class TestTask:
         assert task.exception is not None
         assert task.exception.type == "RuntimeError"
         assert any("runtime error" in line for line in task.exception.traceback)
+
+    @pytest.mark.asyncio
+    async def test___exit___should_record_the_qualified_name_when_exception_class_is_nested(  # noqa: E501
+        self, sample_task
+    ):
+        """Test __exit__ records the exception class's qualified name.
+
+        Given:
+            A :py:class:`Task` context manager and an exception class
+            defined inside another class.
+        When:
+            That exception is raised inside the ``with`` block.
+        Then:
+            It should attach a :py:class:`TaskException` whose type is
+            the class's qualified name, not its bare name.
+        """
+        # Arrange
+        task = sample_task()
+
+        # Act
+        async def run_with_exception():
+            with pytest.raises(_Outer.Inner):
+                with task:
+                    await asyncio.sleep(0)
+                    raise _Outer.Inner("nested error")
+
+        await run_with_exception()
+
+        # Assert
+        assert task.exception is not None
+        assert task.exception.type == "_Outer.Inner"
 
     @settings(max_examples=50, deadline=None)
     @given(


### PR DESCRIPTION
## Summary

`Task.__exit__` narrows on `exception_value` and then reads `__qualname__` from `exception_type`, a second `Optional` parameter the narrowing never touched. The context-manager protocol makes the two parameters present or absent together, so the access is sound at runtime, and pyright through 1.1.411 accepted it. pyright 1.1.412 stopped inferring one parameter's presence from the other, and the lint job, which resolves an unpinned `pyright` from the dev extra, began failing on every branch with `"__qualname__" is not a known attribute of "None"` at `task.py:223`.

Read the name from `type(exception_value)`, which the protocol guarantees is `exception_type`, and narrow on presence rather than truth. Pin `pyright==1.1.413` in the dev extra, since `uv.lock` is not tracked and the extra is the only record of the checked version; the issue's proposal to install from the lock has no lock to install from. A pyright release can no longer fail CI without a change in the repository.

Closes #417

## Proposed changes

### Derive the name from the value (`wool/src/wool/runtime/routine/task.py`)

The recorded `TaskException.type` is unchanged: `type(exception_value)` is `exception_type` at every call the protocol makes. The guard becomes `is not None`, which states the parameter's contract, presence, rather than its truth; `BaseException` instances are truthy, so the runtime path is also unchanged. `traceback.format_exception` keeps all three arguments, each of which its stub accepts as `Optional`.

### Pin the checked pyright version (`wool/pyproject.toml`)

`pyright==1.1.413` replaces the bare `pyright` entry in the dev extra. The lint job installs that extra with `uv pip install -e './wool[dev]'` and runs `uv run pyright`, so the pin is the whole of the CI change. Raising it is a deliberate one-line commit rather than a side effect of a runner's resolution.

### Tests (`wool/tests/runtime/routine/test_task.py`)

The two existing `__exit__` capture tests assert `ValueError` and `RuntimeError`, names that coincide with their qualified names, so nothing pinned the qualified name the `TaskException.type` docstring promises. A new test raises an exception class nested inside another through the `with` idiom and asserts the recorded type is `_Outer.Inner`. Both pyright versions report zero errors on `src` and `tests`.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestTask` | A `Task` context manager and an exception class defined inside another class | That exception is raised inside the `with` block | Attaches a `TaskException` whose type is the class's qualified name, `_Outer.Inner` | Qualified-name contract of `TaskException.type` |